### PR TITLE
feat(types,clerk-js): Allow users to delete external accounts

### DIFF
--- a/packages/clerk-js/src/core/resources/ExternalAccount.test.ts
+++ b/packages/clerk-js/src/core/resources/ExternalAccount.test.ts
@@ -1,0 +1,25 @@
+import { BaseResource, ExternalAccount } from 'core/resources/internal';
+
+describe('External account', () => {
+  it('destroy', async () => {
+    const targetId = 'test_id';
+
+    const deletedObjectJSON = {
+      object: 'external_account',
+      id: targetId,
+      deleted: true,
+    };
+
+    // @ts-ignore
+    BaseResource._fetch = jest.fn().mockReturnValue(Promise.resolve({ response: deletedObjectJSON }));
+
+    const externalAccount = new ExternalAccount({ id: targetId }, '/me/external_accounts');
+    await externalAccount.destroy();
+
+    // @ts-ignore
+    expect(BaseResource._fetch).toHaveBeenCalledWith({
+      method: 'DELETE',
+      path: `/me/external_accounts/${targetId}`,
+    });
+  });
+});

--- a/packages/clerk-js/src/core/resources/ExternalAccount.ts
+++ b/packages/clerk-js/src/core/resources/ExternalAccount.ts
@@ -26,6 +26,8 @@ export class ExternalAccount extends BaseResource implements ExternalAccountReso
     this.fromJSON(data);
   }
 
+  destroy = (): Promise<void> => this._baseDelete();
+
   protected fromJSON(data: ExternalAccountJSON): this {
     this.id = data.id;
     this.identificationId = data.identification_id;

--- a/packages/types/src/externalAccount.ts
+++ b/packages/types/src/externalAccount.ts
@@ -15,6 +15,7 @@ export interface ExternalAccountResource {
   publicMetadata: Record<string, unknown>;
   label?: string;
   verification: VerificationResource | null;
+  destroy: () => Promise<void>;
   providerSlug: () => OAuthProvider;
   providerTitle: () => string;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Allow users to delete a connected external account

<!-- Fixes # (issue number) -->
