### PR TITLE
fix(clerk-js): Set provider as busy when initiating oauth connection …

### DIFF
--- a/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
@@ -3398,9 +3398,13 @@ Array [
             <div
               className="iconContainer"
             >
-              <svg
-                data-filename="../shared/assets/icons/arrow-right.svg"
-              />
+              <div
+                className="icon"
+              >
+                <svg
+                  data-filename="../shared/assets/icons/arrow-right.svg"
+                />
+              </div>
             </div>
           </div>
         </button>

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountList.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountList.tsx
@@ -28,6 +28,7 @@ export function ConnectedAccountList(): JSX.Element {
 
 function ConnectedAccountListRows(): JSX.Element {
   const [error, setError] = useState<string | undefined>();
+  const [busyProvider, setBusyProvider] = useState<OAuthStrategy | null>(null);
   const user = useCoreUser();
   const { navigate } = useNavigate();
   const {
@@ -52,6 +53,7 @@ function ConnectedAccountListRows(): JSX.Element {
 
   const handleConnect = (strategy: OAuthStrategy) => {
     setError(undefined);
+    setBusyProvider(strategy);
 
     user
       .createExternalAccount({ strategy: strategy, redirect_url: window.location.href })
@@ -60,6 +62,7 @@ function ConnectedAccountListRows(): JSX.Element {
       })
       .catch(err => {
         setError(err.message || err);
+        setBusyProvider(null);
         console.log(err);
       });
   };
@@ -77,6 +80,7 @@ function ConnectedAccountListRows(): JSX.Element {
           <VerifiedAccountListItem
             key={externalAccount.id}
             externalAccount={externalAccount}
+            isDisabled={!!busyProvider}
           />
         ))}
 
@@ -85,6 +89,8 @@ function ConnectedAccountListRows(): JSX.Element {
             key={externalAccount.id}
             externalAccount={externalAccount}
             handleConnect={handleConnect}
+            isBusy={busyProvider == `oauth_${externalAccount.provider}`}
+            isDisabled={!!busyProvider}
           />
         ))}
 
@@ -93,6 +99,8 @@ function ConnectedAccountListRows(): JSX.Element {
             key={unconnectedProvider.strategy}
             oauthProviderSettings={unconnectedProvider}
             handleConnect={handleConnect}
+            isBusy={busyProvider == unconnectedProvider.strategy}
+            isDisabled={!!busyProvider}
           />
         ))}
       </List>

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/UnconnectedAccountListItem.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/UnconnectedAccountListItem.tsx
@@ -1,4 +1,6 @@
+import { ArrowRightIcon } from '@clerk/shared/assets/icons';
 import { List } from '@clerk/shared/components/list';
+import { Spinner } from '@clerk/shared/components/spinner';
 import { titleize } from '@clerk/shared/utils/string';
 import type { OAuthProvider, OAuthProviderSettings, OAuthStrategy } from '@clerk/types';
 import React from 'react';
@@ -7,12 +9,16 @@ import { svgUrl } from 'ui/common/constants';
 type UnconnectedAccountListItemProps = {
   oauthProviderSettings: OAuthProviderSettings;
   handleConnect: (strategy: OAuthStrategy) => void;
+  isBusy: boolean;
+  isDisabled: boolean;
 };
 
 export function UnconnectedAccountListItem({
-                                             oauthProviderSettings,
-                                             handleConnect,
-                                           }: UnconnectedAccountListItemProps): JSX.Element {
+  oauthProviderSettings,
+  handleConnect,
+  isBusy,
+  isDisabled,
+}: UnconnectedAccountListItemProps): JSX.Element {
   const oauthProvider = oauthProviderSettings.strategy.replace('oauth_', '') as OAuthProvider;
 
   return (
@@ -20,6 +26,8 @@ export function UnconnectedAccountListItem({
       className='cl-list-item'
       key={oauthProviderSettings.strategy}
       onClick={() => handleConnect(oauthProviderSettings.strategy)}
+      detailIcon={isBusy ? <Spinner /> : <ArrowRightIcon />}
+      disabled={isDisabled}
     >
       <div>
         <img
@@ -27,7 +35,6 @@ export function UnconnectedAccountListItem({
           src={svgUrl(oauthProvider)}
           className='cl-left-icon-wrapper'
         />
-
         Connect {titleize(oauthProvider)} account
       </div>
     </List.Item>

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/UnverifiedAccountListItem.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/UnverifiedAccountListItem.tsx
@@ -1,24 +1,32 @@
+import { ArrowRightIcon } from '@clerk/shared/assets/icons';
 import { List } from '@clerk/shared/components/list';
-import { VerificationStatusTag } from "@clerk/shared/components/tag";
+import { Spinner } from '@clerk/shared/components/spinner';
+import { VerificationStatusTag } from '@clerk/shared/components/tag';
 import type { ExternalAccountResource } from '@clerk/types';
-import { OAuthStrategy } from "@clerk/types";
+import { OAuthStrategy } from '@clerk/types';
 import React from 'react';
-import { svgUrl } from 'ui/common/constants'
+import { svgUrl } from 'ui/common/constants';
 
 type UnverifiedAccountListItemProps = {
   externalAccount: ExternalAccountResource;
   handleConnect: (strategy: OAuthStrategy) => void;
+  isBusy: boolean;
+  isDisabled: boolean;
 };
 
 export function UnverifiedAccountListItem({
   externalAccount,
   handleConnect,
+  isBusy,
+  isDisabled,
 }: UnverifiedAccountListItemProps): JSX.Element {
   return (
     <List.Item
       className='cl-list-item'
       key={externalAccount.id}
       onClick={() => handleConnect(`oauth_${externalAccount.provider}`)}
+      detailIcon={isBusy ? <Spinner /> : <ArrowRightIcon />}
+      disabled={isDisabled}
     >
       <div>
         <img
@@ -30,7 +38,10 @@ export function UnverifiedAccountListItem({
 
         {externalAccount.label && ` (${externalAccount.label})`}
 
-        <VerificationStatusTag className='cl-tag' status={externalAccount.verification?.status || 'unverified'} />
+        <VerificationStatusTag
+          className='cl-tag'
+          status={externalAccount.verification?.status || 'unverified'}
+        />
 
         <span className='cl-verification-error'>{externalAccount.verification?.error?.longMessage}</span>
       </div>

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/VerifiedAccountListItem.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/VerifiedAccountListItem.tsx
@@ -7,9 +7,10 @@ import { useNavigate } from 'ui/hooks';
 
 type VerifiedAccountListItemProps = {
   externalAccount: ExternalAccountResource;
+  isDisabled: boolean;
 };
 
-export function VerifiedAccountListItem({ externalAccount }: VerifiedAccountListItemProps): JSX.Element {
+export function VerifiedAccountListItem({ externalAccount, isDisabled }: VerifiedAccountListItemProps): JSX.Element {
   const { navigate } = useNavigate();
 
   return (
@@ -17,6 +18,7 @@ export function VerifiedAccountListItem({ externalAccount }: VerifiedAccountList
       className='cl-list-item'
       key={externalAccount.id}
       onClick={() => navigate(externalAccount.id)}
+      disabled={isDisabled}
     >
       <div>
         <img

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/__snapshots__/ConnectedAccountList.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/__snapshots__/ConnectedAccountList.test.tsx.snap
@@ -132,9 +132,13 @@ Array [
           <div
             className="iconContainer"
           >
-            <svg
-              data-filename="../shared/assets/icons/arrow-right.svg"
-            />
+            <div
+              className="icon"
+            >
+              <svg
+                data-filename="../shared/assets/icons/arrow-right.svg"
+              />
+            </div>
           </div>
         </div>
       </button>
@@ -163,9 +167,13 @@ Array [
           <div
             className="iconContainer"
           >
-            <svg
-              data-filename="../shared/assets/icons/arrow-right.svg"
-            />
+            <div
+              className="icon"
+            >
+              <svg
+                data-filename="../shared/assets/icons/arrow-right.svg"
+              />
+            </div>
           </div>
         </div>
       </button>


### PR DESCRIPTION
…& prevent further clicks

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

Double-clicks when initiating an oauth connection can lead to errors.

It doesn't make sense to allow more than one in progress connection anyway.

Therefore now setting the corresponding provider as busy & ignoring further clicks (by disabling the buttons) until either the redirect succeeds or the connect request fails to start.

While busy the arrow icon will turn into a spinner.

<img width="890" alt="image" src="https://user-images.githubusercontent.com/5611795/162037131-0f5d0308-e52a-4488-8680-d66b0a349773.png">

