### PR TITLE
fix(clerk-sdk-node): Restore the setClerkHttpOptions capability

### DIFF
--- a/packages/sdk-node/examples/node/src/clients.ts
+++ b/packages/sdk-node/examples/node/src/clients.ts
@@ -5,8 +5,6 @@ import clerk, { clients } from '@clerk/clerk-sdk-node';
 const clientId = process.env.CLIENT_ID || '';
 const sessionToken = process.env.SESSION_TOKEN || '';
 
-// setClerkServerApiUrl(serverApiUrl);
-
 console.log('Get client list');
 const clientList = await clients.getClientList();
 console.log(clientList);

--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -56,6 +56,7 @@ const verifySignature = async (
 
 export default class Clerk extends ClerkBackendAPI {
   base: Base;
+  httpOptions: OptionsOfUnknownResponseBody;
 
   _jwksClient: JwksClient;
 
@@ -79,7 +80,7 @@ export default class Clerk extends ClerkBackendAPI {
       url,
       { method, authorization, contentType, userAgent, body }
     ) => {
-      const finalHTTPOptions = deepmerge(httpOptions, {
+      const finalHTTPOptions = deepmerge(this.httpOptions, {
         method,
         responseType: contentType === 'text/html' ? 'text' : 'json',
         headers: {
@@ -107,6 +108,8 @@ export default class Clerk extends ClerkBackendAPI {
     if (!apiKey) {
       throw Error(SupportMessages.API_KEY_NOT_FOUND);
     }
+
+    this.httpOptions = httpOptions;
 
     this._jwksClient = jwks({
       jwksUri: `${serverApiUrl}/${apiVersion}/jwks`,
@@ -331,9 +334,5 @@ export default class Clerk extends ClerkBackendAPI {
     { onError }: MiddlewareOptions = { onError: this.strictOnError }
   ) {
     return this.withSession(handler, { onError });
-  }
-
-  set httpOptions(value: OptionsOfUnknownResponseBody) {
-    this.httpOptions = value;
   }
 }

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -1,3 +1,5 @@
+import { OptionsOfUnknownResponseBody } from 'got';
+
 import Clerk from './instance';
 
 const singletonInstance = Clerk.getInstance();
@@ -85,4 +87,8 @@ export function setClerkServerApiUrl(value: string) {
 
 export function setClerkApiVersion(value: string) {
   Clerk.getInstance().apiVersion = value;
+}
+
+export function setClerkHttpOptions(value: OptionsOfUnknownResponseBody) {
+  Clerk.getInstance().httpOptions = value;
 }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Restoring the`setClerkHttpOptions` method after accidental removal. 
