### PR TITLE
feat(types,clerk-js,backend-core,clerk-react): Replace thrown error w…

### DIFF
--- a/packages/backend-core/src/util/createGetToken.ts
+++ b/packages/backend-core/src/util/createGetToken.ts
@@ -20,14 +20,14 @@ type CreateGetToken = (params: {
  */
 export const createGetToken: CreateGetToken = params => {
   const { cookieToken, fetcher, headerToken, sessionId } = params || {};
-  return (options: ServerGetTokenOptions = {}) => {
+  return async (options: ServerGetTokenOptions = {}) => {
     if (!sessionId) {
-      throw new Error('getToken cannot be called without a session.');
+      return null;
     }
     if (options.template) {
       return fetcher(sessionId, options.template);
     }
-    return Promise.resolve(headerToken || cookieToken) as Promise<string>;
+    return (headerToken || cookieToken) as string;
   };
 };
 

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -51,9 +51,9 @@ export class Session extends BaseResource implements SessionResource {
     });
   };
 
-  getToken: GetToken = async (options?: GetTokenOptions): Promise<string> => {
+  getToken: GetToken = async (options?: GetTokenOptions): Promise<string | null> => {
     if (!this.user) {
-      throw new Error('You cannot call getToken when user is null');
+      return null;
     }
 
     const { leewayInSeconds = 10, template, skipCache = false } = options || {};

--- a/packages/react/src/hooks/utils.ts
+++ b/packages/react/src/hooks/utils.ts
@@ -18,9 +18,7 @@ const clerkLoaded = (isomorphicClerk: IsomorphicClerk) => {
 export const createGetToken = (isomorphicClerk: IsomorphicClerk) => async (options: any) => {
   await clerkLoaded(isomorphicClerk);
   if (!isomorphicClerk.session) {
-    throw new Error(
-      'getToken cannot be called without a session. Check if sessionId has a value before calling getToken',
-    );
+    return null;
   }
   return isomorphicClerk.session.getToken(options);
 };

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -55,4 +55,4 @@ export interface PublicUserData {
 }
 
 export type GetTokenOptions = { template: string; leewayInSeconds?: number; skipCache?: boolean };
-export type GetToken = (options?: GetTokenOptions) => Promise<string>;
+export type GetToken = (options?: GetTokenOptions) => Promise<string | null>;

--- a/packages/types/src/ssr.ts
+++ b/packages/types/src/ssr.ts
@@ -3,7 +3,7 @@ import { SessionResource } from './session';
 import { UserResource } from './user';
 
 export type ServerGetTokenOptions = { template?: string };
-export type ServerGetToken = (options?: ServerGetTokenOptions) => Promise<string>;
+export type ServerGetToken = (options?: ServerGetTokenOptions) => Promise<string | null>;
 
 export type ServerSideAuth = {
   sessionId: string | null;


### PR DESCRIPTION
…ith null return in getToken

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
After discussing internally, we all agreed that our main target should be TS cobases so our API design should be optimised for that.

So instead of throwing an error if getToken were to be called without an active session, we change the getToken return value to Promise<string | null>
<!-- Fixes # (issue number) -->
