### PR TITLE
Make casing consistent across clerk-js APIs

### DIFF
--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -1,4 +1,5 @@
 import type { Clerk, ClerkAPIErrorJSON, ClientJSON } from '@clerk/types';
+import { camelToSnake } from '@clerk/shared/utils';
 import qs from 'qs';
 import {
   buildEmailAddress as buildEmailAddressUtil,
@@ -44,6 +45,15 @@ export type FapiRequestCallback<T> = (
   request: FapiRequestInit,
   response?: FapiResponse<T>,
 ) => void;
+
+const camelToSnakeEncoder: qs.IStringifyOptions['encoder'] = (
+  str,
+  defaultEncoder,
+  _,
+  type,
+) => {
+  return type === 'key' ? camelToSnake(str) : defaultEncoder(str);
+};
 
 // TODO: Move to @clerk/types
 export interface FapiResponseJSON<T> {
@@ -165,7 +175,7 @@ export default function createFapiClient(clerkInstance: Clerk): FapiClient {
     // In case FormData is provided, we don't want to mess with the headers,
     // because for file uploads the header is properly set by the browser.
     if (method !== 'GET' && !(body instanceof FormData)) {
-      requestInit.body = qs.stringify(body);
+      requestInit.body = qs.stringify(body, { encoder: camelToSnakeEncoder });
       // @ts-ignore
       requestInit.headers.set(
         'Content-Type',

--- a/packages/clerk-js/src/core/resources/EmailAddress.ts
+++ b/packages/clerk-js/src/core/resources/EmailAddress.ts
@@ -65,7 +65,7 @@ export class EmailAddress extends BaseResource implements EmailAddressResource {
       }
       await this.prepareVerification({
         strategy: 'email_link',
-        redirect_url: redirectUrl,
+        redirectUrl: redirectUrl,
       });
       return new Promise((resolve, reject) => {
         void run(() => {

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -9,6 +9,7 @@ import { unixEpochToDate } from 'utils/date';
 
 import { SessionTokenCache } from '../tokenCache';
 import { BaseResource, Token, User } from './internal';
+import { deepSnakeToCamel } from '@clerk/shared/utils';
 
 export class Session extends BaseResource implements SessionResource {
   pathRoot = '/client/sessions';
@@ -119,12 +120,9 @@ export class Session extends BaseResource implements SessionResource {
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     this.user = new User(data.user);
-    this.publicUserData = {
-      firstName: data.public_user_data.first_name,
-      lastName: data.public_user_data.last_name,
-      profileImageUrl: data.public_user_data.profile_image_url,
-      identifier: data.public_user_data.identifier,
-    };
+    this.publicUserData = deepSnakeToCamel(
+      data.public_user_data,
+    ) as PublicUserData;
     this.lastActiveToken = data.last_active_token
       ? new Token(data.last_active_token)
       : null;

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -1,4 +1,4 @@
-import { deepCamelToSnake } from '@clerk/shared/utils/object';
+import { deepCamelToSnake, deepSnakeToCamel } from '@clerk/shared/utils/object';
 import { Poller } from '@clerk/shared/utils/poller';
 import type {
   AttemptFirstFactorParams,
@@ -70,18 +70,18 @@ export class SignIn extends BaseResource implements SignInResource {
       case 'email_link':
         params = {
           ...params,
-          email_address_id: factor.email_address_id,
-          redirect_url: factor.redirect_url,
+          email_address_id: factor.emailAddressId,
+          redirect_url: factor.redirectUrl,
         };
         break;
       case 'email_code':
-        params = { ...params, email_address_id: factor.email_address_id };
+        params = { ...params, email_address_id: factor.emailAddressId };
         break;
       case 'phone_code':
-        params = { ...params, phone_number_id: factor.phone_number_id };
+        params = { ...params, phone_number_id: factor.phoneNumberId };
         break;
       case STRATEGY_WEB3_METAMASK_SIGNATURE:
-        params = { ...params, web3_wallet_id: factor.web3_wallet_id };
+        params = { ...params, web3_wallet_id: factor.web3WalletId };
         break;
       default:
         clerkInvalidStrategy('SignIn.prepareFirstFactor', factor.strategy);
@@ -113,8 +113,8 @@ export class SignIn extends BaseResource implements SignInResource {
       }
       await this.prepareFirstFactor({
         strategy: 'email_link',
-        email_address_id: emailAddressId,
-        redirect_url: redirectUrl,
+        emailAddressId: emailAddressId,
+        redirectUrl: redirectUrl,
       });
       return new Promise((resolve, reject) => {
         void run(() => {
@@ -160,8 +160,8 @@ export class SignIn extends BaseResource implements SignInResource {
   }: AuthenticateWithRedirectParams): Promise<void> => {
     const { firstFactorVerification } = await this.create({
       strategy,
-      redirect_url: redirectUrl,
-      action_complete_redirect_url: redirectUrlComplete,
+      redirectUrl: redirectUrl,
+      actionCompleteRedirectUrl: redirectUrlComplete,
     });
     const { status, externalVerificationRedirectURL } = firstFactorVerification;
 
@@ -211,7 +211,6 @@ export class SignIn extends BaseResource implements SignInResource {
 
   public authenticateWithMetamask = async (): Promise<SignInResource> => {
     const identifier = await getMetamaskIdentifier();
-
     return this.authenticateWithWeb3({
       identifier,
       generateSignature: generateSignatureWithMetamask,
@@ -224,12 +223,12 @@ export class SignIn extends BaseResource implements SignInResource {
       this.status = data.status;
       this.supportedIdentifiers = data.supported_identifiers;
       this.identifier = data.identifier;
-      this.supportedFirstFactors = data.supported_first_factors;
-      this.supportedSecondFactors = data.supported_second_factors;
+      this.supportedFirstFactors = deepSnakeToCamel(data.supported_first_factors) as SignInFirstFactor[];
+      this.supportedSecondFactors = deepSnakeToCamel(data.supported_second_factors) as SignInSecondFactor[];
       this.firstFactorVerification = new Verification(data.first_factor_verification);
       this.secondFactorVerification = new Verification(data.second_factor_verification);
       this.createdSessionId = data.created_session_id;
-      this.userData = data.user_data;
+      this.userData = deepSnakeToCamel(data.user_data) as UserData;
     }
     return this;
   }

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -1,4 +1,3 @@
-import { deepCamelToSnake } from '@clerk/shared/utils/object';
 import { Poller } from '@clerk/shared/utils/poller';
 import type {
   AttemptEmailAddressVerificationParams,
@@ -66,7 +65,7 @@ export class SignUp extends BaseResource implements SignUpResource {
   create = (params: SignUpCreateParams): Promise<SignUpResource> => {
     return this._basePost({
       path: this.pathRoot,
-      body: normalizeUnsafeMetadata(deepCamelToSnake(params)),
+      body: normalizeUnsafeMetadata(params),
     });
   };
 
@@ -101,7 +100,7 @@ export class SignUp extends BaseResource implements SignUpResource {
       }
       await this.prepareEmailAddressVerification({
         strategy: 'email_link',
-        redirect_url: redirectUrl,
+        redirectUrl,
       });
 
       return new Promise((resolve, reject) => {
@@ -169,8 +168,8 @@ export class SignUp extends BaseResource implements SignUpResource {
     const { redirectUrl, redirectUrlComplete, strategy } = params || {};
     const { verifications } = await this.create({
       strategy,
-      redirect_url: redirectUrl,
-      action_complete_redirect_url: redirectUrlComplete,
+      redirectUrl,
+      actionCompleteRedirectUrl: redirectUrlComplete,
     });
     const { externalAccount } = verifications;
     const { status, externalVerificationRedirectURL } = externalAccount;
@@ -187,7 +186,7 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   update = (params: SignUpUpdateParams): Promise<SignUpResource> => {
     return this._basePatch({
-      body: normalizeUnsafeMetadata(deepCamelToSnake(params)),
+      body: normalizeUnsafeMetadata(params),
     });
   };
 

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -1,9 +1,11 @@
-import { deepCamelToSnake } from '@clerk/shared/utils/object';
 import type {
+  CreateEmailAddressParams,
+  CreatePhoneNumberParams,
   EmailAddressResource,
   ExternalAccountResource,
   ImageResource,
   PhoneNumberResource,
+  SetProfileImageParams,
   UpdateUserParams,
   UserJSON,
   UserResource,
@@ -91,7 +93,10 @@ export class User extends BaseResource implements UserResource {
     return enabled;
   };
 
-  createEmailAddress = (email: string): Promise<EmailAddressResource> => {
+  createEmailAddress = (
+    params: CreateEmailAddressParams,
+  ): Promise<EmailAddressResource> => {
+    const { email } = params || {};
     return new EmailAddress(
       {
         email_address: email,
@@ -100,7 +105,10 @@ export class User extends BaseResource implements UserResource {
     ).create();
   };
 
-  createPhoneNumber = (phoneNumber: string): Promise<PhoneNumberResource> => {
+  createPhoneNumber = (
+    params: CreatePhoneNumberParams,
+  ): Promise<PhoneNumberResource> => {
+    const { phoneNumber } = params || {};
     return new PhoneNumber(
       {
         phone_number: phoneNumber,
@@ -111,7 +119,7 @@ export class User extends BaseResource implements UserResource {
 
   update = (params: UpdateUserParams): Promise<UserResource> => {
     return this._basePatch({
-      body: normalizeUnsafeMetadata(deepCamelToSnake(params)),
+      body: normalizeUnsafeMetadata(params),
     });
   };
 
@@ -124,7 +132,8 @@ export class User extends BaseResource implements UserResource {
     return res;
   };
 
-  setProfileImage = (file: Blob | File): Promise<ImageResource> => {
+  setProfileImage = (params: SetProfileImageParams): Promise<ImageResource> => {
+    const { file } = params || {};
     return Image.create(`${this.path()}/profile_image`, {
       file,
     });

--- a/packages/clerk-js/src/ui/signIn/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorOne.test.tsx
@@ -142,8 +142,8 @@ describe('<SignInFactorOne/>', () => {
         supportedFirstFactors: [
           {
             strategy: 'password',
-            safe_identifier: 'jdoe@example.com',
-            email_address_id: 'deadbeef',
+            safeIdentifier: 'jdoe@example.com',
+            emailAddressId: 'deadbeef',
           } as SignInFactor,
         ],
         attemptFirstFactor: mockAttemptFirstFactor.mockReturnValue({
@@ -201,8 +201,8 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'email_code',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
             ],
             attemptFirstFactor: mockAttemptFirstFactor.mockReturnValue({
@@ -228,8 +228,8 @@ describe('<SignInFactorOne/>', () => {
       expect(mockPrepareFirstFactor).toHaveBeenCalledTimes(1);
       expect(mockPrepareFirstFactor).toHaveBeenCalledWith({
         strategy: 'email_code',
-        safe_identifier: 'jdoe@example.com',
-        email_address_id: 'deadbeef',
+        safeIdentifier: 'jdoe@example.com',
+        emailAddressId: 'deadbeef',
       } as SignInFactor);
 
       const text = '123456';
@@ -288,8 +288,8 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'email_link',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
             ],
             firstFactorVerification: {
@@ -351,8 +351,8 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'email_link',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
             ],
             firstFactorVerification: {
@@ -397,13 +397,13 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'email_link',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
               {
                 strategy: 'email_code',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
             ],
             firstFactorVerification: {
@@ -448,8 +448,8 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'phone_code',
-                safe_identifier: '+1********9',
-                phone_number_id: 'deadbeef',
+                safeIdentifier: '+1********9',
+                phoneNumberId: 'deadbeef',
               } as SignInFactor,
             ],
             attemptFirstFactor: mockAttemptFirstFactor.mockReturnValue({
@@ -475,8 +475,8 @@ describe('<SignInFactorOne/>', () => {
       expect(mockPrepareFirstFactor).toHaveBeenCalledTimes(1);
       expect(mockPrepareFirstFactor).toHaveBeenCalledWith({
         strategy: 'phone_code',
-        safe_identifier: '+1********9',
-        phone_number_id: 'deadbeef',
+        safeIdentifier: '+1********9',
+        phoneNumberId: 'deadbeef',
       } as SignInFactor);
 
       const text = '123456';
@@ -525,13 +525,13 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'email_code',
-                safe_identifier: 'ccoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'ccoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
               {
                 strategy: 'email_code',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'cafebabe',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'cafebabe',
               } as SignInFactor,
             ],
             attemptFirstFactor: mockAttemptFirstFactor.mockReturnValue({
@@ -562,13 +562,13 @@ describe('<SignInFactorOne/>', () => {
       await waitFor(() => {
         expect(mockPrepareFirstFactor).toHaveBeenNthCalledWith(1, {
           strategy: 'email_code',
-          safe_identifier: 'ccoe@example.com',
-          email_address_id: 'deadbeef',
+          safeIdentifier: 'ccoe@example.com',
+          emailAddressId: 'deadbeef',
         } as SignInFactor);
         expect(mockPrepareFirstFactor).toHaveBeenNthCalledWith(2, {
           strategy: 'email_code',
-          safe_identifier: 'jdoe@example.com',
-          email_address_id: 'cafebabe',
+          safeIdentifier: 'jdoe@example.com',
+          emailAddressId: 'cafebabe',
         } as SignInFactor);
       });
     });
@@ -593,8 +593,8 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'email_code',
-                safe_identifier: 'ccoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'ccoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
             ],
             attemptFirstFactor: mockAttemptFirstFactor.mockReturnValue({
@@ -635,13 +635,13 @@ describe('<SignInFactorOne/>', () => {
             supportedFirstFactors: [
               {
                 strategy: 'email_link',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
               {
                 strategy: 'email_code',
-                safe_identifier: 'jdoe@example.com',
-                email_address_id: 'deadbeef',
+                safeIdentifier: 'jdoe@example.com',
+                emailAddressId: 'deadbeef',
               } as SignInFactor,
             ],
             firstFactorVerification: {

--- a/packages/clerk-js/src/ui/signIn/SignInFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorTwo.test.tsx
@@ -1,5 +1,4 @@
 import {
-  act,
   render,
   renderJSON,
   screen,
@@ -49,7 +48,7 @@ jest.mock('ui/contexts', () => {
       supportedSecondFactors: [
         {
           strategy: 'phone_code',
-          safe_identifier: '+1********9',
+          safeIdentifier: '+1********9',
         },
       ],
       secondFactorVerification: {

--- a/packages/clerk-js/src/ui/signIn/SignInFactorTwo.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorTwo.tsx
@@ -65,13 +65,13 @@ function _SignInFactorTwo(): JSX.Element {
 
     const defaultIdentifier = secondFactors.find(factor => factor.default);
     const phoneNumberId = defaultIdentifier
-      ? defaultIdentifier.phone_number_id
-      : secondFactors[0]?.phone_number_id;
+      ? defaultIdentifier.phoneNumberId
+      : secondFactors[0]?.phoneNumberId;
 
     signIn
       .prepareSecondFactor({
         strategy: 'phone_code',
-        phone_number_id: phoneNumberId,
+        phoneNumberId,
       })
       .catch(err => handleError(err, [code], setError));
   };
@@ -104,8 +104,8 @@ function _SignInFactorTwo(): JSX.Element {
 
   const defaultIdentifier = secondFactors.find(factor => factor.default);
   const cachedSafeIdentifier = defaultIdentifier
-    ? defaultIdentifier.safe_identifier
-    : secondFactors[0]?.safe_identifier;
+    ? defaultIdentifier.safeIdentifier
+    : secondFactors[0]?.safeIdentifier;
 
   return (
     <>

--- a/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneInputBased.tsx
+++ b/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneInputBased.tsx
@@ -43,17 +43,17 @@ function factorsAreSame(
   }
 
   if (
-    'email_address_id' in prev &&
-    'email_address_id' in cur &&
-    prev.email_address_id !== cur.email_address_id
+    'emailAddressId' in prev &&
+    'emailAddressId' in cur &&
+    prev.emailAddressId !== cur.emailAddressId
   ) {
     return false;
   }
 
   if (
-    'phone_number_id' in prev &&
-    'phone_number_id' in cur &&
-    prev.phone_number_id !== cur.phone_number_id
+    'phoneNumberId' in prev &&
+    'phoneNumberId' in cur &&
+    prev.phoneNumberId !== cur.phoneNumberId
   ) {
     return false;
   }

--- a/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneMagicLink.tsx
+++ b/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneMagicLink.tsx
@@ -28,7 +28,7 @@ export function SignInFactorOneMagicLink({
 }: SignInFactorOneMagicLinkProps): JSX.Element {
   const signIn = useCoreSignIn();
   const identifierRef = React.useRef(
-    ('safe_identifier' in currentFactor && currentFactor.safe_identifier) || '',
+    ('safeIdentifier' in currentFactor && currentFactor.safeIdentifier) || '',
   );
   const { setSession } = useCoreClerk();
   const { navigate } = useNavigate();

--- a/packages/clerk-js/src/ui/signIn/strategies/All.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/strategies/All.test.tsx
@@ -50,18 +50,18 @@ describe('<All/>', () => {
     },
     {
       strategy: 'email_code',
-      safe_identifier: 'j***@e*****.com',
-      email_address_id: '123',
+      safeIdentifier: 'j***@e*****.com',
+      emailAddressId: '123',
     },
     {
       strategy: 'phone_code',
-      safe_identifier: '+1*********9',
-      phone_number_id: '456',
+      safeIdentifier: '+1*********9',
+      phoneNumberId: '456',
     },
     {
       strategy: 'email_link',
-      safe_identifier: '+1*********9',
-      email_address_id: '456',
+      safeIdentifier: '+1*********9',
+      emailAddressId: '456',
     },
   ];
 

--- a/packages/clerk-js/src/ui/signIn/strategies/All.tsx
+++ b/packages/clerk-js/src/ui/signIn/strategies/All.tsx
@@ -10,11 +10,11 @@ import { OAuth } from './OAuth';
 export function getButtonLabel(factor: SignInFactor): string {
   switch (factor.strategy) {
     case 'email_link':
-      return `Send magic link to ${factor.safe_identifier}`;
+      return `Send magic link to ${factor.safeIdentifier}`;
     case 'email_code':
-      return `Email code to ${factor.safe_identifier}`;
+      return `Email code to ${factor.safeIdentifier}`;
     case 'phone_code':
-      return `Send code to ${factor.safe_identifier}`;
+      return `Send code to ${factor.safeIdentifier}`;
     case 'password':
       return 'Sign in with your password';
     default:

--- a/packages/clerk-js/src/ui/signIn/strategies/OTP.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/strategies/OTP.test.tsx
@@ -31,7 +31,7 @@ describe('<OTP/>', () => {
 
   const factor = {
     strategy: 'phone_code',
-    safe_identifier: 'jdoe@example.com',
+    safeIdentifier: 'jdoe@example.com',
   } as SignInFactor;
 
   it('renders the OTP form component', async () => {

--- a/packages/clerk-js/src/ui/signIn/strategies/OTP.tsx
+++ b/packages/clerk-js/src/ui/signIn/strategies/OTP.tsx
@@ -35,7 +35,7 @@ export function OTP({
       <Label className='cl-auth-form-message'>
         Enter the 6-digit code sent to
         <br />
-        <strong>{factor.safe_identifier}</strong>
+        <strong>{factor.safeIdentifier}</strong>
       </Label>
       <OneTimeCodeInput
         value={code.value}

--- a/packages/clerk-js/src/ui/signIn/strategies/factorSortingUtils.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/strategies/factorSortingUtils.test.tsx
@@ -11,10 +11,10 @@ describe('otpPrefFactorComparator(a,b)', function () {
     const factors: SignInFactor[] = [
       { strategy: 'password' },
       { strategy: 'password' },
-      { strategy: 'email_code', email_address_id: '', safe_identifier: '' },
-      { strategy: 'phone_code', phone_number_id: '', safe_identifier: '' },
-      { strategy: 'email_link', email_address_id: '', safe_identifier: '' },
-      { strategy: 'email_link', email_address_id: '', safe_identifier: '' },
+      { strategy: 'email_code', emailAddressId: '', safeIdentifier: '' },
+      { strategy: 'phone_code', phoneNumberId: '', safeIdentifier: '' },
+      { strategy: 'email_link', emailAddressId: '', safeIdentifier: '' },
+      { strategy: 'email_link', emailAddressId: '', safeIdentifier: '' },
     ];
 
     const expectedOrder: SignInStrategy[] = [
@@ -35,12 +35,12 @@ describe('otpPrefFactorComparator(a,b)', function () {
 describe('passwordPrefFactorComparator(a,b)', function () {
   it('sorts an array of factors based on the password pref sorter', function () {
     const factors: SignInFactor[] = [
-      { strategy: 'email_code', email_address_id: '', safe_identifier: '' },
+      { strategy: 'email_code', emailAddressId: '', safeIdentifier: '' },
       { strategy: 'password' },
-      { strategy: 'phone_code', phone_number_id: '', safe_identifier: '' },
-      { strategy: 'email_link', email_address_id: '', safe_identifier: '' },
+      { strategy: 'phone_code', phoneNumberId: '', safeIdentifier: '' },
+      { strategy: 'email_link', emailAddressId: '', safeIdentifier: '' },
       { strategy: 'password' },
-      { strategy: 'email_link', email_address_id: '', safe_identifier: '' },
+      { strategy: 'email_link', emailAddressId: '', safeIdentifier: '' },
     ];
 
     const expectedOrder: SignInStrategy[] = [
@@ -61,12 +61,12 @@ describe('passwordPrefFactorComparator(a,b)', function () {
 describe('allStrategiesButtonsComparator(a,b)', function () {
   it('sorts an array of factors based on the password pref sorter', function () {
     const factors: SignInFactor[] = [
-      { strategy: 'email_code', email_address_id: '', safe_identifier: '' },
+      { strategy: 'email_code', emailAddressId: '', safeIdentifier: '' },
       { strategy: 'password' },
-      { strategy: 'phone_code', phone_number_id: '', safe_identifier: '' },
-      { strategy: 'email_link', email_address_id: '', safe_identifier: '' },
+      { strategy: 'phone_code', phoneNumberId: '', safeIdentifier: '' },
+      { strategy: 'email_link', emailAddressId: '', safeIdentifier: '' },
       { strategy: 'password' },
-      { strategy: 'email_link', email_address_id: '', safe_identifier: '' },
+      { strategy: 'email_link', emailAddressId: '', safeIdentifier: '' },
     ];
 
     const expectedOrder: SignInStrategy[] = [

--- a/packages/clerk-js/src/ui/signIn/utils.test.ts
+++ b/packages/clerk-js/src/ui/signIn/utils.test.ts
@@ -29,11 +29,11 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         supportedFirstFactors: [
           {
             strategy: 'email_code',
-            safe_identifier: 'ccoe@example.com',
+            safeIdentifier: 'ccoe@example.com',
           },
           {
             strategy: 'phone_code',
-            safe_identifier: 'jdoe@example.com',
+            safeIdentifier: 'jdoe@example.com',
           },
         ],
       } as unknown as SignInResource;
@@ -45,7 +45,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         ),
       ).toEqual({
         strategy: 'phone_code',
-        safe_identifier: 'jdoe@example.com',
+        safeIdentifier: 'jdoe@example.com',
       });
     });
 
@@ -55,11 +55,11 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         supportedFirstFactors: [
           {
             strategy: 'phone_code',
-            safe_identifier: 'jdoe@example.com',
+            safeIdentifier: 'jdoe@example.com',
           },
           {
             strategy: 'email_code',
-            safe_identifier: 'ccoe@example.com',
+            safeIdentifier: 'ccoe@example.com',
           },
         ],
       } as unknown as SignInResource;
@@ -71,7 +71,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         ),
       ).toEqual({
         strategy: 'email_code',
-        safe_identifier: 'ccoe@example.com',
+        safeIdentifier: 'ccoe@example.com',
       });
     });
 
@@ -81,7 +81,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         supportedFirstFactors: [
           {
             strategy: 'phone_code',
-            safe_identifier: 'jdoe@example.com',
+            safeIdentifier: 'jdoe@example.com',
           },
         ],
       } as unknown as SignInResource;
@@ -93,7 +93,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         ),
       ).toEqual({
         strategy: 'phone_code',
-        safe_identifier: 'jdoe@example.com',
+        safeIdentifier: 'jdoe@example.com',
       });
     });
 
@@ -122,11 +122,11 @@ describe('determineStrategy(signIn, displayConfig)', () => {
           },
           {
             strategy: 'email_code',
-            safe_identifier: 'ccoe@example.com',
+            safeIdentifier: 'ccoe@example.com',
           },
           {
             strategy: 'phone_code',
-            safe_identifier: 'jdoe@example.com',
+            safeIdentifier: 'jdoe@example.com',
           },
         ],
       } as unknown as SignInResource;
@@ -138,7 +138,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         ),
       ).toEqual({
         strategy: 'phone_code',
-        safe_identifier: 'jdoe@example.com',
+        safeIdentifier: 'jdoe@example.com',
       });
     });
 
@@ -151,11 +151,11 @@ describe('determineStrategy(signIn, displayConfig)', () => {
           },
           {
             strategy: 'phone_code',
-            safe_identifier: 'jdoe@example.com',
+            safeIdentifier: 'jdoe@example.com',
           },
           {
             strategy: 'email_code',
-            safe_identifier: 'ccoe@example.com',
+            safeIdentifier: 'ccoe@example.com',
           },
         ],
       } as unknown as SignInResource;
@@ -167,7 +167,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         ),
       ).toEqual({
         strategy: 'email_code',
-        safe_identifier: 'ccoe@example.com',
+        safeIdentifier: 'ccoe@example.com',
       });
     });
 
@@ -180,7 +180,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
           },
           {
             strategy: 'phone_code',
-            safe_identifier: 'jdoe@example.com',
+            safeIdentifier: 'jdoe@example.com',
           },
         ],
       } as unknown as SignInResource;
@@ -192,7 +192,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
         ),
       ).toEqual({
         strategy: 'phone_code',
-        safe_identifier: 'jdoe@example.com',
+        safeIdentifier: 'jdoe@example.com',
       });
     });
 
@@ -230,13 +230,13 @@ describe('determineStrategy(signIn, displayConfig)', () => {
     });
   });
 
-  fdescribe('determineSaluation(signIn)', () => {
+  describe('determineSalutation(signIn)', () => {
     it('returns firstname, then lastname or the identifier', () => {
       let signIn = {
         identifier: 'jdoe@example.com',
         userData: {
-          first_name: 'Joe',
-          last_name: 'Doe',
+          firstName: 'Joe',
+          lastName: 'Doe',
         },
       } as unknown as SignInResource;
       expect(determineSalutation(signIn)).toBe('Joe');
@@ -244,7 +244,7 @@ describe('determineStrategy(signIn, displayConfig)', () => {
       signIn = {
         identifier: 'jdoe@example.com',
         userData: {
-          last_name: 'Doe',
+          lastName: 'Doe',
         },
       } as unknown as SignInResource;
       expect(determineSalutation(signIn)).toBe('Doe');

--- a/packages/clerk-js/src/ui/signIn/utils.ts
+++ b/packages/clerk-js/src/ui/signIn/utils.ts
@@ -63,7 +63,7 @@ export function fitTextInOneLine(
 }
 
 const factorForIdentifier = (i: string | null) => (f: SignInFactor) => {
-  return 'safe_identifier' in f && f.safe_identifier === i;
+  return 'safeIdentifier' in f && f.safeIdentifier === i;
 };
 
 function determineStrategyWhenPasswordIsPreferred(
@@ -119,8 +119,8 @@ export function determineSalutation(signIn: Partial<SignInResource>): string {
   }
 
   return (
-    titleize(signIn.userData?.first_name) ||
-    titleize(signIn.userData?.last_name) ||
+    titleize(signIn.userData?.firstName) ||
+    titleize(signIn.userData?.lastName) ||
     signIn?.identifier ||
     ''
   );

--- a/packages/clerk-js/src/ui/userProfile/account/avatarWithUploader/AvatarWithUploader.tsx
+++ b/packages/clerk-js/src/ui/userProfile/account/avatarWithUploader/AvatarWithUploader.tsx
@@ -11,7 +11,7 @@ type Empty = unknown;
 export const AvatarWithUploader = (props: AvatarProps): JSX.Element => {
   const user = useCoreUser();
   const saveImage = (file: File): Promise<Empty> => {
-    return user.setProfileImage(file).catch(error => {
+    return user.setProfileImage({ file }).catch(error => {
       alert(error);
     });
   };

--- a/packages/clerk-js/src/ui/userProfile/emailAdressess/AddNewEmail.tsx
+++ b/packages/clerk-js/src/ui/userProfile/emailAdressess/AddNewEmail.tsx
@@ -49,7 +49,7 @@ export function AddNewEmail(): JSX.Element {
   const createEmailAddress = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     return user
-      .createEmailAddress(emailValue.value)
+      .createEmailAddress({ email: emailValue.value })
       .then(res => {
         createdEmailRef.current = res;
         nextStep();

--- a/packages/clerk-js/src/ui/userProfile/phoneNumbers/AddNewPhone.tsx
+++ b/packages/clerk-js/src/ui/userProfile/phoneNumbers/AddNewPhone.tsx
@@ -35,7 +35,7 @@ export const AddNewPhone = (): JSX.Element => {
           </>
         ),
       }}
-      onAdd={(value: string) => user.createPhoneNumber(value)}
+      onAdd={(value: string) => user.createPhoneNumber({ phoneNumber: value })}
     />
   );
 };

--- a/packages/clerk-js/src/ui/userProfile/phoneNumbers/PhoneDetail.tsx
+++ b/packages/clerk-js/src/ui/userProfile/phoneNumbers/PhoneDetail.tsx
@@ -4,13 +4,20 @@ import { default as BinIcon } from '@clerk/shared/assets/icons/bin.svg';
 import { default as PhoneIcon } from '@clerk/shared/assets/icons/phone.svg';
 import { Button } from '@clerk/shared/components/button';
 import { List } from '@clerk/shared/components/list';
-import { OneTimeCodeInput, VerifyCodeHandler } from '@clerk/shared/components/oneTimeCodeInput';
+import {
+  OneTimeCodeInput,
+  VerifyCodeHandler,
+} from '@clerk/shared/components/oneTimeCodeInput';
 import { PhoneViewer } from '@clerk/shared/components/phoneInput';
 import { VerificationStatusTag } from '@clerk/shared/components/tag';
 import { TitledCard } from '@clerk/shared/components/titledCard';
 import { Toggle } from '@clerk/shared/components/toggle';
 import React from 'react';
-import { handleError, useFieldState, verificationErrorMessage } from 'ui/common';
+import {
+  handleError,
+  useFieldState,
+  verificationErrorMessage,
+} from 'ui/common';
 import { Error } from 'ui/common/error';
 import { useCoreUser } from 'ui/contexts';
 import { useNavigate } from 'ui/hooks';
@@ -29,7 +36,9 @@ export const PhoneDetail = (): JSX.Element => {
   const currentCode = useFieldState('', '');
   const [error, setError] = React.useState<string | undefined>();
 
-  const phoneIdent = user.phoneNumbers.find(pi => pi.id === params.phone_number_id);
+  const phoneIdent = user.phoneNumbers.find(
+    pi => pi.id === params.phone_number_id,
+  );
 
   const verificationStatus = phoneIdent?.verification?.status || '';
   const isVerified = verificationStatus === 'verified';
@@ -79,7 +88,7 @@ export const PhoneDetail = (): JSX.Element => {
 
   const makeIdentPrimary = async () => {
     try {
-      await user.update({ primary_phone_number_id: phoneIdent?.id });
+      await user.update({ primaryPhoneNumberId: phoneIdent?.id });
       setIsPrimary(true);
     } catch (err) {
       handleError(err, [currentCode], setError);
@@ -120,7 +129,9 @@ export const PhoneDetail = (): JSX.Element => {
     <>
       <PageHeading
         title='Phone number'
-        subtitle={isVerified ? 'Manage this phone number' : 'Verify this phone number'}
+        subtitle={
+          isVerified ? 'Manage this phone number' : 'Verify this phone number'
+        }
         backTo='./../'
       />
       {showRemovalPage ? (
@@ -129,13 +140,24 @@ export const PhoneDetail = (): JSX.Element => {
         <TitledCard className='cl-themed-card cl-list-card'>
           <Error style={{ margin: '0 2em' }}>{error}</Error>
           <List>
-            <List.Item className='cl-list-item' hoverable={false} detail={false} lines>
+            <List.Item
+              className='cl-list-item'
+              hoverable={false}
+              detail={false}
+              lines
+            >
               <div>
                 <div className='cl-ident-detail'>
-                  <PhoneViewer phoneNumber={phoneIdent.phoneNumber} showFlag={true} />
+                  <PhoneViewer
+                    phoneNumber={phoneIdent.phoneNumber}
+                    showFlag={true}
+                  />
                   <div className='cl-tags'>
                     {isPrimary && <PrimaryTag />}
-                    <VerificationStatusTag className='cl-tag' status={verificationStatus} />
+                    <VerificationStatusTag
+                      className='cl-tag'
+                      status={verificationStatus}
+                    />
                   </div>
                 </div>
                 <div>{connections}</div>
@@ -143,13 +165,21 @@ export const PhoneDetail = (): JSX.Element => {
             </List.Item>
 
             {isVerified && (
-              <List.Item className='cl-list-item' hoverable={false} detail={false} lines>
+              <List.Item
+                className='cl-list-item'
+                hoverable={false}
+                detail={false}
+                lines
+              >
                 <div className='cl-primary-status-container'>
                   <div className='cl-description'>
                     <PhoneIcon />
                     <div className='cl-text'>
                       <div className='cl-title'>Primary phone</div>
-                      <div className='cl-subtitle'>This phone will receive communications regarding your account.</div>
+                      <div className='cl-subtitle'>
+                        This phone will receive communications regarding your
+                        account.
+                      </div>
                     </div>
                   </div>
                   <Toggle

--- a/packages/clerk-js/src/utils/resourceParams.test.ts
+++ b/packages/clerk-js/src/utils/resourceParams.test.ts
@@ -5,8 +5,8 @@ import { normalizeUnsafeMetadata } from './resourceParams';
 describe('normalizeUnsafeMetadata', () => {
   it('handles unsafe_metadata', () => {
     const params: UpdateUserParams = {
-      first_name: 'clerk',
-      unsafe_metadata: {
+      firstName: 'clerk',
+      unsafeMetadata: {
         role: 'admin',
       },
     };
@@ -22,7 +22,7 @@ describe('normalizeUnsafeMetadata', () => {
 
   it('handles params without unsafe_metadata', () => {
     const params: UpdateUserParams = {
-      first_name: 'clerk',
+      firstName: 'clerk',
     };
 
     const res = normalizeUnsafeMetadata(params);
@@ -40,8 +40,8 @@ describe('normalizeUnsafeMetadata', () => {
 
   it('handles unsafe_metadata passed as string', () => {
     const params: UpdateUserParams = {
-      first_name: 'clerk',
-      unsafe_metadata: JSON.stringify({
+      firstName: 'clerk',
+      unsafeMetadata: JSON.stringify({
         role: 'admin',
       }) as any,
     };

--- a/packages/clerk-js/src/utils/resourceParams.ts
+++ b/packages/clerk-js/src/utils/resourceParams.ts
@@ -1,8 +1,11 @@
+import { deepCamelToSnake } from '@clerk/shared/utils';
+
 export function normalizeUnsafeMetadata<
   T extends Record<string, unknown> & {
     unsafe_metadata?: Record<string, unknown>;
   },
 >(params: T) {
+  params = deepCamelToSnake(params);
   const { unsafe_metadata } = { ...params };
   const unsafeMetadataJSON = unsafe_metadata
     ? typeof unsafe_metadata === 'object'

--- a/packages/shared/utils/object.test.ts
+++ b/packages/shared/utils/object.test.ts
@@ -1,6 +1,21 @@
 import { deepCamelToSnake, deepSnakeToCamel } from './object';
 
 describe('camelToSnakeKeys', () => {
+  it('creates a copy and does not modify the original', () => {
+    const original = {
+      an_arr: [{ hello_there: 'hey' }],
+      a_nested_object: { a_message: 'hey' },
+    };
+    const originalCopy = { ...original };
+    const res = deepSnakeToCamel(original);
+    expect(res).toStrictEqual({
+      anArr: [{ helloThere: 'hey' }],
+      aNestedObject: { aMessage: 'hey' },
+    });
+    expect(original).toStrictEqual(originalCopy);
+    expect(original === res).toBeFalsy();
+  });
+
   it('transforms camelCased keys to snake_cased', () => {
     expect(deepCamelToSnake({ key: 1, anotherKey: 2 })).toStrictEqual({
       key: 1,

--- a/packages/shared/utils/object.ts
+++ b/packages/shared/utils/object.ts
@@ -1,9 +1,7 @@
 import { camelToSnake, snakeToCamel } from './string';
 
 const createDeepObjectTransformer = (transform: any) => {
-  const deepTransform = <T extends Record<string, any> | Array<any>>(
-    obj: T,
-  ): any => {
+  const deepTransform = (obj: any): any => {
     if (!obj) {
       return obj;
     }
@@ -17,19 +15,19 @@ const createDeepObjectTransformer = (transform: any) => {
       });
     }
 
-    const keys = Object.keys(obj) as Array<keyof T>;
+    const copy = { ...obj };
+    const keys = Object.keys(copy) as string[];
     for (const oldName of keys) {
-      const newName = transform(oldName.toString()) as keyof T;
+      const newName = transform(oldName.toString());
       if (newName !== oldName) {
-        obj[newName] = obj[oldName];
-        delete obj[oldName];
+        copy[newName] = copy[oldName];
+        delete copy[oldName];
       }
-      if (typeof obj[newName] === 'object') {
-        // @ts-ignore
-        obj[newName] = deepTransform(obj[newName]);
+      if (typeof copy[newName] === 'object') {
+        copy[newName] = deepTransform(copy[newName]);
       }
     }
-    return obj;
+    return copy;
   };
 
   return deepTransform;

--- a/packages/types/src/emailAddress.ts
+++ b/packages/types/src/emailAddress.ts
@@ -1,7 +1,11 @@
 import { IdentificationLinkResource } from './identificationLink';
 import { ClerkResource } from './resource';
 import { EmailCodeStrategy, EmailLinkStrategy } from './strategies';
-import { CreateMagicLinkFlowReturn, StartMagicLinkFlowParams, VerificationResource } from './verification';
+import {
+  CreateMagicLinkFlowReturn,
+  StartMagicLinkFlowParams,
+  VerificationResource,
+} from './verification';
 
 export type PrepareEmailAddressVerificationParams =
   | {
@@ -9,7 +13,7 @@ export type PrepareEmailAddressVerificationParams =
     }
   | {
       strategy: EmailLinkStrategy;
-      redirect_url: string;
+      redirectUrl: string;
     };
 
 export type AttemptEmailAddressVerificationParams = {
@@ -22,8 +26,15 @@ export interface EmailAddressResource extends ClerkResource {
   verification: VerificationResource;
   linkedTo: IdentificationLinkResource[];
   toString: () => string;
-  prepareVerification: (params?: PrepareEmailAddressVerificationParams) => Promise<EmailAddressResource>;
-  attemptVerification: (params: AttemptEmailAddressVerificationParams) => Promise<EmailAddressResource>;
-  createMagicLinkFlow: () => CreateMagicLinkFlowReturn<StartMagicLinkFlowParams, EmailAddressResource>;
+  prepareVerification: (
+    params?: PrepareEmailAddressVerificationParams,
+  ) => Promise<EmailAddressResource>;
+  attemptVerification: (
+    params: AttemptEmailAddressVerificationParams,
+  ) => Promise<EmailAddressResource>;
+  createMagicLinkFlow: () => CreateMagicLinkFlowReturn<
+    StartMagicLinkFlowParams,
+    EmailAddressResource
+  >;
   destroy: () => Promise<void>;
 }

--- a/packages/types/src/factors.ts
+++ b/packages/types/src/factors.ts
@@ -9,26 +9,26 @@ import {
 
 export type EmailCodeFactor = {
   strategy: EmailCodeStrategy;
-  email_address_id: string;
-  safe_identifier: string;
+  emailAddressId: string;
+  safeIdentifier: string;
 };
 
 export type EmailLinkFactor = {
   strategy: EmailLinkStrategy;
-  email_address_id: string;
-  safe_identifier: string;
+  emailAddressId: string;
+  safeIdentifier: string;
 };
 
 export type PhoneCodeFactor = {
   strategy: PhoneCodeStrategy;
-  phone_number_id: string;
-  safe_identifier: string;
+  phoneNumberId: string;
+  safeIdentifier: string;
   default?: boolean;
 };
 
 export type Web3SignatureFactor = {
   strategy: Web3Strategy;
-  web3_wallet_id: string;
+  web3WalletId: string;
 };
 
 export type PasswordFactor = {
@@ -39,15 +39,15 @@ export type OauthFactor = {
   strategy: OAuthStrategy;
 };
 
-export type EmailCodeConfig = Omit<EmailCodeFactor, 'safe_identifier'>;
-export type EmailLinkConfig = Omit<EmailLinkFactor, 'safe_identifier'> & { redirect_url: string };
-export type PhoneCodeConfig = Omit<PhoneCodeFactor, 'safe_identifier'>;
+export type EmailCodeConfig = Omit<EmailCodeFactor, 'safeIdentifier'>;
+export type EmailLinkConfig = Omit<EmailLinkFactor, 'safeIdentifier'> & { redirectUrl: string };
+export type PhoneCodeConfig = Omit<PhoneCodeFactor, 'safeIdentifier'>;
 export type Web3SignatureConfig = Web3SignatureFactor;
-export type OAuthConfig = OauthFactor & { redirect_url: string; action_complete_redirect_url: string };
+export type OAuthConfig = OauthFactor & { redirectUrl: string; actionCompleteRedirect_url: string };
 
 export type PhoneCodeSecondFactorConfig = {
   strategy: PhoneCodeStrategy;
-  phone_number_id?: string;
+  phoneNumberId?: string;
 };
 
 export type EmailCodeAttempt = {

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -7,12 +7,13 @@ import { OAuthProvider } from './oauth';
 import { OrganizationInvitationStatus } from './organizationInvitation';
 import { MembershipRole } from './organizationMembership';
 import { SessionStatus } from './session';
-import { SignInJSON } from './signIn';
+import { SignInFirstFactor, SignInJSON, SignInSecondFactor } from './signIn';
 import { SignUpField, SignUpIdentificationField, SignUpStatus } from './signUp';
 import { OAuthStrategy } from './strategies';
 import { BoxShadow, Color, EmUnit, FontFamily, FontWeight, HexColor } from './theme';
 import { UserSettingsJSON } from './userSettings';
 import { VerificationStatus } from './verification';
+import { CamelToSnake } from './utils';
 
 export interface ClerkResourceJSON {
   // TODO: Shall we make this optional?
@@ -264,3 +265,12 @@ export interface OrganizationInvitationJSON extends ClerkResourceJSON {
   created_at: number;
   updated_at: number;
 }
+
+export interface UserDataJSON {
+  first_name?: string;
+  last_name?: string;
+  profile_image_url?: string;
+}
+
+export type SignInFirstFactorJSON = CamelToSnake<SignInFirstFactor>;
+export type SignInSecondFactorJSON = CamelToSnake<SignInSecondFactor>;

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -16,7 +16,12 @@ import {
   Web3SignatureConfig,
   Web3SignatureFactor,
 } from './factors';
-import { EmailAddressIdentifier, PhoneNumberIdentifier, UsernameIdentifier, Web3WalletIdentifier } from './identifiers';
+import {
+  EmailAddressIdentifier,
+  PhoneNumberIdentifier,
+  UsernameIdentifier,
+  Web3WalletIdentifier,
+} from './identifiers';
 import {
   ClerkResourceJSON,
   SignInFirstFactorJSON,
@@ -35,7 +40,11 @@ import {
   TicketStrategy,
   Web3Strategy,
 } from './strategies';
-import { CreateMagicLinkFlowReturn, StartMagicLinkFlowParams, VerificationResource } from './verification';
+import {
+  CreateMagicLinkFlowReturn,
+  StartMagicLinkFlowParams,
+  VerificationResource,
+} from './verification';
 import { AuthenticateWithWeb3Params } from './web3Wallet';
 
 export interface SignInResource extends ClerkResource {
@@ -51,24 +60,43 @@ export interface SignInResource extends ClerkResource {
 
   create: (params: SignInCreateParams) => Promise<SignInResource>;
 
-  prepareFirstFactor: (params: PrepareFirstFactorParams) => Promise<SignInResource>;
+  prepareFirstFactor: (
+    params: PrepareFirstFactorParams,
+  ) => Promise<SignInResource>;
 
-  attemptFirstFactor: (params: AttemptFirstFactorParams) => Promise<SignInResource>;
+  attemptFirstFactor: (
+    params: AttemptFirstFactorParams,
+  ) => Promise<SignInResource>;
 
-  prepareSecondFactor: (params: PrepareSecondFactorParams) => Promise<SignInResource>;
+  prepareSecondFactor: (
+    params: PrepareSecondFactorParams,
+  ) => Promise<SignInResource>;
 
-  attemptSecondFactor: (params: AttemptSecondFactorParams) => Promise<SignInResource>;
+  attemptSecondFactor: (
+    params: AttemptSecondFactorParams,
+  ) => Promise<SignInResource>;
 
-  authenticateWithRedirect: (params: AuthenticateWithRedirectParams) => Promise<void>;
+  authenticateWithRedirect: (
+    params: AuthenticateWithRedirectParams,
+  ) => Promise<void>;
 
-  authenticateWithWeb3: (params: AuthenticateWithWeb3Params) => Promise<SignInResource>;
+  authenticateWithWeb3: (
+    params: AuthenticateWithWeb3Params,
+  ) => Promise<SignInResource>;
 
   authenticateWithMetamask: () => Promise<SignInResource>;
 
-  createMagicLinkFlow: () => CreateMagicLinkFlowReturn<SignInStartMagicLinkFlowParams, SignInResource>;
+  createMagicLinkFlow: () => CreateMagicLinkFlowReturn<
+    SignInStartMagicLinkFlowParams,
+    SignInResource
+  >;
 }
 
-export type SignInStatus = 'needs_identifier' | 'needs_first_factor' | 'needs_second_factor' | 'complete';
+export type SignInStatus =
+  | 'needs_identifier'
+  | 'needs_first_factor'
+  | 'needs_second_factor'
+  | 'complete';
 
 export type SignInIdentifier =
   | UsernameIdentifier
@@ -101,7 +129,11 @@ export type PrepareFirstFactorParams =
   | Web3SignatureConfig
   | OAuthConfig;
 
-export type AttemptFirstFactorParams = EmailCodeAttempt | PhoneCodeAttempt | PasswordAttempt | Web3Attempt;
+export type AttemptFirstFactorParams =
+  | EmailCodeAttempt
+  | PhoneCodeAttempt
+  | PasswordAttempt
+  | Web3Attempt;
 
 export type PrepareSecondFactorParams = PhoneCodeSecondFactorConfig;
 
@@ -134,9 +166,11 @@ export type SignInCreateParams = (
   | {
       identifier: string;
     }
+  | { transfer?: boolean }
 ) & { transfer?: boolean };
 
-export interface SignInStartMagicLinkFlowParams extends StartMagicLinkFlowParams {
+export interface SignInStartMagicLinkFlowParams
+  extends StartMagicLinkFlowParams {
   emailAddressId: string;
 }
 

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -17,7 +17,13 @@ import {
   Web3SignatureFactor,
 } from './factors';
 import { EmailAddressIdentifier, PhoneNumberIdentifier, UsernameIdentifier, Web3WalletIdentifier } from './identifiers';
-import { ClerkResourceJSON, VerificationJSON } from './json';
+import {
+  ClerkResourceJSON,
+  SignInFirstFactorJSON,
+  SignInSecondFactorJSON,
+  UserDataJSON,
+  VerificationJSON,
+} from './json';
 import { AuthenticateWithRedirectParams } from './oauth';
 import { ClerkResource } from './resource';
 import {
@@ -29,7 +35,6 @@ import {
   TicketStrategy,
   Web3Strategy,
 } from './strategies';
-import { SnakeToCamel } from './utils';
 import { CreateMagicLinkFlowReturn, StartMagicLinkFlowParams, VerificationResource } from './verification';
 import { AuthenticateWithWeb3Params } from './web3Wallet';
 
@@ -82,9 +87,9 @@ export type SignInFirstFactor =
 export type SignInSecondFactor = PhoneCodeFactor;
 
 export interface UserData {
-  first_name?: string;
-  last_name?: string;
-  profile_image_url?: string;
+  firstName?: string;
+  lastName?: string;
+  profileImageUrl?: string;
 }
 
 export type SignInFactor = SignInFirstFactor | SignInSecondFactor;
@@ -102,11 +107,11 @@ export type PrepareSecondFactorParams = PhoneCodeSecondFactorConfig;
 
 export type AttemptSecondFactorParams = PhoneCodeAttempt;
 
-type SignInAttributes = (
+export type SignInCreateParams = (
   | {
       strategy: OAuthStrategy;
-      redirect_url: string;
-      action_complete_redirect_url?: string;
+      redirectUrl: string;
+      actionCompleteRedirectUrl?: string;
     }
   | {
       strategy: TicketStrategy;
@@ -124,11 +129,12 @@ type SignInAttributes = (
   | {
       strategy: EmailLinkStrategy;
       identifier: string;
-      redirect_url?: string;
+      redirectUrl?: string;
+    }
+  | {
+      identifier: string;
     }
 ) & { transfer?: boolean };
-
-export type SignInCreateParams = Partial<SnakeToCamel<SignInAttributes> & SignInAttributes>;
 
 export interface SignInStartMagicLinkFlowParams extends StartMagicLinkFlowParams {
   emailAddressId: string;
@@ -150,9 +156,9 @@ export interface SignInJSON extends ClerkResourceJSON {
   supported_identifiers: SignInIdentifier[];
   supported_external_accounts: OAuthStrategy[];
   identifier: string;
-  user_data: UserData;
-  supported_first_factors: SignInFirstFactor[];
-  supported_second_factors: SignInSecondFactor[];
+  user_data: UserDataJSON;
+  supported_first_factors: SignInFirstFactorJSON[];
+  supported_second_factors: SignInSecondFactorJSON[];
   first_factor_verification: VerificationJSON | null;
   second_factor_verification: VerificationJSON | null;
   created_session_id: string | null;

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -24,9 +24,9 @@ import {
   TicketStrategy,
   Web3Strategy,
 } from './strategies';
-import { SnakeToCamel } from './utils';
 import { CreateMagicLinkFlowReturn, StartMagicLinkFlowParams, VerificationResource } from './verification';
 import { AuthenticateWithWeb3Params, GenerateSignature } from './web3Wallet';
+import type { SnakeToCamel } from './utils';
 
 export interface SignUpResource extends ClerkResource {
   status: SignUpStatus | null;
@@ -80,17 +80,13 @@ export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';
 
 export type SignUpField = SignUpAttributeField | SignUpIdentificationField;
 
-export type SignUpCreateParams = Partial<SnakeToCamel<SignUpAttributes> & SignUpAttributes>;
-
-export type SignUpUpdateParams = SignUpCreateParams;
-
 export type PrepareVerificationParams =
   | {
       strategy: EmailCodeStrategy;
     }
   | {
       strategy: EmailLinkStrategy;
-      redirect_url?: string;
+      redirectUrl?: string;
     }
   | {
       strategy: PhoneCodeStrategy;
@@ -136,19 +132,21 @@ export type SignUpVerifiableField =
 export type SignUpIdentificationField = SignUpVerifiableField | OAuthStrategy;
 
 // TODO: Replace with discriminated union type
-export type SignUpAttributes = Partial<
+export type SignUpCreateParams = Partial<
   {
-    external_account_strategy: string;
-    external_account_redirect_url: string;
-    external_account_action_complete_redirect_url: string;
+    externalAccountStrategy: string;
+    externalAccountRedirectUrl: string;
+    externalAccountActionCompleteRedirectUrl: string;
     strategy: OAuthStrategy | TicketStrategy;
-    redirect_url: string;
-    action_complete_redirect_url: string;
+    redirectUrl: string;
+    actionCompleteRedirectUrl: string;
     transfer: boolean;
-    unsafe_metadata: Record<string, unknown>;
+    unsafeMetadata: Record<string, unknown>;
     ticket: string;
-  } & Record<SignUpAttributeField | SignUpVerifiableField, string>
+  } & SnakeToCamel<Record<SignUpAttributeField | SignUpVerifiableField, string>>
 >;
+
+export type SignUpUpdateParams = SignUpCreateParams;
 
 export interface SignUpVerificationsResource {
   emailAddress: SignUpVerificationResource;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -32,15 +32,23 @@ export interface UserResource extends ClerkResource {
   createdAt: Date | null;
 
   update: (params: UpdateUserParams) => Promise<UserResource>;
-  createEmailAddress: (email: string) => Promise<EmailAddressResource>;
-  createPhoneNumber: (phoneNumber: string) => Promise<PhoneNumberResource>;
+  createEmailAddress: (
+    params: CreateEmailAddressParams,
+  ) => Promise<EmailAddressResource>;
+  createPhoneNumber: (
+    params: CreatePhoneNumberParams,
+  ) => Promise<PhoneNumberResource>;
   twoFactorEnabled: () => boolean;
   isPrimaryIdentification: (
     ident: EmailAddressResource | PhoneNumberResource,
   ) => boolean;
   getSessions: () => Promise<SessionWithActivitiesResource[]>;
-  setProfileImage: (file: Blob | File) => Promise<ImageResource>;
+  setProfileImage: (params: SetProfileImageParams) => Promise<ImageResource>;
 }
+
+export type CreateEmailAddressParams = { email: string };
+export type CreatePhoneNumberParams = { phoneNumber: string };
+export type SetProfileImageParams = { file: Blob | File };
 
 type UpdateUserJSON = Pick<
   UserJSON,
@@ -54,6 +62,4 @@ type UpdateUserJSON = Pick<
   | 'unsafe_metadata'
 >;
 
-export type UpdateUserParams = Partial<
-  SnakeToCamel<UpdateUserJSON> & UpdateUserJSON
->;
+export type UpdateUserParams = Partial<SnakeToCamel<UpdateUserJSON>>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Updates all FE public facing apis to accept and return camelCased props. Up until now some of our olders apis used both camel and snake_casing and this was confusing, especially for non-TS codebases.

Our DTOs still use snake_casing. In order to avoid refactoring clerk-js right now, we have updated the public api and we use transformers in the http client level to convert between the two formats. All objects from FAPI -> Clerkjs pass through the `snakeToCamel` utils and any outbound requests towards FAPI pass through the `camelToSnakeEncoder`

<!-- Fixes # (issue number) -->
