### PR TITLE
fix(backend-core): Correct the nbf-exp check

### DIFF
--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -3,3 +3,4 @@ export * from './api/ClerkBackendAPI';
 export * from './api/resources';
 export type { ClerkFetcher } from './api/utils/RestClient';
 export type { Session } from './api/resources/Session';
+export type { Nullable } from "./util/nullable"

--- a/packages/backend-core/src/util/jwt.ts
+++ b/packages/backend-core/src/util/jwt.ts
@@ -1,16 +1,20 @@
 import { JWTPayload } from './types';
+const DEFAULT_ADDITIONAL_CLOCK_SKEW = 0;
 
 export function isExpired(
-  payload: JWTPayload
+  payload: JWTPayload,
+  additionalClockSkew = DEFAULT_ADDITIONAL_CLOCK_SKEW
 ) {
   // verify exp+nbf claims
   const now = Date.now() / 1000;
 
-  if (payload.exp && payload.exp < now) {
+  if (payload.exp && now > payload.exp + additionalClockSkew) {
     throw new Error(`Expired token`);
   }
 
-  // TODO: Error handling logic based on nbf attribute and clock skew.
+  if (payload.nbf && now < payload.nbf - additionalClockSkew) {
+    throw new Error(`Token not active yet`);
+  }
 }
 
 export function checkClaims(claims: JWTPayload) {

--- a/packages/backend-core/src/util/jwt.ts
+++ b/packages/backend-core/src/util/jwt.ts
@@ -1,9 +1,7 @@
 import { JWTPayload } from './types';
-const DEFAULT_ALLOWED_CLOCK_SKEW = 10;
 
 export function isExpired(
-  payload: JWTPayload,
-  allowedClerkSkew = DEFAULT_ALLOWED_CLOCK_SKEW
+  payload: JWTPayload
 ) {
   // verify exp+nbf claims
   const now = Date.now() / 1000;
@@ -12,9 +10,7 @@ export function isExpired(
     throw new Error(`Expired token`);
   }
 
-  if (payload.nbf && now < payload.nbf + allowedClerkSkew) {
-    throw new Error(`Expired token`);
-  }
+  // TODO: Error handling logic based on nbf attribute and clock skew.
 }
 
 export function checkClaims(claims: JWTPayload) {

--- a/packages/backend-core/src/util/jwt.ts
+++ b/packages/backend-core/src/util/jwt.ts
@@ -9,16 +9,16 @@ export function isExpired(
   const now = Date.now() / 1000;
 
   if (payload.exp && now > payload.exp + additionalClockSkew) {
-    throw new Error(`Expired token`);
+    throw new Error(`Token is expired`);
   }
 
   if (payload.nbf && now < payload.nbf - additionalClockSkew) {
-    throw new Error(`Token not active yet`);
+    throw new Error(`Token is not active yet`);
   }
 }
 
 export function checkClaims(claims: JWTPayload) {
   if (!claims.iss || !claims.iss.startsWith('https://clerk')) {
-    throw new Error(`Invalid issuer: ${claims.iss}`);
+    throw new Error(`Issuer is invalid: ${claims.iss}`);
   }
 }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Temporary removal of `nbf` due to clock skew miscalculation.
Following up we will add the correct logic for `nbf` checks and configurable skew time.

/+ Correct `Nullable` export.