### PR TITLE
fix(clerk-js): Go back to sign in when back button is clicked and no local factor strategies exist

### DIFF
--- a/packages/clerk-js/src/ui/signIn/SignInFactorOne.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorOne.tsx
@@ -40,10 +40,11 @@ function _SignInFactorOne(): JSX.Element {
   }
 
   if (showAllStrategies) {
+    const shouldHideAllStrategies = factorHasLocalStrategy(currentFactor);
     return (
       <AllFirstFactorStrategies
         factors={availableFactors}
-        handleBack={handleBackButtonClicked}
+        handleBack={shouldHideAllStrategies ? handleBackButtonClicked : null}
         handleSelect={handleAlternativeFactorSelect}
       />
     );


### PR DESCRIPTION

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.

Problem
When back button was clicked, it hides the all strategies page and renders the factor-one
But we have no first factors hence it renders empty page

Solution
When no local strategies exist, we display the all strategies page and when back button is clicked we go back to `/sign-in`

<!-- Description of the Pull Request -->
![Screenshot 2022-04-07 at 16 44 14](https://user-images.githubusercontent.com/6136507/163383968-13f4a455-019f-4d32-b87f-9dbf1d44b4cc.png)

<!-- Fixes # (issue number) -->
