### PR TITLE
fix(edge): Return plain or promise-like possible results

### DIFF
--- a/packages/edge/src/vercel-edge/types.ts
+++ b/packages/edge/src/vercel-edge/types.ts
@@ -26,7 +26,8 @@ export type RequestWithAuth<
 } & (Options extends { loadSession: true } ? { session: Session | null } : {}) &
   (Options extends { loadUser: true } ? { user: User | null } : {});
 
-export type NextMiddlewareResult = NextResponse | Response | null | undefined;
+type NextMiddlewareReturnOptions = NextResponse | Response | null | undefined;
+export type NextMiddlewareResult = NextMiddlewareReturnOptions;
 
 export type WithAuthNextMiddlewareHandler<Options> = (
   req: RequestWithAuth<Options>,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
## Issue
Using a default handler without a promisified result works fine:
```js
import { withEdgeMiddlewareAuth } from "@clerk/edge/vercel-edge";

const handler = (req) => {
  console.log(req.session);
  if (req.session) {
    return new Response("Session");
  } else {
    return new Response("No session");
  }
};

export default withEdgeMiddlewareAuth(handler);
```

but the TS compiler complains when the handler is async.

The PR fixes that by expanding the return type. As it seems Next.js will resolve a promise-type handler in the same manner as a non promise one.
