### PR TITLE
fix(edge): Correct interstitial Content-Type and User-Agent

### DIFF
--- a/packages/edge/src/vercel-edge.ts
+++ b/packages/edge/src/vercel-edge.ts
@@ -65,7 +65,7 @@ export const ClerkAPI = new ClerkBackendAPI({
         'X-Clerk-SDK': `vercel-edge/${LIB_VERSION}`,
       },
       ...(body && { body: JSON.stringify(body) }),
-    }).then(body => body.json());
+    }).then(body => (contentType === 'text/html' ? body : body.json()));
   },
 });
 
@@ -97,6 +97,7 @@ export function withAuth(
         headerToken: req.headers.get('authorization'),
         origin: req.headers.get('origin'),
         host: req.headers.get('host') as string,
+        userAgent: req.headers.get('user-agent'),
         forwardedPort: req.headers.get('x-forwarded-port'),
         forwardedHost: req.headers.get('x-forwarded-host'),
         referrer: req.headers.get('referrer'),


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Correct interstitial content type on vercel-edge fetcher and User-Agent setting on `getAuthState`.