### PR TITLE
Adjust eslint config and replaced deprecated `mocked` method

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,10 +14,12 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-non-null-assertion': 'warn',
-    '@typescript-eslint/no-unsafe-assignment': 'warn',
+    '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
-    '@typescript-eslint/no-unsafe-return': 'warn',
+    '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/restrict-template-expressions': 'off',
     'simple-import-sort/imports': 'error',
   },
 };

--- a/packages/shared/utils/testUtils.ts
+++ b/packages/shared/utils/testUtils.ts
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import { render, RenderOptions } from '@testing-library/react';
+import {render, RenderOptions} from '@testing-library/react';
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { noop } from '../utils';
+import {noop} from '../utils';
 
 // Wrap components with test providers
 const customRender = (ui: React.ReactElement, options?: RenderOptions) => {
@@ -30,7 +30,7 @@ const renderJSONAfterFirstAct = (c: React.ReactElement) => {
 export * from '@testing-library/react';
 export { act as actHook, renderHook } from '@testing-library/react-hooks';
 export { default as userEvent } from '@testing-library/user-event';
-export { mocked } from 'ts-jest/utils';
+export { mocked } from 'jest-mock';
 
 // Override render method
 export { customRender as render, renderJSON, renderJSONAfterFirstAct, noop };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-remix`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Temporarily disables eslint `no-unsafe` checks - will be tackled on a different PR.
- Replace deprecated jest `mocked` method
