### PR TITLE
feat(backend-core): Update organization

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -20,7 +20,8 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [revokeInvitation(invitationId)](#revokeinvitationinvitationId)
 - [Organization operations](#organization-operations)
   - [createOrganization(params)](#createorganizationparams)
-  - [updateOrganizationMetadata(params)](#updateorganizationmetadataparams)
+  - [updateOrganization(organizationId, params)](#updateorganizationorganizationid-params)
+  - [updateOrganizationMetadata(organizationId, params)](#updateorganizationmetadataorganizationid-params)
 - [Session operations](#session-operations)
   - [getSessionList({ clientId, userId })](#getsessionlist-clientid-userid-)
   - [getSession(sessionId)](#getsessionsessionid)
@@ -171,7 +172,21 @@ const organization = await clerkAPI.organizations.createOrganization({
 });
 ```
 
-#### updateOrganizationMetadata(params)
+#### updateOrganization(organizationId, params)
+
+Update the organization specified by `organizationId`.
+
+Available parameters are:
+
+- _name_ The name for the organization.
+
+```js
+const organization = await clerkAPI.organizations.updateOrganization('org_1o4q123qMeCkKKIXcA9h8', {
+  name: 'Acme Inc',
+});
+```
+
+#### updateOrganizationMetadata(organizationId, params)
 
 Update an organization's metadata attributes by merging existing values with the provided parameters.
 
@@ -183,7 +198,7 @@ Available parameters are:
 - _privateMetadata_ Metadata saved on the organization, that is only visible to your Backend API.
 
 ```js
-const organization = await clerkAPI.organizations.updateOrganizationMetadata({
+const organization = await clerkAPI.organizations.updateOrganizationMetadata('org_1o4q123qMeCkKKIXcA9h8', {
   publicMetadata: { color: 'blue' },
   privateMetadata: { sandbox_mode: true },
 });

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -50,6 +50,30 @@ test('createOrganization() creates an organization', async () => {
   );
 });
 
+test('updateOrganization() updates organization', async () => {
+  const id = 'org_randomid';
+  const name = 'New name';
+  const resJSON = {
+    object: 'organization',
+    id,
+    name,
+    created_at: 1611948436,
+    updated_at: 1611948436,
+  };
+
+  nock('https://api.clerk.dev').patch(`/v1/organizations/${id}`, { name }).reply(200, resJSON);
+
+  const organization = await TestBackendAPIClient.organizations.updateOrganization(id, { name });
+  expect(organization).toEqual(
+    new Organization({
+      id,
+      name: resJSON.name,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    }),
+  );
+});
+
 test('updateOrganizationMetadata() updates organization metadata', async () => {
   const id = 'org_randomid';
   const publicMetadata = { hello: 'world' };

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -19,6 +19,10 @@ type OrganizationMetadataRequestBody = {
   privateMetadata?: string;
 };
 
+type UpdateParams = {
+  name?: string;
+};
+
 type UpdateMetadataParams = OrganizationMetadataParams;
 
 export class OrganizationApi extends AbstractApi {
@@ -34,6 +38,15 @@ export class OrganizationApi extends AbstractApi {
           privateMetadata,
         }),
       },
+    });
+  }
+
+  public async updateOrganization(organizationId: string, params: UpdateParams) {
+    this.requireId(organizationId);
+    return this._restClient.makeRequest<Organization>({
+      method: 'PATCH',
+      path: `${basePath}/${organizationId}`,
+      bodyParams: params,
     });
   }
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added support for updating an organization in the backend-core package. The new method signature is `Organization#update(organizationId, params)`.

<!-- Fixes # (issue number) -->
