### PR TITLE
chore(repo): Update Typescript to 4.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@commitlint/config-conventional": "^16.0.0",
         "@commitlint/config-lerna-scopes": "^16.0.0",
         "@types/node": "14.14.33",
+        "@types/web": "^0.0.55",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "conventional-changelog-conventionalcommits": "^4.6.3",
@@ -24,7 +25,7 @@
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",
         "turbo": "^1.1.5",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=16.8.0",
@@ -5398,15 +5399,15 @@
       }
     },
     "node_modules/@peculiar/webcrypto": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.2.3.tgz",
-      "integrity": "sha512-q7wDfZy3k/tpnsYB23/MyyDkjn6IdHh8w+xwoVMS5cu6CjVoFzngXDZEOOuSE4zus2yO6ciQhhHxd4XkLpwVnQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.3.2.tgz",
+      "integrity": "sha512-oUgNj+8oT7uROEMEpZZ3U+kZjyxj1KXuvA8P5kiMUveTya9eyS8KTqu/dzdEtYC3u7dvjknVz+0sUfkWOBHfQg==",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.0.44",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.2.1",
+        "pvtsutils": "^1.2.2",
         "tslib": "^2.3.1",
-        "webcrypto-core": "^1.4.0"
+        "webcrypto-core": "^1.7.1"
       },
       "engines": {
         "node": ">=10.12.0"
@@ -6752,6 +6753,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@types/web": {
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.55.tgz",
+      "integrity": "sha512-YMH9aZrSJIMRMioCUwrgauI3iS/w2wRFN45Xxm0FE9Tt3hqaqkvOzjDFGsNjyKZzz7GJC0ilb+0tv59ytSUbrQ=="
     },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
@@ -16664,9 +16670,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -18978,17 +18984,17 @@
       }
     },
     "node_modules/pvtsutils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.2.1.tgz",
-      "integrity": "sha512-Q867jEr30lBR2YSFFLZ0/XsEvpweqH6Kj096wmlRAFXrdRGPCNq2iz9B5Tk085EZ+OBZyYAVA5UhPkjSHGrUzQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.2.2.tgz",
+      "integrity": "sha512-OALo5ZEdqiI127i64+CXwkCOyFHUA+tCQgaUO/MvRDFXWPr53f2sx28ECNztUEzuyu5xvuuD1EB/szg9mwJoGA==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/pvutils": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -21862,9 +21868,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -22224,14 +22230,15 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.4.0.tgz",
-      "integrity": "sha512-HY3Zo0GcRIQUUDnlZ/shGjN+4f7LVMkdJZoGPog+oHhJsJdMz6iM8Za5xZ0t6qg7Fx/JXXz+oBv2J2p982hGTQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.1.tgz",
+      "integrity": "sha512-Gw2zLzYSJ7Imp5lLDu3CcWB5oTTACMDEE2PjoLfttGgIhd7BfackBdVgEzd9ZM/i65gpNq0+IelL0JZ48QwzNg==",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.0.44",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^2.1.1",
-        "pvtsutils": "^1.2.0",
+        "@types/web": "^0.0.55",
+        "asn1js": "^2.2.0",
+        "pvtsutils": "^1.2.2",
         "tslib": "^2.3.1"
       }
     },
@@ -23077,7 +23084,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@peculiar/webcrypto": "^1.2.3",
+        "@peculiar/webcrypto": "^1.3.2",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.12",
         "@types/node-fetch": "^2",
@@ -23086,7 +23093,7 @@
         "nock": "^13.2.1",
         "node-fetch": "^2.6.0",
         "ts-jest": "^27.1.3",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       }
     },
     "packages/backend-core/node_modules/@types/node": {
@@ -23161,7 +23168,7 @@
         "style-loader": "^2.0.0",
         "ts-jest": "^27.1.3",
         "type-fest": "^0.20.2",
-        "typescript": "4.5.5",
+        "typescript": "^4.6.2",
         "webpack": "^5.64.1",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.5.0",
@@ -23215,7 +23222,7 @@
         "@types/node": "^16.11.12",
         "jest": "^27.4.7",
         "ts-jest": "^27.1.3",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=12"
@@ -23247,7 +23254,7 @@
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -23291,7 +23298,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -23406,7 +23413,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -23442,7 +23449,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=16"
@@ -23572,7 +23579,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.5.0",
         "ts-jest": "^27.1.3",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=12"
@@ -23858,7 +23865,8 @@
         "react-dom": "17.0.2",
         "react-popper": "^2.2.4",
         "react-test-renderer": "17.0.2",
-        "ts-jest": "^27.1.3"
+        "ts-jest": "^27.1.3",
+        "typescript": "^4.6.2"
       },
       "peerDependencies": {
         "@popperjs/core": "^2.5.4",
@@ -23896,7 +23904,7 @@
         "jest": "^27.4.7",
         "ts-jest": "^27.1.3",
         "typedoc": "^0.22.11",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -25191,7 +25199,7 @@
     "@clerk/backend-core": {
       "version": "file:packages/backend-core",
       "requires": {
-        "@peculiar/webcrypto": "^1.2.3",
+        "@peculiar/webcrypto": "^1.3.2",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.12",
         "@types/node-fetch": "^2",
@@ -25204,7 +25212,7 @@
         "snakecase-keys": "^5.1.2",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@types/node": {
@@ -25231,7 +25239,7 @@
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@clerk/types": {
@@ -25310,7 +25318,7 @@
         "style-loader": "^2.0.0",
         "ts-jest": "^27.1.3",
         "type-fest": "^0.20.2",
-        "typescript": "4.5.5",
+        "typescript": "^4.6.2",
         "webpack": "^5.64.1",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.5.0",
@@ -25360,7 +25368,7 @@
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@types/node": {
@@ -25397,7 +25405,7 @@
         "snakecase-keys": "^3.2.1",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@humanwhocodes/config-array": {
@@ -25582,7 +25590,7 @@
         "jest": "^27.4.7",
         "next": "^12.0.7",
         "ts-jest": "^27.1.3",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@types/node": {
@@ -25609,7 +25617,7 @@
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@clerk/backend-core": {
@@ -25696,7 +25704,7 @@
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@clerk/backend-core": {
@@ -25809,7 +25817,8 @@
         "react-dom": "17.0.2",
         "react-popper": "^2.2.4",
         "react-test-renderer": "17.0.2",
-        "ts-jest": "^27.1.3"
+        "ts-jest": "^27.1.3",
+        "typescript": "^4.6.2"
       },
       "dependencies": {
         "@clerk/types": {
@@ -25833,7 +25842,7 @@
         "jest": "^27.4.7",
         "ts-jest": "^27.1.3",
         "typedoc": "^0.22.11",
-        "typescript": "4.5.5"
+        "typescript": "^4.6.2"
       }
     },
     "@commitlint/cli": {
@@ -28567,15 +28576,15 @@
       }
     },
     "@peculiar/webcrypto": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.2.3.tgz",
-      "integrity": "sha512-q7wDfZy3k/tpnsYB23/MyyDkjn6IdHh8w+xwoVMS5cu6CjVoFzngXDZEOOuSE4zus2yO6ciQhhHxd4XkLpwVnQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.3.2.tgz",
+      "integrity": "sha512-oUgNj+8oT7uROEMEpZZ3U+kZjyxj1KXuvA8P5kiMUveTya9eyS8KTqu/dzdEtYC3u7dvjknVz+0sUfkWOBHfQg==",
       "requires": {
         "@peculiar/asn1-schema": "^2.0.44",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.2.1",
+        "pvtsutils": "^1.2.2",
         "tslib": "^2.3.1",
-        "webcrypto-core": "^1.4.0"
+        "webcrypto-core": "^1.7.1"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -29646,6 +29655,11 @@
           "dev": true
         }
       }
+    },
+    "@types/web": {
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.55.tgz",
+      "integrity": "sha512-YMH9aZrSJIMRMioCUwrgauI3iS/w2wRFN45Xxm0FE9Tt3hqaqkvOzjDFGsNjyKZzz7GJC0ilb+0tv59ytSUbrQ=="
     },
     "@types/webpack": {
       "version": "4.41.32",
@@ -37134,9 +37148,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -38868,17 +38882,17 @@
       "dev": true
     },
     "pvtsutils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.2.1.tgz",
-      "integrity": "sha512-Q867jEr30lBR2YSFFLZ0/XsEvpweqH6Kj096wmlRAFXrdRGPCNq2iz9B5Tk085EZ+OBZyYAVA5UhPkjSHGrUzQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.2.2.tgz",
+      "integrity": "sha512-OALo5ZEdqiI127i64+CXwkCOyFHUA+tCQgaUO/MvRDFXWPr53f2sx28ECNztUEzuyu5xvuuD1EB/szg9mwJoGA==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "pvutils": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
     "q": {
       "version": "1.5.1",
@@ -41012,9 +41026,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "uglify-js": {
@@ -41304,14 +41318,15 @@
       "dev": true
     },
     "webcrypto-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.4.0.tgz",
-      "integrity": "sha512-HY3Zo0GcRIQUUDnlZ/shGjN+4f7LVMkdJZoGPog+oHhJsJdMz6iM8Za5xZ0t6qg7Fx/JXXz+oBv2J2p982hGTQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.1.tgz",
+      "integrity": "sha512-Gw2zLzYSJ7Imp5lLDu3CcWB5oTTACMDEE2PjoLfttGgIhd7BfackBdVgEzd9ZM/i65gpNq0+IelL0JZ48QwzNg==",
       "requires": {
         "@peculiar/asn1-schema": "^2.0.44",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^2.1.1",
-        "pvtsutils": "^1.2.0",
+        "@types/web": "^0.0.55",
+        "asn1js": "^2.2.0",
+        "pvtsutils": "^1.2.2",
         "tslib": "^2.3.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@commitlint/config-conventional": "^16.0.0",
     "@commitlint/config-lerna-scopes": "^16.0.0",
     "@types/node": "14.14.33",
+    "@types/web": "^0.0.55",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "conventional-changelog-conventionalcommits": "^4.6.3",
@@ -29,7 +30,7 @@
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",
     "turbo": "^1.1.5",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "scripts": {
     "dev": "lerna run dev --parallel --scope @clerk/types --scope @clerk/clerk-js --scope @clerk/clerk-react --scope @clerk/remix --scope @clerk/nextjs",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -17,7 +17,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@peculiar/webcrypto": "^1.2.3",
+    "@peculiar/webcrypto": "^1.3.2",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.12",
     "@types/node-fetch": "^2",
@@ -26,7 +26,7 @@
     "nock": "^13.2.1",
     "node-fetch": "^2.6.0",
     "ts-jest": "^27.1.3",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/backend-core/tsconfig.json
+++ b/packages/backend-core/tsconfig.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020"],
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -99,7 +99,7 @@
     "style-loader": "^2.0.0",
     "ts-jest": "^27.1.3",
     "type-fest": "^0.20.2",
-    "typescript": "4.5.5",
+    "typescript": "^4.6.2",
     "webpack": "^5.64.1",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.5.0",

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^16.11.12",
     "jest": "^27.4.7",
     "ts-jest": "^27.1.3",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "repository": {
     "type": "git",

--- a/packages/edge/tsconfig.json
+++ b/packages/edge/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020"],
     "strict": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -41,7 +41,7 @@
     "react-dom": "17.0.2",
     "ts-jest": "^27.1.3",
     "tslib": "^2.3.1",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -47,7 +47,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ts-jest": "^27.1.3",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "peerDependencies": {
     "next": ">=10"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ts-jest": "^27.1.3",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -48,7 +48,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ts-jest": "^27.1.3",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "peerDependencies": {
     "@remix-run/react": "^1.2.1",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -48,7 +48,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.0",
     "ts-jest": "^27.1.3",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "dependencies": {
     "@clerk/backend-core": "^0.5.2-staging.0",

--- a/packages/sdk-node/tsconfig.json
+++ b/packages/sdk-node/tsconfig.json
@@ -15,6 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "target": "ES2019",
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["ES2020"]
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -58,6 +58,7 @@
     "react-dom": "17.0.2",
     "react-popper": "^2.2.4",
     "react-test-renderer": "17.0.2",
-    "ts-jest": "^27.1.3"
+    "ts-jest": "^27.1.3",
+    "typescript": "^4.6.2"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -32,7 +32,7 @@
     "jest": "^27.4.7",
     "ts-jest": "^27.1.3",
     "typedoc": "^0.22.11",
-    "typescript": "4.5.5"
+    "typescript": "^4.6.2"
   },
   "engines": {
     "node": ">=14"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "inlineSources": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es6"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitHelpers": true,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [x] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Bumps TS to 4.6.2
<!-- Fixes # (issue number) -->
