### PR TITLE
feat(backend-core): Organization slug

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -151,7 +151,9 @@ Organization operations are exposed by the `organizations` sub-api (`clerkAPI.or
 
 #### createOrganization(params)
 
-Creates a new organization with the given name. You need to provide the user ID who is going to be the organization owner. The user will become an administrator for the organization.
+Creates a new organization with the given name and optional slug.
+
+You need to provide the user ID who is going to be the organization owner. The user will become an administrator for the organization.
 
 Available parameters are:
 
@@ -163,6 +165,7 @@ Available parameters are:
 ```js
 const organization = await clerkAPI.organizations.createOrganization({
   name: 'Acme Inc',
+  slug: 'acme-inc',
   createdBy: 'user_1o4q123qMeCkKKIXcA9h8',
 });
 ```

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -5,6 +5,7 @@ import { TestBackendAPIClient } from '../TestBackendAPI';
 
 test('createOrganization() creates an organization', async () => {
   const name = 'Acme Inc';
+  const slug = 'acme-inc';
   const createdBy = 'user_randomid';
   const publicMetadata = { public: 'metadata' };
   const privateMetadata = { private: 'metadata' };
@@ -12,6 +13,7 @@ test('createOrganization() creates an organization', async () => {
     object: 'organization',
     id: 'org_randomid',
     name,
+    slug,
     public_metadata: publicMetadata,
     private_metadata: privateMetadata,
     created_at: 1611948436,
@@ -21,6 +23,7 @@ test('createOrganization() creates an organization', async () => {
   nock('https://api.clerk.dev')
     .post('/v1/organizations', {
       name,
+      slug,
       public_metadata: JSON.stringify(publicMetadata),
       private_metadata: JSON.stringify(privateMetadata),
       created_by: createdBy,
@@ -29,6 +32,7 @@ test('createOrganization() creates an organization', async () => {
 
   const organization = await TestBackendAPIClient.organizations.createOrganization({
     name,
+    slug,
     createdBy,
     publicMetadata,
     privateMetadata,
@@ -37,6 +41,7 @@ test('createOrganization() creates an organization', async () => {
     new Organization({
       id: resJSON.id,
       name,
+      slug,
       publicMetadata,
       privateMetadata,
       createdAt: resJSON.created_at,

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -10,6 +10,7 @@ type OrganizationMetadataParams = {
 
 type CreateParams = {
   name: string;
+  slug?: string;
   createdBy: string;
 } & OrganizationMetadataParams;
 

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -133,6 +133,7 @@ export interface InvitationJSON extends ClerkResourceJSON {
 export interface OrganizationJSON extends ClerkResourceJSON {
   object: ObjectType.Organization;
   name: string;
+  slug: string | null;
   public_metadata: Record<string, unknown>;
   private_metadata: Record<string, unknown>;
   created_at: number;

--- a/packages/backend-core/src/api/resources/Organization.ts
+++ b/packages/backend-core/src/api/resources/Organization.ts
@@ -7,7 +7,7 @@ import type { OrganizationProps } from './Props';
 interface OrganizationPayload extends OrganizationProps {}
 
 export class Organization {
-  static attributes = ['id', 'name', 'publicMetadata', 'privateMetadata', 'createdAt', 'updatedAt'];
+  static attributes = ['id', 'name', 'slug', 'publicMetadata', 'privateMetadata', 'createdAt', 'updatedAt'];
 
   static defaults = [];
 

--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -75,6 +75,7 @@ export interface InvitationProps extends ClerkProps {
 
 export interface OrganizationProps extends ClerkProps {
   name: string;
+  slug: Nullable<string>;
   publicMetadata: Record<string, unknown>;
   privateMetadata: Record<string, unknown>;
   createdAt: number;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added support for organization slugs in the backend-core package. The organization API's `create()` function accepts an optional string argument for the slug.

<!-- Fixes # (issue number) -->
