### PR TITLE
fix(clerk-sdk-node): Add ServerGetToken on AuthProp enhancers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23210,6 +23210,7 @@
       "license": "MIT",
       "dependencies": {
         "@clerk/backend-core": "^1.0.2-staging.0",
+        "@clerk/types": "^2.1.2-staging.0",
         "@peculiar/webcrypto": "^1.2.3",
         "camelcase-keys": "^6.2.2",
         "cookies": "^0.8.0",
@@ -24822,6 +24823,7 @@
       "version": "file:packages/sdk-node",
       "requires": {
         "@clerk/backend-core": "^1.0.2-staging.0",
+        "@clerk/types": "*",
         "@peculiar/webcrypto": "^1.2.3",
         "@types/cookies": "^0.7.7",
         "@types/express": "^4.17.11",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@clerk/backend-core": "^1.0.2-staging.0",
+    "@clerk/types": "^2.1.2-staging.0",
     "@peculiar/webcrypto": "^1.2.3",
     "camelcase-keys": "^6.2.2",
     "cookies": "^0.8.0",

--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -23,6 +23,7 @@ import Logger from './utils/Logger';
 import { Crypto, CryptoKey } from '@peculiar/webcrypto';
 
 import { decodeBase64, toSPKIDer } from './utils/crypto';
+import { ServerGetToken } from '@clerk/types';
 
 const defaultApiKey = process.env.CLERK_API_KEY || '';
 const defaultJWTKey = process.env.CLERK_JWT_KEY;
@@ -42,6 +43,7 @@ export type WithAuthProp<T> = T & {
   auth: {
     sessionId: string | null;
     userId: string | null;
+    getToken: ServerGetToken;
   };
 };
 
@@ -49,6 +51,7 @@ export type RequireAuthProp<T> = T & {
   auth: {
     sessionId: string;
     userId: string;
+    getToken: ServerGetToken;
   };
 };
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Fix missing `getToken` attribute from the auth prop enhancer.
This PR adds @clerk/types dependency on sdk-node
