### PR TITLE
Introduce getToken for SSR

### DIFF
--- a/packages/backend-core/src/api/collection/SessionApi.ts
+++ b/packages/backend-core/src/api/collection/SessionApi.ts
@@ -1,4 +1,5 @@
 import { Session } from '../resources/Session';
+import { Token } from '../resources/Token';
 import { AbstractApi } from './AbstractApi';
 
 type QueryParams = {
@@ -38,5 +39,16 @@ export class SessionApi extends AbstractApi {
       path: `/sessions/${sessionId}/verify`,
       bodyParams: { token },
     });
+  }
+
+  public async getToken(sessionId: string, template: string) {
+    this.requireId(sessionId);
+    console.log('sessions api', sessionId, template, `/sessions/${sessionId}/tokens/${template}`);
+    return (
+      (await this._restClient.makeRequest<Token>({
+        method: 'POST',
+        path: `/sessions/${sessionId}/tokens/${template}`,
+      })) as any
+    ).jwt;
   }
 }

--- a/packages/backend-core/src/api/collection/SessionApi.ts
+++ b/packages/backend-core/src/api/collection/SessionApi.ts
@@ -43,11 +43,10 @@ export class SessionApi extends AbstractApi {
 
   public async getToken(sessionId: string, template: string) {
     this.requireId(sessionId);
-    console.log('sessions api', sessionId, template, `/sessions/${sessionId}/tokens/${template}`);
     return (
       (await this._restClient.makeRequest<Token>({
         method: 'POST',
-        path: `/sessions/${sessionId}/tokens/${template}`,
+        path: `/sessions/${sessionId}/tokens/${template || ''}`,
       })) as any
     ).jwt;
   }

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -24,11 +24,17 @@ export enum ObjectType {
   SmsMessage = 'sms_message',
   User = 'user',
   Web3Wallet = 'web3_wallet',
+  Token = 'token',
 }
 
 export interface ClerkResourceJSON {
   object: ObjectType;
   id: string;
+}
+
+export interface TokenJSON {
+  object: ObjectType.Token;
+  jwt: string;
 }
 
 export interface AllowlistIdentifierJSON extends ClerkResourceJSON {
@@ -107,10 +113,7 @@ export interface ExtAccountJSON extends ClerkResourceJSON {
   label?: string;
 }
 
-export type ExternalAccountJSON =
-  | FacebookAccountJSON
-  | GoogleAccountJSON
-  | ExtAccountJSON;
+export type ExternalAccountJSON = FacebookAccountJSON | GoogleAccountJSON | ExtAccountJSON;
 
 export interface IdentificationLinkJSON extends ClerkResourceJSON {
   type: string;

--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -12,6 +12,11 @@ export interface ClerkProps {
   id: Nullable<string>;
 }
 
+export interface TokenProps extends ClerkProps {
+  id: null;
+  jwt: string;
+}
+
 export interface AllowlistIdentifierProps extends ClerkProps {
   identifier: string;
   createdAt: number;

--- a/packages/backend-core/src/api/resources/Token.ts
+++ b/packages/backend-core/src/api/resources/Token.ts
@@ -1,0 +1,23 @@
+import camelcaseKeys from 'camelcase-keys';
+
+import filterKeys from '../utils/Filter';
+import type { TokenProps } from './Props';
+import { TokenJSON } from './JSON';
+
+interface TokenPayload extends TokenProps {}
+
+export class Token {
+  static attributes = ['jwt'];
+
+  static defaults = [];
+
+  constructor(data: Partial<TokenProps> = {}) {
+    Object.assign(this, Token.defaults, data);
+  }
+
+  static fromJSON(data: TokenJSON): Token {
+    const camelcased = camelcaseKeys(data);
+    const filtered = filterKeys(camelcased, Token.attributes);
+    return new Token(filtered as TokenPayload);
+  }
+}

--- a/packages/backend-core/src/api/resources/index.ts
+++ b/packages/backend-core/src/api/resources/index.ts
@@ -14,3 +14,4 @@ export * from './Session';
 export * from './SMSMessage';
 export * from './User';
 export * from './Verification';
+export * from './Token';

--- a/packages/backend-core/src/api/utils/Deserializer.ts
+++ b/packages/backend-core/src/api/utils/Deserializer.ts
@@ -6,6 +6,7 @@ import {
   Organization,
   Session,
   SMSMessage,
+  Token,
   User,
 } from '../resources';
 import { ObjectType } from '../resources/JSON';
@@ -40,6 +41,8 @@ function jsonToObject(item: any): any {
       return Session.fromJSON(item);
     case ObjectType.SmsMessage:
       return SMSMessage.fromJSON(item);
+    case ObjectType.Token:
+      return Token.fromJSON(item);
     default:
       Logger.error(`Unexpected object type: ${item.object}`);
   }

--- a/packages/types/src/ssr.ts
+++ b/packages/types/src/ssr.ts
@@ -1,12 +1,14 @@
 import { SessionJSON, UserJSON } from './json';
 import { SessionResource } from './session';
-import { GetSessionTokenOptions } from './token';
 import { UserResource } from './user';
+
+export type GetTokenOptions = { template?: string };
+export type GetToken = (options?: GetTokenOptions) => Promise<string | null>;
 
 export type ServerSideAuth = {
   sessionId: string | null;
   userId: string | null;
-  getToken: (options?: GetSessionTokenOptions) => Promise<string | null>;
+  getToken: GetToken;
 };
 
 type SsrSessionState<SessionType> =


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Makes getToken({ tempalte: ''}) available during SSR.

Server caching and client keep alive will be handled in a separate PR.
<!-- Fixes # (issue number) -->
