### PR TITLE
feat(edge): Align edge version of withAuth props and return values.

### DIFF
--- a/packages/edge/src/vercel-edge/ClerkAPI.ts
+++ b/packages/edge/src/vercel-edge/ClerkAPI.ts
@@ -1,0 +1,22 @@
+import { ClerkBackendAPI } from '@clerk/backend-core';
+
+import { PACKAGE_REPO } from '../constants';
+import { LIB_NAME, LIB_VERSION } from '../info';
+
+export const ClerkAPI = new ClerkBackendAPI({
+  libName: LIB_NAME,
+  libVersion: LIB_VERSION,
+  packageRepo: PACKAGE_REPO,
+  fetcher: (url, { method, authorization, contentType, userAgent, body }) => {
+    return fetch(url, {
+      method,
+      headers: {
+        authorization: authorization,
+        'Content-Type': contentType,
+        'User-Agent': userAgent,
+        'X-Clerk-SDK': `vercel-edge/${LIB_VERSION}`,
+      },
+      ...(body && { body: JSON.stringify(body) }),
+    }).then(body => (contentType === 'text/html' ? body : body.json()));
+  },
+});

--- a/packages/edge/src/vercel-edge/types.ts
+++ b/packages/edge/src/vercel-edge/types.ts
@@ -1,0 +1,53 @@
+import type { Session, User } from '@clerk/backend-core';
+import type { GetSessionTokenOptions } from '@clerk/types';
+import type { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
+
+export type WithAuthOptions = {
+  loadUser?: boolean;
+  loadSession?: boolean;
+  authorizedParties?: string[];
+};
+
+export type WithAuthMiddlewareCallback<Return, Options> = (
+  req: RequestWithAuth<Options>,
+  event: NextFetchEvent,
+) => Return;
+
+export type WithAuthMiddlewareResult<CallbackReturn, Options> = (
+  req: RequestWithAuth<Options>,
+  event: NextFetchEvent,
+) => Promise<Awaited<CallbackReturn>>;
+export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+
+export type RequestWithAuth<Options extends WithAuthOptions = any> =
+  NextRequest & {
+    auth: MiddlewareAuth;
+  } & (Options extends { loadSession: true }
+      ? { session: Session | null }
+      : {}) &
+    (Options extends { loadUser: true } ? { user: User | null } : {});
+
+export type NextMiddlewareResult = NextResponse | Response | null | undefined;
+
+export type WithAuthNextMiddlewareHandler<Options> = (
+  req: RequestWithAuth<Options>,
+  event: NextFetchEvent,
+) => NextMiddlewareResult | Promise<NextMiddlewareResult>;
+
+export type MiddlewareAuth = {
+  sessionId: string | null;
+  userId: string | null;
+  getToken: (
+    options?: GetSessionTokenOptions,
+  ) => Promise<string | null> | string | null;
+};
+
+export type AuthData = {
+  sessionId: string | null;
+  session: Session | undefined | null;
+  userId: string | null;
+  user: User | undefined | null;
+  getToken: (
+    options?: GetSessionTokenOptions,
+  ) => Promise<string | null> | string | null;
+};

--- a/packages/edge/src/vercel-edge/utils/getAuthData.ts
+++ b/packages/edge/src/vercel-edge/utils/getAuthData.ts
@@ -1,0 +1,37 @@
+import { JWTPayload } from '@clerk/backend-core';
+import { GetSessionTokenOptions } from '@clerk/types';
+import { NextRequest } from 'next/server';
+
+import { ClerkAPI } from '../ClerkAPI';
+import { AuthData, WithAuthOptions } from '../types';
+
+export async function getAuthData(
+  req: NextRequest,
+  { sid, sub, loadSession, loadUser }: WithAuthOptions & JWTPayload,
+): Promise<AuthData> {
+  const getToken = (options: GetSessionTokenOptions = {}) => {
+    if (options.template) {
+      throw new Error(
+        'Retrieving a JWT template during edge runtime will be supported soon.',
+      );
+    }
+    return req.cookies['__session'] || null;
+  };
+
+  const [user, session] = await Promise.all([
+    loadUser
+      ? ClerkAPI.users.getUser(sub as string)
+      : Promise.resolve(undefined),
+    loadSession
+      ? ClerkAPI.sessions.getSession(sid as string)
+      : Promise.resolve(undefined),
+  ]);
+
+  return {
+    sessionId: sid as string,
+    userId: sub as string,
+    getToken,
+    user,
+    session,
+  };
+}

--- a/packages/edge/src/vercel-edge/utils/index.ts
+++ b/packages/edge/src/vercel-edge/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './getAuthData';
+export * from './injectAuthIntoRequest';

--- a/packages/edge/src/vercel-edge/utils/injectAuthIntoRequest.ts
+++ b/packages/edge/src/vercel-edge/utils/injectAuthIntoRequest.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server';
+
+import { AuthData, RequestWithAuth } from '../types';
+
+export function injectAuthIntoRequest(
+  req: NextRequest,
+  authData: AuthData,
+): RequestWithAuth {
+  const { user, session, userId, sessionId } = authData;
+  const auth = {
+    userId,
+    sessionId,
+    getToken: authData.getToken,
+  };
+
+  /* Object.assign is used here as NextRequest properties also include Symbols */
+  return Object.assign(req, { auth, user, session });
+}

--- a/packages/edge/vercel-edge/package.json
+++ b/packages/edge/vercel-edge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vercel-edge",
     "description": "Clerk for Vercel Edge",
-    "main": "../dist/cjs/vercel-edge.js",
-    "module": "../dist/mjs/vercel-edge.js"
+    "main": "../dist/cjs/vercel-edge/index.js",
+    "module": "../dist/mjs/vercel-edge/index.js"
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Align the return values and props of the `withAuth` helper in `@clerk/edge`:
- `withAuth(handler, { ...opts, loadUser, loadSession })`

Post @3 release we will look into some consolidation of the SSR state calculations between edge, next, remix and node.