### PR TITLE
fix(clerk-js): Prevent post auth redirects in Metamask flow

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -560,12 +560,14 @@ export default class Clerk implements ClerkInterface {
       }
     }
 
-    await this.setSession(signInOrSignUp.createdSessionId, () => {
-      if (redirectUrl) {
-        return this.navigate(redirectUrl);
-      }
-      return Promise.resolve();
-    });
+    if (signInOrSignUp.createdSessionId) {
+      await this.setSession(signInOrSignUp.createdSessionId, () => {
+        if (redirectUrl) {
+          return this.navigate(redirectUrl);
+        }
+        return Promise.resolve();
+      });
+    }
   };
 
   updateClient = (newClient: ClientResource): void => {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-remix`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Check if session is created before calling Clerk.setSession and redirecting the user.
Especially during sign ups, the session wont be created unless all the sign up requirements (e.g. names and emails)  are met.