### PR TITLE
Expose clerk prop in isomorphic clerk props

### DIFF
--- a/packages/react/src/contexts/ClerkProvider.tsx
+++ b/packages/react/src/contexts/ClerkProvider.tsx
@@ -3,14 +3,13 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import { multipleClerkProvidersError } from '../errors';
 import IsomorphicClerk from '../isomorphicClerk';
-import type { ClerkProp, IsomorphicClerkOptions } from '../types';
+import type { IsomorphicClerkOptions } from '../types';
 import { withMaxAllowedInstancesGuard } from '../utils';
 import { ClerkContextProvider } from './ClerkContextProvider';
 import { StructureContext, StructureContextStates } from './StructureContext';
 
 export interface ClerkProviderProps extends IsomorphicClerkOptions {
   frontendApi?: string;
-  Clerk?: ClerkProp;
   initialState?: InitialState;
 }
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,6 +1,7 @@
 import type { Clerk, ClerkOptions, ClientResource, LoadedClerk, RedirectOptions, UserResource } from '@clerk/types';
 
 export interface IsomorphicClerkOptions extends ClerkOptions {
+  Clerk?: ClerkProp;
   clerkJSUrl?: string;
   clerkJSVariant?: 'headless' | '';
 }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

That way, Clerk prop will be available in Next.js, Remix and all future libraries that will extend the React ClerkProvider.

<!-- Fixes # (issue number) -->
https://github.com/clerkinc/javascript/pull/135
