### PR TITLE
set intersticial script tag as crossOrigin='anonymous'

### DIFF
--- a/packages/remix/src/client/Interstitial.tsx
+++ b/packages/remix/src/client/Interstitial.tsx
@@ -60,6 +60,7 @@ const createInterstitialHTMLString = (frontendApi: string, libVersion: string, d
                 script.setAttribute('data-clerk-frontend-api', '${frontendApi}');
                 script.async = true;
                 script.src = '${getScriptUrl(frontendApi, libVersion)}';
+                script.crossOrigin = '';
                 script.addEventListener('load', startClerk);
                 document.body.appendChild(script);
             })();


### PR DESCRIPTION
This should fix issues when apps are using https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy

| NOTE: This change may need to happen in other places but this is one that I need. 

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
