### PR TITLE
feat(clerk-js): Move auth state to request in rootAuthLoader

### DIFF
--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -4,7 +4,7 @@ import { invalidRootLoaderCallbackResponseReturn, invalidRootLoaderCallbackRetur
 import { assertFrontendApi } from '../utils';
 import { getAuthData } from './getAuthData';
 import { LoaderFunctionArgs, LoaderFunctionReturn, RootAuthLoaderCallback, RootAuthLoaderOptions } from './types';
-import { assertObject, injectAuthIntoArgs, isRedirect, isResponse, sanitizeAuthData, wrapClerkState } from './utils';
+import { assertObject, injectAuthIntoRequest, isRedirect, isResponse, sanitizeAuthData, wrapClerkState } from './utils';
 
 interface RootAuthLoader {
   <Options extends RootAuthLoaderOptions>(
@@ -40,7 +40,7 @@ export const rootAuthLoader: RootAuthLoader = async (
     return { ...wrapClerkState({ __clerk_ssr_state: authData, __frontendApi: frontendApi }) };
   }
 
-  const callbackResult = await callback?.(injectAuthIntoArgs(args, sanitizeAuthData(authData!)));
+  const callbackResult = await callback?.(injectAuthIntoRequest(args, sanitizeAuthData(authData!)));
   assertObject(callbackResult, invalidRootLoaderCallbackReturn);
 
   // Pass through custom responses

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -1,6 +1,6 @@
 import { Session, User } from '@clerk/backend-core/src';
 import { ServerSideAuth } from '@clerk/types';
-import { LoaderFunction } from '@remix-run/server-runtime';
+import { DataFunctionArgs, LoaderFunction } from '@remix-run/server-runtime';
 
 export type GetAuthReturn = Promise<ServerSideAuth>;
 
@@ -20,11 +20,14 @@ export type RootAuthLoaderCallbackReturn =
   | Promise<Record<string, unknown>>
   | Record<string, unknown>;
 
-export type LoaderFunctionArgs = Parameters<LoaderFunction>[0];
-
+export type LoaderFunctionArgs = DataFunctionArgs;
 export type LoaderFunctionReturn = ReturnType<LoaderFunction>;
 
 export type LoaderFunctionArgsWithAuth<Options extends RootAuthLoaderOptions = any> = LoaderFunctionArgs & {
+  request: RequestWithAuth<Options>;
+};
+
+export type RequestWithAuth<Options extends RootAuthLoaderOptions = any> = LoaderFunctionArgs['request'] & {
   auth: ServerSideAuth;
 } & (Options extends { loadSession: true } ? { session: Session | null } : {}) &
   (Options extends { loadUser: true } ? { user: User | null } : {});

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -14,19 +14,15 @@ export const wrapClerkState = (data: any) => {
 };
 
 /**
- * Inject the `auth` attribute to the SSR provided context (ctx) object and
- * `user` and `session` attribute to the request (req) object.
- *
+ * Inject `auth`, `user` and `session` properties into `request`
  * @internal
  */
-export function injectAuthIntoArgs(ctx: LoaderFunctionArgs, authData: AuthData): LoaderFunctionArgsWithAuth {
-  const { user, session, userId, sessionId } = authData;
-  const auth = {
-    userId,
-    sessionId,
-    getToken: authData.getToken,
-  };
-  return { ...ctx, auth, user, session };
+export function injectAuthIntoRequest(args: LoaderFunctionArgs, authData: AuthData): LoaderFunctionArgsWithAuth {
+  const { user, session, userId, sessionId, getToken } = authData;
+  (args.request as any).auth = { userId, sessionId, getToken };
+  (args.request as any).user = user;
+  (args.request as any).session = session;
+  return args as LoaderFunctionArgsWithAuth;
 }
 
 /**


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Changes the `rootAuthLoader` api from
```tsx
export const loader: LoaderFunction = args => {
  return rootAuthLoader(args, ({ request, auth, user }) => {
    const { userId, getToken, sessionId } = auth;
    console.log(userId, user, ...)
  }, { loadUser: true })
}
```

to
```tsx
export const loader: LoaderFunction = args => {
  return rootAuthLoader(args, ({ request, auth, user }) => {
    const { auth, user } = request;
    const { userId, getToken, sessionId } = auth;
    console.log(userId, user, ...)
  }, { loadUser: true })
}
```

This change intends to make accessing auth state/ user/ session consistent across all environments and repos.
<!-- Fixes # (issue number) -->
