### PR TITLE
feat(backend-core): Update organization metadata

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -20,6 +20,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [revokeInvitation(invitationId)](#revokeinvitationinvitationId)
 - [Organization operations](#organization-operations)
   - [createOrganization(params)](#createorganizationparams)
+  - [updateOrganizationMetadata(params)](#updateorganizationmetadataparams)
 - [Session operations](#session-operations)
   - [getSessionList({ clientId, userId })](#getsessionlist-clientid-userid-)
   - [getSession(sessionId)](#getsessionsessionid)
@@ -167,6 +168,24 @@ const organization = await clerkAPI.organizations.createOrganization({
   name: 'Acme Inc',
   slug: 'acme-inc',
   createdBy: 'user_1o4q123qMeCkKKIXcA9h8',
+});
+```
+
+#### updateOrganizationMetadata(params)
+
+Update an organization's metadata attributes by merging existing values with the provided parameters.
+
+You can remove metadata keys at any level by setting their value to `null`.
+
+Available parameters are:
+
+- _publicMetadata_ Metadata saved on the organization, that is visible to both your Frontend and Backend APIs.
+- _privateMetadata_ Metadata saved on the organization, that is only visible to your Backend API.
+
+```js
+const organization = await clerkAPI.organizations.updateOrganizationMetadata({
+  publicMetadata: { color: 'blue' },
+  privateMetadata: { sandbox_mode: true },
 });
 ```
 

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -49,3 +49,40 @@ test('createOrganization() creates an organization', async () => {
     }),
   );
 });
+
+test('updateOrganizationMetadata() updates organization metadata', async () => {
+  const id = 'org_randomid';
+  const publicMetadata = { hello: 'world' };
+  const privateMetadata = { goodbye: 'world' };
+  const resJSON = {
+    object: 'organization',
+    id,
+    name: 'Org',
+    public_metadata: publicMetadata,
+    private_metadata: privateMetadata,
+    created_at: 1611948436,
+    updated_at: 1611948436,
+  };
+
+  nock('https://api.clerk.dev')
+    .patch(`/v1/organizations/${id}/metadata`, {
+      public_metadata: JSON.stringify(publicMetadata),
+      private_metadata: JSON.stringify(privateMetadata),
+    })
+    .reply(200, resJSON);
+
+  const organization = await TestBackendAPIClient.organizations.updateOrganizationMetadata(id, {
+    publicMetadata,
+    privateMetadata,
+  });
+  expect(organization).toEqual(
+    new Organization({
+      id,
+      name: resJSON.name,
+      publicMetadata,
+      privateMetadata,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    }),
+  );
+});

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -19,6 +19,8 @@ type OrganizationMetadataRequestBody = {
   privateMetadata?: string;
 };
 
+type UpdateMetadataParams = OrganizationMetadataParams;
+
 export class OrganizationApi extends AbstractApi {
   public async createOrganization(params: CreateParams) {
     const { publicMetadata, privateMetadata } = params;
@@ -32,6 +34,16 @@ export class OrganizationApi extends AbstractApi {
           privateMetadata,
         }),
       },
+    });
+  }
+
+  public async updateOrganizationMetadata(organizationId: string, params: UpdateMetadataParams) {
+    this.requireId(organizationId);
+
+    return this._restClient.makeRequest<Organization>({
+      method: 'PATCH',
+      path: `${basePath}/${organizationId}/metadata`,
+      bodyParams: stringifyMetadataParams(params),
     });
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added a new method in the organizations API to update and merge organization metadata. 

The method name is `updateOrganizationMetadata`. It triggers a `PATCH /v1/organizations/:id/metadata` request to the Clerk API and accepts `publicMetadata` and `privateMetadata` parameters.

The metadata will be merged with any existing metadata on the organization.

<!-- Fixes # (issue number) -->
