### PR TITLE
Clerk jwt key injection

### DIFF
--- a/packages/backend-core/src/Base.ts
+++ b/packages/backend-core/src/Base.ts
@@ -30,10 +30,6 @@ export type VerifySessionTokenOptions = {
   jwtKey?: string;
 };
 
-const verifySessionTokenDefaultOptions: VerifySessionTokenOptions = {
-  authorizedParties: [],
-};
-
 type AuthState = {
   status: AuthStatus;
   session?: Session;
@@ -108,7 +104,7 @@ export class Base {
    */
   verifySessionToken = async (
     token: string,
-    { authorizedParties, jwtKey }: VerifySessionTokenOptions = verifySessionTokenDefaultOptions,
+    { authorizedParties, jwtKey }: VerifySessionTokenOptions,
   ): Promise<JWTPayload> => {
     /**
      * Priority of JWT key search

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -68,12 +68,12 @@ export function withEdgeMiddlewareAuth<
 export function withEdgeMiddlewareAuth(
   handler: any,
   options: any = {
-    authorizedParties: [],
     loadSession: false,
     loadUser: false,
   },
 ): any {
   return async function clerkAuth(req: NextRequest, event: NextFetchEvent) {
+    const { loadUser, loadSession, jwtKey, authorizedParties } = options;
     const cookieToken = req.cookies['__session'];
     const headerToken = req.headers.get('authorization');
     const { status, interstitial, sessionClaims } = await vercelEdgeBase.getAuthState({
@@ -86,7 +86,8 @@ export function withEdgeMiddlewareAuth(
       forwardedPort: req.headers.get('x-forwarded-port'),
       forwardedHost: req.headers.get('x-forwarded-host'),
       referrer: req.headers.get('referrer'),
-      authorizedParties: options.authorizedParties,
+      authorizedParties,
+      jwtKey,
       fetchInterstitial,
     });
 
@@ -106,8 +107,8 @@ export function withEdgeMiddlewareAuth(
     const userId = sessionClaims!.sub;
 
     const [user, session] = await Promise.all([
-      options.loadUser ? ClerkAPI.users.getUser(userId) : Promise.resolve(undefined),
-      options.loadSession ? ClerkAPI.sessions.getSession(sessionId) : Promise.resolve(undefined),
+      loadUser ? ClerkAPI.users.getUser(userId) : Promise.resolve(undefined),
+      loadSession ? ClerkAPI.sessions.getSession(sessionId) : Promise.resolve(undefined),
     ]);
 
     const getToken = createGetToken({

--- a/packages/edge/src/vercel-edge/types.ts
+++ b/packages/edge/src/vercel-edge/types.ts
@@ -6,6 +6,7 @@ export type WithEdgeMiddlewareAuthOptions = {
   loadUser?: boolean;
   loadSession?: boolean;
   authorizedParties?: string[];
+  jwtKey?: string;
 };
 
 export type WithEdgeMiddlewareAuthCallback<Return, Options> = (

--- a/packages/nextjs/src/middleware/types.ts
+++ b/packages/nextjs/src/middleware/types.ts
@@ -8,6 +8,8 @@ export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 export type WithServerSideAuthOptions = {
   loadUser?: boolean;
   loadSession?: boolean;
+  jwtKey?: string;
+  authorizedParties?: string[];
 };
 
 export type WithServerSideAuthCallback<Return, Options> = (context: ContextWithAuth<Options>) => Return;

--- a/packages/nextjs/src/middleware/utils/getAuthData.ts
+++ b/packages/nextjs/src/middleware/utils/getAuthData.ts
@@ -12,7 +12,7 @@ export async function getAuthData(
   opts: WithServerSideAuthOptions = {},
 ): Promise<AuthData | null> {
   const { headers, cookies } = ctx.req;
-  const { loadSession, loadUser } = opts;
+  const { loadSession, loadUser, jwtKey, authorizedParties } = opts;
 
   try {
     const cookieToken = cookies['__session'];
@@ -28,6 +28,8 @@ export async function getAuthData(
       referrer: headers.referer,
       userAgent: headers['user-agent'] as string,
       fetchInterstitial: () => Clerk.fetchInterstitial(),
+      jwtKey,
+      authorizedParties,
     });
 
     if (status === AuthStatus.Interstitial) {

--- a/packages/remix/src/ssr/getAuthData.ts
+++ b/packages/remix/src/ssr/getAuthData.ts
@@ -20,7 +20,7 @@ export async function getAuthData(
   req: Request,
   opts: RootAuthLoaderOptions = {},
 ): Promise<{ authData: AuthData | null; showInterstitial?: boolean }> {
-  const { loadSession, loadUser } = opts;
+  const { loadSession, loadUser, jwtKey, authorizedParties } = opts;
   const { headers } = req;
   const cookies = parseCookies(req);
 
@@ -38,6 +38,8 @@ export async function getAuthData(
       referrer: headers.get('referer'),
       userAgent: headers.get('user-agent') as string,
       fetchInterstitial: () => Promise.resolve(''),
+      authorizedParties,
+      jwtKey,
     });
 
     if (status === AuthStatus.Interstitial) {

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -8,6 +8,8 @@ export type RootAuthLoaderOptions = {
   frontendApi?: string;
   loadUser?: boolean;
   loadSession?: boolean;
+  jwtKey?: string;
+  authorizedParties?: [];
 };
 
 export type RootAuthLoaderCallback<Options> = (

--- a/packages/sdk-node/README.md
+++ b/packages/sdk-node/README.md
@@ -713,6 +713,32 @@ export clerk.withAuth(handler);
 export clerk.requireAuth(handler);
 ```
 
+## Networkless token verification using the JWT verification key
+
+Clerk's JWT session token can be verified in a networkless manner using the JWT verification key. By default Clerk will use our JWKs endpoint to fetch and cache the key for any subsequent verification. If you use the `CLERK_JWT_KEY` environment variable to supply the key, Clerk will pick it up and do networkless verification for session tokens using it.
+
+To learn more about Clerk's token verification you can find more information on our [documentation](https://docs.clerk.dev/popular-guides/validating-session-tokens).
+
+The value of the JWT verification key can also be added on the instance level or on any single middleware call e.g.
+
+```ts
+import { withAuth } from '@clerk/clerk-sdk-node';
+
+const handler = (req, res) => {
+  // ...
+};
+
+withAuth(handler, { jwtKey: 'my_clerk_public_key' });
+```
+
+Custom instance initialization:
+
+```ts
+import Clerk from '@clerk/clerk-sdk-node/instance';
+
+const clerk = new Clerk({ jwtKey: 'my_clerk_public_key' });
+```
+
 ## Validate the Authorized Party of a session token
 
 Clerk's JWT session token, contains the azp claim, which equals the Origin of the request during token generation. You can provide the middlewares with a list of whitelisted origins to verify against, to protect your application of the subdomain cookie leaking attack. You can find an example below:

--- a/packages/sdk-node/src/__tests__/instance.test.ts
+++ b/packages/sdk-node/src/__tests__/instance.test.ts
@@ -1,4 +1,5 @@
 const TEST_API_KEY = 'TEST_API_KEY';
+const TEST_JWT_KEY = 'TEST_JWT_KEY';
 
 describe('Custom Clerk instance initialization', () => {
   test('throw error when initialized without apiKey', () => {
@@ -26,17 +27,21 @@ describe('Custom Clerk instance initialization', () => {
   test('custom keys overrides process env and default params', () => {
     jest.resetModules();
     process.env.CLERK_API_KEY = TEST_API_KEY;
+    process.env.CLERK_JWT_KEY = TEST_JWT_KEY;
     const Clerk = require('../instance').default;
     expect(() => {
-      const customKey = 'custom_key';
+      const customAPIKey = 'custom_api_key';
+      const customJWTKey = 'custom_jwt_key';
       const customAPIVersion = 'v0';
       const customAPIUrl = 'https://customdomain.com';
       const instance = new Clerk({
-        apiKey: customKey,
+        apiKey: customAPIKey,
+        jwtKey: customJWTKey,
         serverApiUrl: customAPIUrl,
         apiVersion: customAPIVersion,
       });
-      expect(instance._restClient.apiKey).toBe(customKey);
+      expect(instance._restClient.apiKey).toBe(customAPIKey);
+      expect(instance.jwtKey).toBe(customJWTKey);
       expect(instance._restClient.serverApiUrl).toBe(customAPIUrl);
       expect(instance._restClient.apiVersion).toBe(customAPIVersion);
     }).not.toThrow(Error);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Add the capability for injected JWT verification key:
- Clerk sdk Node instance creation.
- Clerk sdk Node by default picking up the `CLERK_JWT_KEY` environment variable if available.
- `verifySessionToken` which is exposed by `base` takes also a `jwtKey` argument to use any supplied key.
- All middlewares have the option of `jwtKey` e.g. `withAuth(..., { jwtKey });`

Note:
Added support for `authorizedParties` option on remix and nextjs middleware.

<!-- Fixes # (issue number) -->
https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=b253a2f980c641de8992cc63ed416fa0&p=88f966d0bcda4b8c9f10a3d80c2c8219