### PR TITLE
Render instant password for password-based instances only

### DIFF
--- a/packages/clerk-js/src/core/resources/UserSettings.test.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.test.ts
@@ -32,7 +32,30 @@ describe('UserSettings', () => {
     expect(res).toEqual(['web3_metamask_signature']);
   });
 
-  it('returns enabled social provier strategies', function () {
+  it('returns if the instance is passwordless or password-based', function () {
+    let sut = new UserSettings({
+      attributes: {
+        password: {
+          enabled: true,
+          required: true,
+        },
+      },
+    } as any as UserSettingsJSON);
+
+    expect(sut.instanceIsPasswordBased).toEqual(true);
+
+    sut = new UserSettings({
+      attributes: {
+        password: {
+          enabled: true,
+          required: false,
+        },
+      },
+    } as any as UserSettingsJSON);
+    expect(sut.instanceIsPasswordBased).toEqual(false);
+  });
+
+  it('returns enabled social provider strategies', function () {
     const sut = new UserSettings({
       social: {
         oauth_google: {

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -9,7 +9,7 @@ import type {
   Web3Strategy,
 } from '@clerk/types';
 
-import {BaseResource} from './internal';
+import { BaseResource } from './internal';
 
 /**
  * @internal
@@ -23,13 +23,15 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
 
   socialProviderStrategies: OAuthStrategy[] = [];
   web3FirstFactors: Web3Strategy[] = [];
-  enabledFirstFactorIdentifiers: Array<
-    keyof UserSettingsResource['attributes']
-  > = [];
+  enabledFirstFactorIdentifiers: Array<keyof UserSettingsResource['attributes']> = [];
 
   public constructor(data: UserSettingsJSON) {
     super();
     this.fromJSON(data);
+  }
+
+  get instanceIsPasswordBased() {
+    return this.attributes.password.enabled && this.attributes.password.required;
   }
 
   protected fromJSON(data: UserSettingsJSON): this {
@@ -37,28 +39,19 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     this.attributes = data.attributes;
     this.signIn = data.sign_in;
     this.signUp = data.sign_up;
-    this.socialProviderStrategies = this.getSocialProviderStrategies(
-      data.social,
-    );
+    this.socialProviderStrategies = this.getSocialProviderStrategies(data.social);
     this.web3FirstFactors = this.getWeb3FirstFactors(data.attributes);
-    this.enabledFirstFactorIdentifiers = this.getEnabledFirstFactorIdentifiers(
-      data.attributes,
-    );
+    this.enabledFirstFactorIdentifiers = this.getEnabledFirstFactorIdentifiers(data.attributes);
     return this;
   }
 
-  private getEnabledFirstFactorIdentifiers(
-    attributes: Attributes,
-  ): Array<keyof UserSettingsResource['attributes']> {
+  private getEnabledFirstFactorIdentifiers(attributes: Attributes): Array<keyof UserSettingsResource['attributes']> {
     if (!attributes) {
       return [];
     }
 
     return Object.entries(attributes)
-      .filter(
-        ([name, attr]) =>
-          attr.used_for_first_factor && !name.startsWith('web3'),
-      )
+      .filter(([name, attr]) => attr.used_for_first_factor && !name.startsWith('web3'))
       .map(([name]) => name) as Array<keyof UserSettingsResource['attributes']>;
   }
 
@@ -68,9 +61,7 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     }
 
     return Object.entries(attributes)
-      .filter(
-        ([name, attr]) => attr.used_for_first_factor && name.startsWith('web3'),
-      )
+      .filter(([name, attr]) => attr.used_for_first_factor && name.startsWith('web3'))
       .map(([, desc]) => desc.first_factors)
       .flat() as any as Web3Strategy[];
   }

--- a/packages/clerk-js/src/ui/signIn/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInStart.test.tsx
@@ -89,7 +89,7 @@ fdescribe('<SignInStart/>', () => {
         },
         password: {
           enabled: true,
-          used_for_first_factor: false,
+          required: true,
         },
       },
       social: {
@@ -195,10 +195,10 @@ fdescribe('<SignInStart/>', () => {
       expect(instantPasswordField).toBeDefined();
 
       const inputField = screen.getByLabelText('Email address');
-      await userEvent.type(inputField, 'boss@clerk.dev');
+      userEvent.type(inputField, 'boss@clerk.dev');
 
       // simulate password being filled by a pwd manager
-      await userEvent.type(instantPasswordField, 'wrong pass');
+      userEvent.type(instantPasswordField, 'wrong pass');
 
       const signEmailButton = screen.getByRole('button', { name: /Continue/i });
       userEvent.click(signEmailButton);
@@ -269,6 +269,21 @@ fdescribe('<SignInStart/>', () => {
         expect(mockSetSession).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalledWith('factor-one');
       });
+    });
+
+    it('does not render instant password is instance is passwordless', () => {
+      mockUserSettings = new UserSettings({
+        attributes: {
+          password: {
+            enabled: true,
+            required: false,
+          },
+        },
+      } as unknown as UserSettingsJSON);
+
+      const { container } = render(<SignInStart />);
+      const instantPasswordField = container.querySelector('input#password') as HTMLInputElement;
+      expect(instantPasswordField).toBeNull();
     });
 
     it.each(['google', 'facebook'])(

--- a/packages/clerk-js/src/ui/signIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInStart.tsx
@@ -39,6 +39,7 @@ export function _SignInStart(): JSX.Element {
   const standardFormAttributes = userSettings.enabledFirstFactorIdentifiers;
   const web3FirstFactors = userSettings.web3FirstFactors;
   const socialProviderStrategies = userSettings.socialProviderStrategies;
+  const passwordBasedInstance = userSettings.instanceIsPasswordBased;
 
   const identifierInputDisplayValues = getIdentifierControlDisplayValues(standardFormAttributes);
 
@@ -157,24 +158,28 @@ export function _SignInStart(): JSX.Element {
                 )}
               </Control>
 
-              <Control
-                key='password'
-                htmlFor='password'
-                label='Password'
-                error={instantPassword.error}
-                className={cn({
-                  'cl-hidden': !instantPassword.value,
-                })}
-              >
-                <Input
-                  id='password'
-                  type='password'
-                  name='password'
-                  value={instantPassword.value}
-                  handleChange={el => instantPassword.setValue(el.value || '')}
-                  tabIndex={-1}
-                />
-              </Control>
+              <>
+                {passwordBasedInstance && (
+                  <Control
+                    key='password'
+                    htmlFor='password'
+                    label='Password'
+                    error={instantPassword.error}
+                    className={cn({
+                      'cl-hidden': !instantPassword.value,
+                    })}
+                  >
+                    <Input
+                      id='password'
+                      type='password'
+                      name='password'
+                      value={instantPassword.value}
+                      handleChange={el => instantPassword.setValue(el.value || '')}
+                      tabIndex={-1}
+                    />
+                  </Control>
+                )}
+              </>
             </Form>
           </>
         )}

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -70,4 +70,5 @@ export interface UserSettingsResource extends ClerkResource {
   socialProviderStrategies: OAuthStrategy[];
   web3FirstFactors: Web3Strategy[];
   enabledFirstFactorIdentifiers: Attribute[];
+  instanceIsPasswordBased: boolean;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- The instant-password field will now only get rendered for password-based instances. 
- Still gracefully handles instances that started as password-based and become passwordless after
<!-- Fixes # (issue number) -->
