### PR TITLE
Make `getAuth` stop loader execution during interstitial

### DIFF
--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -65,3 +65,7 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
     return { data: posts };
 })
 `);
+
+export const getAuthInterstitialErrorRendered = createErrorMessage(
+  `This state shouldn't be possible. Please reach out to support@clerk.dev so we can help, or use the links below:`,
+);

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -1,15 +1,23 @@
-import { noRequestPassedInGetAuth } from '../errors';
+import { json } from '@remix-run/server-runtime';
+
+import { getAuthInterstitialErrorRendered, noRequestPassedInGetAuth } from '../errors';
 import { getAuthData } from './getAuthData';
 import { GetAuthReturn, LoaderFunctionArgs } from './types';
 import { sanitizeAuthData } from './utils';
+
+const EMPTY_INTERSTITIAL_RESPONSE = { message: getAuthInterstitialErrorRendered };
 
 export async function getAuth(argsOrReq: Request | LoaderFunctionArgs): GetAuthReturn {
   if (!argsOrReq) {
     throw new Error(noRequestPassedInGetAuth);
   }
-
   const request = 'request' in argsOrReq ? argsOrReq.request : argsOrReq;
-  const { authData } = await getAuthData(request);
+  const { authData, interstitial } = await getAuthData(request);
+
+  if (interstitial) {
+    throw json(EMPTY_INTERSTITIAL_RESPONSE);
+  }
+
   // @ts-expect-error This can only return null during interstitial,
   // but the public types should not know that
   return sanitizeAuthData(authData || {});


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The loaders run in parallel, so when the interstitial needs to be thrown, CP won’t be reached before **every loader** runs and returns.

This raises an issue when a nested loader has a conditional redirect, eg:
```
export const loader = () => {
   const { userId } = getAuth()
   if(!userId) {
      redirect('/login')
   }
}
```
So even though the user is already signed in, the redirect will still take place before we get a chance to render the interstitial.

This PR uses and empty `json()` response from within `getAuth` to effectively stop the loader early. Even if a CatchBoundary is exists for the corresponding page, it will not render because CP will render first.

Usage example: 

```
export const loader: LoaderFunction = async ({ request }) => {
  const { userId } = await getAuth(request);
  if (!userId) {
    return redirect('/login');
  }
  const user = await users.getUser(userId);
  return { message: `hello ${user?.firstName}` };
};
```

 
<!-- Fixes # (issue number) -->
