### PR TITLE
feat(clerk-js): Organization slugs

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -548,8 +548,8 @@ export default class Clerk implements ClerkInterface {
     }
   };
 
-  public createOrganization = async ({ name }: CreateOrganizationParams): Promise<OrganizationResource> => {
-    return await Organization.create(name);
+  public createOrganization = async ({ name, slug }: CreateOrganizationParams): Promise<OrganizationResource> => {
+    return Organization.create({ name, slug });
   };
 
   public getOrganizationMemberships = async (): Promise<OrganizationMembership[]> => {

--- a/packages/clerk-js/src/core/resources/Organization.test.ts
+++ b/packages/clerk-js/src/core/resources/Organization.test.ts
@@ -7,6 +7,7 @@ describe('Organization', () => {
       id: 'test_id',
       name: 'test_name',
       public_metadata: { public: 'metadata' },
+      slug: 'test_slug',
       created_at: 12345,
       updated_at: 5678,
     });

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -1,4 +1,5 @@
 import type {
+  CreateOrganizationParams,
   GetMembershipsParams,
   MembershipRole,
   OrganizationInvitationJSON,
@@ -16,6 +17,7 @@ export class Organization extends BaseResource implements OrganizationResource {
 
   id!: string;
   name!: string;
+  slug!: string;
   publicMetadata: Record<string, unknown> = {};
   createdAt!: Date;
   updatedAt!: Date;
@@ -25,12 +27,26 @@ export class Organization extends BaseResource implements OrganizationResource {
     this.fromJSON(data);
   }
 
-  static async create(name: string): Promise<OrganizationResource> {
+  static async create(params: CreateOrganizationParams): Promise<OrganizationResource>;
+  /**
+   * @deprecated Calling `create` with a string is deprecated. Use an object of type {@link CreateOrganizationParams} instead.
+   */
+  static async create(name: string): Promise<OrganizationResource>;
+  static async create(paramsOrName: string | CreateOrganizationParams): Promise<OrganizationResource> {
+    let name;
+    let slug;
+    if (typeof paramsOrName === 'string') {
+      // DX: Deprecated v3.5.2
+      name = paramsOrName;
+    } else {
+      name = paramsOrName.name;
+      slug = paramsOrName.slug;
+    }
     const json = (
       await BaseResource._fetch<OrganizationJSON>({
         path: '/organizations',
         method: 'POST',
-        body: { name } as any,
+        body: { name, slug } as any,
       })
     )?.response as unknown as OrganizationJSON;
 
@@ -90,6 +106,7 @@ export class Organization extends BaseResource implements OrganizationResource {
   protected fromJSON(data: OrganizationJSON): this {
     this.id = data.id;
     this.name = data.name;
+    this.slug = data.slug;
     this.publicMetadata = data.public_metadata;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.test.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.test.ts
@@ -11,6 +11,7 @@ describe('OrganizationMembership', () => {
       organization: {
         id: 'test_org_id',
         name: 'test_name',
+        slug: 'test_slug',
         public_metadata: { public: 'metadata' },
         object: 'organization',
         created_at: 12345,

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -13,6 +13,7 @@ Organization {
     "public": "metadata",
   },
   "removeMember": [Function],
+  "slug": "test_slug",
   "update": [Function],
   "updateMember": [Function],
   "updatedAt": 1970-01-01T00:00:05.678Z,

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -17,6 +17,7 @@ OrganizationMembership {
       "public": "metadata",
     },
     "removeMember": [Function],
+    "slug": "test_slug",
     "update": [Function],
     "updateMember": [Function],
     "updatedAt": 1970-01-01T00:01:07.890Z,

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -429,6 +429,7 @@ export type CreateOrganizationInvitationParams = {
 
 export interface CreateOrganizationParams {
   name: string;
+  slug?: string;
 }
 
 export interface AuthenticateWithMetamaskParams {

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -245,6 +245,7 @@ export interface OrganizationJSON extends ClerkResourceJSON {
   object: 'organization';
   id: string;
   name: string;
+  slug: string;
   public_metadata: Record<string, unknown>;
   created_at: number;
   updated_at: number;

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -16,6 +16,7 @@ declare global {
 export interface OrganizationResource {
   id: string;
   name: string;
+  slug: string;
   publicMetadata: OrganizationPublicMetadata;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added support for organization slugs. Added slug as a parameter in `clerk.createOrganization()`.


<!-- Fixes # (issue number) -->
