### PR TITLE
fix(backend-core): Fix case of buildAuthState erroneous return value

### DIFF
--- a/packages/backend-core/src/Base.ts
+++ b/packages/backend-core/src/Base.ts
@@ -295,6 +295,8 @@ export class Base {
         interstitial: await fetchInterstitial(),
         errorReason: AuthErrorReason.CookieOutDated,
       };
+    } else if (!authenticatedState.sessionClaims) {
+      return authenticatedState;
     }
 
     return {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- When `buildAuthState` returned an erroneous AuthState status _(`!== SignedIn`)._ the response was not returned as it should be to the user. 
