### PR TITLE
fix(clerk-expo): Make Clerk loading smarter

### DIFF
--- a/packages/expo/src/ClerkProvider.tsx
+++ b/packages/expo/src/ClerkProvider.tsx
@@ -9,16 +9,17 @@ import { buildClerk } from './singleton';
 export type ClerkProviderProps = ClerkReactProviderProps & {
   children: React.ReactNode;
   tokenCache?: TokenCache;
+  hotload?: boolean;
 };
 
 export function ClerkProvider(props: ClerkProviderProps): JSX.Element {
-  const { children, tokenCache, ...rest } = props;
+  const { children, tokenCache, hotload, ...rest } = props;
   const frontendApi = props.frontendApi || process.env.CLERK_FRONTEND_API || '';
 
   const clerkRef = React.useRef<ReturnType<typeof buildClerk> | null>(null);
 
   function getClerk() {
-    if (clerkRef.current === null) {
+    if (clerkRef.current === null && !hotload) {
       clerkRef.current = buildClerk({
         frontendApi,
         tokenCache,

--- a/packages/expo/src/singleton.ts
+++ b/packages/expo/src/singleton.ts
@@ -22,8 +22,7 @@ export function buildClerk({ frontendApi, tokenCache }: BuildClerkOptions): Cler
     clerk = new Clerk(frontendApi);
 
     if (!tokenCache) {
-      // Exit early if tokenCache is not provided, assuming web platform
-      return;
+      return clerk;
     }
 
     // @ts-expect-error


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

- [x] Introduce a new hotloading prop to control whether ClerkJS should be hotloaded in Expo browser environments
- [x] Always return the created Clerk instance regardless of the tokenCache prop. That way, we will prevent ClerkJS hotloading efforts in native applications when tokenCache prop is not set
<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
