### PR TITLE
feat(nextjs): Strictly type all possible withServerSideAuth return va…

### DIFF
--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -6,7 +6,7 @@ import { getAuthData, injectAuthIntoContext, injectSSRStateIntoProps, sanitizeAu
 const EMPTY_GSSP_RESPONSE = { props: {} };
 
 export function withServerSideAuth<
-  CallbackReturn extends GetServerSidePropsResult<any>,
+  CallbackReturn extends GetServerSidePropsResult<any> | Promise<GetServerSidePropsResult<any>>,
   Options extends WithServerSideAuthOptions,
 >(
   callback: WithServerSideAuthCallback<CallbackReturn, Options>,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Nextjs getServerSideProps always needs to return a value of 
```
export type GetServerSidePropsResult<P> =
  | { props: P }
  | { redirect: Redirect }
  | { notFound: true }
```

This PR makes our `withServerSideAuth` a little more restrictive. With this change, we only allow wSSA callbacks that return a proper `GetServerSidePropsResult` value in **all branches**  

```tsx

export const a = withServerSideAuth(context => {
  const { params } = context;
  if (!params?.slug) {
    return { notFound: true };
  }
  return { props: {} };
});

export const b = withServerSideAuth(context => {
  const { params } = context;
  if (!params?.slug) {
    return { notFound: true };
  }
  return {
    redirect: { statusCode: 301, destination: '' },
  };
});

export const d = withServerSideAuth(async context => {
  const { params } = context;
  await new Promise(r => r('1'));

  if (!params?.slug) {
    return { notFound: true };
  }

  return { props: { test: 'str' } };
});

export const g = withServerSideAuth(async context => {
  await new Promise(r => r('1'));

  const { params } = context;
  if (!params?.slug) {
    return { notFound: true };
  }

  return {
    redirect: { statusCode: 301, destination: '' },
  };
});
```

and throw errors for callbacks that don't conform to the above restrictions, like: 

```tsx
export const a = withServerSideAuth(context => {
  const { params } = context;
  if (!params?.slug) {
    return { notFound: true };
  }
  // possibly undefined
});

export const b = withServerSideAuth(context => {
  const { params } = context;
  // always undefined
});

export const d = withServerSideAuth(async context => {
  const { params } = context;
  if (!params?.slug) {
    return { notFound: true };
  }
  // possibly Promise<undefined>
});
```

That way we mimic exactly what the default Nextjs `GetServerSideProps` type allows. 

Question: Our wSSA always wraps the returned value into a `{ props: { ... } }` object, so practically,  a callback with no returned value would still be valid.  Do you believe that wSSA should follow the original NextJS type restrictions?