### PR TITLE
fix(clerk-js): Hide unverified accts from profile, skip unverified ac…

### DIFF
--- a/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.tsx
+++ b/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.tsx
@@ -1,5 +1,5 @@
 import { List } from '@clerk/shared/components/list';
-import { VerificationStatusTag } from "@clerk/shared/components/tag";
+import { VerificationStatusTag } from '@clerk/shared/components/tag';
 import { TitledCard } from '@clerk/shared/components/titledCard';
 import type { UserResource } from '@clerk/types';
 import { ExternalAccountResource } from '@clerk/types';
@@ -53,21 +53,19 @@ export function ProfileCard(): JSX.Element {
 
   const buildConnectedAccountsRow = () => {
     const verifiedAccounts = user.verifiedExternalAccounts;
-    const unverifiedAccounts = user.unverifiedExternalAccounts;
 
     return (
-    <List.Item
-      className='cl-list-item'
-      key='connected-accounts'
-      itemTitle='Connected accounts'
-      onClick={() => navigate('connected-accounts')}
-    >
-      {(verifiedAccounts.length + unverifiedAccounts.length) === 0 ? (
-        <div className='cl-empty-list-item'>None</div>
-      ) : (
-        <div className='cl-list-item-entry'>
-          {verifiedAccounts.map(
-            (externalAccount: ExternalAccountResource) => (
+      <List.Item
+        className='cl-list-item'
+        key='connected-accounts'
+        itemTitle='Connected accounts'
+        onClick={() => navigate('connected-accounts')}
+      >
+        {verifiedAccounts.length === 0 ? (
+          <div className='cl-empty-list-item'>None</div>
+        ) : (
+          <div className='cl-list-item-entry'>
+            {verifiedAccounts.map((externalAccount: ExternalAccountResource) => (
               <div key={externalAccount.id}>
                 <img
                   alt={externalAccount.providerTitle()}
@@ -76,27 +74,16 @@ export function ProfileCard(): JSX.Element {
                 />
                 {externalAccount.emailAddress}
 
-                <VerificationStatusTag className='cl-tag' status={externalAccount.verification?.status || 'verified'} />
+                <VerificationStatusTag
+                  className='cl-tag'
+                  status={externalAccount.verification?.status || 'verified'}
+                />
               </div>
-            ),
-          )}
-
-          {unverifiedAccounts.map((externalAccount: ExternalAccountResource) => (
-            <div key={externalAccount.id}>
-              <img
-                alt={externalAccount.providerTitle()}
-                src={svgUrl(externalAccount.providerSlug())}
-                className='cl-left-icon-wrapper'
-              />
-              {externalAccount.emailAddress}
-
-                <VerificationStatusTag className='cl-tag' status={externalAccount.verification?.status || 'unverified'} />
-            </div>
-          ))}
-        </div>
-      )}
-    </List.Item>
-    )
+            ))}
+          </div>
+        )}
+      </List.Item>
+    );
   };
 
   const avatarRow = (

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountList.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountList.tsx
@@ -1,10 +1,10 @@
 import { List } from '@clerk/shared/components/list';
 import { TitledCard } from '@clerk/shared/components/titledCard';
-import { OAuthProvider, OAuthStrategy } from "@clerk/types";
+import { OAuthProvider, OAuthStrategy } from '@clerk/types';
 import React, { useState } from 'react';
 import { Error } from 'ui/common/error';
 import { useCoreUser, useEnvironment } from 'ui/contexts';
-import { useNavigate } from "ui/hooks";
+import { useNavigate } from 'ui/hooks';
 import { PageHeading } from 'ui/userProfile/pageHeading';
 
 import { UnconnectedAccountListItem } from './UnconnectedAccountListItem';
@@ -12,31 +12,40 @@ import { UnverifiedAccountListItem } from './UnverifiedAccountListItem';
 import { VerifiedAccountListItem } from './VerifiedAccountListItem';
 
 export function ConnectedAccountList(): JSX.Element {
-  return <>
-    <PageHeading title='Connected accounts' backTo='../' />
+  return (
+    <>
+      <PageHeading
+        title='Connected accounts'
+        backTo='../'
+      />
 
-    <TitledCard className='cl-themed-card cl-list-card'>
-      <ConnectedAccountListRows/>
-    </TitledCard>
-  </>;
+      <TitledCard className='cl-themed-card cl-list-card'>
+        <ConnectedAccountListRows />
+      </TitledCard>
+    </>
+  );
 }
 
 function ConnectedAccountListRows(): JSX.Element {
   const [error, setError] = useState<string | undefined>();
   const user = useCoreUser();
   const { navigate } = useNavigate();
-  const { userSettings: { social } } = useEnvironment();
+  const {
+    userSettings: { social },
+  } = useEnvironment();
 
-  const availableProviders = Object.values(social)
-    .filter(oauthProvider => oauthProvider.enabled)
+  const availableProviders = Object.values(social).filter(oauthProvider => oauthProvider.enabled);
 
   const verifiedAccounts = user.verifiedExternalAccounts;
   const verifiedProviders = verifiedAccounts.map(externalAccount => externalAccount.provider);
 
-  const unverifiedAccounts = user.unverifiedExternalAccounts;
+  // To avoid visual clutter, filter out external accounts for which there is no error set (potentially abandoned flows)
+  const unverifiedAccounts = user.unverifiedExternalAccounts.filter(
+    externalAccount => !!externalAccount?.verification?.error,
+  );
   const unverifiedProviders = unverifiedAccounts.map(externalAccount => externalAccount.provider);
 
-  const unconnectedProviders = availableProviders.filter((oauthProvider) => {
+  const unconnectedProviders = availableProviders.filter(oauthProvider => {
     const provider = oauthProvider.strategy.replace('oauth_', '') as OAuthProvider; // :-(
     return !verifiedProviders.includes(provider) && !unverifiedProviders.includes(provider);
   });
@@ -44,49 +53,49 @@ function ConnectedAccountListRows(): JSX.Element {
   const handleConnect = (strategy: OAuthStrategy) => {
     setError(undefined);
 
-    user.createExternalAccount({ strategy: strategy, redirect_url: window.location.href })
+    user
+      .createExternalAccount({ strategy: strategy, redirect_url: window.location.href })
       .then(externalAccount => {
         navigate(externalAccount.verification!.externalVerificationRedirectURL);
-      }).catch(err => {
+      })
+      .catch(err => {
         setError(err.message || err);
         console.log(err);
-    });
-  }
+      });
+  };
 
   if (availableProviders.length == 0) {
-    return (
-      <div className='cl-empty-list-item'>
-        There are no available external account providers
-      </div>
-    );
+    return <div className='cl-empty-list-item'>There are no available external account providers</div>;
   }
 
-  return <>
-    <Error>{error}</Error>
+  return (
+    <>
+      <Error>{error}</Error>
 
-    <List>
-      {verifiedAccounts.map(externalAccount => (
-        <VerifiedAccountListItem
-          key={externalAccount.id}
-          externalAccount={externalAccount}
-        />
-      ))}
+      <List>
+        {verifiedAccounts.map(externalAccount => (
+          <VerifiedAccountListItem
+            key={externalAccount.id}
+            externalAccount={externalAccount}
+          />
+        ))}
 
-      {unverifiedAccounts.map(externalAccount => (
-        <UnverifiedAccountListItem
-          key={externalAccount.id}
-          externalAccount={externalAccount}
-          handleConnect={handleConnect}
-        />
-      ))}
+        {unverifiedAccounts.map(externalAccount => (
+          <UnverifiedAccountListItem
+            key={externalAccount.id}
+            externalAccount={externalAccount}
+            handleConnect={handleConnect}
+          />
+        ))}
 
-      {unconnectedProviders.map(unconnectedProvider => (
-        <UnconnectedAccountListItem
-          key={unconnectedProvider.strategy}
-          oauthProviderSettings={unconnectedProvider}
-          handleConnect={handleConnect}
-        />
-      ))}
-    </List>
-  </>
+        {unconnectedProviders.map(unconnectedProvider => (
+          <UnconnectedAccountListItem
+            key={unconnectedProvider.strategy}
+            oauthProviderSettings={unconnectedProvider}
+            handleConnect={handleConnect}
+          />
+        ))}
+      </List>
+    </>
+  );
 }


### PR DESCRIPTION
…cts w/o known error from list

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

On the profile card only verified accounts will be shown.

In the connected account list, unverified accounts for which no error is set (i.e. usually abandoned flows), will be show simply as unconnected.

## Issue

https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=531db68c98394e709bafd5b5e1df4add&p=12a3096bd9374fd190dac232a0cfbe21
