### PR TITLE
Align useSignIn,useSignUp and useSessionList hooks

### DIFF
--- a/packages/react/src/contexts/ClientContext.tsx
+++ b/packages/react/src/contexts/ClientContext.tsx
@@ -1,17 +1,7 @@
-import {
-  ClientResource,
-  SessionResource,
-  SignInResource,
-  SignUpResource,
-} from '@clerk/types';
-import React, { useContext } from 'react';
+import { ClientResource } from '@clerk/types';
+import React from 'react';
 
 import { makeContextAndHook } from '../utils/makeContextAndHook';
-import {
-  assertClerkLoadedGuarantee,
-  assertWrappedByClerkProvider,
-} from './assertHelpers';
-import { StructureContext } from './StructureContext';
 
 /**
  * @internal
@@ -19,27 +9,3 @@ import { StructureContext } from './StructureContext';
 export const [ClientContext, useClientContext] = makeContextAndHook<
   ClientResource | undefined | null
 >('ClientContext');
-
-export function useSignIn(): SignInResource {
-  const structureCtx = useContext(StructureContext);
-  const client = useClientContext();
-  assertWrappedByClerkProvider(structureCtx);
-  assertClerkLoadedGuarantee(structureCtx.guaranteedLoaded, 'useSignIn()');
-  return (client as ClientResource).signIn;
-}
-
-export function useSignUp(): SignUpResource {
-  const structureCtx = useContext(StructureContext);
-  const client = useClientContext();
-  assertWrappedByClerkProvider(structureCtx);
-  assertClerkLoadedGuarantee(structureCtx.guaranteedLoaded, 'useSignUp()');
-  return (client as ClientResource).signUp;
-}
-
-export function useSessionList(): SessionResource[] {
-  const structureCtx = useContext(StructureContext);
-  const client = useClientContext();
-  assertWrappedByClerkProvider(structureCtx);
-  assertClerkLoadedGuarantee(structureCtx.guaranteedLoaded, 'useSessionList()');
-  return (client as ClientResource).sessions;
-}

--- a/packages/react/src/contexts/index.ts
+++ b/packages/react/src/contexts/index.ts
@@ -1,2 +1,1 @@
 export { ClerkProvider, ClerkProviderProps } from './ClerkProvider';
-export { useSignIn, useSessionList, useSignUp } from './ClientContext';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -2,5 +2,8 @@ export * from './useUser';
 export * from './useAuth';
 export * from './useSession';
 export * from './useClerk';
+export * from './useSignIn';
+export * from './useSignUp';
+export * from './useSessionList';
 export * from './useOrganizations';
 export * from './useMagicLink';

--- a/packages/react/src/hooks/useSessionList.ts
+++ b/packages/react/src/hooks/useSessionList.ts
@@ -1,0 +1,19 @@
+import { SessionResource } from '@clerk/types';
+
+import { useClientContext } from '../contexts/ClientContext';
+
+type UseSessionListReturn =
+  | { isLoaded: false; sessions: undefined }
+  | { isLoaded: true; sessions: SessionResource[] };
+
+type UseSessionList = () => UseSessionListReturn;
+
+export const useSessionList: UseSessionList = () => {
+  const client = useClientContext();
+
+  if (!client) {
+    return { isLoaded: false, sessions: undefined };
+  }
+
+  return { isLoaded: true, sessions: client.sessions };
+};

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -1,0 +1,19 @@
+import { SignInResource } from '@clerk/types';
+
+import { useClientContext } from '../contexts/ClientContext';
+
+type UseSignInReturn =
+  | { isLoaded: false; signIn: null }
+  | { isLoaded: true; signIn: SignInResource };
+
+type UseSignIn = () => UseSignInReturn;
+
+export const useSignIn: UseSignIn = () => {
+  const client = useClientContext();
+
+  if (!client) {
+    return { isLoaded: false, signIn: null };
+  }
+
+  return { isLoaded: true, signIn: client.signIn };
+};

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -3,7 +3,7 @@ import { SignInResource } from '@clerk/types';
 import { useClientContext } from '../contexts/ClientContext';
 
 type UseSignInReturn =
-  | { isLoaded: false; signIn: null }
+  | { isLoaded: false; signIn: undefined }
   | { isLoaded: true; signIn: SignInResource };
 
 type UseSignIn = () => UseSignInReturn;
@@ -12,7 +12,7 @@ export const useSignIn: UseSignIn = () => {
   const client = useClientContext();
 
   if (!client) {
-    return { isLoaded: false, signIn: null };
+    return { isLoaded: false, signIn: undefined };
   }
 
   return { isLoaded: true, signIn: client.signIn };

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -3,7 +3,7 @@ import { SignUpResource } from '@clerk/types';
 import { useClientContext } from '../contexts/ClientContext';
 
 type UseSignUpReturn =
-  | { isLoaded: false; signUp: null }
+  | { isLoaded: false; signUp: undefined }
   | { isLoaded: true; signUp: SignUpResource };
 
 type UseSignUp = () => UseSignUpReturn;
@@ -12,7 +12,7 @@ export const useSignUp: UseSignUp = () => {
   const client = useClientContext();
 
   if (!client) {
-    return { isLoaded: false, signUp: null };
+    return { isLoaded: false, signUp: undefined };
   }
 
   return { isLoaded: true, signUp: client.signUp };

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -1,0 +1,19 @@
+import { SignUpResource } from '@clerk/types';
+
+import { useClientContext } from '../contexts/ClientContext';
+
+type UseSignUpReturn =
+  | { isLoaded: false; signUp: null }
+  | { isLoaded: true; signUp: SignUpResource };
+
+type UseSignUp = () => UseSignUpReturn;
+
+export const useSignUp: UseSignUp = () => {
+  const client = useClientContext();
+
+  if (!client) {
+    return { isLoaded: false, signUp: null };
+  }
+
+  return { isLoaded: true, signUp: client.signUp };
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Aligns the useSignIn,useSignUp and useSessionList hooks with the rest of the v3 apis.

Examples: 
```
export default function CustomFlow() {
  const { isLoaded, signIn } = useSignIn();

  if (!isLoaded) {
    return '...';
  }

  const start = async () => {
    const res = await signIn.create({ identifier, password });
  };

  return (
    <div>...</div>
  );
}
```

```
export default function CustomFlow() {
  const { isLoaded, signUp } = useSignUp();

  if (!isLoaded) {
    return '...';
  }

  const start = async () => {
    const res = await signIn.signUp({ ... });
  };

  return (
    <div>...</div>
  );
}
```

```
export default function CustomFlow() {
  const { isLoaded, sessions } = useSessionList();

  if (!isLoaded) {
    return '...';
  }
  
  return (
    <div>...</div>
  );
}
```

<!-- Fixes # (issue number) -->
