### PR TITLE
Auth v1 cookie cleanups

### DIFF
--- a/packages/clerk-js/src/core/devBrowserHandler.ts
+++ b/packages/clerk-js/src/core/devBrowserHandler.ts
@@ -88,9 +88,9 @@ export default function createDevBrowserHandler({
     }
   }
 
-  async function clear(strict = true) {
+  async function clear() {
     removeDevBrowserJWT();
-    await cookieHandler.removeAllDevBrowserCookies(strict);
+    await cookieHandler.removeAllDevBrowserCookies();
   }
 
   async function setup({ purge }: { purge: boolean }): Promise<void> {
@@ -101,10 +101,7 @@ export default function createDevBrowserHandler({
       // Note 1: When setup runs for production instances, clear will work only in staging and production Clerk environments
       // as lclclerk.com is not in the PSL yet.  As a result we can't delete the .(prod|dev).lclclerk.com cookie
       // that is set from auth V1 applications in local environment
-
-      // Note 2: Production instances should clear dev browser cookies in a best-effort way to avoid resolving tldts library
-      // from CDN so as not to cause extra latency to the application bootstrapping.
-      await clear(devOrStgApi);
+      await clear();
     }
 
     if (devOrStgApi) {
@@ -127,8 +124,7 @@ export default function createDevBrowserHandler({
       return setFirstPartyCookieForDevBrowser();
     }
 
-    // TODO: Remove legacy Auth V1 handling
-    if (!devOrStgHost && devOrStgApi && !cookieHandler.getSSODevBrowserCookie() && !getDevBrowserJWT()) {
+    if (!devOrStgHost && devOrStgApi && !getDevBrowserJWT()) {
       return setThirdPartyCookieForDevBrowser();
     }
   }

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -1,6 +1,6 @@
 import { addYears } from '@clerk/shared/utils/date';
 import type { ClientResource } from '@clerk/types';
-import { buildURL, getAllETLDs, getETLDPlusOne } from 'utils';
+import { buildURL, getAllETLDs } from 'utils';
 
 import { clientCookie } from './client';
 import { clientUatCookie } from './client_uat';
@@ -57,38 +57,10 @@ export const createCookieHandler = () => {
   // Third party cookie helpers
   const ssoCookie = clientCookie;
 
-  // TODO: Clean up these cookie handlers after Auth v2 becomes the only authentication method
-  // Dev Browser cookie will be handled 100% be local storage
-  const getSSODevBrowserCookie = () => ssoCookie.get();
-
-  const setSSODevBrowserCookie = async (token: string) => {
-    const domain = await getETLDPlusOne();
-    const expires = addYears(Date.now(), 1);
-    const path = COOKIE_PATH;
-    const inIframe = window.location !== window.parent.location;
-    const sameSite = inIframe ? 'None' : 'Lax';
-    const secure = sameSite === 'None' || window.location.protocol === 'https:';
-
-    return ssoCookie.set(token, {
-      domain,
-      expires,
-      path,
-      sameSite,
-      secure,
-    });
-  };
-
-  const removeAllDevBrowserCookies = async (strict = true) => {
+  const removeAllDevBrowserCookies = () => {
     inittedCookie.remove({ path: COOKIE_PATH });
-
-    if (strict) {
-      // Delete cookie accurately by calculating the ETLD+1 domain
-      const domain = await getETLDPlusOne();
-      ssoCookie.remove({ domain, path: COOKIE_PATH });
-    } else {
-      // Delete cookie in a best-effort way by iterating all ETLDs
-      getAllETLDs().forEach(domain => ssoCookie.remove({ domain, path: COOKIE_PATH }));
-    }
+    // Delete cookie in a best-effort way by iterating all ETLDs
+    getAllETLDs().forEach(domain => ssoCookie.remove({ domain, path: COOKIE_PATH }));
   };
 
   const clearLegacyAuthV1SessionCookie = async () => {
@@ -129,8 +101,6 @@ export const createCookieHandler = () => {
     setSessionCookie,
     setClientUatCookie,
     removeSessionCookie,
-    getSSODevBrowserCookie,
-    setSSODevBrowserCookie,
     removeAllDevBrowserCookies,
     clearLegacyAuthV1SessionCookie,
   };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

In Auth V2 Dev Browser cookie is handled 100% by local storage. As a result the PSL domain resolution is not required anymore in ClerkJS since in V3 Auth V1 support was dropped.

<!-- Fixes # (issue number) -->
