### PR TITLE
fix(clerk-js): Hide signup input form when an oauth exists but we have no auth factor

### DIFF
--- a/packages/clerk-js/src/core/resources/UserSettings.test.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.test.ts
@@ -55,6 +55,143 @@ describe('UserSettings', () => {
     expect(sut.instanceIsPasswordBased).toEqual(false);
   });
 
+  it('returns true if the instance has a valid email address auth factor', function () {
+    let sut = new UserSettings({
+      attributes: {
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        password: {
+          enabled: true,
+          required: false,
+        },
+      },
+    } as any as UserSettingsJSON);
+
+    expect(sut.hasValidAuthFactor).toEqual(false);
+
+    sut = new UserSettings({
+      attributes: {
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        password: {
+          enabled: true,
+          required: false,
+        },
+      },
+    } as any as UserSettingsJSON);
+    expect(sut.hasValidAuthFactor).toEqual(true);
+  });
+
+  it('returns true if the instance has a valid phone number auth factor', function () {
+    let sut = new UserSettings({
+      attributes: {
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        password: {
+          enabled: true,
+          required: false,
+        },
+      },
+    } as any as UserSettingsJSON);
+
+    expect(sut.hasValidAuthFactor).toEqual(false);
+
+    sut = new UserSettings({
+      attributes: {
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+        password: {
+          enabled: true,
+          required: false,
+        },
+      },
+    } as any as UserSettingsJSON);
+    expect(sut.hasValidAuthFactor).toEqual(true);
+  });
+
+  it('returns true if the instance has username and password auth factor', function () {
+    let sut = new UserSettings({
+      attributes: {
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        password: {
+          enabled: true,
+          required: false,
+        },
+        username: {
+          enabled: true,
+          required: false,
+        },
+      },
+    } as any as UserSettingsJSON);
+
+    expect(sut.hasValidAuthFactor).toEqual(false);
+
+    sut = new UserSettings({
+      attributes: {
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+        password: {
+          enabled: true,
+          required: true,
+        },
+        username: {
+          enabled: true,
+          required: true,
+        },
+      },
+    } as any as UserSettingsJSON);
+    expect(sut.hasValidAuthFactor).toEqual(true);
+  });
+
   it('returns enabled social provider strategies', function () {
     const sut = new UserSettings({
       social: {

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -34,6 +34,14 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     return this.attributes.password.enabled && this.attributes.password.required;
   }
 
+  get hasValidAuthFactor() {
+    return (
+      this.attributes.email_address.used_for_first_factor ||
+      this.attributes.phone_number.used_for_first_factor ||
+      (this.attributes.password.required && this.attributes.username.required)
+    );
+  }
+
   protected fromJSON(data: UserSettingsJSON): this {
     this.social = data.social;
     this.attributes = data.attributes;

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
@@ -457,6 +457,10 @@ describe('<SignUpStart/>', () => {
               phone_number: {
                 enabled: true,
                 required: true,
+                used_for_first_factor: true,
+              },
+              email_address: {
+                used_for_first_factor: false,
               },
               password: {
                 required: false,
@@ -479,5 +483,46 @@ describe('<SignUpStart/>', () => {
 
     runTokenTests('__clerk_invitation_token');
     runTokenTests('__clerk_ticket');
+  });
+
+  it('hides sign up form when no at least an oauth is enabled and no auth factor is enabled', async () => {
+    mockUserSettings = new UserSettings({
+      attributes: {
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        email_address: {
+          used_for_first_factor: false,
+        },
+        password: {
+          required: false,
+        },
+        username: {
+          enabled: true,
+          required: true,
+        },
+        first_name: {
+          enabled: true,
+          required: true,
+        },
+        last_name: {
+          enabled: true,
+          required: true,
+        },
+      },
+      social: {
+        oauth_google: {
+          authenticatable: true,
+          enabled: true,
+          required: false,
+          strategy: 'oauth_google',
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+    expect(screen.queryByRole('button', { name: 'Sign up' })).not.toBeInTheDocument();
   });
 });

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -302,12 +302,7 @@ function _SignUpStart(): JSX.Element {
       </Control>
     ) : null;
 
-  const atLeastOneAuthFactor =
-    userSettings.attributes.email_address.used_for_first_factor ||
-    userSettings.attributes.phone_number.used_for_first_factor ||
-    (userSettings.attributes.password.required && userSettings.attributes.username.required);
-
-  const showFormFields = atLeastOneAuthFactor || !oauthOptions.length;
+  const showFormFields = userSettings.hasValidAuthFactor || (!oauthOptions.length && !web3Options.length);
 
   return (
     <>

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -302,7 +302,12 @@ function _SignUpStart(): JSX.Element {
       </Control>
     ) : null;
 
-  const atLeastOneFormField = nameField || usernameField || emailAddressField || phoneNumberField || passwordField;
+  const atLeastOneAuthFactor =
+    userSettings.attributes.email_address.used_for_first_factor ||
+    userSettings.attributes.phone_number.used_for_first_factor ||
+    (userSettings.attributes.password.required && userSettings.attributes.username.required);
+
+  const showFormFields = atLeastOneAuthFactor || !oauthOptions.length;
 
   return (
     <>
@@ -323,7 +328,7 @@ function _SignUpStart(): JSX.Element {
             setError={setError}
           />
         )}
-        {atLeastOneFormField && (
+        {showFormFields && (
           <>
             {(oauthOptions.length > 0 || web3Options.length > 0) && <Separator />}
             {/* @ts-ignore */}

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -70,4 +70,5 @@ export interface UserSettingsResource extends ClerkResource {
   web3FirstFactors: Web3Strategy[];
   enabledFirstFactorIdentifiers: Attribute[];
   instanceIsPasswordBased: boolean;
+  hasValidAuthFactor: boolean;
 }


### PR DESCRIPTION

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

Hide signup input form when an oauth exists but we have no auth factor
https://www.notion.so/clerkdev/Hide-name-in-SignUp-when-OAuth-is-the-only-factor-dd5341fba63c4237a7f66672d234e97a

<!-- Fixes # (issue number) -->
