### PR TITLE
Simplify interstitial fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34922,8 +34922,8 @@
     "packages/gatsby-plugin-clerk": {
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-react": "^3.2.7-alpha.0",
-        "@clerk/clerk-sdk-node": "^3.3.5-alpha.0",
+        "@clerk/clerk-react": "^3.2.14",
+        "@clerk/clerk-sdk-node": "^3.4.1",
         "@clerk/types": "^2.6.1-alpha.0",
         "cookie": "^0.5.0",
         "tslib": "^2.3.1"
@@ -34940,67 +34940,6 @@
         "gatsby": "^4.0.0"
       }
     },
-    "packages/gatsby-plugin-clerk/node_modules/@clerk/backend-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend-core/-/backend-core-1.5.0.tgz",
-      "integrity": "sha512-WL7+gRqe5qLocC5uk6IuNi8GdcNGoTZkK4TGrEHe/RIr7T201+PMkPGAAV75bjog3ruUTYbsoZRIvmI2hvAt4A==",
-      "dependencies": {
-        "@clerk/types": "^2.7.0",
-        "camelcase-keys": "^7.0.1",
-        "query-string": "^7.0.1",
-        "snakecase-keys": "^5.1.2",
-        "tslib": "^2.3.1"
-      }
-    },
-    "packages/gatsby-plugin-clerk/node_modules/@clerk/clerk-sdk-node": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-3.3.5.tgz",
-      "integrity": "sha512-i4l40/0Bj/FDQbAo6CGoimWvGbgAZe7xzZKck5jeva8F/WDf+5nPmgaJYQxrjCMK2i24ZaeC4tv4/q+dZqzMsw==",
-      "dependencies": {
-        "@clerk/backend-core": "^1.5.0",
-        "@clerk/types": "^2.7.0",
-        "@peculiar/webcrypto": "^1.2.3",
-        "camelcase-keys": "^6.2.2",
-        "cookies": "^0.8.0",
-        "deepmerge": "^4.2.2",
-        "got": "^11.8.2",
-        "jsonwebtoken": "^8.5.1",
-        "jwks-rsa": "^2.0.4",
-        "snakecase-keys": "^3.2.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/gatsby-plugin-clerk/node_modules/@clerk/clerk-sdk-node/node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/gatsby-plugin-clerk/node_modules/@clerk/clerk-sdk-node/node_modules/snakecase-keys": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
-      "integrity": "sha512-CjU5pyRfwOtaOITYv5C8DzpZ8XA/ieRsDpr93HI2r6e3YInC6moZpSQbmUtg8cTk58tq2x3jcG2gv+p1IZGmMA==",
-      "dependencies": {
-        "map-obj": "^4.1.0",
-        "to-snake-case": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "packages/gatsby-plugin-clerk/node_modules/@types/cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
@@ -35013,28 +34952,12 @@
       "integrity": "sha512-C1pD3kgLoZ56Uuy5lhfOxie4aZlA3UMGLX9rXteq4WitEZH6Rl80mwactt9QG0w0gLFlN/kLBTFnGXtDVWvWQw==",
       "dev": true
     },
-    "packages/gatsby-plugin-clerk/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "packages/gatsby-plugin-clerk/node_modules/cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "packages/gatsby-plugin-clerk/node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "packages/nextjs": {
@@ -49637,8 +49560,8 @@
     "gatsby-plugin-clerk": {
       "version": "file:packages/gatsby-plugin-clerk",
       "requires": {
-        "@clerk/clerk-react": "^3.2.7-alpha.0",
-        "@clerk/clerk-sdk-node": "^3.3.5-alpha.0",
+        "@clerk/clerk-react": "^3.2.14",
+        "@clerk/clerk-sdk-node": "^3.4.1",
         "@clerk/types": "^2.6.1-alpha.0",
         "@types/cookie": "^0.5.0",
         "@types/node": "^16.11.9",
@@ -49647,57 +49570,6 @@
         "typescript": "^4.6.2"
       },
       "dependencies": {
-        "@clerk/backend-core": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@clerk/backend-core/-/backend-core-1.5.0.tgz",
-          "integrity": "sha512-WL7+gRqe5qLocC5uk6IuNi8GdcNGoTZkK4TGrEHe/RIr7T201+PMkPGAAV75bjog3ruUTYbsoZRIvmI2hvAt4A==",
-          "requires": {
-            "@clerk/types": "^2.7.0",
-            "camelcase-keys": "^7.0.1",
-            "query-string": "^7.0.1",
-            "snakecase-keys": "^5.1.2",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@clerk/clerk-sdk-node": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-3.3.5.tgz",
-          "integrity": "sha512-i4l40/0Bj/FDQbAo6CGoimWvGbgAZe7xzZKck5jeva8F/WDf+5nPmgaJYQxrjCMK2i24ZaeC4tv4/q+dZqzMsw==",
-          "requires": {
-            "@clerk/backend-core": "^1.5.0",
-            "@clerk/types": "^2.7.0",
-            "@peculiar/webcrypto": "^1.2.3",
-            "camelcase-keys": "^6.2.2",
-            "cookies": "^0.8.0",
-            "deepmerge": "^4.2.2",
-            "got": "^11.8.2",
-            "jsonwebtoken": "^8.5.1",
-            "jwks-rsa": "^2.0.4",
-            "snakecase-keys": "^3.2.1",
-            "tslib": "^2.3.1"
-          },
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "6.2.2",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-              "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-              "requires": {
-                "camelcase": "^5.3.1",
-                "map-obj": "^4.0.0",
-                "quick-lru": "^4.0.1"
-              }
-            },
-            "snakecase-keys": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
-              "integrity": "sha512-CjU5pyRfwOtaOITYv5C8DzpZ8XA/ieRsDpr93HI2r6e3YInC6moZpSQbmUtg8cTk58tq2x3jcG2gv+p1IZGmMA==",
-              "requires": {
-                "map-obj": "^4.1.0",
-                "to-snake-case": "^1.0.0"
-              }
-            }
-          }
-        },
         "@types/cookie": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
@@ -49710,20 +49582,10 @@
           "integrity": "sha512-C1pD3kgLoZ56Uuy5lhfOxie4aZlA3UMGLX9rXteq4WitEZH6Rl80mwactt9QG0w0gLFlN/kLBTFnGXtDVWvWQw==",
           "dev": true
         },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
         "cookie": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
           "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
-        },
-        "quick-lru": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-          "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
         }
       }
     },

--- a/packages/backend-core/src/Base.ts
+++ b/packages/backend-core/src/Base.ts
@@ -169,13 +169,9 @@ export class Base {
   };
 
   /**
-   *
    * Retrieve the authentication state for a request by using client specific information.
    *
    * @throws {Error} Token expired, Wrong azp, Malformed token. All of these cases should result in signed out state.
-   *
-   * @param {AuthStateParams}
-   * @returns {Promise<AuthState>}
    */
   getAuthState = async ({
     cookieToken,
@@ -189,14 +185,12 @@ export class Base {
     referrer,
     userAgent,
     authorizedParties,
-    fetchInterstitial,
     jwtKey,
   }: AuthStateParams): Promise<AuthState> => {
     if (headerToken) {
       return this.buildAuthenticatedState(headerToken, {
         jwtKey,
         authorizedParties,
-        fetchInterstitial,
         tokenType: 'header',
       });
     }
@@ -230,7 +224,6 @@ export class Base {
     if (isDevelopmentKey && !clientUat) {
       return {
         status: AuthStatus.Interstitial,
-        interstitial: await fetchInterstitial(),
         errorReason: AuthErrorReason.UATMissing,
       };
     }
@@ -249,7 +242,6 @@ export class Base {
     ) {
       return {
         status: AuthStatus.Interstitial,
-        interstitial: await fetchInterstitial(),
         errorReason: AuthErrorReason.CrossOriginReferrer,
       };
     }
@@ -275,7 +267,6 @@ export class Base {
     if (isProductionKey && clientUat && !cookieToken) {
       return {
         status: AuthStatus.Interstitial,
-        interstitial: await fetchInterstitial(),
         errorReason: AuthErrorReason.CookieMissing,
       };
     }
@@ -283,7 +274,6 @@ export class Base {
     const authenticatedState = await this.buildAuthenticatedState(cookieToken as string, {
       jwtKey,
       authorizedParties,
-      fetchInterstitial,
       tokenType: 'cookie',
     });
 
@@ -292,7 +282,6 @@ export class Base {
     } else if (authenticatedState.sessionClaims && authenticatedState.sessionClaims.iat < Number(clientUat)) {
       return {
         status: AuthStatus.Interstitial,
-        interstitial: await fetchInterstitial(),
         errorReason: AuthErrorReason.CookieOutDated,
       };
     } else if (!authenticatedState.sessionClaims) {
@@ -301,14 +290,13 @@ export class Base {
 
     return {
       status: AuthStatus.Interstitial,
-      interstitial: await fetchInterstitial(),
       errorReason: AuthErrorReason.Unknown,
     };
   };
 
   buildAuthenticatedState = async (
     token: string,
-    { authorizedParties, jwtKey, fetchInterstitial, tokenType }: BuildAuthenticatedStateOptions,
+    { authorizedParties, jwtKey, tokenType }: BuildAuthenticatedStateOptions,
   ): Promise<AuthState> => {
     try {
       const sessionClaims = await this.verifySessionToken(token, {
@@ -332,7 +320,6 @@ export class Base {
         }
         return {
           status: AuthStatus.Interstitial,
-          interstitial: await fetchInterstitial(),
           errorReason,
         };
       }

--- a/packages/backend-core/src/types/core.ts
+++ b/packages/backend-core/src/types/core.ts
@@ -20,7 +20,6 @@ export type VerifySessionTokenOptions = {
 export type BuildAuthenticatedStateOptions = {
   jwtKey?: string;
   authorizedParties?: string[];
-  fetchInterstitial: () => Promise<string>;
   tokenType: TokenType;
 };
 
@@ -29,7 +28,6 @@ export type TokenType = 'cookie' | 'header';
 export type AuthState = {
   status: AuthStatus;
   session?: Session;
-  interstitial?: string;
   sessionClaims?: JWTPayload;
   /* Error reason for signed-out and interstitial states. Would probably be set on the `Auth-Result` response header. */
   errorReason?: AuthErrorReason;
@@ -58,8 +56,6 @@ export type AuthStateParams = {
   userAgent?: string | null;
   /* A list of authorized parties to validate against the session token azp claim */
   authorizedParties?: string[];
-  /* HTTP utility for fetching a text/html string */
-  fetchInterstitial: () => Promise<string>;
   /* Value corresponding to the JWT verification key */
   jwtKey?: string;
 };

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -76,7 +76,7 @@ export function withEdgeMiddlewareAuth(
     const { loadUser, loadSession, jwtKey, authorizedParties } = options;
     const cookieToken = req.cookies['__session'];
     const headerToken = req.headers.get('authorization');
-    const { status, interstitial, sessionClaims, errorReason } = await vercelEdgeBase.getAuthState({
+    const { status, sessionClaims, errorReason } = await vercelEdgeBase.getAuthState({
       cookieToken,
       headerToken,
       clientUat: req.cookies['__client_uat'],
@@ -88,11 +88,10 @@ export function withEdgeMiddlewareAuth(
       referrer: req.headers.get('referrer'),
       authorizedParties,
       jwtKey,
-      fetchInterstitial,
     });
 
     if (status === AuthStatus.Interstitial) {
-      return new NextResponse(interstitial, {
+      return new NextResponse(await fetchInterstitial(), {
         headers: { 'Content-Type': 'text/html', 'Auth-Result': errorReason || '' },
         status: 401,
       });

--- a/packages/gatsby-plugin-clerk/package.json
+++ b/packages/gatsby-plugin-clerk/package.json
@@ -31,8 +31,8 @@
     "dev": "tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
-    "@clerk/clerk-react": "^3.2.7-alpha.0",
-    "@clerk/clerk-sdk-node": "^3.3.5-alpha.0",
+    "@clerk/clerk-react": "^3.2.14",
+    "@clerk/clerk-sdk-node": "^3.4.1",
     "@clerk/types": "^2.6.1-alpha.0",
     "cookie": "^0.5.0",
     "tslib": "^2.3.1"

--- a/packages/gatsby-plugin-clerk/src/ssr/getAuthData.ts
+++ b/packages/gatsby-plugin-clerk/src/ssr/getAuthData.ts
@@ -48,7 +48,6 @@ export async function getAuthData(
       forwardedHost: returnReferrerAsXForwardedHostToFixLocalDevGatsbyProxy(headers),
       referrer: headers.get('referer') as string,
       userAgent: headers.get('user-agent') as string,
-      fetchInterstitial: () => Promise.resolve(''),
     });
 
     if (status === AuthStatus.Interstitial) {

--- a/packages/nextjs/src/middleware/utils/getAuthData.ts
+++ b/packages/nextjs/src/middleware/utils/getAuthData.ts
@@ -17,7 +17,7 @@ export async function getAuthData(
   try {
     const cookieToken = cookies['__session'];
     const headerToken = headers.authorization?.replace('Bearer ', '');
-    const { status, sessionClaims, interstitial, errorReason } = await Clerk.base.getAuthState({
+    const { status, sessionClaims, errorReason } = await Clerk.base.getAuthState({
       cookieToken,
       headerToken,
       clientUat: cookies['__client_uat'],
@@ -27,7 +27,6 @@ export async function getAuthData(
       forwardedHost: headers['x-forwarded-host'] as string,
       referrer: headers.referer,
       userAgent: headers['user-agent'] as string,
-      fetchInterstitial: () => Clerk.fetchInterstitial(),
       jwtKey,
       authorizedParties,
     });
@@ -36,7 +35,7 @@ export async function getAuthData(
 
     if (status === AuthStatus.Interstitial) {
       ctx.res.writeHead(401, { 'Content-Type': 'text/html' });
-      ctx.res.end(interstitial);
+      ctx.res.end(await Clerk.fetchInterstitial());
       return null;
     }
 

--- a/packages/remix/src/ssr/getAuthData.ts
+++ b/packages/remix/src/ssr/getAuthData.ts
@@ -38,7 +38,6 @@ export async function getAuthData(
       forwardedHost: headers.get('x-forwarded-host') as string,
       referrer: headers.get('referer'),
       userAgent: headers.get('user-agent') as string,
-      fetchInterstitial: () => Promise.resolve(''),
       authorizedParties,
       jwtKey,
     });

--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -259,7 +259,7 @@ export default class Clerk extends ClerkBackendAPI {
         const cookieToken = cookies.get('__session') as string;
         const headerToken = req.headers.authorization?.replace('Bearer ', '');
 
-        const { status, interstitial, sessionClaims, errorReason } =
+        const { status, sessionClaims, errorReason } =
           await this.base.getAuthState({
             cookieToken,
             headerToken,
@@ -272,7 +272,6 @@ export default class Clerk extends ClerkBackendAPI {
             userAgent: req.headers['user-agent'] as string,
             authorizedParties,
             jwtKey: jwtKey || this.jwtKey,
-            fetchInterstitial: () => this.fetchInterstitial(),
           });
 
         errorReason && res.setHeader('Auth-Result', errorReason);
@@ -299,7 +298,7 @@ export default class Clerk extends ClerkBackendAPI {
         }
 
         res.writeHead(401, { 'Content-Type': 'text/html' });
-        res.write(interstitial);
+        res.write(this.fetchInterstitial());
         res.end();
       } catch (error) {
         // Auth object will be set to the signed out auth state


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Small refactor to move the responsibility of fetching the interstitial page to each wrapping package (nextjs, remix, gatsby).
Can be also considered as preparatory work so it'll be more straightforward to remove the interstitial BAPI call in the near future.

Extracted from https://github.com/clerkinc/javascript/pull/197

<!-- Fixes # (issue number) -->
