### PR TITLE
fix(clerk-js): Remove integration_ prefix for legacy user token requests

### DIFF
--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -98,6 +98,10 @@ export class Session extends BaseResource implements SessionResource {
     return (template || '').startsWith('integration_');
   };
 
+  #removeLegacyIntegrationPrefix = (template: string | undefined): string => {
+    return (template || '').replace('integration_', '');
+  };
+
   // Can be removed once `integration_firebase` and `integration_hasura`
   // are no longer supported
   #handleLegacyIntegrationToken = async (options: GetTokenOptions): Promise<string> => {
@@ -107,7 +111,7 @@ export class Session extends BaseResource implements SessionResource {
       return cachedEntry.tokenResolver.then(res => res.getRawString());
     }
     const resolver = Token.create(this.user!.pathRoot + '/tokens', {
-      service: template,
+      service: this.#removeLegacyIntegrationPrefix(template),
     });
     SessionTokenCache.set({
       tokenId: this.user!.id,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The /me/token endpoints expects a clean service name, without the `integration_` prefix
<!-- Fixes # (issue number) -->
