### PR TITLE
Adding a no cache cache control header to solve infinite loop issues

### DIFF
--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -15,7 +15,7 @@ export async function getAuth(argsOrReq: Request | LoaderFunctionArgs): GetAuthR
   const { authData, showInterstitial } = await getAuthData(request);
 
   if (showInterstitial || !authData) {
-    throw json(EMPTY_INTERSTITIAL_RESPONSE);
+    throw json(EMPTY_INTERSTITIAL_RESPONSE, { status: 401 });
   }
 
   return sanitizeAuthData(authData);

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -33,7 +33,10 @@ export const rootAuthLoader: RootAuthLoader = async (
   const { authData, showInterstitial } = await getAuthData(args.request, opts);
 
   if (showInterstitial) {
-    throw json(wrapClerkState({ __clerk_ssr_interstitial: showInterstitial, __frontendApi: frontendApi }));
+    throw json(
+      wrapClerkState({ __clerk_ssr_interstitial: showInterstitial, __frontendApi: frontendApi }), 
+      {headers: {"Cache-Control": "no-cache"}}
+    );
   }
 
   if (!callback) {

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -35,7 +35,7 @@ export const rootAuthLoader: RootAuthLoader = async (
   if (showInterstitial) {
     throw json(
       wrapClerkState({ __clerk_ssr_interstitial: showInterstitial, __frontendApi: frontendApi }), 
-      {headers: {"Cache-Control": "no-cache"}}
+      { status: 401 }
     );
   }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
     - Is it possible to have the package allow Node 14? AWS Lambda's latest version is Node 14 so that's what I run locally.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

When Clerk returns an interstitial and the developer has caching implemented, it will continually redirect bc cached versions will continue to load the interstitial. Adding a "no cache" Cache Control header solved it on my end, which basically tells my CDN to not keep the interstitial in the cache. I think this could be a reasonable default, or at the very least, a parameter we could pass into `rootAuthLoader`

<!-- Fixes # (issue number) -->
