### PR TITLE
fix(backend-core): Add JWTPayload orgs claim type

### DIFF
--- a/packages/backend-core/src/util/types.ts
+++ b/packages/backend-core/src/util/types.ts
@@ -40,10 +40,17 @@ export interface JWTPayload {
   azp?: string;
 
   /**
+   *
+   */
+  orgs?: Record<string, MembershipRole>;
+
+  /**
    * Any other JWT Claim Set member.
    */
   [propName: string]: unknown;
 }
+
+type MembershipRole = 'admin' | 'basic_member';
 
 export interface JWT {
   header: JWTHeader;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

- Adding the `orgs` claim on the JWTPayload type exposed on `sessionClaims` attribute.