### PR TITLE
feat(backend-core): Add public_metadata to invitation create API

### DIFF
--- a/packages/backend-core/src/__tests__/apis/InvitationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/InvitationApi.test.ts
@@ -76,6 +76,42 @@ test('createInvitation() accepts a redirectUrl', async () => {
   );
 });
 
+test('createInvitation() accepts publicMetadata', async () => {
+  const emailAddress = 'test@example.com';
+  const publicMetadata = {
+    hello: 'world',
+  };
+  const resJSON = {
+    object: 'invitation',
+    id: 'inv_randomid',
+    email_address: emailAddress,
+    public_metadata: publicMetadata,
+    created_at: 1611948436,
+    updated_at: 1611948436,
+  };
+
+  nock('https://api.clerk.dev')
+    .post('/v1/invitations', {
+      email_address: emailAddress,
+      public_metadata: publicMetadata,
+    })
+    .reply(200, resJSON);
+
+  const invitation = await TestBackendAPIClient.invitations.createInvitation({
+    emailAddress,
+    publicMetadata,
+  });
+  expect(invitation).toEqual(
+    new Invitation({
+      id: resJSON.id,
+      emailAddress,
+      publicMetadata,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    })
+  );
+});
+
 test('revokeInvitation() revokes an invitation', async () => {
   const id = 'inv_randomid';
   const resJSON = {

--- a/packages/backend-core/src/api/collection/InvitationApi.ts
+++ b/packages/backend-core/src/api/collection/InvitationApi.ts
@@ -6,6 +6,7 @@ const basePath = '/invitations';
 type CreateParams = {
   emailAddress: string;
   redirectUrl?: string;
+  publicMetadata?: Record<string, unknown>;
 };
 
 export class InvitationApi extends AbstractApi {

--- a/packages/backend-core/src/api/resources/Invitation.ts
+++ b/packages/backend-core/src/api/resources/Invitation.ts
@@ -9,7 +9,7 @@ interface InvitationPayload extends InvitationProps {}
 export interface Invitation extends InvitationPayload {}
 
 export class Invitation {
-  static attributes = ['id', 'emailAddress', 'createdAt', 'updatedAt'];
+  static attributes = ['id', 'emailAddress', 'publicMetadata', 'createdAt', 'updatedAt'];
 
   static defaults = [];
 

--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -59,6 +59,7 @@ export interface IdentificationLinkProps extends ClerkProps {
 
 export interface InvitationProps extends ClerkProps {
   emailAddress: string;
+  publicMetadata?: Record<string, unknown>;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [X] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The invitation creation API supports sending `public_metadata` that will be attached to the user upon sign up. This PR adds the type definition to allow that metadata to be used when creating an invitation. I've also added `publicMetadata` to the `Invitation` class.

> Invitations can optionally carry metadata that will eventually end up in the created user once they sign up.
> The metadata must be a well-formed JSON object. In order to add metadata to an invitation, you can use the public_metadata property when the invitation is created:

[Clerk Invitation Documentation](https://docs.clerk.dev/popular-guides/invitations#invitation-metadata)

<!-- Fixes # (issue number) -->

## Additional Testing using `curl`

```bash
curl https://api.clerk.dev/v1/invitations -X POST -d '{"email_address": "devin@example.com"}' -H "Authorization:Bearer $API_KEY" -H 'Content-Type:application/json'
curl https://api.clerk.dev/v1/invitations -X GET -H "Authorization:Bearer $API_KEY" -H 'Content-Type:application/json'
```

```json
[{"object":"invitation","id":"inv_test","email_address":"devin@example.com","public_metadata":{},"created_at":1646430671575,"updated_at":1646430671575}]
```
