### PR TITLE
fix(clerk-js): Force client update on resource reload

### DIFF
--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -132,6 +132,6 @@ export abstract class BaseResource {
   }
 
   public async reload(): Promise<this> {
-    return this._baseGet();
+    return this._baseGet({ forceUpdateClient: true });
   }
 }

--- a/packages/clerk-js/src/core/resources/EmailAddress.ts
+++ b/packages/clerk-js/src/core/resources/EmailAddress.ts
@@ -60,7 +60,7 @@ export class EmailAddress extends BaseResource implements EmailAddressResource {
       });
       return new Promise((resolve, reject) => {
         void run(() => {
-          return this._baseGet({ forceUpdateClient: true })
+          return this.reload()
             .then(async res => {
               if (res.verification.status === 'verified') {
                 stop();

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -113,7 +113,7 @@ export class SignIn extends BaseResource implements SignInResource {
       });
       return new Promise((resolve, reject) => {
         void run(() => {
-          return this._baseGet({ forceUpdateClient: true })
+          return this.reload()
             .then(res => {
               const status = res.firstFactorVerification.status;
               if (status === 'verified' || status === 'expired') {

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -106,7 +106,7 @@ export class SignUp extends BaseResource implements SignUpResource {
 
       return new Promise((resolve, reject) => {
         void run(() => {
-          return this._baseGet({ forceUpdateClient: true })
+          return this.reload()
             .then(res => {
               const status = res.verifications.emailAddress.status;
               if (status === 'verified' || status === 'expired') {


### PR DESCRIPTION
Apply a minor refactoring across all _baseGet usages.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
