### PR TITLE
fix(clerk-js): Redirect user to signUp url when there is an error with external account sign up

### DIFF
--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -627,6 +627,54 @@ describe('Clerk singleton', () => {
         expect(mockNavigate).toHaveBeenCalledWith('/custom-sign-in');
       });
     });
+
+    it('redirects user to signUp url if there is an external account signup attempt has an error', async () => {
+      mockEnvironmentFetch.mockReturnValue(
+        Promise.resolve({
+          authConfig: {},
+          displayConfig: mockDisplayConfig,
+          isSingleSession: () => false,
+          isProduction: () => false,
+          onWindowLocationHost: () => false,
+        }),
+      );
+
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          activeSessions: [],
+          signIn: new SignIn(null),
+          signUp: new SignUp({
+            status: 'missing_requirements',
+            verifications: {
+              external_account: {
+                status: 'unverified',
+                strategy: 'oauth_google',
+                external_verification_redirect_url: '',
+                error: {
+                  code: 'external_account_not_found',
+                  long_message: 'The External Account was not found.',
+                  message: 'Invalid external account',
+                  meta: {
+                    session_id: 'sess_1yDceUR8SIKtQ0gIOO8fNsW7nhe',
+                  },
+                },
+              },
+            },
+          } as any as SignUpJSON),
+        }),
+      );
+
+      const sut = new Clerk(frontendApi);
+      await sut.load({
+        navigate: mockNavigate,
+      });
+
+      sut.handleRedirectCallback();
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/signUpUrl');
+      });
+    })
   });
 
   describe('.handleMagicLinkVerification()', () => {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -30,6 +30,7 @@ import { ERROR_CODES } from 'ui/common/constants';
 import {
   appendAsQueryParams,
   CLERK_BEFORE_UNLOAD_EVENT,
+  hasExternalAccountSignUpError,
   ignoreEventValue,
   isAccountsHostedPages,
   isDevOrStagingUrl,
@@ -460,20 +461,22 @@ export default class Clerk implements ClerkInterface {
 
     const navigateToSignIn = makeNavigate(displayConfig.signInUrl);
 
+    const navigateToSignUp = makeNavigate(displayConfig.signUpUrl);
+
     const navigateToFactorTwo = makeNavigate(
       params.secondFactorUrl || displayConfig.signInUrl + '#/factor-two',
     );
 
     const navigateAfterSignIn = makeNavigate(
       params.afterSignInUrl ||
-        params.redirectUrl ||
-        displayConfig.afterSignInUrl,
+      params.redirectUrl ||
+      displayConfig.afterSignInUrl,
     );
 
     const navigateAfterSignUp = makeNavigate(
       params.afterSignUpUrl ||
-        params.redirectUrl ||
-        displayConfig.afterSignUpUrl,
+      params.redirectUrl ||
+      displayConfig.afterSignUpUrl,
     );
 
     const userExistsButNeedsToSignIn =
@@ -527,6 +530,10 @@ export default class Clerk implements ClerkInterface {
       if (sessionId) {
         return this.setSession(sessionId, navigateAfterSignIn);
       }
+    }
+
+    if (hasExternalAccountSignUpError(signUp)) {
+      return navigateToSignUp();
     }
 
     return navigateToSignIn();

--- a/packages/clerk-js/src/utils/url.test.ts
+++ b/packages/clerk-js/src/utils/url.test.ts
@@ -1,4 +1,4 @@
-import { SignUpResource } from '../../../types/dist';
+import { SignUpResource } from '@clerk/types';
 import {
   appendAsQueryParams,
   buildURL,

--- a/packages/clerk-js/src/utils/url.test.ts
+++ b/packages/clerk-js/src/utils/url.test.ts
@@ -1,7 +1,9 @@
+import { SignUpResource } from '../../../types/dist';
 import {
   appendAsQueryParams,
   buildURL,
   getAllETLDs,
+  hasExternalAccountSignUpError,
   isAccountsHostedPages,
   isDevOrStagingUrl,
   trimTrailingSlash,
@@ -227,5 +229,27 @@ describe('getAllETLDs(hostname)', () => {
       'qux.baz',
       'bar.qux.baz',
     ]);
+  });
+});
+
+describe('hasExternalAccountSignUpError(signUpResource)', () => {
+  it('returns true if the signup attempt with external account has an error', () => {
+    expect(hasExternalAccountSignUpError({
+      verifications: {
+        externalAccount: {
+          error: {}
+        }
+      }
+    } as SignUpResource)).toBe(true);
+  });
+
+  it('returns false if there is no signup attempt error on an external account', () => {
+    expect(hasExternalAccountSignUpError({
+      verifications: {
+        externalAccount: {
+          error: null
+        }
+      }
+    } as SignUpResource)).toBe(false);
   });
 });

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -1,6 +1,6 @@
 import { camelToSnake, isIPV4Address } from '@clerk/shared/utils/string';
 import { loadScript } from 'utils';
-import { SignUpResource } from '../../../types/dist';
+import { SignUpResource } from '@clerk/types';
 
 declare global {
   export interface Window {

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -1,5 +1,6 @@
 import { camelToSnake, isIPV4Address } from '@clerk/shared/utils/string';
 import { loadScript } from 'utils';
+import { SignUpResource } from '../../../types/dist';
 
 declare global {
   export interface Window {
@@ -196,3 +197,8 @@ export const appendAsQueryParams = (
   }
   return base + (params.toString() ? '#/?' + params.toString() : '');
 };
+
+export const hasExternalAccountSignUpError = (signUp: SignUpResource): boolean => {
+  const { externalAccount } = signUp.verifications
+  return !!externalAccount.error;
+}


### PR DESCRIPTION


## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
When attempting to sign up with sso while we have set an allowlist that forbids the specific sso email to sign up then after getting the relative error we are redirected to [signIn page](https://github.com/clerkinc/javascript/blob/0bc7abed4ae686441f87a41ded4012cfa427b44f/packages/clerk-js/src/core/clerk.ts#L539) which doesn't have access to the signUp state to show the proper error.
The fix, after an unsuccessful sso sign up attempt, [redirects to the signUp page](https://github.com/clerkinc/javascript/blob/0bc7abed4ae686441f87a41ded4012cfa427b44f/packages/clerk-js/src/core/clerk.ts#L535-L537) so that the proper error is can be displayed.


<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
https://www.notion.so/clerkdev/SSO-sign-up-w-Allowlist-doesn-t-display-error-58267ed1448d466b811d4d92510e2e7f
