### PR TITLE
Navigation improvements 

### DIFF
--- a/packages/clerk-js/src/ui/router/BaseRouter.tsx
+++ b/packages/clerk-js/src/ui/router/BaseRouter.tsx
@@ -78,7 +78,7 @@ export const BaseRouter = ({
   useWindowEventListener(refreshEvents, refresh);
 
   // TODO: Look into the real possible types of globalNavigate
-  const baseNavigate = async (toURL: URL): Promise<void> => {
+  const baseNavigate = async (toURL: URL): Promise<unknown> => {
     if (
       toURL.origin !== window.location.origin ||
       !toURL.pathname.startsWith('/' + basePath)
@@ -86,8 +86,7 @@ export const BaseRouter = ({
       if (onExternalNavigate) {
         onExternalNavigate();
       }
-      await externalNavigate(toURL.href);
-      return;
+      return await externalNavigate(toURL.href);
     }
 
     // For internal navigation, preserve any query params
@@ -101,11 +100,9 @@ export const BaseRouter = ({
       });
       toURL.search = qs.stringify(toQueryParams);
     }
-    await internalNavigate(toURL);
-    setRouteParts({
-      path: toURL.pathname,
-      queryString: toURL.search,
-    });
+    const internalNavRes = await internalNavigate(toURL);
+    setRouteParts({ path: toURL.pathname, queryString: toURL.search });
+    return internalNavRes;
   };
 
   return (

--- a/packages/clerk-js/src/ui/router/RouteContext.tsx
+++ b/packages/clerk-js/src/ui/router/RouteContext.tsx
@@ -6,7 +6,7 @@ export interface RouteContextValue {
   indexPath: string;
   currentPath: string;
   matches: (path?: string, index?: boolean) => boolean;
-  baseNavigate: (toURL: URL) => Promise<void>;
+  baseNavigate: (toURL: URL) => Promise<unknown>;
   navigate: (to: string) => Promise<void>;
   resolve: (to: string) => URL;
   refresh: () => void;

--- a/packages/clerk-js/src/utils/beforeUnloadTracker.ts
+++ b/packages/clerk-js/src/utils/beforeUnloadTracker.ts
@@ -1,0 +1,32 @@
+import { CLERK_BEFORE_UNLOAD_EVENT } from 'utils/windowNavigate';
+
+/**
+ * Tracks beforeUnload events.
+ *
+ * Ideally we should not be always listening for the beforeUnload event
+ * as it effectively disables the browser's BF cache.
+
+ * To avoid this limitation, use the startTracking/ stopTracking methods
+ * to listen for the event just before potential navigation is about to happen
+ *
+ * @internal
+ */
+export const createBeforeUnloadTracker = () => {
+  let _isUnloading = false;
+
+  const toggle = () => (_isUnloading = true);
+
+  const startTracking = () => {
+    window.addEventListener('beforeunload', toggle);
+    window.addEventListener(CLERK_BEFORE_UNLOAD_EVENT, toggle);
+  };
+
+  const stopTracking = () => {
+    window.removeEventListener('beforeunload', toggle);
+    window.removeEventListener(CLERK_BEFORE_UNLOAD_EVENT, toggle);
+  };
+
+  const isUnloading = () => _isUnloading;
+
+  return { startTracking, stopTracking, isUnloading };
+};

--- a/packages/clerk-js/src/utils/index.ts
+++ b/packages/clerk-js/src/utils/index.ts
@@ -19,3 +19,5 @@ export * from './script';
 export * from './url';
 export * from './web3';
 export * from './windowNavigate';
+export * from './pageLifecycle';
+export * from './beforeUnloadTracker';

--- a/packages/clerk-js/src/utils/pageLifecycle.ts
+++ b/packages/clerk-js/src/utils/pageLifecycle.ts
@@ -1,0 +1,37 @@
+import { inClientSide } from '@clerk/shared/utils/ssr';
+
+const noop = () => {
+  //
+};
+
+/**
+ * Abstracts native browser event listener registration.
+ * Instead, this helper exposes hooks (eg. onPageVisible) that handle
+ * specific use cases.
+ *
+ * This is an effort to decouple event handling from the Clerk singleton,
+ * any future events should be handled here.
+ *
+ * @internal
+ */
+export const createPageLifecycle = () => {
+  if (!inClientSide()) {
+    return { isUnloading: noop, onPageVisible: noop };
+  }
+
+  const callbackQueue: Record<string, Array<() => void>> = {
+    'visibilitychange:visible': [],
+  };
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      callbackQueue['visibilitychange:visible'].forEach(cb => cb());
+    }
+  });
+
+  const onPageVisible = (cb: () => void) => {
+    callbackQueue['visibilitychange:visible'].push(cb);
+  };
+
+  return { onPageVisible };
+};

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -1,9 +1,9 @@
 import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
 import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
-import { useNavigate } from '@remix-run/react';
 import React from 'react';
 
 import { assertFrontendApi, assertValidClerkState, warnForSsr } from '../utils';
+import { useAwaitableNavigate } from './useAwaitableNavigate';
 
 export * from '@clerk/clerk-react';
 
@@ -13,8 +13,8 @@ export type RemixClerkProviderProps<ClerkStateT extends { __type: 'clerkState' }
 } & IsomorphicClerkOptions;
 
 export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): JSX.Element {
+  const awaitableNavigate = useAwaitableNavigate();
   const { clerkJSUrl, clerkState, ...restProps } = rest;
-  const navigate = useNavigate();
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 
   assertValidClerkState(clerkState);
@@ -31,7 +31,7 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
     <ReactClerkProvider
       frontendApi={__frontendApi}
       clerkJSUrl={clerkJSUrl}
-      navigate={to => navigate(to)}
+      navigate={awaitableNavigate}
       initialState={__clerk_ssr_state}
       {...restProps}
     >

--- a/packages/remix/src/client/useAwaitableNavigate.tsx
+++ b/packages/remix/src/client/useAwaitableNavigate.tsx
@@ -1,0 +1,29 @@
+import { useNavigate, useTransition } from '@remix-run/react';
+import React from 'react';
+
+type Resolve = (value?: unknown) => void;
+
+export const useAwaitableNavigate = () => {
+  const navigate = useNavigate();
+  const transition = useTransition();
+  const resolveFunctionsRef = React.useRef<Resolve[]>([]);
+
+  const resolveAll = () => {
+    if (transition.state !== 'idle') {
+      return;
+    }
+    resolveFunctionsRef.current.forEach(resolve => resolve());
+    resolveFunctionsRef.current.splice(0, resolveFunctionsRef.current.length);
+  };
+
+  React.useEffect(() => {
+    resolveAll();
+  }, [transition.state]);
+
+  return (to: string) => {
+    return new Promise(res => {
+      resolveFunctionsRef.current.push(res);
+      navigate(to);
+    });
+  };
+};

--- a/packages/shared/utils/index.ts
+++ b/packages/shared/utils/index.ts
@@ -5,3 +5,4 @@ export * from './noop';
 export * from './object';
 export * from './string';
 export * from './url';
+export * from './ssr';

--- a/packages/shared/utils/ssr.ts
+++ b/packages/shared/utils/ssr.ts
@@ -1,0 +1,3 @@
+export const inClientSide = (): boolean => {
+  return typeof window !== 'undefined';
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The default `navigate` function provided by Remix works in 5 phases:
1. calls the route loader
2. replaces the current url
3. waits for the loader to return route data
4. unmounts the old tree
5. finally, it mounts the new page

In our case, SignIn remained mounted up until step 5. Because we couldn't reliably await the navigation, withRedirectToHome in some cases would trigger before the new page is mounted causing a redirect to the home page instead of respecting the redirectUrl prop.

We used the useTransition remix hook to create a custom awaitable navigate function for use with Remix applications. The hook stores all pending navigations and resolves them when the state changes to idle (loading -> idle). 

I'm also considering adding a small delay for extra safety - keep in mind that this delay will only applied to navigations triggered by clerk (after sign in, after sign out etc) so it shouldn't be noticeable at all. 

This PR also includes a beforeUnload fix - we now use listen for the native `beforeUnload` event as well as the custom `clerk:beforeUnload` event (which exists to cover inconsistencies between browsers and only fires when windowNavigate is called). Ideally we don't want to listen for the native `beforeUnload` event always as this disabled the BF cache - to prevent this, we created a `beforeUnloadTracker` which starts tracking just before a potential navigation is going to happen and stops tracking right after. 

PS: We use `beforeUnload` in one more [place](https://github.com/clerkinc/javascript/blob/8b00a66c18924a2a99afdb3539bd6663d68eb673/packages/clerk-js/src/utils/safeLock.ts#L6) but my tests show that this does not affect BF at all, however I need to investigate further to make sure.


Additional context:
- https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-beforeunload-event
- https://developers.google.com/web/updates/2018/07/page-lifecycle-api#managing-cross-browsers-differences
- https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes

<!-- Fixes # (issue number) -->
