### PR TITLE
feat(remix): Add Auth-Result response header

### DIFF
--- a/packages/remix/src/client/ClerkCatchBoundary.tsx
+++ b/packages/remix/src/client/ClerkCatchBoundary.tsx
@@ -7,13 +7,15 @@ import { Interstitial } from './Interstitial';
 export function ClerkCatchBoundary(RootCatchBoundary?: () => JSX.Element) {
   return () => {
     const { data } = useCatch();
-    const { __clerk_ssr_interstitial, __frontendApi } = data?.clerkState?.__internal_clerk_state || {};
+    const { __clerk_ssr_interstitial, __frontendApi, __lastAuthResult } =
+      data?.clerkState?.__internal_clerk_state || {};
 
     if (__clerk_ssr_interstitial) {
       return (
         <Interstitial
           frontendApi={__frontendApi}
           version={LIB_VERSION}
+          debugData={{ __lastAuthResult }}
         />
       );
     }

--- a/packages/remix/src/client/Interstitial.tsx
+++ b/packages/remix/src/client/Interstitial.tsx
@@ -13,13 +13,14 @@ const getScriptUrl = (frontendApi: string, libVersion: string) => {
   return `https://${frontendApi}/npm/@clerk/clerk-js@${major}/dist/clerk.browser.js`;
 };
 
-const createInterstitialHTMLString = (frontendApi: string, libVersion: string) => {
+const createInterstitialHTMLString = (frontendApi: string, libVersion: string, debugData: any) => {
   return `
     <head>
         <meta charset="UTF-8" />
     </head>
     <body>
         <script>
+            window.__clerk_debug = ${JSON.stringify(debugData || {})};
             window.startClerk = async () => {
                 const Clerk = window.Clerk;
                 try {
@@ -42,6 +43,10 @@ const createInterstitialHTMLString = (frontendApi: string, libVersion: string) =
 `;
 };
 
-export function Interstitial({ frontendApi, version }: { frontendApi: string; version: string }) {
-  return <html dangerouslySetInnerHTML={{ __html: createInterstitialHTMLString(frontendApi, version) }} />;
+export function Interstitial(opts: { frontendApi: string; version: string; debugData: any }) {
+  return (
+    <html
+      dangerouslySetInnerHTML={{ __html: createInterstitialHTMLString(opts.frontendApi, opts.version, opts.debugData) }}
+    />
+  );
 }

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -3,13 +3,14 @@ import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
 import React from 'react';
 
 import { assertFrontendApi, assertValidClerkState, warnForSsr } from '../utils';
+import { ClerkState } from './types';
 import { useAwaitableNavigate } from './useAwaitableNavigate';
 
 export * from '@clerk/clerk-react';
 
-export type RemixClerkProviderProps<ClerkStateT extends { __type: 'clerkState' } = any> = {
+export type RemixClerkProviderProps = {
   children: React.ReactNode;
-  clerkState: ClerkStateT;
+  clerkState: ClerkState;
 } & IsomorphicClerkOptions;
 
 export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): JSX.Element {
@@ -18,12 +19,15 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 
   assertValidClerkState(clerkState);
+  const { __clerk_ssr_state, __frontendApi, __lastAuthResult } = clerkState?.__internal_clerk_state || {};
 
   React.useEffect(() => {
     warnForSsr(clerkState);
   }, []);
 
-  const { __clerk_ssr_state, __frontendApi } = clerkState?.__internal_clerk_state || {};
+  React.useEffect(() => {
+    (window as any).__clerk_debug = { __lastAuthResult };
+  }, []);
 
   assertFrontendApi(__frontendApi);
 

--- a/packages/remix/src/client/types.ts
+++ b/packages/remix/src/client/types.ts
@@ -6,6 +6,7 @@ export type ClerkState = {
     __clerk_ssr_interstitial: string;
     __clerk_ssr_state: InitialState;
     __frontendApi: string;
+    __lastAuthResult: string;
   };
 };
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add the `Auth-Result` response header on Remix.