### PR TITLE
fix(backend-core): Allow username and unsafeMetadata updates from BAPI

### DIFF
--- a/packages/backend-core/src/__tests__/apis/UserApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/UserApi.test.ts
@@ -119,7 +119,7 @@ test('getUser() returns a single user', async () => {
 
   expect(user.web3Wallets.length).toEqual(1);
   expect(user.web3Wallets[0].web3Wallet).toEqual(
-    '0x0000000000000000000000000000000000000000'
+    '0x0000000000000000000000000000000000000000',
   );
   expect(user.web3Wallets[0].verification).toMatchObject({
     attempts: 1,
@@ -133,19 +133,7 @@ test('getUser() returns a single user', async () => {
 
 test('getUser() throws an error without user ID', async () => {
   await expect(TestBackendAPIClient.users.getUser('')).rejects.toThrow(
-    'A valid ID is required.'
-  );
-});
-
-test('updateUser() throws an error without user ID', async () => {
-  await expect(TestBackendAPIClient.users.updateUser('', {})).rejects.toThrow(
-    'A valid ID is required.'
-  );
-});
-
-test('deleteUser() throws an error without user ID', async () => {
-  await expect(TestBackendAPIClient.users.deleteUser('')).rejects.toThrow(
-    'A valid ID is required.'
+    'A valid ID is required.',
   );
 });
 
@@ -166,4 +154,40 @@ test('createUser() creates a user', async () => {
 
   const user = await TestBackendAPIClient.users.createUser(params);
   expect(user.firstName).toEqual('Boss');
+});
+
+test('updateUser() updates a user', async () => {
+  const params = {
+    emailAddress: ['boss@clerk.dev'],
+    phoneNumber: ['+15555555555'],
+    username: 'clerk_boss',
+    password: '123456',
+    firstName: 'Boss',
+    lastName: 'Clerk',
+  };
+
+  nock('https://api.clerk.dev')
+    .patch('/v1/users/user_1oBNj55jOjSK9rOYrT5QHqj7eaK', snakecaseKeys(params))
+    .replyWithFile(200, __dirname + '/responses/updateUser.json', {
+      'Content-Type': '',
+    });
+
+  const user = await TestBackendAPIClient.users.updateUser(
+    'user_1oBNj55jOjSK9rOYrT5QHqj7eaK',
+    params,
+  );
+  expect(user.firstName).toEqual('Boss');
+  expect(user.username).toEqual('clerk_boss');
+});
+
+test('updateUser() throws an error without user ID', async () => {
+  await expect(TestBackendAPIClient.users.updateUser('', {})).rejects.toThrow(
+    'A valid ID is required.',
+  );
+});
+
+test('deleteUser() throws an error without user ID', async () => {
+  await expect(TestBackendAPIClient.users.deleteUser('')).rejects.toThrow(
+    'A valid ID is required.',
+  );
 });

--- a/packages/backend-core/src/__tests__/apis/responses/updateUser.json
+++ b/packages/backend-core/src/__tests__/apis/responses/updateUser.json
@@ -1,7 +1,7 @@
 {
   "id": "user_1oBNj55jOjSK9rOYrT5QHqj7eaK",
   "object": "user",
-  "username": null,
+  "username": "clerk_boss",
   "first_name": "Boss",
   "last_name": "Clerk",
   "profile_image_url": "https://images.clerk.services/clerk/default-profile.svg",

--- a/packages/backend-core/src/api/collection/UserApi.ts
+++ b/packages/backend-core/src/api/collection/UserApi.ts
@@ -4,11 +4,13 @@ import { AbstractApi } from './AbstractApi';
 interface UserParams {
   firstName?: string;
   lastName?: string;
+  username?: string;
   password?: string;
   primaryEmailAddressID?: string;
   primaryPhoneNumberID?: string;
   publicMetadata?: Record<string, unknown> | string;
   privateMetadata?: Record<string, unknown> | string;
+  unsafeMetadata?: Record<string, unknown> | string;
 }
 
 interface UserListParams {
@@ -103,6 +105,10 @@ export class UserApi extends AbstractApi {
       params.privateMetadata = JSON.stringify(params.privateMetadata);
     }
 
+    if (params.unsafeMetadata && !(typeof params.unsafeMetadata == 'string')) {
+      params.unsafeMetadata = JSON.stringify(params.unsafeMetadata);
+    }
+
     return this._restClient.makeRequest<User>({
       method: 'PATCH',
       path: `/users/${userId}`,
@@ -122,7 +128,7 @@ export class UserApi extends AbstractApi {
 function sanitizeMetadataParams(
   params: UserMetadataParams & {
     [key: string]: Record<string, unknown> | undefined;
-  }
+  },
 ): UserMetadataRequestBody {
   return userMetadataKeys.reduce(
     (res: Record<string, string>, key: string): Record<string, string> => {
@@ -131,6 +137,6 @@ function sanitizeMetadataParams(
       }
       return res;
     },
-    {}
+    {},
   );
 }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Allow username and unsafeMetadata updates from BAPI