### PR TITLE
fix(clerk-js): Introduce rotating_token_nonce param

### DIFF
--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -1,18 +1,18 @@
-import type { ClerkAPIErrorJSON, ClerkResourceJSON } from '@clerk/types';
+import type { ClerkAPIErrorJSON, ClerkResourceJSON, ClerkResourceReloadParams } from '@clerk/types';
 import type { FapiClient, FapiRequestInit, FapiResponseJSON, HTTPMethod } from 'core/fapiClient';
 
 import { clerkMissingFapiClientInResources } from '../errors';
 import type { Clerk } from './internal';
 import { ClerkAPIResponseError, Client } from './internal';
 
-export type BaseFetchOptions = { forceUpdateClient?: boolean };
+export type BaseFetchOptions = ClerkResourceReloadParams & { forceUpdateClient?: boolean };
 
-interface BaseMutateParams {
+export type BaseMutateParams = {
   action?: string;
   body?: any;
   method?: HTTPMethod;
   path?: string;
-}
+};
 
 export abstract class BaseResource {
   static clerk: Clerk;
@@ -131,7 +131,8 @@ export abstract class BaseResource {
     await this._baseMutate<J>({ ...params, method: 'DELETE' });
   }
 
-  public async reload(): Promise<this> {
-    return this._baseGet({ forceUpdateClient: true });
+  public async reload(params?: ClerkResourceReloadParams): Promise<this> {
+    const { rotatingTokenNonce } = params || {};
+    return this._baseGet({ forceUpdateClient: true, rotatingTokenNonce });
   }
 }

--- a/packages/clerk-js/src/core/resources/EmailAddress.ts
+++ b/packages/clerk-js/src/core/resources/EmailAddress.ts
@@ -61,7 +61,7 @@ export class EmailAddress extends BaseResource implements EmailAddressResource {
       return new Promise((resolve, reject) => {
         void run(() => {
           return this.reload()
-            .then(async res => {
+            .then(res => {
               if (res.verification.status === 'verified') {
                 stop();
                 resolve(res);

--- a/packages/types/src/resource.ts
+++ b/packages/types/src/resource.ts
@@ -1,5 +1,9 @@
+export type ClerkResourceReloadParams = {
+  rotatingTokenNonce?: string;
+};
+
 export interface ClerkResource {
   readonly id?: string;
   pathRoot: string;
-  reload(): Promise<this>;
+  reload(p: ClerkResourceReloadParams): Promise<this>;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Add _rotating_token_nonce parameter to reload function for each ClerkJS resource.

This token nonce can is used to safely update `__client` jwt in authentication scenarios where the auth takes place across two different outlets e.g. OAuth in native apps.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
