### PR TITLE
feat(backend-core): Organization metadata

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -153,6 +153,13 @@ Organization operations are exposed by the `organizations` sub-api (`clerkAPI.or
 
 Creates a new organization with the given name. You need to provide the user ID who is going to be the organization owner. The user will become an administrator for the organization.
 
+Available parameters are:
+
+- _name_ The name for the organization.
+- _createdBy_ The ID of the user who is going to be the organization administrator.
+- _publicMetadata_ Metadata saved on the organization, that is visible to both your Frontend and Backend APIs.
+- _privateMetadata_ Metadata saved on the organization, that is only visible to your Backend API.
+
 ```js
 const organization = await clerkAPI.organizations.createOrganization({
   name: 'Acme Inc',

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -6,10 +6,14 @@ import { TestBackendAPIClient } from '../TestBackendAPI';
 test('createOrganization() creates an organization', async () => {
   const name = 'Acme Inc';
   const createdBy = 'user_randomid';
+  const publicMetadata = { public: 'metadata' };
+  const privateMetadata = { private: 'metadata' };
   const resJSON = {
     object: 'organization',
     id: 'org_randomid',
     name,
+    public_metadata: publicMetadata,
+    private_metadata: privateMetadata,
     created_at: 1611948436,
     updated_at: 1611948436,
   };
@@ -17,6 +21,8 @@ test('createOrganization() creates an organization', async () => {
   nock('https://api.clerk.dev')
     .post('/v1/organizations', {
       name,
+      public_metadata: JSON.stringify(publicMetadata),
+      private_metadata: JSON.stringify(privateMetadata),
       created_by: createdBy,
     })
     .reply(200, resJSON);
@@ -24,11 +30,15 @@ test('createOrganization() creates an organization', async () => {
   const organization = await TestBackendAPIClient.organizations.createOrganization({
     name,
     createdBy,
+    publicMetadata,
+    privateMetadata,
   });
   expect(organization).toEqual(
     new Organization({
       id: resJSON.id,
       name,
+      publicMetadata,
+      privateMetadata,
       createdAt: resJSON.created_at,
       updatedAt: resJSON.updated_at,
     }),

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -3,17 +3,50 @@ import { AbstractApi } from './AbstractApi';
 
 const basePath = '/organizations';
 
+type OrganizationMetadataParams = {
+  publicMetadata?: Record<string, unknown>;
+  privateMetadata?: Record<string, unknown>;
+};
+
 type CreateParams = {
   name: string;
   createdBy: string;
+} & OrganizationMetadataParams;
+
+type OrganizationMetadataRequestBody = {
+  publicMetadata?: string;
+  privateMetadata?: string;
 };
 
 export class OrganizationApi extends AbstractApi {
   public async createOrganization(params: CreateParams) {
+    const { publicMetadata, privateMetadata } = params;
     return this._restClient.makeRequest<Organization>({
       method: 'POST',
       path: basePath,
-      bodyParams: params,
+      bodyParams: {
+        ...params,
+        ...stringifyMetadataParams({
+          publicMetadata,
+          privateMetadata,
+        }),
+      },
     });
   }
+}
+
+function stringifyMetadataParams(
+  params: OrganizationMetadataParams & {
+    [key: string]: Record<string, unknown> | undefined;
+  },
+): OrganizationMetadataRequestBody {
+  return ['publicMetadata', 'privateMetadata'].reduce(
+    (res: Record<string, string>, key: string): Record<string, string> => {
+      if (params[key]) {
+        res[key] = JSON.stringify(params[key]);
+      }
+      return res;
+    },
+    {},
+  );
 }

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -133,6 +133,8 @@ export interface InvitationJSON extends ClerkResourceJSON {
 export interface OrganizationJSON extends ClerkResourceJSON {
   object: ObjectType.Organization;
   name: string;
+  public_metadata: Record<string, unknown>;
+  private_metadata: Record<string, unknown>;
   created_at: number;
   updated_at: number;
 }

--- a/packages/backend-core/src/api/resources/Organization.ts
+++ b/packages/backend-core/src/api/resources/Organization.ts
@@ -7,7 +7,7 @@ import type { OrganizationProps } from './Props';
 interface OrganizationPayload extends OrganizationProps {}
 
 export class Organization {
-  static attributes = ['id', 'name', 'createdAt', 'updatedAt'];
+  static attributes = ['id', 'name', 'publicMetadata', 'privateMetadata', 'createdAt', 'updatedAt'];
 
   static defaults = [];
 

--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -75,6 +75,8 @@ export interface InvitationProps extends ClerkProps {
 
 export interface OrganizationProps extends ClerkProps {
   name: string;
+  publicMetadata: Record<string, unknown>;
+  privateMetadata: Record<string, unknown>;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added support for organization public and private metadata. Both can be set upon organization creation by the backend.

<!-- Fixes # (issue number) -->
