### PR TITLE
feat(clerk-js): Support organization metadata

### DIFF
--- a/packages/clerk-js/src/core/resources/Organization.test.ts
+++ b/packages/clerk-js/src/core/resources/Organization.test.ts
@@ -6,6 +6,7 @@ describe('Organization', () => {
       object: 'organization',
       id: 'test_id',
       name: 'test_name',
+      public_metadata: { public: 'metadata' },
       created_at: 12345,
       updated_at: 5678,
     });

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -16,6 +16,7 @@ export class Organization extends BaseResource implements OrganizationResource {
 
   id!: string;
   name!: string;
+  publicMetadata: Record<string, unknown> = {};
   createdAt!: Date;
   updatedAt!: Date;
 
@@ -89,6 +90,7 @@ export class Organization extends BaseResource implements OrganizationResource {
   protected fromJSON(data: OrganizationJSON): this {
     this.id = data.id;
     this.name = data.name;
+    this.publicMetadata = data.public_metadata;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     return this;

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.test.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.test.ts
@@ -11,6 +11,7 @@ describe('OrganizationMembership', () => {
       organization: {
         id: 'test_org_id',
         name: 'test_name',
+        public_metadata: { public: 'metadata' },
         object: 'organization',
         created_at: 12345,
         updated_at: 67890,

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -9,6 +9,9 @@ Organization {
   "inviteMember": [Function],
   "name": "test_name",
   "pathRoot": "/organizations",
+  "publicMetadata": Object {
+    "public": "metadata",
+  },
   "removeMember": [Function],
   "update": [Function],
   "updateMember": [Function],

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -13,6 +13,9 @@ OrganizationMembership {
     "inviteMember": [Function],
     "name": "test_name",
     "pathRoot": "/organizations",
+    "publicMetadata": Object {
+      "public": "metadata",
+    },
     "removeMember": [Function],
     "update": [Function],
     "updateMember": [Function],

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -245,6 +245,7 @@ export interface OrganizationJSON extends ClerkResourceJSON {
   object: 'organization';
   id: string;
   name: string;
+  public_metadata: Record<string, unknown>;
   created_at: number;
   updated_at: number;
 }

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -2,9 +2,21 @@ import { OrganizationInvitationResource } from './organizationInvitation';
 import { OrganizationMembershipResource } from './organizationMembership';
 import { MembershipRole } from './organizationMembership';
 
+declare global {
+  /**
+   * If you want to provide custom types for the organization.publicMetadata object,
+   * simply redeclare this rule in the global namespace.
+   * Every user object will use the provided type.
+   */
+  interface OrganizationPublicMetadata {
+    [k: string]: unknown;
+  }
+}
+
 export interface OrganizationResource {
   id: string;
   name: string;
+  publicMetadata: OrganizationPublicMetadata;
   createdAt: Date;
   updatedAt: Date;
   update: (params: UpdateOrganizationParams) => Promise<OrganizationResource>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added support for organization `publicMetadata`. The metadata can be read from server responses, but not modified.

<!-- Fixes # (issue number) -->
