### PR TITLE
fix(clerk-react): Make useSession hook correctly return an ActiveSess…

### DIFF
--- a/packages/react/src/hooks/useSession.ts
+++ b/packages/react/src/hooks/useSession.ts
@@ -1,11 +1,11 @@
-import { SessionResource } from '@clerk/types';
+import { ActiveSessionResource } from '@clerk/types';
 
 import { useSessionContext } from '../contexts/SessionContext';
 
 type UseSessionReturn =
   | { isLoaded: false; isSignedIn: undefined; session: undefined }
   | { isLoaded: true; isSignedIn: false; session: null }
-  | { isLoaded: true; isSignedIn: true; session: SessionResource };
+  | { isLoaded: true; isSignedIn: true; session: ActiveSessionResource };
 
 type UseSession = () => UseSessionReturn;
 


### PR DESCRIPTION
…ionResource

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
useSession should be returning an ActiveSessionResource instead of a normal SessionResource.

Thanks for the catch @npetridis 
More context: https://github.com/clerkinc/dashboard/pull/376/files#r833111208
<!-- Fixes # (issue number) -->
