### PR TITLE
Allow usernames to be optional

### DIFF
--- a/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
@@ -93,6 +93,7 @@ describe('<SignUpStart/>', () => {
       attributes: {
         username: {
           enabled: true,
+          required: true,
         },
         first_name: {
           enabled: true,

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -223,6 +223,7 @@ function _SignUpStart(): JSX.Element {
       key='username'
       label='Username'
       error={formFields.username.error}
+      hint={fields.username === 'on' ? 'Optional' : undefined}
     >
       <Input
         id='username'


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

With the latest BE code changes, we now support instances with optional usernames.
This means that during sign up, if the username attribute is enabled, it doesn't necessarily mean that it's also required.

This commit modifies the sign up component to reflect that and show that the username field is optional if it's enabled but not required.