### PR TITLE
feat(clerk-js,clerk-react): Replace signOutOne with signOut(options)

### DIFF
--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -49,7 +49,7 @@ describe('Clerk singleton', () => {
     global.window.location = location;
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     const mockAddEventListener = (type: string, callback: (e: any) => void) => {
       if (type === 'message') {
         callback({
@@ -144,6 +144,109 @@ describe('Clerk singleton', () => {
     });
   });
 
+  describe('.signOut()', () => {
+    const mockClientDestroy = jest.fn();
+    const mockSession1 = { id: '1', remove: jest.fn(), status: 'active' };
+    const mockSession2 = { id: '2', remove: jest.fn(), status: 'active' };
+
+    beforeEach(() => {
+      mockClientDestroy.mockReset();
+      mockSession1.remove.mockReset();
+      mockSession2.remove.mockReset();
+    });
+
+    it('has no effect if called when no active sessions exist', async () => {
+      const sut = new Clerk(frontendApi);
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          activeSessions: [],
+          destroy: mockClientDestroy,
+        }),
+      );
+      await sut.load();
+      await sut.signOut();
+      await waitFor(() => {
+        expect(mockClientDestroy).not.toHaveBeenCalled();
+        expect(mockSession1.remove).not.toHaveBeenCalled();
+      });
+    });
+
+    it('signs out all sessions if no sessionId is passed and multiple sessions are active', async () => {
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          activeSessions: [mockSession1, mockSession2],
+          destroy: mockClientDestroy,
+        }),
+      );
+
+      const sut = new Clerk(frontendApi);
+      sut.setSession = jest.fn();
+      await sut.load();
+      await sut.signOut();
+      await waitFor(() => {
+        expect(mockClientDestroy).toHaveBeenCalled();
+        expect(sut.setSession).toHaveBeenCalledWith(null, undefined);
+      });
+    });
+
+    it('signs out all sessions if no sessionId is passed and only one session is active', async () => {
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          activeSessions: [mockSession1],
+          destroy: mockClientDestroy,
+        }),
+      );
+
+      const sut = new Clerk(frontendApi);
+      sut.setSession = jest.fn();
+      await sut.load();
+      await sut.signOut();
+      await waitFor(() => {
+        expect(mockClientDestroy).toHaveBeenCalled();
+        expect(mockSession1.remove).not.toHaveBeenCalled();
+        expect(sut.setSession).toHaveBeenCalledWith(null, undefined);
+      });
+    });
+
+    it('only removes the session that corresponds to the passed sessionId if it is not the current', async () => {
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          activeSessions: [mockSession1, mockSession2],
+          destroy: mockClientDestroy,
+        }),
+      );
+
+      const sut = new Clerk(frontendApi);
+      sut.setSession = jest.fn();
+      await sut.load();
+      await sut.signOut({ sessionId: '2' });
+      await waitFor(() => {
+        expect(mockSession2.remove).toHaveBeenCalled();
+        expect(mockClientDestroy).not.toHaveBeenCalled();
+        expect(sut.setSession).not.toHaveBeenCalledWith(null, undefined);
+      });
+    });
+
+    it('removes and signs out the session that corresponds to the passed sessionId if it is the current', async () => {
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          activeSessions: [mockSession1, mockSession2],
+          destroy: mockClientDestroy,
+        }),
+      );
+
+      const sut = new Clerk(frontendApi);
+      sut.setSession = jest.fn();
+      await sut.load();
+      await sut.signOut({ sessionId: '1' });
+      await waitFor(() => {
+        expect(mockSession1.remove).toHaveBeenCalled();
+        expect(mockClientDestroy).not.toHaveBeenCalled();
+        expect(sut.setSession).toHaveBeenCalledWith(null, undefined);
+      });
+    });
+  });
+
   describe('.navigate(to)', () => {
     let mockWindowLocation;
     let mockHref: jest.Mock;
@@ -195,7 +298,7 @@ describe('Clerk singleton', () => {
   });
 
   describe('.handleRedirectCallback()', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       mockClientFetch.mockReset();
       mockEnvironmentFetch.mockReset();
     });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -153,12 +153,14 @@ export default class Clerk implements ClerkInterface {
         ? callbackOrOptions
         : options || {};
 
-    if (!opts.sessionId || this.client.sessions.length === 1) {
+    if (!opts.sessionId || this.client.activeSessions.length === 1) {
       await this.client.destroy();
       return this.setSession(null, ignoreEventValue(cb));
     }
 
-    const session = this.client.sessions.find(s => s.id === opts.sessionId);
+    const session = this.client.activeSessions.find(
+      s => s.id === opts.sessionId,
+    );
     const shouldSignOutCurrent = this.session.id === session?.id;
     await session?.remove();
     if (shouldSignOutCurrent) {

--- a/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
+++ b/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
@@ -1,7 +1,7 @@
 import { ActiveSessionResource, SessionResource } from '@clerk/types';
 import React from 'react';
 import { PoweredByClerk } from 'ui/common';
-import { useCoreClerk, useEnvironment } from 'ui/contexts';
+import { useCoreClerk, useCoreSession, useEnvironment } from 'ui/contexts';
 import { useNavigate } from 'ui/hooks';
 import { useUserButtonPopupVisibility } from 'ui/userButton/contexts/PopupVisibilityContext';
 import { windowNavigate } from 'utils';
@@ -29,12 +29,12 @@ export function ActiveAccountsManager({
   userProfileUrl,
   showActiveAccountButtons = true,
 }: ActiveAccountsManagerProps): JSX.Element {
-  const { setSession, signOut, signOutOne } = useCoreClerk();
+  const { setSession, signOut } = useCoreClerk();
+  const { id: currentSessionId } = useCoreSession();
   const { authConfig } = useEnvironment();
   const { navigate } = useNavigate();
   const [signoutInProgress, setSignoutInProgress] = React.useState(false);
-  const [managementNavigationInProgress, setManagementNavigationInProgress] =
-    React.useState(false);
+  const [managementNavigationInProgress, setManagementNavigationInProgress] = React.useState(false);
   const { setPopupVisible } = useUserButtonPopupVisibility();
 
   const handleSignOutSingle = () => {
@@ -46,9 +46,7 @@ export function ActiveAccountsManager({
       return;
     }
 
-    signOutOne(navigateAfterSignOutOne).catch(() =>
-      setSignoutInProgress(false),
-    );
+    signOut(navigateAfterSignOutOne, { sessionId: currentSessionId }).catch(() => setSignoutInProgress(false));
   };
 
   const handleManageAccountClick = () => {
@@ -76,8 +74,7 @@ export function ActiveAccountsManager({
     return signOut(navigateAfterSignOutAll);
   };
 
-  const shouldRenderAccountSwitcher =
-    sessions.length || !authConfig.singleSessionMode;
+  const shouldRenderAccountSwitcher = sessions.length || !authConfig.singleSessionMode;
   return (
     <div className='cl-active-accounts-manager'>
       {showActiveAccountButtons && (
@@ -96,9 +93,7 @@ export function ActiveAccountsManager({
           handleAddAccountClick={handleAddAccountClick}
         />
       )}
-      {Boolean(sessions.length) && (
-        <SignOutAll handleSignOutAll={handleSignOutAll} />
-      )}
+      {Boolean(sessions.length) && <SignOutAll handleSignOutAll={handleSignOutAll} />}
       <PoweredByClerk className='cl-powered-by-clerk' />
     </div>
   );

--- a/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
+++ b/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
@@ -34,7 +34,8 @@ export function ActiveAccountsManager({
   const { authConfig } = useEnvironment();
   const { navigate } = useNavigate();
   const [signoutInProgress, setSignoutInProgress] = React.useState(false);
-  const [managementNavigationInProgress, setManagementNavigationInProgress] = React.useState(false);
+  const [managementNavigationInProgress, setManagementNavigationInProgress] =
+    React.useState(false);
   const { setPopupVisible } = useUserButtonPopupVisibility();
 
   const handleSignOutSingle = () => {
@@ -46,7 +47,9 @@ export function ActiveAccountsManager({
       return;
     }
 
-    signOut(navigateAfterSignOutOne, { sessionId: currentSessionId }).catch(() => setSignoutInProgress(false));
+    signOut(navigateAfterSignOutOne, { sessionId: currentSessionId }).catch(
+      () => setSignoutInProgress(false),
+    );
   };
 
   const handleManageAccountClick = () => {
@@ -74,7 +77,8 @@ export function ActiveAccountsManager({
     return signOut(navigateAfterSignOutAll);
   };
 
-  const shouldRenderAccountSwitcher = sessions.length || !authConfig.singleSessionMode;
+  const shouldRenderAccountSwitcher =
+    sessions.length || !authConfig.singleSessionMode;
   return (
     <div className='cl-active-accounts-manager'>
       {showActiveAccountButtons && (
@@ -93,7 +97,9 @@ export function ActiveAccountsManager({
           handleAddAccountClick={handleAddAccountClick}
         />
       )}
-      {Boolean(sessions.length) && <SignOutAll handleSignOutAll={handleSignOutAll} />}
+      {Boolean(sessions.length) && (
+        <SignOutAll handleSignOutAll={handleSignOutAll} />
+      )}
       <PoweredByClerk className='cl-powered-by-clerk' />
     </div>
   );

--- a/packages/clerk-js/src/ui/contexts/CoreClerkContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/CoreClerkContext.tsx
@@ -2,43 +2,13 @@ import type { LoadedClerk } from '@clerk/types';
 import React from 'react';
 import { assertContextExists } from 'ui/contexts/utils';
 
-const excludedProps = ['user', 'session', 'client'] as const;
+export type CoreClerkProps = LoadedClerk;
 
-type ExcludedProp = typeof excludedProps[number];
-type ClerkSingletonPropName = Exclude<keyof LoadedClerk, ExcludedProp>;
-
-export type CoreClerkProps = {
-  [k in ClerkSingletonPropName]: LoadedClerk[k];
-};
-
-function clerkSingletonProps(clerk: LoadedClerk): CoreClerkProps {
-  return Object.keys(clerk).reduce((acc, propName) => {
-    const prop = propName as keyof LoadedClerk & keyof CoreClerkProps;
-    if (excludedProps.includes(prop as ExcludedProp)) {
-      return acc;
-    }
-
-    let propVal = clerk[prop];
-    propVal = typeof propVal === 'function' ? propVal.bind(clerk) : propVal;
-    acc[prop] = propVal as any;
-    return acc;
-  }, {} as CoreClerkProps);
-}
-
-export const CoreClerkContext = React.createContext<LoadedClerk | undefined>(
-  undefined,
-);
+export const CoreClerkContext = React.createContext<LoadedClerk | undefined>(undefined);
 CoreClerkContext.displayName = 'CoreClerkContext';
-
-let cachedClerkSingletonProps: CoreClerkProps | undefined;
 
 export function useCoreClerk(): CoreClerkProps {
   const context = React.useContext(CoreClerkContext);
   assertContextExists(context, 'CoreClerkContextProvider');
-
-  if (!cachedClerkSingletonProps) {
-    cachedClerkSingletonProps = clerkSingletonProps(context);
-  }
-
-  return cachedClerkSingletonProps;
+  return context;
 }

--- a/packages/react/src/components/SignOutButton.test.tsx
+++ b/packages/react/src/components/SignOutButton.test.tsx
@@ -8,11 +8,11 @@ import React from 'react';
 
 import { SignOutButton } from './SignOutButton';
 
-const mockSignOutOne = jest.fn();
+const mockSignOut = jest.fn();
 const originalError = console.error;
 
 const mockClerk = {
-  signOutOne: mockSignOutOne,
+  signOut: mockSignOut,
 } as any;
 
 jest.mock('./withClerk', () => {
@@ -33,7 +33,7 @@ describe('<SignOutButton />', () => {
   });
 
   beforeEach(() => {
-    mockSignOutOne.mockReset();
+    mockSignOut.mockReset();
   });
 
   it('calls clerk.signOutOne when clicked', async () => {
@@ -41,7 +41,7 @@ describe('<SignOutButton />', () => {
     const btn = screen.getByText('Sign out');
     userEvent.click(btn);
     await waitFor(() => {
-      expect(mockSignOutOne).toHaveBeenCalled();
+      expect(mockSignOut).toHaveBeenCalled();
     });
   });
 

--- a/packages/react/src/components/SignOutButton.tsx
+++ b/packages/react/src/components/SignOutButton.tsx
@@ -1,26 +1,25 @@
+import { SignOutCallback, SignOutOptions } from '@clerk/types';
 import React from 'react';
 
-import { SignOutButtonProps, WithClerkProp } from '../types';
-import {
-  assertSingleChild,
-  normalizeWithDefaultValue,
-  safeExecute,
-} from '../utils';
+import { WithClerkProp } from '../types';
+import { assertSingleChild, normalizeWithDefaultValue, safeExecute } from '../utils';
 import { withClerk } from './withClerk';
 
+export type SignOutButtonProps = {
+  signOutCallback?: SignOutCallback;
+  signOutOptions?: SignOutOptions;
+  children?: React.ReactNode;
+};
+
 export const SignOutButton = withClerk(
-  ({
-    clerk,
-    children,
-    ...props
-  }: React.PropsWithChildren<WithClerkProp<SignOutButtonProps>>) => {
-    const { signOutCallback, ...rest } = props;
+  ({ clerk, children, ...props }: React.PropsWithChildren<WithClerkProp<SignOutButtonProps>>) => {
+    const { signOutCallback, signOutOptions, ...rest } = props;
 
     children = normalizeWithDefaultValue(children, 'Sign out');
     const child = assertSingleChild(children)('SignOutButton');
 
     const clickHandler = () => {
-      return clerk.signOutOne(signOutCallback);
+      return clerk.signOut(signOutCallback, signOutOptions);
     };
 
     const wrappedChildClickHandler: React.MouseEventHandler = async e => {

--- a/packages/react/src/hooks/utils.ts
+++ b/packages/react/src/hooks/utils.ts
@@ -1,0 +1,34 @@
+import IsomorphicClerk from '../isomorphicClerk';
+
+/**
+ * @internal
+ */
+const clerkLoaded = (isomorphicClerk: IsomorphicClerk) => {
+  return new Promise<void>(resolve => {
+    if (isomorphicClerk.loaded) {
+      resolve();
+    }
+    isomorphicClerk.addOnLoaded(resolve);
+  });
+};
+
+/**
+ * @internal
+ */
+export const createGetToken = (isomorphicClerk: IsomorphicClerk) => async (options: any) => {
+  await clerkLoaded(isomorphicClerk);
+  if (isomorphicClerk.session) {
+    return isomorphicClerk.session.getToken(options);
+  }
+  return null;
+};
+
+/**
+ * @internal
+ */
+export const createSignOut =
+  (isomorphicClerk: IsomorphicClerk) =>
+  async (...args: any) => {
+    await clerkLoaded(isomorphicClerk);
+    return isomorphicClerk.signOut(...args);
+  };

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -5,13 +5,15 @@ import type {
   CreateOrganizationParams,
   HandleMagicLinkVerificationParams,
   HandleOAuthCallbackParams,
+  InitialState,
   OrganizationMembershipResource,
   OrganizationResource,
-  InitialState,
   RedirectOptions,
   Resources,
   SignInProps,
+  SignOut,
   SignOutCallback,
+  SignOutOptions,
   SignUpProps,
   UserButtonProps,
   UserProfileProps,
@@ -461,21 +463,16 @@ export default class IsomorphicClerk {
     }
   };
 
-  signOut = async (signOutCallback?: SignOutCallback): Promise<void> => {
-    const callback = () => this.clerkjs?.signOut(signOutCallback);
+  signOut: SignOut = async (
+    signOutCallbackOrOptions?: SignOutCallback | SignOutOptions,
+    options?: SignOutOptions,
+  ): Promise<void> => {
+    const callback = () =>
+      this.clerkjs?.signOut(signOutCallbackOrOptions as any, options);
     if (this.clerkjs && this._loaded) {
       return callback() as Promise<void>;
     } else {
       this.premountMethodCalls.set('signOut', callback);
-    }
-  };
-
-  signOutOne = async (signOutCallback?: SignOutCallback): Promise<void> => {
-    const callback = () => this.clerkjs?.signOutOne(signOutCallback);
-    if (this.clerkjs && this._loaded) {
-      return callback() as Promise<void>;
-    } else {
-      this.premountMethodCalls.set('signOutOne', callback);
     }
   };
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,12 +1,4 @@
-import type {
-  Clerk,
-  ClerkOptions,
-  ClientResource,
-  LoadedClerk,
-  RedirectOptions,
-  SignOutCallback,
-  UserResource,
-} from '@clerk/types';
+import type { Clerk, ClerkOptions, ClientResource, LoadedClerk, RedirectOptions, UserResource } from '@clerk/types';
 
 export interface IsomorphicClerkOptions extends ClerkOptions {
   clerkJSUrl?: string;
@@ -35,11 +27,7 @@ export interface BrowserClerk extends Clerk {
   components: any;
 }
 
-export type ClerkProp =
-  | BrowserClerkConstructor
-  | BrowserClerk
-  | undefined
-  | null;
+export type ClerkProp = BrowserClerkConstructor | BrowserClerk | undefined | null;
 
 type ButtonProps = {
   afterSignInUrl?: string;
@@ -52,14 +40,6 @@ type ButtonProps = {
 export type SignInButtonProps = ButtonProps;
 export type SignUpButtonProps = ButtonProps;
 
-export type SignInWithMetamaskButtonProps = Pick<
-  ButtonProps,
-  'redirectUrl' | 'children'
->;
-
-export type SignOutButtonProps = {
-  signOutCallback?: SignOutCallback;
-  children?: React.ReactNode;
-};
+export type SignInWithMetamaskButtonProps = Pick<ButtonProps, 'redirectUrl' | 'children'>;
 
 export type RedirectToProps = RedirectOptions;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -12,7 +12,22 @@ export type UnsubscribeCallback = () => void;
 export type BeforeEmitCallback = (
   session: ActiveSessionResource | null,
 ) => void | Promise<any>;
+
 export type SignOutCallback = () => void | Promise<any>;
+
+export type SignOutOptions = {
+  /**
+   * Specify a specific session to sign out. Useful for
+   * multi-session applications.
+   */
+  sessionId?: string;
+};
+
+export interface SignOut {
+  (options?: SignOutOptions): Promise<void>;
+  (signOutCallback?: SignOutCallback, options?: SignOutOptions): Promise<void>;
+}
+
 
 export type SetSession = (
   session: ActiveSessionResource | string | null,
@@ -40,24 +55,13 @@ export interface Clerk {
   /** Current User. */
   user?: UserResource | null;
 
-  /** Clerk environment. */
-  __unstable__environment?: EnvironmentResource | null;
-
   /**
-   * Signs out the current user on single-session instances, or all users on multi-session instances.
-   *
+   * Signs out the current user on single-session instances, or all users on multi-session instances
    * @param signOutCallback - Optional A callback that runs after sign out completes.
+   * @param options - Optional Configuration options, see {@link SignOutOptions}
    * @returns A promise that resolves when the sign out process completes.
    */
-  signOut: (signOutCallback?: SignOutCallback) => Promise<void>;
-
-  /**
-   * Signs out the current user.
-   *
-   * @param signOutCallback - Optional A callback that runs after sign out completes.
-   * @returns A promise that resolves when the sign out process completes.
-   */
-  signOutOne: (signOutCallback?: SignOutCallback) => Promise<void>;
+  signOut: SignOut;
 
   /**
    * Opens the Clerk sign in modal.


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Replaces signOutOne with signOut(options). 

Currently, we have 2 different signOut methods on Clerk: `signOut()` and `signOutOne` as shown below:
```
function TestComponent() {
  const clerk = useClerk();

  const signOutAllUsers = () => {
    return clerk.signOut(() => navigate('...'));
  };

  const signOutCurrent = () => {
    return clerk.signOutOne(() => navigate('...'));
  };
}
```


Proposed change: Combine the 2 methods into a single `signOut` that accepts an optional `callback` and an optional `options`  obj

- If no sessionId is provided, the client will be destroyed and the user will be signed out
- If a sessionId is provided and
  - its the only active session, the client will be destroyed and the user will be signed out
  - its the current active session, the session will be removed and the user will be signed out
  - its included in the client.sessions array but its not the current session, it will be removed but the current session will remain active

Example usage: 

### Sign out from all (multi + single session apps):
```
function TestComponent() {
  const { signOut } = useAuth();

  const signOutAll = () => {
    return signOut(() => navigate('...'));
  };
}
```

### Sign out from current (multi-session app): 
```
function TestComponent() {
  const { signOut, sessionId } = useAuth();

  const signOutCurrent = () => {
    return signOut(() => navigate(), { sessionId });
  };
}
```

### Removing an arbitrary session (multisession app):
```
function TestComponent() {
  const { signOut } = useAuth();
  const { sessions } = useSessionList();

  // single or multi session
  const signOutOtherSession = () => {
    return signOut(() => navigate('...'), { sessionId: sessions[3] });
  };
}

```

<!-- Fixes # (issue number) -->
