### PR TITLE
Fix Expo tokenCache

### DIFF
--- a/packages/expo/src/singleton.ts
+++ b/packages/expo/src/singleton.ts
@@ -25,8 +25,8 @@ export function buildClerk({
   frontendApi,
   tokenCache,
 }: BuildClerkOptions): ClerkProp {
-  const getToken = tokenCache ? tokenCache.getToken : getTokenFromMemory;
-  const saveToken = tokenCache ? tokenCache.saveToken : saveTokenInMemory;
+  const getToken = (tokenCache && tokenCache.getToken) ?? getTokenFromMemory;
+  const saveToken = (tokenCache && tokenCache.saveToken) ?? saveTokenInMemory;
 
   if (!clerk) {
     clerk = new Clerk(frontendApi);

--- a/packages/expo/src/singleton.ts
+++ b/packages/expo/src/singleton.ts
@@ -31,6 +31,11 @@ export function buildClerk({
   if (!clerk) {
     clerk = new Clerk(frontendApi);
 
+    if (!tokenCache) {
+      // Exit early if tokenCache is not provided, assuming web platform
+      return;
+    }
+
     // @ts-expect-error
     clerk.__unstable__onBeforeRequest(async (requestInit: FapiRequestInit) => {
       // https://reactnative.dev/docs/0.61/network#known-issues-with-fetch-and-cookie-based-authentication


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- ⛔️ `npm test` runs as expected.
- ⛔️ `npm run build` runs as expected.

☝️ Both are failing but unrelated to my changes. The build succeeds for `clerk-expo` package without errors.

<!-- Description of the Pull Request -->

This fix does two things. 

The first is add a guard to check for the existence of `tokenCache.getToken` and `tokenCache.saveToken`. Previously, if a `tokenCache` was passed in, but had different methods on it, e.g. `get` / `set`, it would attempt to call `undefined` functions instead of falling back to the `getTokenFromMemory` and `saveTokenInMemory` operations, which are sensible defaults.

The second change here adds an early return if the `tokenCache` is not provided at all. This makes an assumption that the token cache is not available for the web platform, which is the case with `expo-secure-store` that is being used in our [clerk-expo-starter](https://github.com/clerkinc/clerk-expo-starter/blob/main/cache.ts).

Ideally, we should do better detection of the platform instead of coupling the logic with the `tokenCache`.  One option would be to use `Platform.OS === 'web'` provided by `react-native` itself, but that introduces `react-native` as a package dependency.

This fix, coupled with [changes I recently made](https://github.com/clerkinc/clerk-expo-starter/commit/f7563edbf56912bca70704518c13d849d7d3001b) to the `clerk-expo-starter`, allow the starter to render on the web without additional changes. It also means we could potentially remove or update this banner in the Docs:

<img width="754" alt="Clerk Expo banner" src="https://user-images.githubusercontent.com/97047001/156588599-304f1161-32b7-4e19-9334-13a94288c500.png">

<!-- Fixes # (issue number) -->
