### PR TITLE
fix(clerk-js): Don't use ResizeObserver on old browsers

### DIFF
--- a/packages/clerk-js/src/ui/common/logo/Logo.tsx
+++ b/packages/clerk-js/src/ui/common/logo/Logo.tsx
@@ -36,6 +36,12 @@ export function Logo(): JSX.Element {
     if (hasLogoImage || !logoContainer || !name) {
       return;
     }
+
+    if (typeof window === 'undefined' || !window.ResizeObserver) {
+      fitTextInOneLine(name, logoContainer, '48px');
+      return;
+    }
+
     const ro = new ResizeObserver(() =>
       fitTextInOneLine(name, logoContainer, '48px'),
     );


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Fixes logo resizing issue on old safari browsers (mobile Safari < 13.4)

<!-- Fixes # (issue number) -->
