### PR TITLE
fix(clerk-js): Invitation based sign up optional fields

### DIFF
--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -82,7 +82,7 @@ function _SignUpStart(): JSX.Element {
         void completeSignUpFlow(res);
       })
       .catch(err => {
-        /* Clear token values when an error occurs in the initial sign up attempt */
+        /* Clear ticket values when an error occurs in the initial sign up attempt */
         formFields.ticket.setValue('');
         handleError(err, [], setError);
       })
@@ -92,6 +92,9 @@ function _SignUpStart(): JSX.Element {
   };
 
   React.useLayoutEffect(() => {
+    if (Object.values(fields).filter(f => f === 'on').length) {
+      return;
+    }
     void handleTokenFlow();
   }, []);
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Allow users to fill in any optional fields that might be available when signing up with an invitation, instead of signing them up immediately.

If the instance supports optional fields and a user lands to our `<SignUp/>` component from an invitation email, give them a chance to enter additional information instead of immediately signing them up.

For instances with no additional information available in the form, the user will be signed up immediately.


https://user-images.githubusercontent.com/1156147/158770796-83f78050-5977-4a31-96db-21a06409d38b.mp4


<!-- Fixes # (issue number) -->
