### PR TITLE
cast snakecaseKeys return type to match ClerkFetcher body

### DIFF
--- a/packages/backend-core/src/api/utils/RestClient.ts
+++ b/packages/backend-core/src/api/utils/RestClient.ts
@@ -64,7 +64,7 @@ export default class RestClient {
 
     let body;
     if (requestOptions.bodyParams) {
-      body = snakecaseKeys(requestOptions.bodyParams);
+      body = snakecaseKeys(requestOptions.bodyParams) as Record<string, unknown>;
     }
 
     // TODO improve error handling


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix(Typescript)
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Fixes the type mismatch between the ClerkFetcher body and the returned type from snakecase-keys.
This is a hotfix that just casts the type of snakecase-keys to be what the fetcher is expecting. Ideally this should have a proper fix eventually.

<!-- Fixes # (issue number) -->
https://github.com/clerkinc/javascript/issues/205