### PR TITLE
add get user oauth access tokens to clerk sdk

### DIFF
--- a/packages/backend-core/src/api/collection/UserApi.ts
+++ b/packages/backend-core/src/api/collection/UserApi.ts
@@ -125,6 +125,14 @@ export class UserApi extends AbstractApi {
       queryParams: params,
     });
   }
+
+  public async getUserOauthAccessTokens(userId: string, provider: `oauth_${string}`) {
+    this.requireId(userId);
+    return this._restClient.makeRequest<User>({
+      method: 'GET',
+      path: `/users/${userId}/oauth_access_tokens/${provider}`,
+    });
+  }
 }
 
 function stringifyMetadataParams(

--- a/packages/backend-core/src/api/collection/UserApi.ts
+++ b/packages/backend-core/src/api/collection/UserApi.ts
@@ -126,7 +126,7 @@ export class UserApi extends AbstractApi {
     });
   }
 
-  public async getUserOauthAccessTokens(userId: string, provider: `oauth_${string}`) {
+  public async getUserOauthAccessToken(userId: string, provider: `oauth_${string}`) {
     this.requireId(userId);
     return this._restClient.makeRequest<User>({
       method: 'GET',


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
    - Still can't `npm install` locally since I'm on node 14 which is the latest AWS Lambda currently supports
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
 
I needed to use [this](https://reference.clerk.dev/reference/backend-api-reference/users#retrieve-the-oauth-access-token-of-a-user) API but couldn't find it on the SDK, so I added it to UsersApi based on the docs.

<!-- Fixes # (issue number) -->
