### PR TITLE
fix(types): Revoke typing on organizationInvitation

### DIFF
--- a/packages/types/src/organizationInvitation.ts
+++ b/packages/types/src/organizationInvitation.ts
@@ -8,6 +8,7 @@ export interface OrganizationInvitationResource {
   status: OrganizationInvitationStatus;
   createdAt: Date;
   updatedAt: Date;
+  revoke: () => Promise<OrganizationInvitationResource>;
 }
 
 export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked';


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Missing `revoke` typing on OrganizationInvitationResource.
