### PR TITLE
Remix integration improvements

### DIFF
--- a/packages/remix/src/client/ConnectClerk.tsx
+++ b/packages/remix/src/client/ConnectClerk.tsx
@@ -1,14 +1,11 @@
-import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
 import { useLoaderData } from '@remix-run/react';
 import React from 'react';
 
-import { ClerkProvider } from './RemixClerkProvider';
+import { ClerkProvider, RemixClerkProviderProps } from './RemixClerkProvider';
 
-type RemixConnectOptions = {
-  frontendApi: string;
-} & Omit<IsomorphicClerkOptions, 'navigate'>;
+type ConnectClerkOptions = Partial<Omit<RemixClerkProviderProps, 'navigate'>>;
 
-export function ConnectClerk(App: () => JSX.Element, opts: RemixConnectOptions) {
+export function ConnectClerk(App: () => JSX.Element, opts: ConnectClerkOptions) {
   return () => {
     const { clerkState } = useLoaderData();
     return (

--- a/packages/remix/src/client/ConnectClerkCatchBoundary.tsx
+++ b/packages/remix/src/client/ConnectClerkCatchBoundary.tsx
@@ -1,3 +1,4 @@
+import { LIB_VERSION } from '@clerk/clerk-react/dist/info';
 import { useCatch } from '@remix-run/react';
 import React from 'react';
 
@@ -6,10 +7,10 @@ import { Interstitial } from './Interstitial';
 export function ConnectClerkCatchBoundary(RootCatchBoundary?: () => JSX.Element) {
   return () => {
     const { data } = useCatch();
-    const { __clerk_ssr_interstitial } = data?.clerkState?.__internal_clerk_state || {};
+    const { __clerk_ssr_interstitial, __frontendApi } = data?.clerkState?.__internal_clerk_state || {};
 
     if (__clerk_ssr_interstitial) {
-      return <Interstitial html={__clerk_ssr_interstitial} />;
+      return <Interstitial frontendApi={__frontendApi} version={LIB_VERSION} />;
     }
 
     if (!RootCatchBoundary) {

--- a/packages/remix/src/client/ConnectClerkCatchBoundary.tsx
+++ b/packages/remix/src/client/ConnectClerkCatchBoundary.tsx
@@ -1,0 +1,21 @@
+import { useCatch } from '@remix-run/react';
+import React from 'react';
+
+import { Interstitial } from './Interstitial';
+
+export function ConnectClerkCatchBoundary(RootCatchBoundary?: () => JSX.Element) {
+  return () => {
+    const { data } = useCatch();
+    const { __clerk_ssr_interstitial } = data?.clerkState?.__internal_clerk_state || {};
+
+    if (__clerk_ssr_interstitial) {
+      return <Interstitial html={__clerk_ssr_interstitial} />;
+    }
+
+    if (!RootCatchBoundary) {
+      return undefined;
+    }
+
+    return <RootCatchBoundary />;
+  };
+}

--- a/packages/remix/src/client/Interstitial.tsx
+++ b/packages/remix/src/client/Interstitial.tsx
@@ -1,5 +1,47 @@
 import React from 'react';
 
-export function Interstitial({ html }: { html: string }) {
-  return <html dangerouslySetInnerHTML={{ __html: html }} />;
+function isStaging(frontendApi: string): boolean {
+  return (
+    frontendApi.endsWith('.lclstage.dev') ||
+    frontendApi.endsWith('.stgstage.dev') ||
+    frontendApi.endsWith('.clerkstage.dev')
+  );
+}
+
+const getScriptUrl = (frontendApi: string, libVersion: string) => {
+  const major = libVersion.includes('alpha') ? 'next' : isStaging(frontendApi) ? 'staging' : libVersion.split('.')[0];
+  return `https://${frontendApi}/npm/@clerk/clerk-js@${major}/dist/clerk.browser.js`;
+};
+
+const createInterstitialHTMLString = (frontendApi: string, libVersion: string) => {
+  return `
+    <head>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <script>
+            window.startClerk = async () => {
+                const Clerk = window.Clerk;
+                try {
+                    await Clerk.load();
+                    window.location.reload();
+                } catch (err) {
+                    console.error('Clerk: ', err);
+                }
+            };
+            (() => {
+                const script = document.createElement('script');
+                script.setAttribute('data-clerk-frontend-api', '${frontendApi}');
+                script.async = true;
+                script.src = '${getScriptUrl(frontendApi, libVersion)}';
+                script.addEventListener('load', startClerk);
+                document.body.appendChild(script);
+            })();
+        </script>
+    </body>
+`;
+};
+
+export function Interstitial({ frontendApi, version }: { frontendApi: string; version: string }) {
+  return <html dangerouslySetInnerHTML={{ __html: createInterstitialHTMLString(frontendApi, version) }} />;
 }

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -3,7 +3,6 @@ import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
 import { useNavigate } from '@remix-run/react';
 import React from 'react';
 
-import { Interstitial } from './Interstitial';
 import { assertValidClerkState, warnForSsr } from './utils';
 
 export * from '@clerk/clerk-react';
@@ -25,10 +24,7 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
     warnForSsr(clerkState);
   }, []);
 
-  const { __clerk_ssr_interstitial, __clerk_ssr_state } = clerkState?.__internal_clerk_state || {};
-  if (__clerk_ssr_interstitial) {
-    return <Interstitial html={__clerk_ssr_interstitial} />;
-  }
+  const { __clerk_ssr_state } = clerkState?.__internal_clerk_state || {};
 
   return (
     <ReactClerkProvider

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -3,18 +3,18 @@ import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
 import { useNavigate } from '@remix-run/react';
 import React from 'react';
 
+import { noFrontendApiError } from '../errors';
 import { assertValidClerkState, warnForSsr } from './utils';
 
 export * from '@clerk/clerk-react';
 
-type RemixClerkProviderProps<ClerkStateT extends { __type: 'clerkState' } = any> = {
-  frontendApi: string;
+export type RemixClerkProviderProps<ClerkStateT extends { __type: 'clerkState' } = any> = {
   children: React.ReactNode;
   clerkState: ClerkStateT;
 } & IsomorphicClerkOptions;
 
 export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): JSX.Element {
-  const { frontendApi, clerkJSUrl, clerkState, ...restProps } = rest;
+  const { clerkJSUrl, clerkState, ...restProps } = rest;
   const navigate = useNavigate();
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 
@@ -24,11 +24,15 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
     warnForSsr(clerkState);
   }, []);
 
-  const { __clerk_ssr_state } = clerkState?.__internal_clerk_state || {};
+  const { __clerk_ssr_state, __frontendApi } = clerkState?.__internal_clerk_state || {};
+
+  if (!__frontendApi) {
+    throw new Error(noFrontendApiError);
+  }
 
   return (
     <ReactClerkProvider
-      frontendApi={frontendApi}
+      frontendApi={__frontendApi}
       clerkJSUrl={clerkJSUrl}
       navigate={to => navigate(to)}
       initialState={__clerk_ssr_state}

--- a/packages/remix/src/client/index.ts
+++ b/packages/remix/src/client/index.ts
@@ -1,4 +1,4 @@
 export * from './RemixClerkProvider';
-export * from './ConnectClerk';
+export { ConnectClerk } from './ConnectClerk';
 export * from './ConnectClerkCatchBoundary';
 export { WithClerkState } from './types';

--- a/packages/remix/src/client/index.ts
+++ b/packages/remix/src/client/index.ts
@@ -1,3 +1,4 @@
 export * from './RemixClerkProvider';
 export * from './ConnectClerk';
+export * from './ConnectClerkCatchBoundary';
 export { WithClerkState } from './types';

--- a/packages/remix/src/client/types.ts
+++ b/packages/remix/src/client/types.ts
@@ -5,6 +5,7 @@ export type ClerkState = {
   __internal_clerk_state: {
     __clerk_ssr_interstitial: string;
     __clerk_ssr_state: InitialState;
+    __frontendApi: string;
   };
 };
 

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -65,3 +65,7 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
     return { data: posts };
 })
 `);
+
+export const getAuthInterstitialErrorRendered = createErrorMessage(
+  `This state shouldn't be possible. Please reach out to support@clerk.dev so we can help, or use the links below:`,
+);

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -69,3 +69,9 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
 export const getAuthInterstitialErrorRendered = createErrorMessage(
   `This state shouldn't be possible. Please reach out to support@clerk.dev so we can help, or use the links below:`,
 );
+
+export const noFrontendApiError = createErrorMessage(`
+The CLERK_FRONTEND_API1 environment variable must be set before using Clerk.
+During development, grab the Frontend Api value from the Clerk dashboard, create an .env file and set the CLERK_FRONTEND_API key.
+For production apps, please consult the Remix documentation on environment variables.
+`);

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -71,7 +71,7 @@ export const getAuthInterstitialErrorRendered = createErrorMessage(
 );
 
 export const noFrontendApiError = createErrorMessage(`
-The CLERK_FRONTEND_API1 environment variable must be set before using Clerk.
-During development, grab the Frontend Api value from the Clerk dashboard, create an .env file and set the CLERK_FRONTEND_API key.
+The CLERK_FRONTEND_API environment variable must be set before using Clerk.
+During development, grab the Frontend Api value from the Clerk Dashboard, create an .env file and set the CLERK_FRONTEND_API key.
 For production apps, please consult the Remix documentation on environment variables.
 `);

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -12,9 +12,9 @@ export async function getAuth(argsOrReq: Request | LoaderFunctionArgs): GetAuthR
     throw new Error(noRequestPassedInGetAuth);
   }
   const request = 'request' in argsOrReq ? argsOrReq.request : argsOrReq;
-  const { authData, interstitial } = await getAuthData(request);
+  const { authData, showInterstitial } = await getAuthData(request);
 
-  if (interstitial || !authData) {
+  if (showInterstitial || !authData) {
     throw json(EMPTY_INTERSTITIAL_RESPONSE);
   }
 

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -1,16 +1,22 @@
-import { noRequestPassedInGetAuth } from '../errors';
+import { json } from '@remix-run/server-runtime';
+
+import { getAuthInterstitialErrorRendered, noRequestPassedInGetAuth } from '../errors';
 import { getAuthData } from './getAuthData';
 import { GetAuthReturn, LoaderFunctionArgs } from './types';
 import { sanitizeAuthData } from './utils';
+
+const EMPTY_INTERSTITIAL_RESPONSE = { message: getAuthInterstitialErrorRendered };
 
 export async function getAuth(argsOrReq: Request | LoaderFunctionArgs): GetAuthReturn {
   if (!argsOrReq) {
     throw new Error(noRequestPassedInGetAuth);
   }
-
   const request = 'request' in argsOrReq ? argsOrReq.request : argsOrReq;
-  const { authData } = await getAuthData(request);
-  // @ts-expect-error This can only return null during interstitial,
-  // but the public types should not know that
-  return sanitizeAuthData(authData || {});
+  const { authData, interstitial } = await getAuthData(request);
+
+  if (interstitial || !authData) {
+    throw json(EMPTY_INTERSTITIAL_RESPONSE);
+  }
+
+  return sanitizeAuthData(authData);
 }

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -26,6 +26,8 @@ export async function rootAuthLoader(
     ? cbOrOptions
     : {};
 
+  const frontendApi = process.env.CLERK_FRONTEND_API || opts.frontendApi;
+
   const { authData, interstitial } = await getAuthData(args.request, opts);
 
   if (interstitial) {
@@ -33,7 +35,7 @@ export async function rootAuthLoader(
   }
 
   if (!callback) {
-    return { ...wrapClerkState({ __clerk_ssr_state: authData }) };
+    return { ...wrapClerkState({ __clerk_ssr_state: authData, __frontendApi: frontendApi }) };
   }
 
   const callbackResult = await callback?.(injectAuthIntoArgs(args, sanitizeAuthData(authData!)));
@@ -47,5 +49,5 @@ export async function rootAuthLoader(
     throw new Error(invalidRootLoaderCallbackResponseReturn);
   }
 
-  return { ...callbackResult, ...wrapClerkState({ __clerk_ssr_state: authData }) };
+  return { ...callbackResult, ...wrapClerkState({ __clerk_ssr_state: authData, __frontendApi: frontendApi }) };
 }

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -1,3 +1,5 @@
+import { json } from '@remix-run/server-runtime';
+
 import { invalidRootLoaderCallbackResponseReturn, invalidRootLoaderCallbackReturn } from '../errors';
 import { getAuthData } from './getAuthData';
 import { LoaderFunctionArgs, LoaderFunctionReturn, RootAuthLoaderCallback, RootAuthLoaderOptions } from './types';
@@ -27,7 +29,7 @@ export async function rootAuthLoader(
   const { authData, interstitial } = await getAuthData(args.request, opts);
 
   if (interstitial) {
-    return wrapClerkState({ __clerk_ssr_interstitial: interstitial });
+    throw json(wrapClerkState({ __clerk_ssr_interstitial: interstitial }));
   }
 
   if (!callback) {
@@ -36,6 +38,7 @@ export async function rootAuthLoader(
 
   const callbackResult = await callback?.(injectAuthIntoArgs(args, sanitizeAuthData(authData!)));
   assertObject(callbackResult, invalidRootLoaderCallbackReturn);
+
   // Pass through custom responses
   if (isResponse(callbackResult)) {
     if (callbackResult.status >= 300 && callbackResult.status < 400) {

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -5,6 +5,7 @@ import { LoaderFunction } from '@remix-run/server-runtime';
 export type GetAuthReturn = Promise<ServerSideAuth>;
 
 export type RootAuthLoaderOptions = {
+  frontendApi?: string;
   loadUser?: boolean;
   loadSession?: boolean;
 };

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -3,8 +3,6 @@ import cookie from 'cookie';
 import { AuthData } from './getAuthData';
 import { LoaderFunctionArgs, LoaderFunctionArgsWithAuth } from './types';
 
-const INTER_HTML_CONTENT_REGEX = /<html>([\s\S.]*)<\/html>/;
-
 /**
  * Wraps obscured clerk internals with a readable `clerkState` key.
  * This is intended to be passed by the user into <ClerkProvider>
@@ -13,19 +11,6 @@ const INTER_HTML_CONTENT_REGEX = /<html>([\s\S.]*)<\/html>/;
  */
 export const wrapClerkState = (data: any) => {
   return { clerkState: { __internal_clerk_state: { ...data } } };
-};
-
-/**
- * Extracts the content inside the <html> tags of the interstitial page
- *
- * @internal
- */
-export const extractInterstitialHtmlContent = (interstitial?: string) => {
-  try {
-    return (interstitial || '').match(INTER_HTML_CONTENT_REGEX)![1];
-  } catch (e) {
-    throw new Error('This is a Clerk bug; Please report');
-  }
 };
 
 /**
@@ -70,6 +55,13 @@ export function isResponse(value: any): value is Response {
     typeof value.headers === 'object' &&
     typeof value.body !== 'undefined'
   );
+}
+
+/**
+ * @internal
+ */
+export function isRedirect(res: Response): boolean {
+  return res.status >= 300 && res.status < 400;
 }
 
 /**


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.


Up until now, we used `throw json()` to stop a loader from inside `getAuth` without having to change the loader api and introduce a loader wrapper (which is not recommended by Remix). However, depending on the app's structure it's possible that a nested `CatchBoundary` will catch this error before `ClerkProvider` renders the interstitial.

Remix runs all loaders in [parallel and waits for all of them to either return or throw](https://github.com/remix-run/remix/blob/5b8a0ce0aa0201aa2402fc41405ffbe89605963b/packages/remix-server-runtime/server.ts#L302). Once all the loaders have run, Remix evaluates the returned values in order, stopping when [the first error or redirect is encountered](https://github.com/remix-run/remix/blob/5b8a0ce0aa0201aa2402fc41405ffbe89605963b/packages/remix-server-runtime/server.ts#L342).  If an error is found, Remix try to match it with a `CatchBoundary`, and if a `CatchBoundary` exists it gets rendered that instead of the normal react tree (that includes our `ClerkProvider`). Notice though, that if Remix finds a redirect before an error, they just follow the redirect and render nothing at all.

The above means that:
- We still need to throw from getAuth to stop the loader early during interstitial, otherwise we risk a returned redirect or an actual error depending on the user’s code inside nested loaders.
- During interstitial, we need to throw from inside `rootAuthLoader`  to prevent Remix from evaluated any nested redirects/errors and catch boundaries

In order to support all the edge cases described so far, we will use the root `CatchBoundary` to render the interstitial.
```
//root.tsx
export const loader: LoaderFunction = args => rootAuthLoader(args);

function App() {
  return (
    <html lang='en'> ... </html>
  );
}

export default ConnectClerk(App);

export const CatchBoundary = ConnectClerkCatchBoundary();
```

Going with this approach also means that if they allow us to return arbitrary responses from the loaders in the future,  we can simply remove  `export const CatchBoundary = ConnectClerkBoundary();` from our docs - no action needed from our users and no breaking changes.

This PR includes the following changes:
- Introduces `ConnectClerkCatchBoundary`. This HOC must be exported from the root.tsx page. If a user needs a custom boundary, they can simply wrap their boundary with the HOC. eg:
```
export const CatchBoundary = ConnectClerkCatchBoundary(() => {
  const caught = useCatch();
  return (
    <html>
           ...
    </html>
  );
});
```

- Removes the `frontendApi` option from `ConnectClerk`. Instead of hardcoding it, the users are now able to use the value directly from the env, by creating a `.env` file. The CLERK_FRONTEND_API value will then become accessible during SSR and CSR. Eg: 
```
CLERK_FRONTEND_API=clerk.***.***-14.lcl.dev
CLERK_API_KEY=test_jP61SgV*******6IVy07li3APw
```
For anyone that wants to override the env value, we added a `frontendApi` option in the `rootAuthLoader` options. Eg:
```
export const loader: LoaderFunction = args => rootAuthLoader(args, {frontendApi: '...'});
```

- Instead of fetching the interstitial, we now compute it locally, requiring 1 less BAPI request (~90-300ms)

<!-- Fixes # (issue number) -->
