### PR TITLE
Introduce ConnectClerk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1737,7 +1737,6 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz",
       "integrity": "sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -5481,11 +5480,25 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@remix-run/react": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.2.2.tgz",
+      "integrity": "sha512-A+g/Y4QnT4ldZovjbP4sNJ29ZZt+oDP152pN8oYOHoQuqqrlc+CnLSMKCN1D+EljBfJx66553TwMIS5kCwdNzg==",
+      "peer": true,
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router-dom": "^6.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@remix-run/server-runtime": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.2.1.tgz",
       "integrity": "sha512-wn01V+O7y4dHQ059QGeXOpbG+d3IrqYnil9YDsJi4kielEFRDHDAFbmrMC+oF5qRYTuVRR3i6h2CSCyV2ICfeQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/cookie": "^0.4.0",
         "cookie": "^0.4.1",
@@ -5503,7 +5516,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "dev": true,
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -5515,7 +5528,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -6320,8 +6333,7 @@
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
     },
     "node_modules/@types/cookies": {
       "version": "0.7.7",
@@ -9231,7 +9243,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12505,7 +12516,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
       "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -19185,7 +19196,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
       "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "history": "^5.2.0"
       },
@@ -19197,7 +19208,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
       "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "history": "^5.2.0",
         "react-router": "6.2.1"
@@ -20336,7 +20347,7 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
-      "dev": true
+      "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -23347,7 +23358,6 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@remix-run/server-runtime": "^1.2.1",
         "@types/cookie": "^0.4.1",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.9",
@@ -23363,7 +23373,9 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "remix": ">=1.1.3"
+        "@remix-run/react": "^1.2.1",
+        "@remix-run/server-runtime": "^1.2.1",
+        "remix": ">=1.2.1"
       }
     },
     "packages/remix/node_modules/@types/node": {
@@ -24967,7 +24979,6 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz",
       "integrity": "sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -25465,7 +25476,6 @@
         "@clerk/clerk-react": "^3.0.0-alpha.7",
         "@clerk/clerk-sdk-node": "^2.9.0",
         "@clerk/types": "^2.0.0-alpha.6",
-        "@remix-run/server-runtime": "^1.2.1",
         "@types/cookie": "^0.4.1",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.9",
@@ -28330,11 +28340,21 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
+    "@remix-run/react": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.2.2.tgz",
+      "integrity": "sha512-A+g/Y4QnT4ldZovjbP4sNJ29ZZt+oDP152pN8oYOHoQuqqrlc+CnLSMKCN1D+EljBfJx66553TwMIS5kCwdNzg==",
+      "peer": true,
+      "requires": {
+        "history": "^5.2.0",
+        "react-router-dom": "^6.2.1"
+      }
+    },
     "@remix-run/server-runtime": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.2.1.tgz",
       "integrity": "sha512-wn01V+O7y4dHQ059QGeXOpbG+d3IrqYnil9YDsJi4kielEFRDHDAFbmrMC+oF5qRYTuVRR3i6h2CSCyV2ICfeQ==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@types/cookie": "^0.4.0",
         "cookie": "^0.4.1",
@@ -28348,13 +28368,13 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
           "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-          "dev": true
+          "peer": true
         },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
+          "peer": true
         }
       }
     },
@@ -28947,8 +28967,7 @@
     "@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
     },
     "@types/cookies": {
       "version": "0.7.7",
@@ -31290,8 +31309,7 @@
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "dev": true
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -33678,7 +33696,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
       "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.7.6"
       }
@@ -38735,7 +38753,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
       "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "history": "^5.2.0"
       }
@@ -38744,7 +38762,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
       "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "history": "^5.2.0",
         "react-router": "6.2.1"
@@ -39643,7 +39661,7 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
-      "dev": true
+      "peer": true
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -39,7 +39,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@remix-run/server-runtime": "^1.2.1",
     "@types/cookie": "^0.4.1",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.9",
@@ -52,7 +51,9 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "remix": ">=1.1.3"
+    "@remix-run/server-runtime": "^1.2.1",
+    "@remix-run/react": "^1.2.1",
+    "remix": ">=1.2.1"
   },
   "engines": {
     "node": ">=16"

--- a/packages/remix/src/client/ConnectClerk.tsx
+++ b/packages/remix/src/client/ConnectClerk.tsx
@@ -1,0 +1,20 @@
+import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
+import { useLoaderData } from '@remix-run/react';
+import React from 'react';
+
+import { ClerkProvider } from './RemixClerkProvider';
+
+type RemixConnectOptions = {
+  frontendApi: string;
+} & Omit<IsomorphicClerkOptions, 'navigate'>;
+
+export function ConnectClerk(App: () => JSX.Element, opts: RemixConnectOptions) {
+  return () => {
+    const { clerkState } = useLoaderData();
+    return (
+      <ClerkProvider {...opts} clerkState={clerkState}>
+        <App />
+      </ClerkProvider>
+    );
+  };
+}

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -1,7 +1,7 @@
 import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
 import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
+import { useNavigate } from '@remix-run/react';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { Interstitial } from './Interstitial';
 import { assertValidClerkState, warnForSsr } from './utils';

--- a/packages/remix/src/client/index.ts
+++ b/packages/remix/src/client/index.ts
@@ -1,1 +1,3 @@
 export * from './RemixClerkProvider';
+export * from './ConnectClerk';
+export { WithClerkState } from './types';

--- a/packages/remix/src/client/types.ts
+++ b/packages/remix/src/client/types.ts
@@ -7,3 +7,8 @@ export type ClerkState = {
     __clerk_ssr_state: InitialState;
   };
 };
+
+export type WithClerkState<U = any> = {
+  data: U;
+  clerkState: { __type: 'clerkState' };
+};

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -7,15 +7,23 @@ or come say hi in our discord server: https://rebrand.ly/clerk-discord
 `;
 };
 
-const ssrExample = `Use 'rootAuthLoader' as your root loader. Then, simply use the 'clerkState' from 'useLoaderData'.
+const ssrExample = `Use 'rootAuthLoader' as your root loader. Then, simply wrap the App component with ConnectClerk and make it the default export.
+Example:
+
+import { ConnectClerk } from '@clerk/remix';
+import { rootAuthLoader } from '@clerk/remix/ssr.server';
+
 export const loader: LoaderFunction = args => rootAuthLoader(args)
 
-export default function App() {
-  const { data, clerkState } = useLoaderData();
-  <ClerkProvider frontendApi={...} clerkState={clerkState}>
-    ...
-  </ClerkProvider>
+function App() {
+  return (
+    <html lang='en'>
+      ...
+    </html>
+  );
 }
+
+export default ConnectClerk(App, { frontendApi: '...' });
 `;
 
 export const invalidClerkStatePropError = createErrorMessage(`
@@ -40,7 +48,20 @@ export const loader: LoaderFunction = async ({request}) => {
 };
 `);
 
-export const invalidRootLoaderCallbackReturn = createErrorMessage(`
+export const invalidRootLoaderCallbackResponseReturn = createErrorMessage(`
 You're returning an invalid 'Response' object from the 'rootAuthLoader' in root.tsx.
 You can return numbers, strings, objects, booleans, and redirect 'Response' objects (status codes in the range of 300 to 400)
+`);
+
+export const invalidRootLoaderCallbackReturn = createErrorMessage(`
+You're returning an invalid value from 'rootAuthLoader' in root.tsx.
+You can only return plain objects or redirect 'Response' objects (status codes in the range of 300 to 400).
+If you want to return a primitive value or an array, wrap the response with an object.
+Example:
+
+export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) => {
+    const { userId } = auth;
+    const posts: Post[] = database.getPostsByUserId(userId);
+    return { data: posts };
+})
 `);

--- a/packages/remix/src/ssr/index.ts
+++ b/packages/remix/src/ssr/index.ts
@@ -1,3 +1,2 @@
 export * from './rootAuthLoader';
 export * from './getAuth';
-export { WithClerkState } from './types';

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -2,11 +2,6 @@ import { Session, User } from '@clerk/backend-core/src';
 import { ServerSideAuth } from '@clerk/types';
 import { LoaderFunction } from '@remix-run/server-runtime';
 
-export type WithClerkState<U = any> = {
-  data: U;
-  clerkState: { __type: 'clerkState' };
-};
-
 export type GetAuthReturn = Promise<ServerSideAuth>;
 
 export type RootAuthLoaderOptions = {
@@ -14,10 +9,20 @@ export type RootAuthLoaderOptions = {
   loadSession?: boolean;
 };
 
-export type RootAuthLoaderCallback<Options> = (args: LoaderFunctionArgsWithAuth<Options>) => LoaderFunctionReturn;
+export type RootAuthLoaderCallback<Options> = (
+  args: LoaderFunctionArgsWithAuth<Options>,
+) => RootAuthLoaderCallbackReturn;
+
+export type RootAuthLoaderCallbackReturn =
+  | Promise<Response>
+  | Response
+  | Promise<Record<string, unknown>>
+  | Record<string, unknown>;
 
 export type LoaderFunctionArgs = Parameters<LoaderFunction>[0];
+
 export type LoaderFunctionReturn = ReturnType<LoaderFunction>;
+
 export type LoaderFunctionArgsWithAuth<Options extends RootAuthLoaderOptions = any> = LoaderFunctionArgs & {
   auth: ServerSideAuth;
 } & (Options extends { loadSession: true } ? { session: Session | null } : {}) &

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -78,3 +78,12 @@ export function isResponse(value: any): value is Response {
 export const parseCookies = (req: Request) => {
   return cookie.parse(req.headers.get('cookie') || '');
 };
+
+/**
+ * @internal
+ */
+export function assertObject(val: any, error?: string): asserts val is Record<string, unknown> {
+  if (!val || typeof val !== 'object' || Array.isArray(val)) {
+    throw new Error(error || '');
+  }
+}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR introduces small but important changes to the setup process our users need to follow in order to integrate Clerk in a Remix project.

Before this PR, the recommended `root.tsx` file would look like:

```tsx
import { ClerkProvider } from "@clerk/remix";
import { rootAuthLoader, WithClerkState } from "@clerk/remix/ssr.server";

export const loader: LoaderFunction = (args) => rootAuthLoader(args, ({ auth }) => {
  const { userId } = auth;
  const posts: Posts[] = database.getPostsByUser(userId);
  return posts;
});

export default function App() {
  const { data: posts, clerkState } = useLoaderData<WithClerkState<Posts[]>>();
  
  return (
    <ClerkProvider frontendApi={"clerk.renewing.hermit-14.lcl.dev"} clerkState={clerkState}>
      <html lang="en">...</html>
    </ClerkProvider>
  );
}

```
This approach however, has 2 major drawbacks: 
1. The user needs to explicitly pass `clerkState` to the `ClerkProvider`
2. In the specific edge cases where the interstitial page needs to be used, the user defined data returned from `useLoaderData` would be undefined. Since we cannot throw the interstitial from the loader directly, we use `ClerkProvider` instead. However, If the user used the undefined `data` before `ClerkProvider` handlers the interstitial, the app could break. Many thanks to @[dvargas92495](https://github.com/dvargas92495) who also reported this in #54 


In order to solve both issues, we're introducing a `ConnectClerk` HOC that can be used as such:

```tsx
export const loader: LoaderFunction = (args) => rootAuthLoader(args, ({ auth }) => {
  const { userId } = auth;
  const posts: Posts[] = database.getPostsByUser(userId);
  return { posts };
});

function App() {
  const { posts } = useLoaderData<{ posts: Posts[] }>();
  return (
    <html lang='en'>
      ....
    </html>
  );
}

export default ConnectClerk(App, { frontendApi: '...' });
```

Notice that the user no longer needs to manually use ClerkProvider or manually pass clerkState to ClerkProvider. Also, now we can handle the interstitial state before any user-defined code runs.

Lastly, `rootAuthLoader` now **requires** either a Response or an object to be returned from the callback, if one is provided . This greatly simplifies how `useLoaderData` is used in the root App component. We updated the types accordingly so we now throw but on compile and on runtime if this rule is not respected:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/1811063/155623480-ca2719a4-ae81-40ef-a92e-31c1cc5896f2.png">
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/1811063/155623490-04532042-238f-4732-a39a-d2949896436c.png">


<!-- Fixes # (issue number) -->
Fixes #54 