### PR TITLE
fix(shared): Phone input should start blank

### DIFF
--- a/packages/shared/components/phoneInput/PhoneInput.test.tsx
+++ b/packages/shared/components/phoneInput/PhoneInput.test.tsx
@@ -49,7 +49,7 @@ describe('<PhoneInput/>', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders the phone input when the is dropdown open', () => {
+  it('renders the phone input when the dropdown is open', () => {
     const { container } = render(
       <PhoneInput handlePhoneChange={handlePhoneChange} />,
     );
@@ -68,10 +68,15 @@ describe('<PhoneInput/>', () => {
     expect(input).toHaveAttribute('maxlength', '25');
   });
 
-  it('emits phone number with country code and no formatting', async () => {
+  it('renders with an empty value', () => {
+    render(<PhoneInput handlePhoneChange={handlePhoneChange} />);
+    expect(handlePhoneChange).not.toHaveBeenCalled();
+  });
+
+  it('emits phone number with country code and no formatting', () => {
     render(<PhoneInput handlePhoneChange={handlePhoneChange} />);
     const input = screen.getByRole('textbox');
-    await userEvent.type(input, '2222222222');
+    userEvent.type(input, '2222222222');
     const lastCall = handlePhoneChange.mock.calls.pop();
     expect(lastCall).toEqual(['+12222222222']);
   });

--- a/packages/shared/components/phoneInput/PhoneInput.tsx
+++ b/packages/shared/components/phoneInput/PhoneInput.tsx
@@ -80,6 +80,9 @@ export function PhoneInput({
   };
 
   React.useEffect(() => {
+    if (!phoneNumber) {
+      return;
+    }
     const dialCode = IsoToCountryMap.get(selectedIso)?.code || '1';
     handlePhoneChange('+' + extractDigits(`${dialCode}${phoneNumber}`));
   }, [handlePhoneChange, selectedIso, phoneNumber]);

--- a/packages/shared/components/phoneInput/__snapshots__/PhoneInput.test.tsx.snap
+++ b/packages/shared/components/phoneInput/__snapshots__/PhoneInput.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`<PhoneInput/> renders the phone input 1`] = `
 </div>
 `;
 
-exports[`<PhoneInput/> renders the phone input when the is dropdown open 1`] = `
+exports[`<PhoneInput/> renders the phone input when the dropdown is open 1`] = `
 <div>
   <div
     class="container"


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

The phone input component's initial value should be a blank string, until the input actually changes.