### PR TITLE
Align getToken api across packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23023,6 +23023,7 @@
       "version": "0.6.4-alpha.0",
       "license": "MIT",
       "dependencies": {
+        "@clerk/types": "^2.0.1-alpha.0",
         "camelcase-keys": "^7.0.1",
         "query-string": "^7.0.1",
         "snakecase-keys": "^5.1.2",
@@ -24779,6 +24780,7 @@
     "@clerk/backend-core": {
       "version": "file:packages/backend-core",
       "requires": {
+        "@clerk/types": "^2.0.1-alpha.0",
         "@peculiar/webcrypto": "^1.3.2",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.12",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.6.2"
   },
   "scripts": {
-    "dev": "lerna run dev --parallel --scope @clerk/types --scope @clerk/clerk-js --scope @clerk/clerk-react --scope @clerk/remix --scope @clerk/nextjs",
+    "dev": "lerna run dev --parallel --ignore @clerk/{expo}",
     "lint-fix": "eslint . --ext .ts",
     "bump": "lerna version",
     "bump:next": "lerna version --conventional-prerelease",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -5,6 +5,7 @@
   "description": "Clerk Backend API core resources and authentication utilities for JavaScript environments.",
   "scripts": {
     "build": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json && ./moduleTypeFix",
+    "dev": "tsc -p tsconfig.esm.json --watch",
     "test": "jest"
   },
   "type": "module",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -12,6 +12,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",
   "dependencies": {
+    "@clerk/types": "^2.0.1-alpha.0",
     "camelcase-keys": "^7.0.1",
     "query-string": "^7.0.1",
     "snakecase-keys": "^5.1.2",

--- a/packages/backend-core/src/api/collection/SessionApi.ts
+++ b/packages/backend-core/src/api/collection/SessionApi.ts
@@ -8,40 +8,39 @@ type QueryParams = {
 };
 
 export class SessionApi extends AbstractApi {
-  public async getSessionList(queryParams?: QueryParams) {
-    return this._restClient.makeRequest<Array<Session>>({
+  public getSessionList = async (queryParams?: QueryParams) =>
+    this._restClient.makeRequest<Array<Session>>({
       method: 'GET',
       path: '/sessions',
       queryParams: queryParams,
     });
-  }
 
-  public async getSession(sessionId: string) {
+  public getSession = async (sessionId: string) => {
     this.requireId(sessionId);
     return this._restClient.makeRequest<Session>({
       method: 'GET',
       path: `/sessions/${sessionId}`,
     });
-  }
+  };
 
-  public async revokeSession(sessionId: string) {
+  public revokeSession = async (sessionId: string) => {
     this.requireId(sessionId);
     return this._restClient.makeRequest<Session>({
       method: 'POST',
       path: `/sessions/${sessionId}/revoke`,
     });
-  }
+  };
 
-  public async verifySession(sessionId: string, token: string) {
+  public verifySession = async (sessionId: string, token: string) => {
     this.requireId(sessionId);
     return this._restClient.makeRequest<Session>({
       method: 'POST',
       path: `/sessions/${sessionId}/verify`,
       bodyParams: { token },
     });
-  }
+  };
 
-  public async getToken(sessionId: string, template: string) {
+  public getToken = async (sessionId: string, template: string) => {
     this.requireId(sessionId);
     return (
       (await this._restClient.makeRequest<Token>({
@@ -49,5 +48,5 @@ export class SessionApi extends AbstractApi {
         path: `/sessions/${sessionId}/tokens/${template || ''}`,
       })) as any
     ).jwt;
-  }
+  };
 }

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Base';
 export * from './api/ClerkBackendAPI';
 export * from './api/resources';
+export { createGetToken, createSignedOutState } from './util/createGetToken';
 export type { ClerkFetcher } from './api/utils/RestClient';
 export type { Session } from './api/resources/Session';
 export type { Nullable } from './util/nullable';

--- a/packages/backend-core/src/util/createGetToken.ts
+++ b/packages/backend-core/src/util/createGetToken.ts
@@ -1,0 +1,49 @@
+import { ServerGetToken, ServerGetTokenOptions } from '@clerk/types';
+
+/**
+ * @internal
+ */
+type TokenFetcher = (sessionId: string, template: string) => Promise<string>;
+
+/**
+ * @internal
+ */
+type CreateGetToken = (params: {
+  sessionId: string | undefined;
+  cookieToken: string | undefined;
+  headerToken: string | undefined;
+  fetcher: TokenFetcher;
+}) => ServerGetToken;
+
+/**
+ * @internal
+ */
+export const createGetToken: CreateGetToken = params => {
+  const { cookieToken, fetcher, headerToken, sessionId } = params || {};
+  return (options: ServerGetTokenOptions = {}) => {
+    if (!sessionId) {
+      throw new Error('getToken cannot be called without a session.');
+    }
+    if (options.template) {
+      return fetcher(sessionId, options.template);
+    }
+    return Promise.resolve(headerToken || cookieToken) as Promise<string>;
+  };
+};
+
+const signedOutGetToken = createGetToken({
+  sessionId: undefined,
+  cookieToken: undefined,
+  headerToken: undefined,
+  fetcher: (() => {}) as any,
+});
+
+export const createSignedOutState = () => {
+  return {
+    sessionId: null,
+    session: null,
+    userId: null,
+    user: null,
+    getToken: signedOutGetToken,
+  };
+};

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -28,8 +28,8 @@
       "require": "./dist/cjs/index.js"
     },
     "./vercel-edge": {
-      "import": "./dist/mjs/vercel-edge.js",
-      "require": "./dist/cjs/vercel-edge.js"
+      "import": "./dist/mjs/vercel-edge/index.js",
+      "require": "./dist/cjs/vercel-edge/index.js"
     }
   },
   "scripts": {

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -1,4 +1,4 @@
-import { AuthStatus, Base } from '@clerk/backend-core';
+import { AuthStatus, Base, createSignedOutState } from '@clerk/backend-core';
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
 import { ClerkAPI } from './ClerkAPI';
@@ -26,12 +26,7 @@ const importKey = async (jwk: JsonWebKey, algorithm: Algorithm) => {
   return await crypto.subtle.importKey('jwk', jwk, algorithm, true, ['verify']);
 };
 
-const verifySignature = async (
-  algorithm: Algorithm,
-  key: CryptoKey,
-  signature: Uint8Array,
-  data: Uint8Array,
-) => {
+const verifySignature = async (algorithm: Algorithm, key: CryptoKey, signature: Uint8Array, data: Uint8Array) => {
   return await crypto.subtle.verify(algorithm, key, signature, data);
 };
 
@@ -56,15 +51,7 @@ const smsMessages = ClerkAPI.smsMessages;
 const users = ClerkAPI.users;
 
 // Export sub-api objects
-export {
-  allowlistIdentifiers,
-  clients,
-  emails,
-  invitations,
-  sessions,
-  smsMessages,
-  users,
-};
+export { allowlistIdentifiers, clients, emails, invitations, sessions, smsMessages, users };
 
 async function fetchInterstitial() {
   const response = await ClerkAPI.fetchInterstitial<Response>();
@@ -91,20 +78,19 @@ export function withEdgeMiddlewareAuth(
 ): any {
   return async function clerkAuth(req: NextRequest, event: NextFetchEvent) {
     /* Get authentication state */
-    const { status, interstitial, sessionClaims } =
-      await vercelEdgeBase.getAuthState({
-        cookieToken: req.cookies['__session'],
-        clientUat: req.cookies['__client_uat'],
-        headerToken: req.headers.get('authorization'),
-        origin: req.headers.get('origin'),
-        host: req.headers.get('host') as string,
-        userAgent: req.headers.get('user-agent'),
-        forwardedPort: req.headers.get('x-forwarded-port'),
-        forwardedHost: req.headers.get('x-forwarded-host'),
-        referrer: req.headers.get('referrer'),
-        authorizedParties: options.authorizedParties,
-        fetchInterstitial,
-      });
+    const { status, interstitial, sessionClaims } = await vercelEdgeBase.getAuthState({
+      cookieToken: req.cookies['__session'],
+      clientUat: req.cookies['__client_uat'],
+      headerToken: req.headers.get('authorization'),
+      origin: req.headers.get('origin'),
+      host: req.headers.get('host') as string,
+      userAgent: req.headers.get('user-agent'),
+      forwardedPort: req.headers.get('x-forwarded-port'),
+      forwardedHost: req.headers.get('x-forwarded-host'),
+      referrer: req.headers.get('referrer'),
+      authorizedParties: options.authorizedParties,
+      fetchInterstitial,
+    });
 
     if (status === AuthStatus.Interstitial) {
       return new NextResponse(interstitial, {
@@ -115,44 +101,26 @@ export function withEdgeMiddlewareAuth(
 
     const getToken = (options: ServerGetTokenOptions = {}) => {
       if (options.template) {
-        throw new Error(
-          'Retrieving a JWT template during edge runtime will be supported soon.',
-        );
+        throw new Error('Retrieving a JWT template during edge runtime will be supported soon.');
       }
       return Promise.resolve(req.cookies['__session']);
     };
 
     /* In both SignedIn and SignedOut states, we just add the attributes to the request object and passthrough. */
     if (status === AuthStatus.SignedOut) {
-      /* Predetermined signed out attributes */
-      const signedOutState = {
-        sessionId: null,
-        session: null,
-        userId: null,
-        user: null,
-        getToken,
-      };
-      return handler(injectAuthIntoRequest(req, signedOutState), event);
+      return handler(injectAuthIntoRequest(req, createSignedOutState()), event);
     }
 
+    const sessionId = sessionClaims!.sid;
+    const userId = sessionClaims!.sub;
+
     const [user, session] = await Promise.all([
-      options.loadUser
-        ? ClerkAPI.users.getUser(sessionClaims?.sub as string)
-        : Promise.resolve(undefined),
-      options.loadSession
-        ? ClerkAPI.sessions.getSession(sessionClaims?.sid as string)
-        : Promise.resolve(undefined),
+      options.loadUser ? ClerkAPI.users.getUser(userId) : Promise.resolve(undefined),
+      options.loadSession ? ClerkAPI.sessions.getSession(sessionId) : Promise.resolve(undefined),
     ]);
 
     /* Inject the auth state into the NextResponse object */
-    const authRequest = injectAuthIntoRequest(req, {
-      user,
-      session,
-      sessionId: sessionClaims?.sid as string,
-      userId: sessionClaims?.sub as string,
-      getToken,
-    });
-
+    const authRequest = injectAuthIntoRequest(req, { user, session, sessionId, userId, getToken });
     return handler(authRequest, event);
   };
 }

--- a/packages/edge/src/vercel-edge/utils/getAuthData.ts
+++ b/packages/edge/src/vercel-edge/utils/getAuthData.ts
@@ -1,42 +1,29 @@
-import { JWTPayload } from '@clerk/backend-core';
-import { ServerGetTokenOptions } from '@clerk/types';
+import { createGetToken, JWTPayload } from '@clerk/backend-core';
 import { NextRequest } from 'next/server';
 
 import { ClerkAPI } from '../ClerkAPI';
 import { AuthData, WithEdgeMiddlewareAuthOptions } from '../types';
 
+/**
+ * @internal
+ */
 export async function getAuthData(
   req: NextRequest,
-  {
-    sid,
-    sub,
-    loadSession,
-    loadUser,
-  }: WithEdgeMiddlewareAuthOptions & JWTPayload,
+  { sid, sub, loadSession, loadUser }: WithEdgeMiddlewareAuthOptions & JWTPayload,
 ): Promise<AuthData> {
-  const getToken = (options: ServerGetTokenOptions = {}) => {
-    if (options.template) {
-      throw new Error(
-        'Retrieving a JWT template during edge runtime will be supported soon.',
-      );
-    }
-    return Promise.resolve(req.cookies['__session']);
-  };
-
   const [user, session] = await Promise.all([
-    loadUser
-      ? ClerkAPI.users.getUser(sub as string)
-      : Promise.resolve(undefined),
-    loadSession
-      ? ClerkAPI.sessions.getSession(sid as string)
-      : Promise.resolve(undefined),
+    loadUser ? ClerkAPI.users.getUser(sub as string) : Promise.resolve(undefined),
+    loadSession ? ClerkAPI.sessions.getSession(sid as string) : Promise.resolve(undefined),
   ]);
 
-  return {
-    sessionId: sid as string,
-    userId: sub as string,
-    getToken,
-    user,
-    session,
-  };
+  const sessionId = sid;
+  const userId = sub;
+  const getToken = createGetToken({
+    sessionId,
+    cookieToken: req.cookies['__session'],
+    headerToken: req.headers.get('authorization')?.replace('Bearer ', ''),
+    fetcher: (...args) => ClerkAPI.sessions.getToken(...args),
+  });
+
+  return { sessionId, userId, getToken, user, session };
 }

--- a/packages/edge/tsconfig.json
+++ b/packages/edge/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "lib": ["ES2020"],
     "strict": true,
     "declaration": true,

--- a/packages/sdk-node/src/__tests__/middleware.test.ts
+++ b/packages/sdk-node/src/__tests__/middleware.test.ts
@@ -1,8 +1,20 @@
-import { AuthStatus } from '@clerk/backend-core';
 import type { NextFunction, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 
 import Clerk from '../Clerk';
+import { AuthStatus } from '@clerk/backend-core';
+
+const mockGetToken = () => {};
+
+jest.mock('@clerk/backend-core', () => {
+  return {
+    ...jest.requireActual('@clerk/backend-core'),
+    createGetToken: () => mockGetToken,
+    createSignedOutState: () => ({
+      getToken: mockGetToken,
+    }),
+  };
+});
 
 const mockNext = jest.fn();
 
@@ -17,11 +29,13 @@ const mockGetAuthStateResult = {
 };
 
 const mockAuthProp = {
+  getToken: mockGetToken,
   userId: 'user_id',
   sessionId: 'session_id',
 };
 
 const mockAuthSignedOutProp = {
+  getToken: mockGetToken,
   userId: null,
   sessionId: null,
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
- Add getToken to the returned value of `/edge` withEdgeMiddlewareAuth
- Add getToken to the returned value of `/api` withAuth and requireAuth  
- Refactor getAuthData to use common utils - this is the first step towards refactoring getAuthData into a common util