### PR TITLE
Enforce withServerSideAuth callback return type

### DIFF
--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -1,36 +1,21 @@
-import { GetServerSidePropsContext } from 'next';
+import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
-import {
-  WithServerSideAuthCallback,
-  WithServerSideAuthOptions,
-  WithServerSideAuthResult,
-} from './types';
-import {
-  getAuthData,
-  injectAuthIntoContext,
-  injectSSRStateIntoProps,
-  sanitizeAuthData,
-} from './utils';
+import { WithServerSideAuthCallback, WithServerSideAuthOptions, WithServerSideAuthResult } from './types';
+import { getAuthData, injectAuthIntoContext, injectSSRStateIntoProps, sanitizeAuthData } from './utils';
 
 const EMPTY_GSSP_RESPONSE = { props: {} };
 
 export function withServerSideAuth<
-  CallbackReturn,
+  CallbackReturn extends GetServerSidePropsResult<any>,
   Options extends WithServerSideAuthOptions,
 >(
   callback: WithServerSideAuthCallback<CallbackReturn, Options>,
   opts?: Options,
 ): WithServerSideAuthResult<CallbackReturn>;
-export function withServerSideAuth(
-  opts?: WithServerSideAuthOptions,
-): WithServerSideAuthResult<void>;
+export function withServerSideAuth(opts?: WithServerSideAuthOptions): WithServerSideAuthResult<void>;
 export function withServerSideAuth(cbOrOptions: any, options?: any): any {
   const cb = typeof cbOrOptions === 'function' ? cbOrOptions : undefined;
-  const opts = options
-    ? options
-    : typeof cbOrOptions !== 'function'
-    ? cbOrOptions
-    : {};
+  const opts = options ? options : typeof cbOrOptions !== 'function' ? cbOrOptions : {};
 
   return async (ctx: GetServerSidePropsContext) => {
     const authData = await getAuthData(ctx, opts);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Shows error if the user does not return an object from the wSSA callback, eg:
```ts
export const getServerSideProps = withServerSideAuth(context => {
  const { userId } = context.auth;
  console.log(userId);
  // throws type error
});
```
![image](https://user-images.githubusercontent.com/1811063/153687076-f6a4eaac-299c-4553-b7a2-343f596358e7.png)

<!-- Fixes # (issue number) -->
