### PR TITLE
fix(clerk-js): Disable input autofocus when oauth is used

### DIFF
--- a/packages/clerk-js/src/ui/signIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInStart.tsx
@@ -209,7 +209,7 @@ export function _SignInStart(): JSX.Element {
                     type={identifierInputDisplayValues.fieldType as any}
                     handleChange={el => identifier.setValue(el.value || '')}
                     value={identifier.value}
-                    autoFocus
+                    autoFocus={!hasSocialOrWeb3Buttons}
                     minLength={1}
                     maxLength={255}
                   />

--- a/packages/clerk-js/src/ui/signIn/__snapshots__/SignInStart.test.tsx.snap
+++ b/packages/clerk-js/src/ui/signIn/__snapshots__/SignInStart.test.tsx.snap
@@ -74,7 +74,7 @@ Array [
             htmlFor="text-field-identifier"
           >
             <input
-              autoFocus={true}
+              autoFocus={false}
               className="input"
               id="text-field-identifier"
               maxLength={255}

--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -18,7 +18,7 @@ interface WithServerSideAuth {
 
 export const withServerSideAuth: WithServerSideAuth = (cbOrOptions: any, options?: any): any => {
   const cb = typeof cbOrOptions === 'function' ? cbOrOptions : undefined;
-  const opts = options ? options : typeof cbOrOptions !== 'function' ? cbOrOptions : {};
+  const opts = (options ? options : typeof cbOrOptions !== 'function' ? cbOrOptions : {}) || {};
 
   return async (ctx: GetServerSidePropsContext) => {
     const authData = await getAuthData(ctx, opts);


### PR DESCRIPTION
## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

When a user opens sign in page on a mobile the input field is focused causing the mobile keyboard to open and hiding the oauth sign in strategies.

This change aims to disable autofocus when oauth is used so that they are properly presented to the user

https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=b253a2f980c641de8992cc63ed416fa0&p=fb3e1055f0a144ba96482c505a65248d
