### PR TITLE
feat(clerk-js): Allow passing of object style search params on fapiclient

### DIFF
--- a/packages/clerk-js/src/core/fapiClient.test.ts
+++ b/packages/clerk-js/src/core/fapiClient.test.ts
@@ -79,6 +79,16 @@ describe('buildUrl(options)', () => {
     ).toBe('https://clerk.example.com/v1/client/foo?_clerk_js_version=42.0.0');
   });
 
+  it('correctly parses search params', () => {
+    expect(
+      fapiClient.buildUrl({ path: '/foo', search: { test: '1' } }).href,
+    ).toBe('https://clerk.example.com/v1/foo?test=1&_clerk_js_version=42.0.0');
+
+    expect(fapiClient.buildUrl({ path: '/foo', search: 'test=2' }).href).toBe(
+      'https://clerk.example.com/v1/foo?test=2&_clerk_js_version=42.0.0',
+    );
+  });
+
   const cases = [
     ['PUT', '_method=PUT'],
     ['PATCH', '_method=PATCH'],

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -20,7 +20,12 @@ export type HTTPMethod =
 
 export type FapiRequestInit = RequestInit & {
   path?: string;
-  search?: string;
+  search?:
+    | string
+    | URLSearchParams
+    | string[][]
+    | Record<string, string>
+    | undefined;
   sessionId?: string;
   url?: URL;
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Allows passing of any type of argument that is expected on [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams).

All search params are passing through a
`    const searchParams = new URLSearchParams(search);`
construct so we can take advantage of all the formats of the contructor.