### PR TITLE
Expose user.external_id attribute

### DIFF
--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -134,6 +134,7 @@ export interface SMSMessageProps extends ClerkProps {
 }
 
 export interface UserProps extends ClerkProps {
+  externalId: Nullable<string>;
   username: Nullable<string>;
   firstName: Nullable<string>;
   lastName: Nullable<string>;
@@ -144,9 +145,6 @@ export interface UserProps extends ClerkProps {
   primaryPhoneNumberId: Nullable<string>;
   passwordEnabled: boolean;
   twoFactorEnabled: boolean;
-  // emailAddresses: EmailAddressProps[];
-  // phoneNumbers: PhoneNumberProps[];
-  // externalAccounts: GoogleAccountProps[];
   publicMetadata: Record<string, unknown>;
   privateMetadata: Record<string, unknown>;
   unsafeMetadata: Record<string, unknown>;

--- a/packages/backend-core/src/api/resources/User.ts
+++ b/packages/backend-core/src/api/resources/User.ts
@@ -24,6 +24,7 @@ export interface User extends UserPayload {}
 export class User {
   static attributes = [
     'id',
+    'externalId',
     'username',
     'firstName',
     'lastName',

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -32,6 +32,7 @@ export class User extends BaseResource implements UserResource {
   pathRoot = '/me';
 
   id = '';
+  externalId: string | null = null;
   username: string | null = null;
   emailAddresses: EmailAddressResource[] = [];
   phoneNumbers: PhoneNumberResource[] = [];
@@ -170,6 +171,7 @@ export class User extends BaseResource implements UserResource {
 
   protected fromJSON(data: UserJSON): this {
     this.id = data.id;
+    this.externalId = data.external_id;
     this.firstName = data.first_name;
     this.lastName = data.last_name;
     if (this.firstName && this.lastName) {

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -153,6 +153,7 @@ export interface ExternalAccountJSON extends ClerkResourceJSON {
 export interface UserJSON extends ClerkResourceJSON {
   object: 'user';
   id: string;
+  external_id: string;
   primary_email_address_id: string;
   primary_phone_number_id: string;
   primary_web3_wallet_id: string;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -31,6 +31,7 @@ declare global {
 
 export interface UserResource extends ClerkResource {
   id: string;
+  externalId: string | null;
   primaryEmailAddressId: string | null;
   primaryEmailAddress: EmailAddressResource | null;
   primaryPhoneNumberId: string | null;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Expose user.externalId field in frontend in backend SDKs.
    
The externalId is used during imports. If developers had an Auth0, Firebase, ... id and need to use that to reference the user after migrating to clerk they can store the value there via the [Clerk backend API](https://app.gitbook.com/o/-MR3KHqfIZeA28O45hN0/s/I9lfkxGTyVexN5kBVE7A/reference/backend-api-reference/users#create-a-user).

<!-- Fixes # (issue number) -->
#180 