### PR TITLE
fix: throw error when the resource is undefined

### DIFF
--- a/packages/clerk-js/src/ui/hooks/useMagicLink.ts
+++ b/packages/clerk-js/src/ui/hooks/useMagicLink.ts
@@ -19,15 +19,15 @@ function useMagicLink(resource: EmailAddressResource): UseMagicLinkEmailAddressR
 function useMagicLink(
   resource: MagicLinkable,
 ): UseMagicLinkSignInReturn | UseMagicLinkSignUpReturn | UseMagicLinkEmailAddressReturn {
-  const { startMagicLinkFlow, cancelMagicLinkFlow } = React.useMemo(() => resource.createMagicLinkFlow(), [resource]);
+  const flow = React.useMemo(() => resource?.createMagicLinkFlow(), [resource]);
 
   React.useEffect(() => {
-    return cancelMagicLinkFlow;
+    return flow?.cancelMagicLinkFlow;
   }, []);
 
   return {
-    startMagicLinkFlow,
-    cancelMagicLinkFlow,
+    startMagicLinkFlow: flow?.startMagicLinkFlow,
+    cancelMagicLinkFlow: flow?.cancelMagicLinkFlow,
   } as UseMagicLinkSignInReturn | UseMagicLinkSignUpReturn | UseMagicLinkEmailAddressReturn;
 }
 

--- a/packages/react/src/hooks/useMagicLink.ts
+++ b/packages/react/src/hooks/useMagicLink.ts
@@ -19,15 +19,15 @@ function useMagicLink(resource: EmailAddressResource): UseMagicLinkEmailAddressR
 function useMagicLink(
   resource: MagicLinkable,
 ): UseMagicLinkSignInReturn | UseMagicLinkSignUpReturn | UseMagicLinkEmailAddressReturn {
-  const { startMagicLinkFlow, cancelMagicLinkFlow } = React.useMemo(() => resource.createMagicLinkFlow(), [resource]);
+  const flow = React.useMemo(() => resource?.createMagicLinkFlow(), [resource]);
 
   React.useEffect(() => {
-    return cancelMagicLinkFlow;
+    return flow?.cancelMagicLinkFlow;
   }, []);
 
   return {
-    startMagicLinkFlow,
-    cancelMagicLinkFlow,
+    startMagicLinkFlow: flow?.startMagicLinkFlow,
+    cancelMagicLinkFlow: flow?.cancelMagicLinkFlow,
   } as UseMagicLinkSignInReturn | UseMagicLinkSignUpReturn | UseMagicLinkEmailAddressReturn;
 }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

When we use this hook alongside `useSignIn`/`useSignUp` these resources are first undefined and will trigger the following error

![image](https://user-images.githubusercontent.com/31737273/166166824-135b98d8-c566-4f05-b0ca-31ad000e6cb8.png)

With this fix, we ensure that when is undefined we don't do anything and when is defined the `useMemo` will update the hook and return the correct values

<!-- Fixes # (issue number) -->
