### PR TITLE
fix(clerk-js): Fall back to generic error when oauth sign in/up fails

### DIFF
--- a/packages/clerk-js/src/ui/signIn/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInStart.test.tsx
@@ -399,4 +399,28 @@ fdescribe('<SignInStart/>', () => {
       expect(mockCreateRequest).toHaveBeenNthCalledWith(1, {});
     });
   });
+
+  describe('when a miscellaneous oauth error occurs', () => {
+    it('renders a generic error message', () => {
+      const genericErrorMsg = 'Unable to complete action at this time. If the problem persists please contact support.';
+
+      mocked(useCoreSignIn as jest.Mock<SignInResource>, true).mockImplementationOnce(
+        () =>
+          ({
+            create: mockCreateRequest,
+            firstFactorVerification: {
+              error: {
+                code: 'omg_they_killed_kenny',
+                longMessage: 'All hope is lost',
+              },
+            },
+          } as unknown as SignInResource),
+      );
+
+      render(<SignInStart />);
+
+      expect(screen.getByText(genericErrorMsg)).toBeInTheDocument();
+      expect(mockCreateRequest).toHaveBeenNthCalledWith(1, {});
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/signIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInStart.tsx
@@ -83,8 +83,18 @@ export function _SignInStart(): JSX.Element {
   React.useEffect(() => {
     async function handleOauthError() {
       const error = signIn?.firstFactorVerification?.error;
-      if (error?.code === ERROR_CODES.NOT_ALLOWED_TO_SIGN_UP || error?.code === ERROR_CODES.OAUTH_ACCESS_DENIED) {
-        setError(error.longMessage);
+
+      if (error) {
+        switch (error.code) {
+          case ERROR_CODES.NOT_ALLOWED_TO_SIGN_UP:
+          case ERROR_CODES.OAUTH_ACCESS_DENIED:
+            setError(error.longMessage);
+            break;
+          default:
+            // Error from server may be too much information for the end user, so set a generic error
+            setError('Unable to complete action at this time. If the problem persists please contact support.');
+        }
+
         // TODO: This is a workaround in order to reset the sign in attempt
         // so that the oauth error does not persist on full page reloads.
         void (await signIn.create({}));

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
@@ -1,11 +1,12 @@
-import { render, renderJSON, screen, userEvent, waitFor } from '@clerk/shared/testUtils';
+import { mocked, render, renderJSON, screen, userEvent, waitFor } from '@clerk/shared/testUtils';
 import { titleize } from '@clerk/shared/utils/string';
-import { UserSettingsJSON } from '@clerk/types';
+import { SignInResource, UserSettingsJSON } from '@clerk/types';
 import { Session, UserSettings } from 'core/resources/internal';
 import React from 'react';
-import { useCoreSignUp } from 'ui/contexts';
+import { useCoreSignIn, useCoreSignUp } from 'ui/contexts';
 
 import { SignUpStart } from './SignUpStart';
+import { SignInStart } from 'ui/signIn/SignInStart';
 
 const navigateMock = jest.fn();
 const mockCreateRequest = jest.fn();
@@ -269,6 +270,31 @@ describe('<SignUpStart/>', () => {
       render(<SignUpStart />);
 
       expect(screen.getByText(errorMsg)).toBeInTheDocument();
+      expect(mockCreateRequest).toHaveBeenNthCalledWith(1, {});
+    });
+  });
+
+  describe('when a miscellaneous oauth error occurs', () => {
+    it('renders a generic error message', () => {
+      const genericErrorMsg = 'Unable to complete action at this time. If the problem persists please contact support.';
+
+      (useCoreSignUp as jest.Mock).mockImplementation(() => {
+        return {
+          create: mockCreateRequest,
+          verifications: {
+            externalAccount: {
+              error: {
+                code: 'omg_they_killed_kenny',
+                longMessage: 'All hope is lost',
+              },
+            },
+          },
+        };
+      });
+
+      render(<SignUpStart />);
+
+      expect(screen.getByText(genericErrorMsg)).toBeInTheDocument();
       expect(mockCreateRequest).toHaveBeenNthCalledWith(1, {});
     });
   });

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -94,8 +94,16 @@ function _SignUpStart(): JSX.Element {
     async function handleOauthError() {
       const error = signUp.verifications.externalAccount.error;
 
-      if (error?.code === ERROR_CODES.NOT_ALLOWED_TO_SIGN_UP || error?.code === ERROR_CODES.OAUTH_ACCESS_DENIED) {
-        setError(error.longMessage);
+      if (error) {
+        switch (error.code) {
+          case ERROR_CODES.NOT_ALLOWED_TO_SIGN_UP:
+          case ERROR_CODES.OAUTH_ACCESS_DENIED:
+            setError(error.longMessage);
+            break;
+          default:
+            // Error from server may be too much information for the end user, so set a generic error
+            setError('Unable to complete action at this time. If the problem persists please contact support.');
+        }
 
         // TODO: This is a hack to reset the sign in attempt so that the oauth error
         // does not persist on full page reloads.


### PR DESCRIPTION
## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

Previously, unless the error was "sign up not allowed" or "access not granted", we would not show any error notification to the user.

However, other issues can occur, due to e.g. network errors or invalid custom scopes.

This PR introduces a fallback to a generic error so that the user can at least be notified that their sign in / up failed (besides the obvious fact that they are not signed in).

<img width="704" alt="image" src="https://user-images.githubusercontent.com/5611795/160600060-aa5e44ba-3498-4c66-88b1-0d63eff00d1e.png">

Related issue:

https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=531db68c98394e709bafd5b5e1df4add&p=70223f2c7a3c4ed8aa4a97df66fd755a