### PR TITLE
chore(remix): remove unused 'remix' package from peer dependencies

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -52,8 +52,7 @@
   },
   "peerDependencies": {
     "@remix-run/react": "^1.2.1",
-    "@remix-run/server-runtime": "^1.2.1",
-    "remix": ">=1.2.1"
+    "@remix-run/server-runtime": "^1.2.1"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

remove unused 'remix' package from peer dependencies

