### PR TITLE
fix(backend-core): Correct handling of expired tokens

### DIFF
--- a/packages/backend-core/src/Base.ts
+++ b/packages/backend-core/src/Base.ts
@@ -90,6 +90,7 @@ export class Base {
    *
    * @param {string} token
    * @return {Promise<JWTPayload>} claims
+   * @throws {JWTExpiredError|Error}
    */
   verifySessionToken = async (token: string): Promise<JWTPayload> => {
     // Try to load the PK from supplied function and

--- a/packages/backend-core/src/api/utils/Errors.ts
+++ b/packages/backend-core/src/api/utils/Errors.ts
@@ -9,6 +9,13 @@ export class HttpError extends Error {
   }
 }
 
+export class JWTExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JWTExpiredError';
+  }
+}
+
 export interface ClerkServerErrorProps {
   message: string;
   longMessage: string;

--- a/packages/backend-core/src/util/jwt.ts
+++ b/packages/backend-core/src/util/jwt.ts
@@ -1,3 +1,4 @@
+import { JWTExpiredError } from '../api/utils/Errors';
 import { JWTPayload } from './types';
 const DEFAULT_ADDITIONAL_CLOCK_SKEW = 0;
 
@@ -9,7 +10,7 @@ export function isExpired(
   const now = Date.now() / 1000;
 
   if (payload.exp && now > payload.exp + additionalClockSkew) {
-    throw new Error(`Token is expired`);
+    throw new JWTExpiredError(`Token is expired`);
   }
 
   if (payload.nbf && now < payload.nbf - additionalClockSkew) {

--- a/packages/backend-core/src/util/jwt.ts
+++ b/packages/backend-core/src/util/jwt.ts
@@ -2,6 +2,14 @@ import { JWTExpiredError } from '../api/utils/Errors';
 import { JWTPayload } from './types';
 const DEFAULT_ADDITIONAL_CLOCK_SKEW = 0;
 
+/**
+ *
+ *
+ * @export
+ * @param {JWTPayload} payload
+ * @param {*} [additionalClockSkew=DEFAULT_ADDITIONAL_CLOCK_SKEW]
+ * @throws {JWTExpiredError|Error}
+ */
 export function isExpired(
   payload: JWTPayload,
   additionalClockSkew = DEFAULT_ADDITIONAL_CLOCK_SKEW


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Correct handling of the token expiration case introducing the new `JWTExpiredError` class.
