### PR TITLE
fix(clerk-js): Add createdUserId attribute to SignUp

### DIFF
--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -186,6 +186,7 @@ export interface SignUpJSON extends ClerkResourceJSON {
   has_password: boolean;
   name_full: string | null;
   created_session_id: string | null;
+  created_user_id: string | null;
   abandon_at: number | null;
 }
 

--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -120,6 +120,7 @@ export interface SignUpProps {
   externalAccount: any;
   hasPassword: boolean;
   createdSessionId: string | null;
+  createdUserId: string | null;
   abandonAt: number | null;
 }
 

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -322,6 +322,7 @@ describe('Clerk singleton', () => {
             identifier: '',
             user_data: null,
             created_session_id: null,
+            created_user_id: null,
           } as any as SignInJSON),
           signUp: new SignUp(null),
         }),

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -55,6 +55,7 @@ export class SignUp extends BaseResource implements SignUpResource {
   hasPassword = false;
   unsafeMetadata: Record<string, unknown> = {};
   createdSessionId: string | null = null;
+  createdUserId: string | null = null;
   abandonAt: number | null = null;
 
   constructor(data: SignUpJSON | null = null) {
@@ -207,6 +208,7 @@ export class SignUp extends BaseResource implements SignUpResource {
       this.hasPassword = data.has_password;
       this.unsafeMetadata = data.unsafe_metadata;
       this.createdSessionId = data.created_session_id;
+      this.createdUserId = data.created_user_id;
       this.abandonAt = data.abandon_at;
       this.web3wallet = data.web3_wallet;
     }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -12,8 +12,8 @@ import { SignUpField, SignUpIdentificationField, SignUpStatus } from './signUp';
 import { OAuthStrategy } from './strategies';
 import { BoxShadow, Color, EmUnit, FontFamily, FontWeight, HexColor } from './theme';
 import { UserSettingsJSON } from './userSettings';
-import { VerificationStatus } from './verification';
 import { CamelToSnake } from './utils';
+import { VerificationStatus } from './verification';
 
 export interface ClerkResourceJSON {
   // TODO: Shall we make this optional?
@@ -86,6 +86,7 @@ export interface SignUpJSON extends ClerkResourceJSON {
   has_password: boolean;
   unsafe_metadata: Record<string, unknown>;
   created_session_id: string | null;
+  created_user_id: string | null;
   abandon_at: number | null;
   verifications: SignUpVerificationsJSON | null;
 }

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -24,9 +24,9 @@ import {
   TicketStrategy,
   Web3Strategy,
 } from './strategies';
+import type { SnakeToCamel } from './utils';
 import { CreateMagicLinkFlowReturn, StartMagicLinkFlowParams, VerificationResource } from './verification';
 import { AuthenticateWithWeb3Params, GenerateSignature } from './web3Wallet';
-import type { SnakeToCamel } from './utils';
 
 export interface SignUpResource extends ClerkResource {
   status: SignUpStatus | null;
@@ -45,6 +45,7 @@ export interface SignUpResource extends ClerkResource {
   hasPassword: boolean;
   unsafeMetadata: Record<string, unknown>;
   createdSessionId: string | null;
+  createdUserId: string | null;
   abandonAt: number | null;
 
   create: (params: SignUpCreateParams) => Promise<SignUpResource>;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Populate `signUp.createdUserId` from the sign up Frontend API response as currently `createdUserId` is not available in ClerkJS.

<!-- Fixes # (issue number) -->
