### PR TITLE
Cleanup interstitial logic

### DIFF
--- a/packages/backend-core/src/__tests__/Base.test.ts
+++ b/packages/backend-core/src/__tests__/Base.test.ts
@@ -1,8 +1,8 @@
 import { Base } from '../Base';
 import { AuthErrorReason, AuthStateParams, AuthStatus } from '../types';
 import { TokenVerificationError } from '../util/errors';
+
 const mockCrossOrigin = jest.fn();
-const mockFetchInterstitial = jest.fn();
 const mockIsDevelopmentOrStaging = jest.fn();
 const mockIsProduction = jest.fn();
 
@@ -20,12 +20,10 @@ jest.mock('../util/clerkApiKey', () => ({
 }));
 
 const environmentJWTKey = 'CLERK_JWT_KEY';
-const mockInterstitialValue = '';
 
 /* An otherwise bare state on a request. */
 const defaultAuthState: AuthStateParams = {
   host: 'clerk.dev',
-  fetchInterstitial: () => mockFetchInterstitial(),
   userAgent: 'Mozilla/',
 };
 
@@ -36,7 +34,7 @@ const mockLoadCryptoKeyFunction = jest.fn();
 
 describe('Base verifySessionToken', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('uses supplied crypto key function by default when present', async () => {
@@ -50,7 +48,7 @@ describe('Base verifySessionToken', () => {
   });
 
   it('throws on failed public key fetching', () => {
-    mockLoadCryptoKeyFunction.mockImplementationOnce(() => {
+    mockLoadCryptoKeyFunction.mockImplementation(() => {
       throw new Error();
     });
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
@@ -93,18 +91,20 @@ describe('Base verifySessionToken', () => {
 
 describe('Base getAuthState', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('uses header token if present to build the state', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    testBase.buildAuthenticatedState = jest.fn();
-    await testBase.getAuthState({ ...defaultAuthState, headerToken: 'test_header_token' });
-    expect(testBase.buildAuthenticatedState).toHaveBeenCalledTimes(1);
+    (testBase as any).buildAuthenticatedState = jest.fn();
+    const params = { ...defaultAuthState, headerToken: 'test_header_token' };
+    await testBase.getAuthState(params);
+    expect((testBase as any).buildAuthenticatedState).toHaveBeenCalledTimes(1);
+    expect((testBase as any).buildAuthenticatedState).toHaveBeenCalledWith(params.headerToken, params);
   });
 
   it('returns correct errorReason on failed pk fetching', async () => {
-    mockLoadCryptoKeyFunction.mockImplementationOnce(() => {
+    mockLoadCryptoKeyFunction.mockImplementation(() => {
       throw new Error();
     });
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
@@ -118,14 +118,12 @@ describe('Base getAuthState', () => {
   it('returns signed out on development non browser requests', async () => {
     const nonBrowserUserAgent = 'curl';
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    testBase.buildAuthenticatedState = jest.fn();
-    mockIsDevelopmentOrStaging.mockImplementationOnce(() => true);
+    mockIsDevelopmentOrStaging.mockImplementation(() => true);
     const authStateResult = await testBase.getAuthState({
       ...defaultAuthState,
       userAgent: nonBrowserUserAgent,
       clientUat: '12345',
     });
-    expect(testBase.buildAuthenticatedState).toHaveBeenCalledTimes(0);
     expect(authStateResult).toEqual({
       status: AuthStatus.SignedOut,
       errorReason: AuthErrorReason.HeaderMissingNonBrowser,
@@ -134,7 +132,7 @@ describe('Base getAuthState', () => {
 
   it('returns signed out when no header token is present in cross-origin request', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    mockCrossOrigin.mockImplementationOnce(() => true);
+    mockCrossOrigin.mockImplementation(() => true);
     const authStateResult = await testBase.getAuthState({ ...defaultAuthState, origin: 'https://clerk.dev' });
     expect(mockCrossOrigin).toHaveBeenCalledTimes(1);
     expect(authStateResult).toEqual({ status: AuthStatus.SignedOut, errorReason: AuthErrorReason.HeaderMissingCORS });
@@ -142,68 +140,55 @@ describe('Base getAuthState', () => {
 
   it('returns interstitial when in development we find no clientUat', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
-    mockIsDevelopmentOrStaging.mockImplementationOnce(() => true);
+    mockIsDevelopmentOrStaging.mockImplementation(() => true);
     const authStateResult = await testBase.getAuthState({
       ...defaultAuthState,
-      fetchInterstitial: mockFetchInterstitial,
     });
-
-    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
     expect(authStateResult).toEqual({
       status: AuthStatus.Interstitial,
-      interstitial: mockInterstitialValue,
       errorReason: AuthErrorReason.UATMissing,
     });
   });
 
   it('returns signed out on first production load without cookieToken and clientUat', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    mockIsProduction.mockImplementationOnce(() => true);
+    mockIsProduction.mockImplementation(() => true);
     const authStateResult = await testBase.getAuthState({ ...defaultAuthState });
     expect(authStateResult).toEqual({ status: AuthStatus.SignedOut, errorReason: AuthErrorReason.CookieAndUATMissing });
   });
 
   it('returns interstitial on development after auth action on Clerk-hosted UIs', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
-    mockIsDevelopmentOrStaging.mockImplementationOnce(() => true);
-    mockCrossOrigin.mockImplementationOnce(() => true);
+    mockIsDevelopmentOrStaging.mockImplementation(() => true);
+    mockCrossOrigin.mockImplementation(() => true);
     const authStateResult = await testBase.getAuthState({
       ...defaultAuthState,
-      fetchInterstitial: mockFetchInterstitial,
       referrer: 'https://random.clerk.hosted.ui',
       clientUat: '12345',
     });
 
-    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
     expect(authStateResult).toEqual({
       status: AuthStatus.Interstitial,
-      interstitial: mockInterstitialValue,
       errorReason: AuthErrorReason.CrossOriginReferrer,
     });
   });
 
   it('returns signed out on clientUat signaled as 0', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    mockIsProduction.mockImplementationOnce(() => true);
+    mockIsProduction.mockImplementation(() => true);
     const authStateResult = await testBase.getAuthState({ ...defaultAuthState, clientUat: '0' });
     expect(authStateResult).toEqual({ status: AuthStatus.SignedOut, errorReason: AuthErrorReason.StandardOut });
   });
 
   it('returns interstitial when on production and have a valid clientUat value without cookieToken', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
-    mockIsProduction.mockImplementationOnce(() => true);
-    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
+    mockIsProduction.mockImplementation(() => true);
     const authStateResult = await testBase.getAuthState({
       ...defaultAuthState,
       clientUat: '12345',
-      fetchInterstitial: mockFetchInterstitial,
     });
-    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
     expect(authStateResult).toEqual({
       status: AuthStatus.Interstitial,
-      interstitial: mockInterstitialValue,
       errorReason: AuthErrorReason.CookieMissing,
     });
   });
@@ -211,7 +196,7 @@ describe('Base getAuthState', () => {
   it('returns sessionClaims cookieToken is available and clientUat is valid', async () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
     const validJwtToken = { sessionClaims: { iat: Number(new Date()) + 50 } };
-    testBase.buildAuthenticatedState = jest.fn().mockImplementationOnce(() => validJwtToken);
+    (testBase as any).buildAuthenticatedState = jest.fn().mockImplementation(() => validJwtToken);
     const authStateResult = await testBase.getAuthState({
       ...defaultAuthState,
       clientUat: String(new Date().getTime()),
@@ -224,18 +209,14 @@ describe('Base getAuthState', () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
 
     const validJwtToken = { sessionClaims: { iat: Number(new Date()) - 50 } };
-    testBase.buildAuthenticatedState = jest.fn().mockImplementationOnce(() => validJwtToken);
-    mockFetchInterstitial.mockImplementationOnce(() => Promise.resolve(mockInterstitialValue));
+    (testBase as any).buildAuthenticatedState = jest.fn().mockImplementation(() => validJwtToken);
     const authStateResult = await testBase.getAuthState({
       ...defaultAuthState,
       clientUat: String(new Date().getTime()),
       cookieToken: 'valid_token',
-      fetchInterstitial: mockFetchInterstitial,
     });
-    expect(mockFetchInterstitial).toHaveBeenCalledTimes(1);
     expect(authStateResult).toEqual({
       status: AuthStatus.Interstitial,
-      interstitial: mockInterstitialValue,
       errorReason: AuthErrorReason.CookieOutDated,
     });
   });

--- a/packages/backend-core/src/types/core.ts
+++ b/packages/backend-core/src/types/core.ts
@@ -20,8 +20,6 @@ export type VerifySessionTokenOptions = {
 export type BuildAuthenticatedStateOptions = {
   jwtKey?: string;
   authorizedParties?: string[];
-  fetchInterstitial: () => Promise<string>;
-  tokenType: TokenType;
 };
 
 export type TokenType = 'cookie' | 'header';
@@ -29,7 +27,6 @@ export type TokenType = 'cookie' | 'header';
 export type AuthState = {
   status: AuthStatus;
   session?: Session;
-  interstitial?: string;
   sessionClaims?: JWTPayload;
   /* Error reason for signed-out and interstitial states. Would probably be set on the `Auth-Result` response header. */
   errorReason?: AuthErrorReason;
@@ -58,8 +55,6 @@ export type AuthStateParams = {
   userAgent?: string | null;
   /* A list of authorized parties to validate against the session token azp claim */
   authorizedParties?: string[];
-  /* HTTP utility for fetching a text/html string */
-  fetchInterstitial: () => Promise<string>;
   /* Value corresponding to the JWT verification key */
   jwtKey?: string;
 };

--- a/packages/backend-core/src/util/interstitialRules.ts
+++ b/packages/backend-core/src/util/interstitialRules.ts
@@ -1,0 +1,85 @@
+import { AuthErrorReason, AuthStateParams, AuthStatus } from '../types';
+import { isDevelopmentOrStaging, isProduction } from './clerkApiKey';
+import { checkCrossOrigin } from './request';
+
+type RuleResult = { status: AuthStatus; errorReason: AuthErrorReason };
+type InterstitialRule = (params: AuthStateParams, key: string) => RuleResult | undefined;
+type RunRules = (params: AuthStateParams, key: string, rules: InterstitialRule[]) => RuleResult | undefined;
+
+export const runInterstitialRules: RunRules = (params, key, rules) => {
+  for (const rule of rules) {
+    const res = rule(params, key);
+    if (res) {
+      return res;
+    }
+  }
+  return undefined;
+};
+
+// In development or staging environments only, based on the request's
+// User Agent, detect non-browser requests (e.g. scripts). Since there
+// is no Authorization header, consider the user as signed out and
+// prevent interstitial rendering
+export const nonBrowserRequestInDevRule: InterstitialRule = (params, key) => {
+  if (isDevelopmentOrStaging(key) && !params.userAgent?.startsWith('Mozilla/')) {
+    return { status: AuthStatus.SignedOut, errorReason: AuthErrorReason.HeaderMissingNonBrowser };
+  }
+  return undefined;
+};
+
+// Is this correct? In cross-origin requests the use of Authorization header is mandatory
+export const crossOriginRequestWithoutCors: InterstitialRule = params => {
+  const { origin, host, forwardedHost, forwardedPort, forwardedProto } = params;
+  const isCrossOrigin =
+    origin && checkCrossOrigin({ originURL: new URL(origin), host, forwardedHost, forwardedPort, forwardedProto });
+  if (isCrossOrigin) {
+    return { status: AuthStatus.SignedOut, errorReason: AuthErrorReason.HeaderMissingCORS };
+  }
+  return undefined;
+};
+
+export const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = (params, key) => {
+  const res = isDevelopmentOrStaging(key);
+  if (res && !params.clientUat) {
+    return { status: AuthStatus.Interstitial, errorReason: AuthErrorReason.UATMissing };
+  }
+  return undefined;
+};
+
+export const potentialRequestAfterSignInOrOurFromClerkHostedUiInDev: InterstitialRule = (params, key) => {
+  const { referrer, host, forwardedHost, forwardedPort, forwardedProto } = params;
+  const crossOriginReferrer =
+    referrer && checkCrossOrigin({ originURL: new URL(referrer), host, forwardedHost, forwardedPort, forwardedProto });
+  if (isDevelopmentOrStaging(key) && crossOriginReferrer) {
+    return { status: AuthStatus.Interstitial, errorReason: AuthErrorReason.CrossOriginReferrer };
+  }
+  return undefined;
+};
+
+export const potentialFirstRequestOnProductionEnvironment: InterstitialRule = (params, key) => {
+  if (isProduction(key) && !params.clientUat && !params.cookieToken) {
+    return { status: AuthStatus.SignedOut, errorReason: AuthErrorReason.CookieAndUATMissing };
+  }
+  return undefined;
+};
+
+// TBD: Can enable if we do not want the __session cookie to be inspected.
+// const signedOutOnDifferentSubdomainButCookieNotRemovedYet: AuthStateRule = (params, key) => {
+//   if (isProduction(key) && !params.clientUat && !params.cookieToken) {
+//     return { status: AuthStatus.Interstitial, errorReason: '' as any };
+//   }
+// };
+
+export const isNormalSignedOutState: InterstitialRule = params => {
+  if (params.clientUat === '0') {
+    return { status: AuthStatus.SignedOut, errorReason: AuthErrorReason.StandardOut };
+  }
+  return undefined;
+};
+
+export const hasClientUatButCookieIsMissingInProd: InterstitialRule = (params, key) => {
+  if (isProduction(key) && params.clientUat && !params.cookieToken) {
+    return { status: AuthStatus.Interstitial, errorReason: AuthErrorReason.CookieMissing };
+  }
+  return undefined;
+};

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -76,7 +76,7 @@ export function withEdgeMiddlewareAuth(
     const { loadUser, loadSession, jwtKey, authorizedParties } = options;
     const cookieToken = req.cookies['__session'];
     const headerToken = req.headers.get('authorization');
-    const { status, interstitial, sessionClaims } = await vercelEdgeBase.getAuthState({
+    const { status, sessionClaims } = await vercelEdgeBase.getAuthState({
       cookieToken,
       headerToken,
       clientUat: req.cookies['__client_uat'],
@@ -88,11 +88,10 @@ export function withEdgeMiddlewareAuth(
       referrer: req.headers.get('referrer'),
       authorizedParties,
       jwtKey,
-      fetchInterstitial,
     });
 
     if (status === AuthStatus.Interstitial) {
-      return new NextResponse(interstitial, {
+      return new NextResponse(await fetchInterstitial(), {
         headers: { 'Content-Type': 'text/html' },
         status: 401,
       });

--- a/packages/nextjs/src/middleware/utils/getAuthData.ts
+++ b/packages/nextjs/src/middleware/utils/getAuthData.ts
@@ -17,7 +17,7 @@ export async function getAuthData(
   try {
     const cookieToken = cookies['__session'];
     const headerToken = headers.authorization?.replace('Bearer ', '');
-    const { status, sessionClaims, interstitial, errorReason } = await Clerk.base.getAuthState({
+    const { status, sessionClaims, errorReason } = await Clerk.base.getAuthState({
       cookieToken,
       headerToken,
       clientUat: cookies['__client_uat'],
@@ -27,7 +27,6 @@ export async function getAuthData(
       forwardedHost: headers['x-forwarded-host'] as string,
       referrer: headers.referer,
       userAgent: headers['user-agent'] as string,
-      fetchInterstitial: () => Clerk.fetchInterstitial(),
       jwtKey,
       authorizedParties,
     });
@@ -36,7 +35,7 @@ export async function getAuthData(
 
     if (status === AuthStatus.Interstitial) {
       ctx.res.writeHead(401, { 'Content-Type': 'text/html' });
-      ctx.res.end(interstitial);
+      ctx.res.end(await Clerk.fetchInterstitial());
       return null;
     }
 

--- a/packages/remix/src/ssr/getAuthData.ts
+++ b/packages/remix/src/ssr/getAuthData.ts
@@ -37,7 +37,6 @@ export async function getAuthData(
       forwardedHost: headers.get('x-forwarded-host') as string,
       referrer: headers.get('referer'),
       userAgent: headers.get('user-agent') as string,
-      fetchInterstitial: () => Promise.resolve(''),
       authorizedParties,
       jwtKey,
     });

--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -257,7 +257,7 @@ export default class Clerk extends ClerkBackendAPI {
         const cookieToken = cookies.get('__session') as string;
         const headerToken = req.headers.authorization?.replace('Bearer ', '');
 
-        const { status, interstitial, sessionClaims, errorReason } =
+        const { status, sessionClaims, errorReason } =
           await this.base.getAuthState({
             cookieToken,
             headerToken,
@@ -270,7 +270,6 @@ export default class Clerk extends ClerkBackendAPI {
             userAgent: req.headers['user-agent'] as string,
             authorizedParties,
             jwtKey: jwtKey || this.jwtKey,
-            fetchInterstitial: () => this.fetchInterstitial(),
           });
 
         errorReason && res.setHeader('Auth-Result', errorReason);
@@ -296,7 +295,7 @@ export default class Clerk extends ClerkBackendAPI {
         }
 
         res.writeHead(401, { 'Content-Type': 'text/html' });
-        res.write(interstitial);
+        res.write(await this.fetchInterstitial());
         res.end();
       } catch (error) {
         // Auth object will be set to the signed out auth state


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Split the `getAuthState` logic into 2 distinct scenarios, `handleRequestWithTokenInHeader` and `handleRequestWithTokenInCookie` that can be handled separately
- For the token in cookie scenario, the complex interstitial logic has been extracted into `InterstitialRules`. These rules run sequentially and in the same order as before
- To further simplify `getAuthState`, it no longer fetches the interstitial. This responsibility is moved back to the caller
<!-- Fixes # (issue number) -->
