### PR TITLE
Rename UserButton signout params

### DIFF
--- a/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.test.tsx
+++ b/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.test.tsx
@@ -83,7 +83,7 @@ describe('ActiveAccountsManager', () => {
     const tree = renderJSON(
       <ActiveAccountsManager
         sessions={sessions}
-        navigateAfterSignOutAll={noop}
+        navigateAfterSignOut={noop}
         navigateAfterSwitchSession={noop}
         userProfileUrl={'user_profile_url'}
         signInUrl={'sign_in_url'}
@@ -99,7 +99,7 @@ describe('ActiveAccountsManager', () => {
       <ActiveAccountsManager
         showActiveAccountButtons={false}
         sessions={[session]}
-        navigateAfterSignOutAll={noop}
+        navigateAfterSignOut={noop}
         navigateAfterSwitchSession={noop}
         userProfileUrl={'user_profile_url'}
         signInUrl={'sign_in_url'}
@@ -115,7 +115,7 @@ describe('ActiveAccountsManager', () => {
       <ActiveAccountsManager
         showActiveAccountButtons={false}
         sessions={[session]}
-        navigateAfterSignOutAll={noop}
+        navigateAfterSignOut={noop}
         navigateAfterSwitchSession={noop}
         userProfileUrl={'user_profile_url'}
         signInUrl={'sign_in_url'}

--- a/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
+++ b/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
@@ -12,9 +12,9 @@ import SignOutAll from './SignOutAll';
 
 interface ActiveAccountsManagerProps {
   sessions: SessionResource[];
-  navigateAfterSignOutAll: () => void;
+  navigateAfterSignOut: () => void;
   navigateAfterSwitchSession: () => void;
-  navigateAfterSignOutOne?: () => void;
+  navigateAfterMultiSessionSingleSignOut?: () => void;
   userProfileUrl: string;
   signInUrl: string;
   showActiveAccountButtons?: boolean;
@@ -22,8 +22,8 @@ interface ActiveAccountsManagerProps {
 
 export function ActiveAccountsManager({
   sessions,
-  navigateAfterSignOutAll,
-  navigateAfterSignOutOne,
+  navigateAfterSignOut,
+  navigateAfterMultiSessionSingleSignOut,
   navigateAfterSwitchSession,
   signInUrl,
   userProfileUrl,
@@ -46,7 +46,9 @@ export function ActiveAccountsManager({
       return;
     }
 
-    signOut(navigateAfterSignOutOne, { sessionId: currentSessionId }).catch(() => setSignoutInProgress(false));
+    signOut(navigateAfterMultiSessionSingleSignOut, { sessionId: currentSessionId }).catch(() =>
+      setSignoutInProgress(false),
+    );
   };
 
   const handleManageAccountClick = () => {
@@ -71,7 +73,7 @@ export function ActiveAccountsManager({
   };
 
   const handleSignOutAll = () => {
-    return signOut(navigateAfterSignOutAll);
+    return signOut(navigateAfterSignOut);
   };
 
   const shouldRenderAccountSwitcher = sessions.length || !authConfig.singleSessionMode;

--- a/packages/clerk-js/src/ui/common/authPropHelpers.ts
+++ b/packages/clerk-js/src/ui/common/authPropHelpers.ts
@@ -20,21 +20,12 @@ type ParseAuthPropArgs =
 
 export const parseAuthProp = ({ ctx, queryParams, displayConfig, field }: ParseAuthPropArgs): string => {
   const snakeCaseField = camelToSnake(field);
-
-  // Todo: Dx: Deprecate afterSignIn and afterSignUp legacy fields
-  const legacyField = field.replace('Url', '');
-  let legacyFieldValue: string | undefined = undefined;
-  if (legacyField in ctx) {
-    // @ts-ignore
-    legacyFieldValue = ctx[legacyField];
-  }
   const queryParamValue = queryParams[snakeCaseField];
 
   return (
     (typeof queryParamValue === 'string' ? queryParamValue : null) ||
     (typeof queryParams.redirect_url === 'string' ? queryParams.redirect_url : null) ||
     ctx[field] ||
-    legacyFieldValue ||
     ctx.redirectUrl ||
     displayConfig[field]
   );

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -169,24 +169,24 @@ export const useUserButtonContext = () => {
   const signInUrl = ctx.signInUrl || displayConfig.signInUrl;
   const userProfileUrl = ctx.userProfileUrl || displayConfig.userProfileUrl;
 
-  const afterSignOutOneUrl = ctx.afterSignOutOneUrl || displayConfig.afterSignOutOneUrl;
-  const navigateAfterSignOutOne = () => navigate(afterSignOutOneUrl);
+  const afterMultiSessionSingleSignOutUrl = ctx.afterMultiSessionSingleSignOutUrl || displayConfig.afterSignOutOneUrl;
+  const navigateAfterMultiSessionSingleSignOut = () => navigate(afterMultiSessionSingleSignOutUrl);
 
-  const afterSignOutAllUrl = ctx.afterSignOutAllUrl || displayConfig.afterSignOutAllUrl;
-  const navigateAfterSignOutAll = () => navigate(afterSignOutAllUrl);
+  const afterSignOutUrl = ctx.afterSignOutUrl || displayConfig.afterSignOutAllUrl;
+  const navigateAfterSignOut = () => navigate(afterSignOutUrl);
 
   const afterSwitchSessionUrl = (ctx.afterSwitchSessionUrl = displayConfig.afterSwitchSessionUrl);
   const navigateAfterSwitchSession = () => navigate(afterSwitchSessionUrl);
 
   return {
     ...ctx,
-    navigateAfterSignOutOne,
-    navigateAfterSignOutAll,
+    navigateAfterMultiSessionSingleSignOut,
+    navigateAfterSignOut,
     navigateAfterSwitchSession,
     signInUrl,
     userProfileUrl,
-    afterSignOutOneUrl,
-    afterSignOutAllUrl,
+    afterMultiSessionSingleSignOutUrl,
+    afterSignOutUrl,
     afterSwitchSessionUrl,
   };
 };

--- a/packages/clerk-js/src/ui/signIn/SignInAccountSwitcher.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInAccountSwitcher.tsx
@@ -19,7 +19,7 @@ function _SignInAccountSwitcher(): JSX.Element | null {
         <ActiveAccountsManager
           sessions={sessions}
           showActiveAccountButtons={false}
-          navigateAfterSignOutAll={() => {
+          navigateAfterSignOut={() => {
             navigate(displayConfig.afterSignOutAllUrl);
           }}
           navigateAfterSwitchSession={navigateAfterSignIn}

--- a/packages/clerk-js/src/ui/userButton/UserButton.test.tsx
+++ b/packages/clerk-js/src/ui/userButton/UserButton.test.tsx
@@ -52,8 +52,8 @@ jest.mock('ui/contexts', () => {
     useUserButtonContext: () => {
       return {
         useUserButtonContext: jest.fn(() => ({
-          navigateAfterSignOutOne: jest.fn(),
-          navigateAfterSignOutAll: jest.fn(),
+          navigateAfterMultiSessionSingleSignOut: jest.fn(),
+          navigateAfterSignOut: jest.fn(),
           navigateAfterSwitchSession: jest.fn(),
           userProfileURL: 'http://test.host/profile',
           signInUrl: 'http://test.host/signin',

--- a/packages/clerk-js/src/ui/userButton/UserButtonPopup.test.tsx
+++ b/packages/clerk-js/src/ui/userButton/UserButtonPopup.test.tsx
@@ -69,8 +69,8 @@ jest.mock('ui/contexts', () => {
       },
     })),
     useUserButtonContext: jest.fn(() => ({
-      navigateAfterSignOutOne: jest.fn(),
-      navigateAfterSignOutAll: jest.fn(),
+      navigateAfterMultiSessionSingleSignOut: jest.fn(),
+      navigateAfterSignOut: jest.fn(),
       navigateAfterSwitchSession: jest.fn(),
       userProfileURL: 'http://test.host/profile',
       signInUrl: 'http://test.host/signin',

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -79,7 +79,7 @@ function App() {
     <>
       <h1>Hello Clerk!</h1>
       <SignedIn>
-        <UserButton afterSignOutAllUrl={window.location.href} />
+        <UserButton afterSignOutUrl={window.location.href} />
       </SignedIn>
       <SignedOut>
         <SignInButton mode='modal' />

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -374,15 +374,15 @@ export type UserButtonProps = {
   showName?: boolean;
 
   /**
-   * Full URL or path to navigate after sign-out is complete
-   * and there are not other active sessions on this client.
+   * Full URL or path to navigate after sign out is complete
    */
-  afterSignOutAllUrl?: string;
+  afterSignOutUrl?: string;
 
   /**
-   * Full URL or path to navigate after sign-out is complete.
+   * Full URL or path to navigate after signing out the current user is complete.
+   * This option applies to multi-session applications.
    */
-  afterSignOutOneUrl?: string;
+  afterMultiSessionSingleSignOutUrl?: string;
 
   /*
    * Full URL or path leading to the


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
We updated the signOut api. This PR also updates the params of UserButton because many found them confusing.

Suggested changes:
afterSignOutUrl - the standard
afterMultiSessionSingleSignOutUrl - the special case for multisession apps


<!-- Fixes # (issue number) -->
