### PR TITLE
fix(backend-core): Fix verifySessionToken to optionally allow params

### DIFF
--- a/packages/backend-core/src/Base.ts
+++ b/packages/backend-core/src/Base.ts
@@ -104,7 +104,7 @@ export class Base {
    */
   verifySessionToken = async (
     token: string,
-    { authorizedParties, jwtKey }: VerifySessionTokenOptions,
+    { authorizedParties, jwtKey }: VerifySessionTokenOptions = {},
   ): Promise<JWTPayload> => {
     /**
      * Priority of JWT key search


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Set default empty object for options on `base.verifySessionToken` 

<!-- Fixes # (issue number) -->
