### PR TITLE
Support for organization invitations in NodeJS SDK

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -25,6 +25,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [deleteOrganization(organizationId)](#deleteorganizationorganizationid)
   - [getPendingOrganizationInvitationList(params)](#getpendingorganizationinvitationlistparams)
   - [createOrganizationInvitation(params)](#createorganizationinvitationparams)
+  - [revokeOrganizationInvitation(params)](#revokeorganizationinvitationparams)
   - [getOrganizationMembershipList(params)](#getorganizationmembershiplistparams)
   - [createOrganizationMembership(params)](#createorganizationmembershipparams)
   - [updateOrganizationMembership(params)](#updateorganizationmembershipparams)
@@ -256,6 +257,26 @@ const invitation = await clerkAPI.organizations.createOrganizationInvitation({
   emailAddress: 'invited@example.org',
   role: 'basic_member',
   redirectUrl: 'https://example.org',
+});
+```
+
+#### revokeOrganizationInvitation(params)
+
+Revoke a pending organization invitation for the organization specified by `organizationId`.
+
+The requesting user must be an administrator in the organization.
+
+The method parameters are:
+
+- _organizationId_ The ID of the organization that the invitation belongs to.
+- _invitationId_ The ID of the pending organization invitation to be revoked.
+- _requestingUserId_ The ID of the user that revokes the invitation. Must be an administrator.
+
+```ts
+const invitation = await clerkAPI.organizations.revokeOrganizationInvitation({
+  organizationId: 'org_1o4q123qMeCkKKIXcA9h8',
+  invitationId: 'orginv_4o4q9883qMeFggTKIXcAArr',
+  requestingUserId: 'user_1o4q123qMeCkKKIXcA9h8',
 });
 ```
 

--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -23,6 +23,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [updateOrganization(organizationId, params)](#updateorganizationorganizationid-params)
   - [updateOrganizationMetadata(organizationId, params)](#updateorganizationmetadataorganizationid-params)
   - [deleteOrganization(organizationId)](#deleteorganizationorganizationid)
+  - [createOrganizationInvitation(params)](#createorganizationinvitationparams)
   - [getOrganizationMembershipList(params)](#getorganizationmembershiplistparams)
   - [createOrganizationMembership(params)](#createorganizationmembershipparams)
   - [updateOrganizationMembership(params)](#updateorganizationmembershipparams)
@@ -215,6 +216,30 @@ Delete an organization with the provided `organizationId`. This action cannot be
 
 ```js
 await clerkAPI.organizations.deleteOrganization(organizationId);
+```
+
+#### createOrganizationInvitation(params)
+
+Create an invitation to join an organization and send an email to the email address of the invited member.
+
+You must pass the ID of the user that invites the new member as `inviterUserId`. The inviter user must be an administrator in the organization.
+
+Available parameters:
+
+- _organizationId_ The unique ID of the organization the invitation is about.
+- _emailAddress_ The email address of the member that's going to be invited to join the organization.
+- _role_ The new member's role in the organization.
+- _inviterUserId_ The ID of the organization administrator that invites the new member.
+- _redirectUrl_ An optional URL to redirect to after the invited member clicks the link from the invitation email.
+
+```js
+const invitation = await clerkAPI.organizations.createOrganizationInvitation({
+  organizationId: 'org_1o4q123qMeCkKKIXcA9h8',
+  inviterUserId: 'user_1o4q123qMeCkKKIXcA9h8',
+  emailAddress: 'invited@example.org',
+  role: 'basic_member',
+  redirectUrl: 'https://example.org',
+});
 ```
 
 #### getOrganizationMembershipList(params)

--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -23,6 +23,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [updateOrganization(organizationId, params)](#updateorganizationorganizationid-params)
   - [updateOrganizationMetadata(organizationId, params)](#updateorganizationmetadataorganizationid-params)
   - [deleteOrganization(organizationId)](#deleteorganizationorganizationid)
+  - [getPendingOrganizationInvitationList(params)](#getpendingorganizationinvitationlistparams)
   - [createOrganizationInvitation(params)](#createorganizationinvitationparams)
   - [getOrganizationMembershipList(params)](#getorganizationmembershiplistparams)
   - [createOrganizationMembership(params)](#createorganizationmembershipparams)
@@ -216,6 +217,22 @@ Delete an organization with the provided `organizationId`. This action cannot be
 
 ```js
 await clerkAPI.organizations.deleteOrganization(organizationId);
+```
+
+#### getPendingOrganizationInvitationList(params)
+
+Retrieve a list of pending organization invitations for the organization specified by `organizationId`.
+
+The method supports pagination via optional `limit` and `offset` parameters. The method parameters are:
+
+- _organizationId_ The unique ID of the organization to retrieve the pending invitations for
+- _limit_ Optionally put a limit on the number of results returned
+- _offset_ Optionally skip some results
+
+```ts
+const invitations = await clerkAPI.organizations.getPendingOrganizationInvitationList({
+  organizationId: 'org_1o4q123qMeCkKKIXcA9h8',
+});
 ```
 
 #### createOrganizationInvitation(params)

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -335,3 +335,31 @@ test('createOrganizationInvitation() creates an invitation for an organization',
     }),
   );
 });
+
+test('getPendingOrganizationInvitationList() returns a list of organization memberships', async () => {
+  const organizationId = 'org_randomid';
+  const resJSON = [
+    {
+      object: 'organization_invitation',
+      id: 'orginv_randomid',
+      role: 'basic_member',
+      email_address: 'invited@example.org',
+      organization_id: organizationId,
+      status: 'pending',
+      redirect_url: null,
+      created_at: 1612378465,
+      updated_at: 1612378465,
+    },
+  ];
+
+  nock('https://api.clerk.dev')
+    .get(new RegExp(`/v1/organizations/${organizationId}/invitations/pending`))
+    .reply(200, resJSON);
+
+  const organizationInvitationList = await TestBackendAPIClient.organizations.getPendingOrganizationInvitationList({
+    organizationId,
+  });
+  expect(organizationInvitationList).toBeInstanceOf(Array);
+  expect(organizationInvitationList.length).toEqual(1);
+  expect(organizationInvitationList[0]).toBeInstanceOf(OrganizationInvitation);
+});

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -363,3 +363,40 @@ test('getPendingOrganizationInvitationList() returns a list of organization memb
   expect(organizationInvitationList.length).toEqual(1);
   expect(organizationInvitationList[0]).toBeInstanceOf(OrganizationInvitation);
 });
+
+test('revokeOrganizationInvitation() revokes an organization invitation', async () => {
+  const organizationId = 'org_randomid';
+  const invitationId = 'orginv_randomid';
+  const resJSON = {
+    object: 'organization_invitation',
+    id: invitationId,
+    role: 'basic_member' as OrganizationMembershipRole,
+    email_address: 'invited@example.org',
+    organization_id: organizationId,
+    status: 'revoked' as OrganizationInvitationStatus,
+    redirect_url: null,
+    created_at: 1612378465,
+    updated_at: 1612378465,
+  };
+  nock('https://api.clerk.dev')
+    .post(`/v1/organizations/${organizationId}/invitations/${invitationId}/revoke`)
+    .reply(200, resJSON);
+
+  const orgInvitation = await TestBackendAPIClient.organizations.revokeOrganizationInvitation({
+    organizationId,
+    invitationId,
+    requestingUserId: 'user_randomid',
+  });
+  expect(orgInvitation).toEqual(
+    new OrganizationInvitation({
+      id: resJSON.id,
+      role: resJSON.role,
+      organizationId,
+      emailAddress: resJSON.email_address,
+      redirectUrl: resJSON.redirect_url,
+      status: resJSON.status,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    }),
+  );
+});

--- a/packages/backend-core/src/__tests__/utils/Deserializer.test.ts
+++ b/packages/backend-core/src/__tests__/utils/Deserializer.test.ts
@@ -4,6 +4,7 @@ import {
   Email,
   Invitation,
   Organization,
+  OrganizationInvitation,
   OrganizationMembership,
   Session,
   SMSMessage,
@@ -56,6 +57,16 @@ const organizationJSON = {
   logo_url: null,
   created_at: 1612378465,
   updated_at: 1612378465,
+};
+
+const organizationInvitationJSON = {
+  object: 'organization_invitation',
+  id: 'orginv_randomid',
+  email_address: 'invitation@example.com',
+  organization_id: 'org_randomid',
+  role: 'basic_member',
+  redirectUrl: null,
+  status: 'pending',
 };
 
 const organizationMembershipJSON = {
@@ -146,6 +157,27 @@ test('deserializes an array of Organization objects', () => {
   expect(organizations).toBeInstanceOf(Array);
   expect(organizations.length).toBe(1);
   expect(organizations[0]).toBeInstanceOf(Organization);
+});
+
+test('deserializes an OrganizationInvitation object', () => {
+  const organizationInvitation = deserialize(organizationInvitationJSON);
+  expect(organizationInvitation).toBeInstanceOf(OrganizationInvitation);
+});
+
+test('deserializes an array of OrganizationInvitation objects', () => {
+  const organizationInvitations = deserialize([organizationInvitationJSON]);
+  expect(organizationInvitations).toBeInstanceOf(Array);
+  expect(organizationInvitations.length).toBe(1);
+  expect(organizationInvitations[0]).toBeInstanceOf(OrganizationInvitation);
+});
+
+test('deserializes a paginated response of OrganizationInvitation objects', () => {
+  const organizationInvitations = deserialize({
+    data: [organizationInvitationJSON],
+  });
+  expect(organizationInvitations).toBeInstanceOf(Array);
+  expect(organizationInvitations.length).toBe(1);
+  expect(organizationInvitations[0]).toBeInstanceOf(OrganizationInvitation);
 });
 
 test('deserializes an OrganizationMembership object', () => {

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -59,6 +59,12 @@ type GetPendingOrganizationInvitationListParams = {
   offset?: number;
 };
 
+type RevokeOrganizationInvitationParams = {
+  organizationId: string;
+  invitationId: string;
+  requestingUserId: string;
+};
+
 export class OrganizationApi extends AbstractApi {
   public async createOrganization(params: CreateParams) {
     const { publicMetadata, privateMetadata } = params;
@@ -168,6 +174,19 @@ export class OrganizationApi extends AbstractApi {
       method: 'POST',
       path: `${basePath}/${organizationId}/invitations`,
       bodyParams,
+    });
+  }
+
+  public async revokeOrganizationInvitation(params: RevokeOrganizationInvitationParams) {
+    const { organizationId, invitationId, requestingUserId } = params;
+    this.requireId(organizationId);
+
+    return this._restClient.makeRequest<OrganizationInvitation>({
+      method: 'POST',
+      path: `${basePath}/${organizationId}/invitations/${invitationId}/revoke`,
+      bodyParams: {
+        requestingUserId,
+      },
     });
   }
 }

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -53,6 +53,12 @@ type CreateOrganizationInvitationParams = {
   redirectUrl?: string;
 };
 
+type GetPendingOrganizationInvitationListParams = {
+  organizationId: string;
+  limit?: number;
+  offset?: number;
+};
+
 export class OrganizationApi extends AbstractApi {
   public async createOrganization(params: CreateParams) {
     const { publicMetadata, privateMetadata } = params;
@@ -140,6 +146,17 @@ export class OrganizationApi extends AbstractApi {
     return this._restClient.makeRequest<OrganizationMembership>({
       method: 'DELETE',
       path: `${basePath}/${organizationId}/memberships/${userId}`,
+    });
+  }
+
+  public async getPendingOrganizationInvitationList(params: GetPendingOrganizationInvitationListParams) {
+    const { organizationId, limit, offset } = params;
+    this.requireId(organizationId);
+
+    return this._restClient.makeRequest<OrganizationInvitation[]>({
+      method: 'GET',
+      path: `${basePath}/${organizationId}/invitations/pending`,
+      queryParams: { limit, offset },
     });
   }
 

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -1,4 +1,4 @@
-import { Organization, OrganizationMembership } from '../resources';
+import { Organization, OrganizationInvitation, OrganizationMembership } from '../resources';
 import { OrganizationMembershipRole } from '../resources/Enums';
 import { AbstractApi } from './AbstractApi';
 
@@ -43,6 +43,14 @@ type UpdateOrganizationMembershipParams = CreateOrganizationMembershipParams;
 type DeleteOrganizationMembershipParams = {
   organizationId: string;
   userId: string;
+};
+
+type CreateOrganizationInvitationParams = {
+  organizationId: string;
+  inviterUserId: string;
+  emailAddress: string;
+  role: OrganizationMembershipRole;
+  redirectUrl?: string;
 };
 
 export class OrganizationApi extends AbstractApi {
@@ -132,6 +140,17 @@ export class OrganizationApi extends AbstractApi {
     return this._restClient.makeRequest<OrganizationMembership>({
       method: 'DELETE',
       path: `${basePath}/${organizationId}/memberships/${userId}`,
+    });
+  }
+
+  public async createOrganizationInvitation(params: CreateOrganizationInvitationParams) {
+    const { organizationId, ...bodyParams } = params;
+    this.requireId(organizationId);
+
+    return this._restClient.makeRequest<OrganizationInvitation>({
+      method: 'POST',
+      path: `${basePath}/${organizationId}/invitations`,
+      bodyParams,
     });
   }
 }

--- a/packages/backend-core/src/api/resources/Enums.ts
+++ b/packages/backend-core/src/api/resources/Enums.ts
@@ -22,6 +22,8 @@ export type OAuthProvider =
 
 export type OAuthStrategy = `oauth_${OAuthProvider}`;
 
+export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked';
+
 export type OrganizationMembershipRole = 'basic_member' | 'admin';
 
 export type SignInIdentifier = 'username' | 'email_address' | 'phone_number' | 'web3_wallet' | OAuthStrategy;

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -1,4 +1,5 @@
 import {
+  OrganizationInvitationStatus,
   OrganizationMembershipRole,
   SignInFactorStrategy,
   SignInIdentifier,
@@ -18,6 +19,7 @@ export enum ObjectType {
   GoogleAccount = 'google_account',
   Invitation = 'invitation',
   Organization = 'organization',
+  OrganizationInvitation = 'organization_invitation',
   OrganizationMembership = 'organization_membership',
   PhoneNumber = 'phone_number',
   Session = 'session',
@@ -140,6 +142,14 @@ export interface OrganizationJSON extends ClerkResourceJSON {
   private_metadata: Record<string, unknown>;
   created_at: number;
   updated_at: number;
+}
+
+export interface OrganizationInvitationJSON extends ClerkResourceJSON {
+  email_address: string;
+  organization_id: string;
+  role: OrganizationMembershipRole;
+  redirect_url: string | null;
+  status: OrganizationInvitationStatus;
 }
 
 export interface OrganizationMembershipJSON extends ClerkResourceJSON {

--- a/packages/backend-core/src/api/resources/OrganizationInvitation.ts
+++ b/packages/backend-core/src/api/resources/OrganizationInvitation.ts
@@ -1,0 +1,32 @@
+import camelcaseKeys from 'camelcase-keys';
+
+import filterKeys from '../utils/Filter';
+import type { OrganizationInvitationJSON } from './JSON';
+import type { OrganizationInvitationProps } from './Props';
+
+export interface OrganizationInvitation extends OrganizationInvitationProps {}
+
+export class OrganizationInvitation {
+  static attributes = [
+    'id',
+    'emailAddress',
+    'organizationId',
+    'role',
+    'redirectUrl',
+    'status',
+    'createdAt',
+    'updatedAt',
+  ];
+
+  static defaults = [];
+
+  constructor(data: OrganizationInvitationProps) {
+    Object.assign(this, OrganizationInvitation.defaults, data);
+  }
+
+  static fromJSON(data: OrganizationInvitationJSON): OrganizationInvitation {
+    const camelcased = camelcaseKeys(data);
+    const filtered = filterKeys(camelcased, OrganizationInvitation.attributes);
+    return new OrganizationInvitation(filtered as OrganizationInvitationProps);
+  }
+}

--- a/packages/backend-core/src/api/resources/Props.ts
+++ b/packages/backend-core/src/api/resources/Props.ts
@@ -1,5 +1,6 @@
 import { Nullable } from '../../util/nullable';
 import {
+  OrganizationInvitationStatus,
   OrganizationMembershipRole,
   SignInFactorStrategy,
   SignInIdentifier,
@@ -79,6 +80,16 @@ export interface OrganizationProps extends ClerkProps {
   slug: Nullable<string>;
   publicMetadata: Record<string, unknown>;
   privateMetadata: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface OrganizationInvitationProps extends ClerkProps {
+  emailAddress: string;
+  organizationId: string;
+  status: OrganizationInvitationStatus;
+  role: OrganizationMembershipRole;
+  redirectUrl: Nullable<string>;
   createdAt: number;
   updatedAt: number;
 }

--- a/packages/backend-core/src/api/resources/index.ts
+++ b/packages/backend-core/src/api/resources/index.ts
@@ -7,6 +7,7 @@ export * from './ExternalAccount';
 export * from './IdentificationLink';
 export * from './Invitation';
 export * from './Organization';
+export * from './OrganizationInvitation';
 export * from './OrganizationMembership';
 export * from './JSON';
 export * from './PhoneNumber';

--- a/packages/backend-core/src/api/utils/Deserializer.ts
+++ b/packages/backend-core/src/api/utils/Deserializer.ts
@@ -4,6 +4,7 @@ import {
   Email,
   Invitation,
   Organization,
+  OrganizationInvitation,
   OrganizationMembership,
   Session,
   SMSMessage,
@@ -49,6 +50,8 @@ function jsonToObject(item: any): any {
       return Invitation.fromJSON(item);
     case ObjectType.Organization:
       return Organization.fromJSON(item);
+    case ObjectType.OrganizationInvitation:
+      return OrganizationInvitation.fromJSON(item);
     case ObjectType.OrganizationMembership:
       return OrganizationMembership.fromJSON(item);
     case ObjectType.User:

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -38,6 +38,7 @@ export {
   IdentificationLink,
   Invitation,
   Organization,
+  OrganizationInvitation,
   OrganizationMembership,
   OrganizationMembershipPublicUserData,
   PhoneNumber,

--- a/packages/sdk-node/src/instance.ts
+++ b/packages/sdk-node/src/instance.ts
@@ -21,6 +21,7 @@ export {
   Invitation,
   Nullable,
   Organization,
+  OrganizationInvitation,
   OrganizationMembership,
   OrganizationMembershipPublicUserData,
   PhoneNumber,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added support for organization invitations in our NodeJS SDK through the backend-core package.

Added a new `OrganizationInvitation` resource and the following methods on the organizations API:

- `createOrganizationInvitation` to create and send an invitation to join an organization.
- `getPendingOrganizationInvitationList` to retrieve a list of pending invitations for an organization.
- `revokeOrganizationInvitation` to revoke a pending organization invitation

<!-- Fixes # (issue number) -->
