### PR TITLE
fix(clerk-js): Make GetTokenOptions.template optional

### DIFF
--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -54,5 +54,5 @@ export interface PublicUserData {
   userId?: string;
 }
 
-export type GetTokenOptions = { template: string; leewayInSeconds?: number; skipCache?: boolean };
+export type GetTokenOptions = { template?: string; leewayInSeconds?: number; skipCache?: boolean };
 export type GetToken = (options?: GetTokenOptions) => Promise<string | null>;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

It was accidentally set as required.

<!-- Fixes # (issue number) -->
