### PR TITLE
Remove deprecated Auth v1 code

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -71,13 +71,7 @@ declare global {
   }
 }
 
-const defaultOptions: ClerkOptions & {
-  polling: boolean;
-  authVersion: 1 | 2;
-} = {
-  polling: true,
-  authVersion: 2,
-};
+const defaultOptions: ClerkOptions & { polling: boolean } = { polling: true };
 
 export default class Clerk implements ClerkInterface {
   public static Components?: typeof Components;
@@ -90,7 +84,7 @@ export default class Clerk implements ClerkInterface {
   #environment?: EnvironmentResource | null;
   #components?: Components | null;
   #listeners: Array<(emission: Resources) => void> = [];
-  #options: ClerkOptions & { authVersion: 1 | 2 } = { authVersion: 2 };
+  #options: ClerkOptions = {};
   #isReady = false;
   #unloading = false;
   #broadcastChannel: LocalStorageBroadcastChannel<ClerkCoreBroadcastChannelEvent> | null =
@@ -128,7 +122,6 @@ export default class Clerk implements ClerkInterface {
     this.#options = {
       ...defaultOptions,
       ...options,
-      authVersion: options?.authVersion || defaultOptions.authVersion,
     };
 
     if (isReactNative()) {
@@ -615,7 +608,6 @@ export default class Clerk implements ClerkInterface {
 
     this.#devBrowserHandler = createDevBrowserHandler({
       frontendApi: this.frontendApi,
-      authVersion: this.#options.authVersion,
       fapiClient: this.#fapiClient,
     });
 
@@ -644,7 +636,6 @@ export default class Clerk implements ClerkInterface {
         this.updateClient(client);
 
         this.#authService.initAuth({
-          authVersion: this.#options.authVersion,
           enablePolling: this.#options.polling,
           environment: this.#environment,
         });
@@ -700,7 +691,7 @@ export default class Clerk implements ClerkInterface {
       return;
     }
 
-    document.addEventListener('visibilitychange', async () => {
+    document.addEventListener('visibilitychange', () => {
       if (
         document.visibilityState === 'visible' &&
         typeof this.session !== 'undefined'
@@ -713,7 +704,7 @@ export default class Clerk implements ClerkInterface {
       this.#unloading = true;
     });
 
-    this.#broadcastChannel?.addEventListener('message', async ({ data }) => {
+    this.#broadcastChannel?.addEventListener('message', ({ data }) => {
       if (data.type === 'signout') {
         void this.handleUnauthenticated({ broadcast: false });
       }

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -9,7 +9,7 @@ import { sessionCookie } from './session';
 
 const COOKIE_PATH = '/';
 export type CookieHandler = ReturnType<typeof createCookieHandler>;
-export const createCookieHandler = (version: number) => {
+export const createCookieHandler = () => {
   // First party cookie helpers
   const getDevBrowserInittedCookie = () => inittedCookie.get();
 
@@ -55,7 +55,7 @@ export const createCookieHandler = (version: number) => {
   };
 
   // Third party cookie helpers
-  const ssoCookie = version > 1 ? clientCookie : sessionCookie;
+  const ssoCookie = clientCookie;
 
   // TODO: Clean up these cookie handlers after Auth v2 becomes the only authentication method
   // Dev Browser cookie will be handled 100% be local storage
@@ -87,9 +87,7 @@ export const createCookieHandler = (version: number) => {
       ssoCookie.remove({ domain, path: COOKIE_PATH });
     } else {
       // Delete cookie in a best-effort way by iterating all ETLDs
-      getAllETLDs().forEach(domain =>
-        ssoCookie.remove({ domain, path: COOKIE_PATH }),
-      );
+      getAllETLDs().forEach(domain => ssoCookie.remove({ domain, path: COOKIE_PATH }));
     }
   };
 
@@ -119,9 +117,7 @@ export const createCookieHandler = (version: number) => {
     const d = new Date();
     d.setTime(d.getTime() + 1000);
 
-    document.cookie = `__session=check;path=/;domain=${
-      window.location.host
-    };expires=${d.toUTCString()}`;
+    document.cookie = `__session=check;path=/;domain=${window.location.host};expires=${d.toUTCString()}`;
     const cookieExists = document.cookie.indexOf('__session=') === -1;
     document.cookie = `__session=;path=/;domain=${window.location.host};max-age=-1`;
     return cookieExists;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -262,7 +262,6 @@ export type CustomNavigation = (to: string) => Promise<unknown> | void;
 export type ClerkThemeOptions = DeepSnakeToCamel<DeepPartial<DisplayThemeJSON>>;
 
 export interface ClerkOptions {
-  authVersion?: 1 | 2;
   navigate?: (to: string) => Promise<unknown> | unknown;
   polling?: boolean;
   selectInitialSession?: (


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Cleanup of the deprecated auth v1 code.

<!-- Fixes # (issue number) -->
