### PR TITLE
Expose Avatar With Uploader Component

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -4,6 +4,7 @@ import { inClientSide } from '@clerk/shared/utils/ssr';
 import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
+  AvatarWithUploaderProps,
   BeforeEmitCallback,
   Clerk as ClerkInterface,
   ClerkOptions,
@@ -238,6 +239,23 @@ export default class Clerk implements ClerkInterface {
   };
 
   public unmountUserButton = (node: HTMLDivElement): void => {
+    this.assertComponentsReady(this.#components);
+    this.#components.unmountComponent({
+      node,
+    });
+  };
+
+  public mountAvatarWithUploader = (node: HTMLDivElement, props?: AvatarWithUploaderProps): void => {
+    this.assertComponentsReady(this.#components);
+    this.#components.mountComponent({
+      name: 'AvatarWithUploader',
+      node,
+      nodeClassName: 'cl-avatar-with-uploader',
+      props,
+    });
+  };
+
+  public unmountAvatarWithUploader = (node: HTMLDivElement): void => {
     this.assertComponentsReady(this.#components);
     this.#components.unmountComponent({
       node,

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -28,6 +28,7 @@ import { SignUp, SignUpModal } from './signUp';
 import type { AvailableComponentCtx, AvailableComponentProps } from './types';
 import { UserButton } from './userButton';
 import { UserProfile } from './userProfile';
+import { avatarWithUploader } from "./userProfile/account/avatarWithUploader"
 
 import './styles/clerk.scss';
 
@@ -36,6 +37,7 @@ const AvailableComponents = {
   SignUp,
   UserButton,
   UserProfile,
+  AvatarWithUploader: avatarWithUploader,
 };
 
 type AvailableComponentNames = keyof typeof AvailableComponents;

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -1,4 +1,4 @@
-import { SignInProps, SignUpProps, UserButtonProps, UserProfileProps } from '@clerk/types';
+import { SignInProps, SignUpProps, UserButtonProps, UserProfileProps, AvatarWithUploaderProps } from '@clerk/types';
 import React from 'react';
 
 import { MountProps, WithClerkProp } from '../types';
@@ -91,3 +91,13 @@ export const UserButton = withClerk(({ clerk, ...props }: WithClerkProp<UserButt
     />
   );
 }, 'UserButton');
+
+export const AvatarWithUploader = withClerk(({ clerk, ...props }: WithClerkProp<AvatarWithUploaderProps>) => {
+  return (
+    <Portal
+      mount={clerk.mountAvatarWithUploader}
+      unmount={clerk.unmountAvatarWithUploader}
+      props={props}
+    />
+  );
+}, 'AvatarWithUploader');

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -1,6 +1,7 @@
 import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
+  AvatarWithUploaderProps,
   ClientResource,
   CreateOrganizationParams,
   HandleMagicLinkVerificationParams,
@@ -47,6 +48,7 @@ export default class IsomorphicClerk {
   private premountSignUpNodes = new Map<HTMLDivElement, SignUpProps>();
   private premountUserProfileNodes = new Map<HTMLDivElement, UserProfileProps>();
   private premountUserButtonNodes = new Map<HTMLDivElement, UserButtonProps>();
+  private premountAvatarWithUploaderNodes = new Map<HTMLDivElement, AvatarWithUploaderProps>();
   private premountMethodCalls = new Map<MethodName<BrowserClerk>, MethodCallback>();
   private loadedListeners: Array<() => void> = [];
 
@@ -176,6 +178,10 @@ export default class IsomorphicClerk {
 
     this.premountUserButtonNodes.forEach((props: UserButtonProps, node: HTMLDivElement) => {
       clerkjs.mountUserButton(node, props);
+    });
+
+    this.premountAvatarWithUploaderNodes.forEach((props: AvatarWithUploaderProps, node: HTMLDivElement) => {
+      clerkjs.mountAvatarWithUploader(node, props);
     });
 
     this._loaded = true;
@@ -327,6 +333,22 @@ export default class IsomorphicClerk {
       this.clerkjs.unmountUserButton(node);
     } else {
       this.premountUserButtonNodes.delete(node);
+    }
+  };
+
+  mountAvatarWithUploader = (node: HTMLDivElement, props: AvatarWithUploaderProps): void => {
+    if (this.clerkjs && this._loaded) {
+      this.clerkjs.mountAvatarWithUploader(node, props);
+    } else {
+      this.premountAvatarWithUploaderNodes.set(node, props);
+    }
+  };
+
+  unmountAvatarWithUploader = (node: HTMLDivElement): void => {
+    if (this.clerkjs && this._loaded) {
+      this.clerkjs.unmountAvatarWithUploader(node);
+    } else {
+      this.premountAvatarWithUploaderNodes.delete(node);
     }
   };
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -144,6 +144,22 @@ export interface Clerk {
   unmountUserProfile: (targetNode: HTMLDivElement) => void;
 
   /**
+   * Mount an avatar with uploader component at the target element.
+   *
+   * @param targetNode Target to mount the UserProfile component.
+   * @param avatarWithUploaderProps Avatar uploader configuration parameters.
+   */
+  mountAvatarWithUploader: (targetNode: HTMLDivElement, avatarWithUploaderProps?: AvatarWithUploaderProps) => void;
+
+  /**
+   * Unmount a user profile component at the target element.
+   * If there is no component mounted at the target node, results in a noop.
+   *
+   * @param targetNode Target node to unmount the UserProfile component from.
+   */
+  unmountAvatarWithUploader: (targetNode: HTMLDivElement) => void;
+
+  /**
    * Register a listener that triggers a callback each time important Clerk resources are changed.
    * Allows to hook up at different steps in the sign up, sign in processes.
    *
@@ -402,6 +418,17 @@ export type UserButtonProps = {
    */
   afterSwitchSessionUrl?: string;
 };
+
+export type AvatarWithUploaderProps = {
+  firstName?: string | null;
+  lastName?: string | null;
+  profileImageUrl?: string;
+  profileImageFetchSize?: number;
+  name?: string | null;
+  size?: number;
+  className?: string;
+  optimize?: boolean;
+}
 
 export interface HandleMagicLinkVerificationParams {
   /**


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
Exposes the Avatar With Uploader component to be used outside of the default User Profile.
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
I'm sure there's probably a more thought out process as to when and how new components are exposed to the API, but I figured I would put up the PR to communicate a feature request. I wanted to use your Profile Image component without having to search `npm` for one (which, I did not find a good one). My approach for the PR was basically command+f-ing `UserProfile` and adapting `AvatarWithUploader` where it made sense.

<!-- Fixes # (issue number) -->
