### PR TITLE
fix(types): Guarantee elements not in oauth sorting array will be sor…

### DIFF
--- a/packages/clerk-js/src/ui/common/constants.ts
+++ b/packages/clerk-js/src/ui/common/constants.ts
@@ -1,4 +1,4 @@
-import type { Web3Provider, OAuthStrategy } from '@clerk/types';
+import type { Web3Provider } from '@clerk/types';
 
 export const FirstFactorConfigs = Object.freeze({
   email_address: {

--- a/packages/clerk-js/src/ui/signUp/SignUpOAuth.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpOAuth.tsx
@@ -1,4 +1,4 @@
-import type { OAuthProvider, OAuthStrategy } from '@clerk/types';
+import type { OAuthStrategy } from '@clerk/types';
 import { getOAuthProviderData } from '@clerk/types';
 import React from 'react';
 import {

--- a/packages/types/src/oauth.ts
+++ b/packages/types/src/oauth.ts
@@ -127,9 +127,19 @@ export function sortedOAuthProviders(sortingArray: OAuthStrategy[]) {
   return OAUTH_PROVIDERS
     .slice()
     .sort(
-      (a, b) =>
-        sortingArray.indexOf(a.strategy) -
-        sortingArray.indexOf(b.strategy),
+      (a, b) => {
+        let aPos = sortingArray.indexOf(a.strategy);
+        if (aPos == -1) {
+          aPos = Number.MAX_SAFE_INTEGER;
+        }
+
+        let bPos = sortingArray.indexOf(b.strategy);
+        if (bPos == -1) {
+          bPos = Number.MAX_SAFE_INTEGER;
+        }
+
+        return aPos - bPos;
+      }
     )
 }
 


### PR DESCRIPTION
…ted last

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [X] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

When an element is not in the sorting array it would be sorted first due to the index equalling -1.

This fix makes non-existing items have an index of `Number.MAX_SAFE_INTEGER` so that they are sorted last when their position is not explicitly specified.

Also removed a couple of unused imports.