### PR TITLE
fix(clerk-expo): Setup createPageLifecycle only in browser environment

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -94,7 +94,7 @@ export default class Clerk implements ClerkInterface {
   #fapiClient: FapiClient;
   #authService: AuthenticationService | null = null;
   #devBrowserHandler: DevBrowserHandler | null = null;
-  #pageLifecycle = createPageLifecycle();
+  #pageLifecycle: ReturnType<typeof createPageLifecycle> | null = null;
 
   /**
    * @inheritDoc {ClerkInterface.version}
@@ -598,6 +598,8 @@ export default class Clerk implements ClerkInterface {
       fapiClient: this.#fapiClient,
     });
 
+    this.#pageLifecycle = createPageLifecycle();
+
     const isFapiDevOrStaging = isDevOrStagingUrl(this.frontendApi);
     const isInAccountsHostedPages = isAccountsHostedPages(window?.location.hostname);
 
@@ -670,7 +672,7 @@ export default class Clerk implements ClerkInterface {
       return;
     }
 
-    this.#pageLifecycle.onPageVisible(() => {
+    this.#pageLifecycle?.onPageVisible(() => {
       if (this.session) {
         void this.#touchLastActiveSession(this.session);
       }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The createPageLifecycle helper depends on the global document object that is only available in Browsers but not in React Native/Expo.

<!-- Fixes # (issue number) -->
