### PR TITLE
feat(clerk-sdk-node): Enable CLERK_JWT_KEY usage from clerk-sdk-node

### DIFF
--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -126,7 +126,7 @@ export default class Clerk extends ClerkBackendAPI {
     this._jwksClient = jwks({
       jwksUri: `${serverApiUrl}/${apiVersion}/jwks`,
       requestHeaders: {
-        Authorization: `Bearer ${defaultApiKey}`,
+        Authorization: `Bearer ${apiKey}`,
       },
       timeout: 5000,
       cache: true,
@@ -158,11 +158,12 @@ export default class Clerk extends ClerkBackendAPI {
 
     /** Base initialization */
 
+    // TODO: More comprehensive base initialization
     this.base = new Base(
       importKey,
       verifySignature,
       decodeBase64,
-      loadCryptoKey
+      process.env.CLERK_JWT_KEY ? undefined : loadCryptoKey
     );
   }
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

- Simple change to allow sdk-node usage of the `CLERK_JWT_KEY` when added from the environment.
- Fix correct apiKey on JWKsClient

FYI on a follow up PR we will make `jwtKey` injectable in the Base contructor making it much more comprehensive.
