### PR TITLE
Prevent re-initialization of Clerk singletons

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint-fix": "eslint . --ext .ts",
     "bump": "lerna version",
     "bump:next": "lerna version --conventional-prerelease",
-    "bump:staging": "lerna version prepatch --preid staging --no-changelog",
+    "bump:staging": "lerna version --conventional-prerelease --preid staging --no-changelog",
     "graduate": "lerna version --conventional-graduate",
     "release:staging": "lerna publish from-package --dist-tag staging",
     "release": "lerna publish from-package",

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -122,6 +122,10 @@ export default class Clerk implements ClerkInterface {
   public isReady = (): boolean => this.#isReady;
 
   public load = async (options?: ClerkOptions): Promise<void> => {
+    if (this.#isReady) {
+      return;
+    }
+
     this.#options = {
       ...defaultOptions,
       ...options,

--- a/packages/react/src/contexts/ClerkProvider.tsx
+++ b/packages/react/src/contexts/ClerkProvider.tsx
@@ -16,9 +16,10 @@ export interface ClerkProviderProps extends IsomorphicClerkOptions {
 
 function ClerkProviderBase(props: React.PropsWithChildren<ClerkProviderProps>) {
   const [clerkLoaded, setClerkLoaded] = useState(false);
+
   const clerk = useMemo(() => {
-    const { frontendApi = '', Clerk: ClerkConstructor, initialState, ...rest } = props;
-    return new IsomorphicClerk(frontendApi, rest, ClerkConstructor, initialState);
+    const { frontendApi = '', Clerk: ClerkConstructor, initialState, ...options } = props;
+    return IsomorphicClerk.getOrCreateInstance({ frontendApi, options, Clerk: ClerkConstructor, initialState });
   }, []);
 
   useEffect(() => {

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -11,34 +11,45 @@ const FAILED_TO_LOAD_ERROR = 'Clerk: Failed to load Clerk';
 const MISSING_PROVIDER_ERROR = 'Clerk: Missing provider';
 const MISSING_BODY_ERROR = 'Clerk: Missing <body> element.';
 
-function isStaging(frontendApi: string): boolean {
+const UNSTABLE_RELEASE_TAGS = ['staging'];
+
+const extractNonStableTag = (packageVersion: string) => {
+  const tag = packageVersion.match(/-(.*)\./)?.[1];
+  return tag && UNSTABLE_RELEASE_TAGS.includes(tag) ? tag : undefined;
+};
+
+const extractMajorVersion = (packageVersion: string) => {
+  return packageVersion.split('.')[0];
+};
+
+const forceStagingReleaseForClerkFapi = (frontendApi: string): boolean => {
   return (
     frontendApi.endsWith('.lclstage.dev') ||
     frontendApi.endsWith('.stgstage.dev') ||
     frontendApi.endsWith('.clerkstage.dev')
   );
-}
-
-function extractTag(packageJsonVersion: string) {
-  return packageJsonVersion.match(/-(.*)\./);
-}
+};
 
 function getScriptSrc({ frontendApi, scriptUrl, scriptVariant = '' }: LoadScriptParams): string {
   if (scriptUrl) {
     return scriptUrl;
   }
 
-  const majorVersion = isStaging(frontendApi) ? 'staging' : parseInt(LIB_VERSION.split('.')[0], 10);
+  const variant = scriptVariant ? `${scriptVariant.replace(/\.+$/, '')}.` : '';
+  const getUrlForTag = (target: string) => {
+    return `https://${frontendApi}/npm/@clerk/clerk-js@${target}/dist/clerk.${variant}browser.js`;
+  };
 
-  const tag = extractTag(LIB_VERSION);
-  const sourceVersion = tag === null ? majorVersion : 'next';
-
-  if (scriptVariant) {
-    scriptVariant = scriptVariant.replace(/\.+$/, '') as ScriptVariant;
-    scriptVariant += '.';
+  if (forceStagingReleaseForClerkFapi(frontendApi)) {
+    return getUrlForTag('staging');
   }
 
-  return `https://${frontendApi}/npm/@clerk/clerk-js@${sourceVersion}/dist/clerk.${scriptVariant}browser.js`;
+  const nonStableTag = extractNonStableTag(LIB_VERSION);
+  if (nonStableTag) {
+    return getUrlForTag(nonStableTag);
+  }
+
+  return getUrlForTag(extractMajorVersion(LIB_VERSION));
 }
 
 export type ScriptVariant = '' | 'headless';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR prevents Clerk from breaking if `IsomorphicClerk.loadClerkJS` is called more than once after Clerk loaded and initialised.

`ClerkProvider` needs to be a top-level component component, wrapping most of the user's app. It should only mount *once* during the lifetime of the app, however this is something we cannot control - it is possible under certain conditions that 3rd party frameworks (eg NextJS, Remix, etc) will trigger a complete unmount-remount of the whole root component, causing effects in `ClerkProvider` to run again.

In this particular case, `ClerkProvider` was creating a new instance of `IsomorphicClerk` that was in turn loading and replacing the window.Clerk singleton, causing it to lose state.

There are a number of changes that we could do to further improve this flow. Another potential cause of bugs is the [module-level initialisation of window.Clerk](https://github.com/clerkinc/javascript/blob/276ef8e7a332f8604ef9956af6386db14187a68a/packages/clerk-js/src/index.browser.ts#L12) - I will share more thoughts on a notion page so we can discuss further.

<!-- Fixes # (issue number) -->
