### PR TITLE
Include phone number id in prepare second factor

### DIFF
--- a/packages/clerk-js/src/ui/signIn/SignInFactorTwo.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorTwo.tsx
@@ -54,9 +54,24 @@ function _SignInFactorTwo(): JSX.Element {
     if (status === 'verified' || !signIn) {
       return;
     }
+
+    const secondFactors = signIn.supportedSecondFactors
+      .filter(factor => factor.strategy === 'phone_code')
+      .map(phoneCodeFactor => phoneCodeFactor as PhoneCodeFactor);
+
+    if (secondFactors.length === 0) {
+      return;
+    }
+
+    const defaultIdentifier = secondFactors.find(factor => factor.default);
+    const phoneNumberId = defaultIdentifier
+      ? defaultIdentifier.phone_number_id
+      : secondFactors[0]?.phone_number_id;
+
     signIn
       .prepareSecondFactor({
         strategy: 'phone_code',
+        phone_number_id: phoneNumberId,
       })
       .catch(err => handleError(err, [code], setError));
   };

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -130,7 +130,9 @@ export type PrepareFirstFactorParams =
       action_complete_redirect_url: string;
     });
 
-export type PrepareSecondFactorParams = Pick<PhoneCodeFactor, 'strategy'>;
+export type PrepareSecondFactorParams = Pick<PhoneCodeFactor, 'strategy'> & {
+  phone_number_id?: string;
+};
 
 export type AttemptFactorParams =
   | {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This PR modifies the signature of `prepareSecondFactor` method in the sign in resource so that it optionally accepts the phone number id which we want to use for the second factor verification.

This aligns the `prepareSecondFactor` with the rest of the prepare methods. 
It's also more future-proof for when we introduce other types of second factor verifications (apart from phone codes).
Finally, it gives greater control to the callers to use any of their defined second factors for verification and not necessarily the default one.

<!-- Fixes # (issue number) -->
