### PR TITLE
feat(backend-core): Delete an organization

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -17,11 +17,12 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
 - [Invitation operations](#invitation-operations)
   - [getInvitationList()](#getinvitationlist)
   - [createInvitation(params)](#createinvitationparams)
-  - [revokeInvitation(invitationId)](#revokeinvitationinvitationId)
+  - [revokeInvitation(invitationId)](#revokeinvitationinvitationid)
 - [Organization operations](#organization-operations)
   - [createOrganization(params)](#createorganizationparams)
   - [updateOrganization(organizationId, params)](#updateorganizationorganizationid-params)
   - [updateOrganizationMetadata(organizationId, params)](#updateorganizationmetadataorganizationid-params)
+  - [deleteOrganization(organizationId)](#deleteorganizationorganizationid)
 - [Session operations](#session-operations)
   - [getSessionList({ clientId, userId })](#getsessionlist-clientid-userid-)
   - [getSession(sessionId)](#getsessionsessionid)
@@ -202,6 +203,14 @@ const organization = await clerkAPI.organizations.updateOrganizationMetadata('or
   publicMetadata: { color: 'blue' },
   privateMetadata: { sandbox_mode: true },
 });
+```
+
+#### deleteOrganization(organizationId)
+
+Delete an organization with the provided `organizationId`. This action cannot be undone.
+
+```js
+await clerkAPI.organizations.deleteOrganization(organizationId);
 ```
 
 ## Session operations

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -110,3 +110,9 @@ test('updateOrganizationMetadata() updates organization metadata', async () => {
     }),
   );
 });
+
+test('deleteOrganization() deletes organization', async () => {
+  const id = 'org_randomid';
+  nock('https://api.clerk.dev').delete(`/v1/organizations/${id}`).reply(200, {});
+  await TestBackendAPIClient.organizations.deleteOrganization(id);
+});

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -59,6 +59,13 @@ export class OrganizationApi extends AbstractApi {
       bodyParams: stringifyMetadataParams(params),
     });
   }
+
+  public async deleteOrganization(organizationId: string) {
+    return this._restClient.makeRequest<Organization>({
+      method: 'DELETE',
+      path: `${basePath}/${organizationId}`,
+    });
+  }
 }
 
 function stringifyMetadataParams(


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added a method to delete an organization in our backend-core package.

The signature is `organizations.deleteOrganization(organizationId)`.
