### PR TITLE
ClerkJS delete organizations and add members without the invitation flow

### DIFF
--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -84,6 +84,14 @@ export class Organization extends BaseResource implements OrganizationResource {
       .catch(() => []);
   };
 
+  addMember = async ({ userId, role }: AddMemberParams) => {
+    return await BaseResource._fetch({
+      method: 'POST',
+      path: `/organizations/${this.id}/memberships`,
+      body: { userId, role } as any,
+    }).then(res => new OrganizationMembership(res?.response as OrganizationMembershipJSON));
+  };
+
   inviteMember = async (inviteMemberParams: InviteMemberParams) => {
     return await OrganizationInvitation.create(this.id, inviteMemberParams);
   };
@@ -121,6 +129,11 @@ export class Organization extends BaseResource implements OrganizationResource {
 export type GetOrganizationParams = {
   limit?: number;
   offset?: number;
+};
+
+export type AddMemberParams = {
+  userId: string;
+  role: MembershipRole;
 };
 
 export type InviteMemberParams = {

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -103,6 +103,10 @@ export class Organization extends BaseResource implements OrganizationResource {
     }).then(res => new OrganizationMembership(res?.response as OrganizationMembershipJSON));
   };
 
+  destroy = async (): Promise<void> => {
+    return this._baseDelete();
+  };
+
   protected fromJSON(data: OrganizationJSON): this {
     this.id = data.id;
     this.name = data.name;

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Organization has the same initial properties 1`] = `
 Organization {
+  "addMember": [Function],
   "createdAt": 1970-01-01T00:00:12.345Z,
   "destroy": [Function],
   "getMemberships": [Function],

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Organization has the same initial properties 1`] = `
 Organization {
   "createdAt": 1970-01-01T00:00:12.345Z,
+  "destroy": [Function],
   "getMemberships": [Function],
   "getPendingInvitations": [Function],
   "id": "test_id",

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -7,6 +7,7 @@ OrganizationMembership {
   "id": "test_id",
   "organization": Organization {
     "createdAt": 1970-01-01T00:00:12.345Z,
+    "destroy": [Function],
     "getMemberships": [Function],
     "getPendingInvitations": [Function],
     "id": "test_org_id",

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -6,6 +6,7 @@ OrganizationMembership {
   "destroy": [Function],
   "id": "test_id",
   "organization": Organization {
+    "addMember": [Function],
     "createdAt": 1970-01-01T00:00:12.345Z,
     "destroy": [Function],
     "getMemberships": [Function],

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -23,6 +23,7 @@ export interface OrganizationResource {
   update: (params: UpdateOrganizationParams) => Promise<OrganizationResource>;
   getMemberships: (params?: GetMembershipsParams) => Promise<OrganizationMembershipResource[]>;
   getPendingInvitations: () => Promise<OrganizationInvitationResource[]>;
+  addMember: (params: AddMemberParams) => Promise<OrganizationMembershipResource>;
   inviteMember: (params: InviteMemberParams) => Promise<OrganizationInvitationResource>;
   updateMember: (params: UpdateMembershipParams) => Promise<OrganizationMembershipResource>;
   removeMember: (userId: string) => Promise<OrganizationMembershipResource>;
@@ -32,6 +33,11 @@ export interface OrganizationResource {
 export interface GetMembershipsParams {
   limit?: number;
   offset?: number;
+}
+
+export interface AddMemberParams {
+  userId: string;
+  role: MembershipRole;
 }
 
 export interface InviteMemberParams {

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -26,6 +26,7 @@ export interface OrganizationResource {
   inviteMember: (params: InviteMemberParams) => Promise<OrganizationInvitationResource>;
   updateMember: (params: UpdateMembershipParams) => Promise<OrganizationMembershipResource>;
   removeMember: (userId: string) => Promise<OrganizationMembershipResource>;
+  destroy: () => Promise<void>;
 }
 
 export interface GetMembershipsParams {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This PR adds two new methods on the organization resource:

### `Organization.destroy`

Allows an admin to delete the current organization.

### `Organization.addMember`

Allows an admin to add other users as members without having to go via the invitation flow.
This method accepts two parameters (given as an object):
* `userId`: The id of the user that will be added as a member to the organization.
* `role`: The role that this user will have in the organization. Valid values for the role are: `admin` and `basic_member`.

Please note that in order to add a user as a member to an organization, he needs to be in the same instance of the organization and not already be a member of that organization.

<!-- Fixes # (issue number) -->
