### PR TITLE
fix(clerk-js): Use redirect_url across all auth flows

### DIFF
--- a/packages/clerk-js/src/ui/signIn/SignIn.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignIn.tsx
@@ -33,6 +33,7 @@ function SignInRoutes(): JSX.Element {
         <SSOCallback
           afterSignInUrl={signInContext.afterSignInUrl}
           afterSignUpUrl={signInContext.afterSignUpUrl}
+          redirectUrl={signInContext.redirectUrl}
           secondFactorUrl={'../factor-two'}
         />
       </Route>
@@ -41,7 +42,7 @@ function SignInRoutes(): JSX.Element {
       </Route>
       <Route path='verify'>
         <VerifyMagicLink
-          redirectUrlComplete={signInContext.afterSignInUrl || undefined}
+          redirectUrlComplete={signInContext.afterSignInUrl || signInContext.redirectUrl || undefined}
           redirectUrl='../factor-two'
         />
       </Route>

--- a/packages/clerk-js/src/ui/signUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUp.tsx
@@ -31,11 +31,12 @@ function SignUpRoutes(): JSX.Element {
         <SSOCallback
           afterSignUpUrl={signUpContext.afterSignUpUrl}
           afterSignInUrl={signUpContext.afterSignInUrl}
+          redirectUrl={signUpContext.redirectUrl}
           secondFactorUrl={signUpContext.signInUrl + '#/factor-two'}
         />
       </Route>
       <Route path='verify'>
-        <VerifyMagicLink redirectUrlComplete={signUpContext.afterSignUpUrl || undefined} />
+        <VerifyMagicLink redirectUrlComplete={signUpContext.afterSignUpUrl || signUpContext.redirectUrl || undefined} />
       </Route>
       <Route index>
         <SignUpStart />


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Teach ClerkJS to respect redirect_url upon completion of OAuth and email verification flows.