### PR TITLE
feat(clerk-js): OAuth with ticket

### DIFF
--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -167,7 +167,9 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   public authenticateWithRedirect = async (params: AuthenticateWithRedirectParams): Promise<void> => {
     const { redirectUrl, redirectUrlComplete, strategy } = params || {};
-    const { verifications } = await this.create({
+    const authenticateFn = (args: SignUpCreateParams | SignUpUpdateParams) =>
+      this.id ? this.update(args) : this.create(args);
+    const { verifications } = await authenticateFn({
       strategy,
       redirectUrl,
       actionCompleteRedirectUrl: redirectUrlComplete,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Modified the sign up flow in the SignUpStart component when a ticket is present in the query parameters, but the sign up cannot be completed. 

We check if there's any social login method available and render it. When the user then clicks on the social login provider button, we'll check if there's an existing sign up object and opt to update it instead of creating a new one.

<!-- Fixes # (issue number) -->
