### PR TITLE
feat(types,clerk-js): Add last_sign_in_at to User

### DIFF
--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -150,6 +150,7 @@ export interface UserProps extends ClerkProps {
   publicMetadata: Record<string, unknown>;
   privateMetadata: Record<string, unknown>;
   unsafeMetadata: Record<string, unknown>;
+  lastSignInAt: Nullable<number>;
   createdAt: Nullable<number>;
   updatedAt: Nullable<number>;
 }

--- a/packages/backend-core/src/api/resources/User.ts
+++ b/packages/backend-core/src/api/resources/User.ts
@@ -43,6 +43,7 @@ export class User {
     'publicMetadata',
     'privateMetadata',
     'unsafeMetadata',
+    'lastSignInAt',
     'createdAt',
     'updatedAt',
   ];

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -50,6 +50,7 @@ export class User extends BaseResource implements UserResource {
   profileImageUrl = '';
   publicMetadata: Record<string, unknown> = {};
   unsafeMetadata: Record<string, unknown> = {};
+  lastSignInAt: Date | null = null;
   updatedAt: Date | null = null;
   createdAt: Date | null = null;
 
@@ -200,8 +201,13 @@ export class User extends BaseResource implements UserResource {
     this.publicMetadata = data.public_metadata;
     this.unsafeMetadata = data.unsafe_metadata;
 
+    if (data.last_sign_in_at) {
+      this.lastSignInAt = unixEpochToDate(data.last_sign_in_at);
+    }
+
     this.updatedAt = unixEpochToDate(data.updated_at);
     this.createdAt = unixEpochToDate(data.created_at);
+
     return this;
   }
 }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -169,6 +169,7 @@ export interface UserJSON extends ClerkResourceJSON {
   last_name: string;
   public_metadata: Record<string, unknown>;
   unsafe_metadata: Record<string, unknown>;
+  last_sign_in_at: number | null;
   updated_at: number;
   created_at: number;
 }

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -29,6 +29,7 @@ export interface UserResource extends ClerkResource {
   passwordEnabled: boolean;
   publicMetadata: Record<string, unknown>;
   unsafeMetadata: Record<string, unknown>;
+  lastSignInAt: Date | null;
   updatedAt: Date | null;
   createdAt: Date | null;
 
@@ -39,9 +40,15 @@ export interface UserResource extends ClerkResource {
   isPrimaryIdentification: (ident: EmailAddressResource | PhoneNumberResource) => boolean;
   getSessions: () => Promise<SessionWithActivitiesResource[]>;
   setProfileImage: (params: SetProfileImageParams) => Promise<ImageResource>;
-  createExternalAccount: ({ strategy, redirect_url }: { strategy: OAuthStrategy, redirect_url?: string }) => Promise<ExternalAccountResource>;
-  get verifiedExternalAccounts(): ExternalAccountResource[]
-  get unverifiedExternalAccounts(): ExternalAccountResource[]
+  createExternalAccount: ({
+    strategy,
+    redirect_url,
+  }: {
+    strategy: OAuthStrategy;
+    redirect_url?: string;
+  }) => Promise<ExternalAccountResource>;
+  get verifiedExternalAccounts(): ExternalAccountResource[];
+  get unverifiedExternalAccounts(): ExternalAccountResource[];
 }
 
 export type CreateEmailAddressParams = { email: string };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [X] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

Expose new `user.last_sign_in` field.

## Related issue

https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=531db68c98394e709bafd5b5e1df4add&p=8a55dd0331204d039009760b8347921a

https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=531db68c98394e709bafd5b5e1df4add&p=a4edf7395a084aafa9fd06e67a3e34fd
