### PR TITLE
fix(clerk-sdk-node): Correct initialization params override on custom…

### DIFF
--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -113,9 +113,9 @@ export default class Clerk extends ClerkBackendAPI {
     };
 
     super({
-      apiKey: defaultApiKey,
-      apiVersion: defaultApiVersion,
-      serverApiUrl: defaultServerApiUrl,
+      apiKey,
+      apiVersion,
+      serverApiUrl,
       libName: LIB_NAME,
       libVersion: LIB_VERSION,
       packageRepo,

--- a/packages/sdk-node/src/__tests__/instance.test.ts
+++ b/packages/sdk-node/src/__tests__/instance.test.ts
@@ -22,4 +22,23 @@ describe('Custom Clerk instance initialization', () => {
     const Clerk = require('../instance').default;
     expect(() => new Clerk()).not.toThrow(Error);
   });
+
+  test('custom keys overrides process env and default params', () => {
+    jest.resetModules();
+    process.env.CLERK_API_KEY = TEST_API_KEY;
+    const Clerk = require('../instance').default;
+    expect(() => {
+      const customKey = 'custom_key';
+      const customAPIVersion = 'v0';
+      const customAPIUrl = 'https://customdomain.com';
+      const instance = new Clerk({
+        apiKey: customKey,
+        serverApiUrl: customAPIUrl,
+        apiVersion: customAPIVersion,
+      });
+      expect(instance._restClient.apiKey).toBe(customKey);
+      expect(instance._restClient.serverApiUrl).toBe(customAPIUrl);
+      expect(instance._restClient.apiVersion).toBe(customAPIVersion);
+    }).not.toThrow(Error);
+  });
 });


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

**Correct instance initialization params.**
Currently when using a custom instance with overriden API key outside of the environment, the default would be used. Same with apiVersion and URL.