### PR TITLE
fix(clerk-js): Show password only if required

### DIFF
--- a/packages/clerk-js/src/ui/userProfile/security/Security.test.tsx
+++ b/packages/clerk-js/src/ui/userProfile/security/Security.test.tsx
@@ -1,4 +1,4 @@
-import { mocked, renderJSON } from '@clerk/shared/testUtils';
+import { mocked, render, renderJSON, screen } from '@clerk/shared/testUtils';
 import {
   EnvironmentResource,
   SessionActivity,
@@ -55,26 +55,73 @@ describe('<Security/>', () => {
       useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>,
       true,
     ).mockImplementation(
-      () => (
-        {
+      () =>
+        ({
           userSettings: {
             attributes: {
               phone_number: {
                 used_for_second_factor: true,
-                second_factors: ['phone_code']
+                second_factors: ['phone_code'],
               },
               password: {
-                enabled: true
-              }
-            }
+                enabled: true,
+              },
+            },
           },
           displayConfig: {
             branded: true,
           },
-        } as PartialDeep<EnvironmentResource>
-      )
+        } as PartialDeep<EnvironmentResource>),
     );
     const tree = renderJSON(<Security />);
     expect(tree).toMatchSnapshot();
+  });
+
+  it('shows the password section when password is required', () => {
+    mocked(
+      useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>,
+      true,
+    ).mockImplementation(
+      () =>
+        ({
+          userSettings: {
+            attributes: {
+              phone_number: {
+                used_for_second_factor: false,
+              },
+              password: {
+                enabled: true,
+                required: true,
+              },
+            },
+          },
+        } as PartialDeep<EnvironmentResource>),
+    );
+    render(<Security />);
+    expect(screen.getByText('Password')).toBeInTheDocument();
+  });
+
+  it('hides the password section when password is not required', () => {
+    mocked(
+      useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>,
+      true,
+    ).mockImplementation(
+      () =>
+        ({
+          userSettings: {
+            attributes: {
+              phone_number: {
+                used_for_second_factor: false,
+              },
+              password: {
+                enabled: true,
+                required: false,
+              },
+            },
+          },
+        } as PartialDeep<EnvironmentResource>),
+    );
+    render(<Security />);
+    expect(screen.queryByText('Password')).not.toBeInTheDocument();
   });
 });

--- a/packages/clerk-js/src/ui/userProfile/security/Security.tsx
+++ b/packages/clerk-js/src/ui/userProfile/security/Security.tsx
@@ -13,7 +13,8 @@ export function Security(): JSX.Element {
   const { navigate } = useNavigate();
   const user = useCoreUser();
 
-  const showPasswordRow = attributes.password.enabled;
+  const showPasswordRow =
+    attributes.password.enabled && attributes.password.required;
 
   const showSecondFactorRow =
     attributes.phone_number.used_for_second_factor &&

--- a/packages/clerk-js/src/ui/userProfile/security/__snapshots__/Security.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/security/__snapshots__/Security.test.tsx.snap
@@ -48,37 +48,6 @@ Array [
         <div
           className="title"
         >
-          Password
-        </div>
-        <div
-          className="listItem line"
-        >
-          <div
-            className="start"
-          >
-            <span
-              className="cl-font-semibold"
-            >
-              ••••••••••
-            </span>
-          </div>
-          <div
-            className="iconContainer"
-          >
-            <svg
-              data-filename="../shared/assets/icons/arrow-right.svg"
-            />
-          </div>
-        </div>
-      </button>
-      <button
-        className="cl-list-item elementContainer button hoverable"
-        disabled={false}
-        onClick={[Function]}
-      >
-        <div
-          className="title"
-        >
           2-step verification
         </div>
         <div

--- a/packages/clerk-js/src/ui/userProfile/security/index.tsx
+++ b/packages/clerk-js/src/ui/userProfile/security/index.tsx
@@ -20,10 +20,13 @@ export function SecurityRoutes({
   index = false,
 }: SecurityRoutesProps): JSX.Element {
   const { userSettings } = useEnvironment();
-  const { attributes: { phone_number } } = userSettings;
+  const {
+    attributes: { phone_number, password },
+  } = userSettings;
   const canActivate2svRoutes = () =>
     phone_number.used_for_second_factor &&
     phone_number.second_factors.includes('phone_code');
+  const canActivatePasswordRoutes = () => password.enabled && password.required;
 
   return (
     <Route
@@ -50,7 +53,11 @@ export function SecurityRoutes({
           </Route>
         </Route>
       </Route>
-      <Route path='password'>
+      <Route
+        path='password'
+        canActivate={canActivatePasswordRoutes}
+        fallbackPath='../'
+      >
         <ChangePassword />
       </Route>
     </Route>


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Don't show the password section and `/security/password` route unless the instance is configured to accept passwords as first factor authentication.

<!-- Fixes # (issue number) -->
