### PR TITLE
feat(clerk-react): Explicitly type children for React.FC components

### DIFF
--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -8,7 +8,7 @@ import { LoadedGuarantee } from '../contexts/StructureContext';
 import type { RedirectToProps, WithClerkProp } from '../types';
 import { withClerk } from './withClerk';
 
-export const SignedIn: React.FC = ({ children }) => {
+export const SignedIn: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const { userId } = useAuthContext();
   if (userId) {
     return <>{children}</>;
@@ -16,7 +16,7 @@ export const SignedIn: React.FC = ({ children }) => {
   return null;
 };
 
-export const SignedOut: React.FC = ({ children }) => {
+export const SignedOut: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const { userId } = useAuthContext();
   if (userId === null) {
     return <>{children}</>;
@@ -24,7 +24,7 @@ export const SignedOut: React.FC = ({ children }) => {
   return null;
 };
 
-export const ClerkLoaded: React.FC = ({ children }) => {
+export const ClerkLoaded: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const isomorphicClerk = useIsomorphicClerkContext();
   if (!isomorphicClerk.loaded) {
     return null;
@@ -32,7 +32,7 @@ export const ClerkLoaded: React.FC = ({ children }) => {
   return <LoadedGuarantee>{children}</LoadedGuarantee>;
 };
 
-export const ClerkLoading: React.FC = ({ children }) => {
+export const ClerkLoading: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const isomorphicClerk = useIsomorphicClerkContext();
   if (isomorphicClerk.loaded) {
     return null;
@@ -86,7 +86,7 @@ export const AuthenticateWithRedirectCallback = withClerk(
   'AuthenticateWithRedirectCallback',
 );
 
-export const MultisessionAppSupport: React.FC = ({ children }) => {
+export const MultisessionAppSupport: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const session = useSessionContext();
   return <React.Fragment key={session ? session.id : 'no-users'}>{children}</React.Fragment>;
 };

--- a/packages/react/src/contexts/StructureContext.tsx
+++ b/packages/react/src/contexts/StructureContext.tsx
@@ -25,7 +25,7 @@ const useStructureContext = (): StructureContextValue => {
   return structureCtx;
 };
 
-export const LoadedGuarantee: React.FC = ({ children }) => {
+export const LoadedGuarantee: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const structure = useStructureContext();
   if (structure.guaranteedLoaded) {
     return <>{children}</>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Make our controlled components compatible with the latest `@types/react@18` package.

`React.FC` no longer includes `children` by default, as seen in this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

<!-- Fixes # (issue number) -->
