### PR TITLE
feat(backend-core): Test Base getAuthState and verifySessionToken

### DIFF
--- a/packages/backend-core/src/Base.ts
+++ b/packages/backend-core/src/Base.ts
@@ -183,11 +183,14 @@ export class Base {
       return this.buildAuthenticatedState(headerToken, { jwtKey, authorizedParties, fetchInterstitial });
     }
 
+    const isDevelopmentKey = isDevelopmentOrStaging(API_KEY);
+    const isProductionKey = isProduction(API_KEY);
+
     // In development or staging environments only, based on the request's
     // User Agent, detect non-browser requests (e.g. scripts). If there
     // is no Authorization header, consider the user as signed out and
     // prevent interstitial rendering
-    if (isDevelopmentOrStaging(API_KEY) && !userAgent?.startsWith('Mozilla/')) {
+    if (isDevelopmentKey && !userAgent?.startsWith('Mozilla/')) {
       return { status: AuthStatus.SignedOut };
     }
 
@@ -206,7 +209,7 @@ export class Base {
     }
 
     // First load of development. Could be logged in on Clerk-hosted UI.
-    if (isDevelopmentOrStaging(API_KEY) && !clientUat) {
+    if (isDevelopmentKey && !clientUat) {
       return {
         status: AuthStatus.Interstitial,
         interstitial: await fetchInterstitial(),
@@ -215,7 +218,7 @@ export class Base {
 
     // Potentially arriving after a sign-in or sign-out on Clerk-hosted UI.
     if (
-      isDevelopmentOrStaging(API_KEY) &&
+      isDevelopmentKey &&
       referrer &&
       checkCrossOrigin({
         originURL: new URL(referrer),
@@ -232,7 +235,7 @@ export class Base {
     }
 
     // Probably first load for production
-    if (isProduction(API_KEY) && !clientUat && !cookieToken) {
+    if (isProductionKey && !clientUat && !cookieToken) {
       return { status: AuthStatus.SignedOut };
     }
 
@@ -249,7 +252,7 @@ export class Base {
       return { status: AuthStatus.SignedOut };
     }
 
-    if (isProduction(API_KEY) && clientUat && !cookieToken) {
+    if (isProductionKey && clientUat && !cookieToken) {
       return {
         status: AuthStatus.Interstitial,
         interstitial: await fetchInterstitial(),

--- a/packages/backend-core/src/__tests__/Base.test.ts
+++ b/packages/backend-core/src/__tests__/Base.test.ts
@@ -1,0 +1,196 @@
+import { Base } from '../Base';
+import { AuthStateParams, AuthStatus } from '../types/core';
+const mockCrossOrigin = jest.fn();
+const mockFetchInterstitial = jest.fn();
+const mockIsDevelopmentOrStaging = jest.fn();
+const mockIsProduction = jest.fn();
+
+jest.mock('../util/jwt', () => ({
+  checkClaims: jest.fn(),
+}));
+
+jest.mock('../util/request', () => ({
+  checkCrossOrigin: () => mockCrossOrigin(),
+}));
+
+jest.mock('../util/clerkApiKey', () => ({
+  isDevelopmentOrStaging: () => mockIsDevelopmentOrStaging(),
+  isProduction: () => mockIsProduction(),
+}));
+
+const environmentJWTKey = 'CLERK_JWT_KEY';
+const mockInterstitialValue = '';
+
+/* An otherwise bare state on a request. */
+const defaultAuthState: AuthStateParams = {
+  host: 'clerk.dev',
+  fetchInterstitial: () => mockFetchInterstitial(),
+  userAgent: 'Mozilla/',
+};
+
+const mockImportKey = jest.fn();
+const mockVerifySignature = jest.fn();
+const mockBase64Decode = jest.fn();
+const mockLoadCryptoKeyFunction = jest.fn();
+
+describe('Base verifySessionToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses supplied crypto key function by default when present', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    testBase.verifyJwt = jest.fn();
+    testBase.loadCryptoKey = jest.fn();
+    await testBase.verifySessionToken('1');
+    expect(testBase.verifyJwt).toHaveBeenCalledTimes(1);
+    expect(testBase.loadCryptoKey).not.toHaveBeenCalled();
+    expect(mockLoadCryptoKeyFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses supplied jwtKey versus loadCryptoKey or CLERK_JWT_KEY', async () => {
+    jest.resetModules();
+    process.env.CLERK_JWT_KEY = environmentJWTKey;
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    testBase.verifyJwt = jest.fn();
+    testBase.loadCryptoKey = jest.fn();
+    await testBase.verifySessionToken('1', { jwtKey: 'test_jwt_key' });
+    expect(testBase.verifyJwt).toHaveBeenCalledTimes(1);
+    expect(testBase.loadCryptoKey).toHaveBeenCalledTimes(1);
+    expect(mockLoadCryptoKeyFunction).not.toHaveBeenCalled();
+    expect(testBase.loadCryptoKey).toHaveBeenCalledWith('test_jwt_key');
+  });
+
+  it('uses environment variable when loadCryptoKey function is not present', async () => {
+    const mockImportKey = jest.fn();
+    const mockVerifySignature = jest.fn();
+    const mockBase64Decode = jest.fn();
+    jest.resetModules();
+    process.env.CLERK_JWT_KEY = environmentJWTKey;
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode);
+    testBase.verifyJwt = jest.fn();
+    testBase.loadCryptoKey = jest.fn();
+    await testBase.verifySessionToken('1');
+    expect(testBase.verifyJwt).toHaveBeenCalledTimes(1);
+    expect(testBase.loadCryptoKey).toHaveBeenCalledTimes(1);
+    expect(testBase.loadCryptoKey).toHaveBeenCalledWith(environmentJWTKey);
+  });
+});
+
+describe('Base getAuthState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses header token if present to build the state', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    testBase.buildAuthenticatedState = jest.fn();
+    await testBase.getAuthState({ ...defaultAuthState, headerToken: 'test_header_token' });
+    expect(testBase.buildAuthenticatedState).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns signed out on development non browser requests', async () => {
+    const nonBrowserUserAgent = 'curl';
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    testBase.buildAuthenticatedState = jest.fn();
+    mockIsDevelopmentOrStaging.mockImplementationOnce(() => true);
+    const authStateResult = await testBase.getAuthState({
+      ...defaultAuthState,
+      userAgent: nonBrowserUserAgent,
+      clientUat: '12345',
+    });
+    expect(testBase.buildAuthenticatedState).toHaveBeenCalledTimes(0);
+    expect(authStateResult).toEqual({ status: AuthStatus.SignedOut });
+  });
+
+  it('returns signed out when no header token is present in cross-origin request', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    mockCrossOrigin.mockImplementationOnce(() => true);
+    const authStateResult = await testBase.getAuthState({ ...defaultAuthState, origin: 'https://clerk.dev' });
+    expect(mockCrossOrigin).toHaveBeenCalledTimes(1);
+    expect(authStateResult).toEqual({ status: AuthStatus.SignedOut });
+  });
+
+  it('returns interstitial when in development we find no clientUat', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
+    mockIsDevelopmentOrStaging.mockImplementationOnce(() => true);
+    const authStateResult = await testBase.getAuthState({
+      ...defaultAuthState,
+      fetchInterstitial: mockFetchInterstitial,
+    });
+
+    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
+    expect(authStateResult).toEqual({ status: AuthStatus.Interstitial, interstitial: mockInterstitialValue });
+  });
+
+  it('returns signed out on first production load without cookieToken and clientUat', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    mockIsProduction.mockImplementationOnce(() => true);
+    const authStateResult = await testBase.getAuthState({ ...defaultAuthState });
+    expect(authStateResult).toEqual({ status: AuthStatus.SignedOut });
+  });
+
+  it('returns interstitial on development after auth action on Clerk-hosted UIs', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
+    mockIsDevelopmentOrStaging.mockImplementationOnce(() => true);
+    mockCrossOrigin.mockImplementationOnce(() => true);
+    const authStateResult = await testBase.getAuthState({
+      ...defaultAuthState,
+      fetchInterstitial: mockFetchInterstitial,
+      referrer: 'random.clerk.hosted.ui',
+    });
+
+    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
+    expect(authStateResult).toEqual({ status: AuthStatus.Interstitial, interstitial: mockInterstitialValue });
+  });
+
+  it('returns signed out on clientUat signaled as 0', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    mockIsProduction.mockImplementationOnce(() => true);
+    const authStateResult = await testBase.getAuthState({ ...defaultAuthState, clientUat: '0' });
+    expect(authStateResult).toEqual({ status: AuthStatus.SignedOut });
+  });
+
+  it('returns interstitial when on production and have a valid clientUat value without cookieToken', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    mockIsProduction.mockImplementationOnce(() => true);
+    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
+    const authStateResult = await testBase.getAuthState({
+      ...defaultAuthState,
+      clientUat: '12345',
+      fetchInterstitial: mockFetchInterstitial,
+    });
+    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
+    expect(authStateResult).toEqual({ status: AuthStatus.Interstitial, interstitial: mockInterstitialValue });
+  });
+
+  it('returns sessionClaims cookieToken is available and clientUat is valid', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+    const validJwtToken = { sessionClaims: { iat: Number(new Date()) + 50 } };
+    testBase.buildAuthenticatedState = jest.fn().mockImplementationOnce(() => validJwtToken);
+    const authStateResult = await testBase.getAuthState({
+      ...defaultAuthState,
+      clientUat: String(new Date().getTime()),
+      cookieToken: 'valid_token',
+    });
+    expect(authStateResult).toEqual(validJwtToken);
+  });
+
+  it('returns interstitial cookieToken is valid but token iat is in past date', async () => {
+    const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
+
+    const validJwtToken = { sessionClaims: { iat: Number(new Date()) - 50 } };
+    testBase.buildAuthenticatedState = jest.fn().mockImplementationOnce(() => validJwtToken);
+    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
+    const authStateResult = await testBase.getAuthState({
+      ...defaultAuthState,
+      clientUat: String(new Date().getTime()),
+      cookieToken: 'valid_token',
+      fetchInterstitial: mockFetchInterstitial,
+    });
+    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
+    expect(authStateResult).toEqual({ status: AuthStatus.Interstitial, interstitial: mockInterstitialValue });
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Finally we can feel more confident deploying changes on our core API `getAuthState` and also `verifySessionToken` which is part of our public API _(also used by RW)_.