### PR TITLE
fix(nextjs,backend-core): Fix handleError parsing

### DIFF
--- a/packages/backend-core/src/api/utils/ErrorHandler.ts
+++ b/packages/backend-core/src/api/utils/ErrorHandler.ts
@@ -6,8 +6,8 @@ export default function handleError(error: any): never {
   const body = error?.response?.body;
   let data;
 
-  if (body && body.errors) {
-    data = (body.errors || []).map((errorJSON: ClerkServerErrorJSON) => {
+  if (body) {
+    data = JSON.parse(body).errors.map((errorJSON: ClerkServerErrorJSON) => {
       return ClerkServerError.fromJSON(errorJSON);
     });
   } else {

--- a/packages/nextjs/src/api/index.ts
+++ b/packages/nextjs/src/api/index.ts
@@ -2,4 +2,5 @@ if (!process.env.CLERK_API_KEY) {
   throw Error('The CLERK_API_KEY environment variable must be set to use imports from @clerk/nextjs/api.');
 }
 
+export { default } from '@clerk/clerk-sdk-node';
 export * from '@clerk/clerk-sdk-node';


### PR DESCRIPTION
Expose Clerk singleton on @clerk/nextjs/api

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

### Two fixes:

#### 1. Error parsing in API error responses
Errors are returned as shown below in the response body from the Clerk backend. 
![Screenshot 2022-04-21 at 9 51 48 PM](https://user-images.githubusercontent.com/15251081/164542888-2464dc84-2fff-43a2-8f54-3bf222823cc5.png)
Previously we did not decode them as needed resulting in failure to return them to the user in a proper manner. This resulted in a cryptic error `(error.data || []).forEach forEach is not a function`

#### 2. Export the Clerk singleton object properly for `@clerk/nextjs/api`
The `export *` syntax does not include default exports. This resulted in the singleton Clerk object not being available to pull from the `@clerk/nextjs/api` .
