### PR TITLE
fix(clerk-sdk-node): Properly stringify metadata params in Invitation…

### DIFF
--- a/packages/backend-core/src/__tests__/apis/InvitationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/InvitationApi.test.ts
@@ -40,7 +40,7 @@ test('createInvitation() creates an invitation', async () => {
       emailAddress,
       createdAt: resJSON.created_at,
       updatedAt: resJSON.updated_at,
-    })
+    }),
   );
 });
 
@@ -72,7 +72,7 @@ test('createInvitation() accepts a redirectUrl', async () => {
       emailAddress,
       createdAt: resJSON.created_at,
       updatedAt: resJSON.updated_at,
-    })
+    }),
   );
 });
 
@@ -93,7 +93,7 @@ test('createInvitation() accepts publicMetadata', async () => {
   nock('https://api.clerk.dev')
     .post('/v1/invitations', {
       email_address: emailAddress,
-      public_metadata: publicMetadata,
+      public_metadata: JSON.stringify(publicMetadata),
     })
     .reply(200, resJSON);
 
@@ -108,7 +108,7 @@ test('createInvitation() accepts publicMetadata', async () => {
       publicMetadata,
       createdAt: resJSON.created_at,
       updatedAt: resJSON.updated_at,
-    })
+    }),
   );
 });
 
@@ -127,7 +127,7 @@ test('revokeInvitation() revokes an invitation', async () => {
     .reply(200, resJSON);
 
   const invitation = await TestBackendAPIClient.invitations.revokeInvitation(
-    id
+    id,
   );
   expect(invitation).toEqual(
     new Invitation({
@@ -135,12 +135,12 @@ test('revokeInvitation() revokes an invitation', async () => {
       emailAddress: resJSON.email_address,
       createdAt: resJSON.created_at,
       updatedAt: resJSON.updated_at,
-    })
+    }),
   );
 });
 
 test('revokeInvitation() throws an error without invitation ID', async () => {
   await expect(
-    TestBackendAPIClient.invitations.revokeInvitation('')
+    TestBackendAPIClient.invitations.revokeInvitation(''),
   ).rejects.toThrow('A valid ID is required.');
 });

--- a/packages/backend-core/src/api/collection/InvitationApi.ts
+++ b/packages/backend-core/src/api/collection/InvitationApi.ts
@@ -21,7 +21,10 @@ export class InvitationApi extends AbstractApi {
     return this._restClient.makeRequest<Invitation>({
       method: 'POST',
       path: basePath,
-      bodyParams: params,
+      bodyParams: {
+        ...params,
+        publicMetadata: JSON.stringify(params.publicMetadata),
+      },
     });
   }
 

--- a/packages/backend-core/src/api/collection/UserApi.ts
+++ b/packages/backend-core/src/api/collection/UserApi.ts
@@ -81,7 +81,7 @@ export class UserApi extends AbstractApi {
       path: '/users',
       bodyParams: {
         ...params,
-        ...sanitizeMetadataParams({
+        ...stringifyMetadataParams({
           publicMetadata,
           privateMetadata,
           unsafeMetadata,
@@ -125,7 +125,7 @@ export class UserApi extends AbstractApi {
   }
 }
 
-function sanitizeMetadataParams(
+function stringifyMetadataParams(
   params: UserMetadataParams & {
     [key: string]: Record<string, unknown> | undefined;
   },

--- a/packages/sdk-node/examples/node/src/invitations.ts
+++ b/packages/sdk-node/examples/node/src/invitations.ts
@@ -5,6 +5,12 @@ import { invitations } from '@clerk/clerk-sdk-node';
 // Create an invitation
 await invitations.createInvitation({
   emailAddress: 'test@example.com',
+  publicMetadata: {
+    some_metadata: 'test',
+    some_nested: {
+      some_metadata: 'test',
+    },
+  },
 });
 
 // Create another invitation


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->

As reported by a client, the invitations create API did not accept the `publicMetadata` parameter as expected. _(JSON.stringify was required)_
