### PR TITLE
feat(backend-core): Retrieve instance organizations

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -19,6 +19,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [createInvitation(params)](#createinvitationparams)
   - [revokeInvitation(invitationId)](#revokeinvitationinvitationid)
 - [Organization operations](#organization-operations)
+  - [getOrganizationList()](#getorganizationlist)
   - [createOrganization(params)](#createorganizationparams)
   - [updateOrganization(organizationId, params)](#updateorganizationorganizationid-params)
   - [updateOrganizationMetadata(organizationId, params)](#updateorganizationmetadataorganizationid-params)
@@ -158,6 +159,20 @@ const invitation = await clerkAPI.invitations.revokeInvitation('inv_some-id');
 ## Organization operations
 
 Organization operations are exposed by the `organizations` sub-api (`clerkAPI.organizations`).
+
+#### getOrganizationList()
+
+Retrieves a list of organizations for an instance.
+
+The instance is determined by the API key you've provided when configuring the API. You can either set the `CLERK_API_KEY` environment variable, or provide the `apiKey` property explicitly when configuring the API client.
+
+Results can be paginated by providing an optional `limit` and `offset` pair of parameters.
+
+Results will be ordered by descending creation date. Most recent organizations will be first in the list.
+
+```ts
+const organizations = await clerkAPI.organizations.getOrganizationList();
+```
 
 #### createOrganization(params)
 

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -9,6 +9,29 @@ import {
 import { OrganizationInvitationStatus, OrganizationMembershipRole } from '../../api/resources/Enums';
 import { TestBackendAPIClient } from '../TestBackendAPI';
 
+test('getOrganizationList() retrieves a list of organizations', async () => {
+  const resJSON = {
+    data: [
+      {
+        object: 'organization',
+        id: 'org_randomid',
+        name: 'Acme Inc',
+        slug: 'acme-inc',
+        public_metadata: {},
+        private_metadata: {},
+        created_at: 1611948436,
+        updated_at: 1611948436,
+      },
+    ],
+  };
+  nock('https://api.clerk.dev').get('/v1/organizations?').reply(200, resJSON);
+
+  const organizationList = await TestBackendAPIClient.organizations.getOrganizationList();
+  expect(organizationList).toBeInstanceOf(Array);
+  expect(organizationList.length).toEqual(1);
+  expect(organizationList[0]).toBeInstanceOf(Organization);
+});
+
 test('createOrganization() creates an organization', async () => {
   const name = 'Acme Inc';
   const slug = 'acme-inc';

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -9,6 +9,11 @@ type OrganizationMetadataParams = {
   privateMetadata?: Record<string, unknown>;
 };
 
+type GetOrganizationListParams = {
+  limit?: number;
+  offset?: number;
+};
+
 type CreateParams = {
   name: string;
   slug?: string;
@@ -66,6 +71,14 @@ type RevokeOrganizationInvitationParams = {
 };
 
 export class OrganizationApi extends AbstractApi {
+  public async getOrganizationList(params?: GetOrganizationListParams) {
+    return this._restClient.makeRequest<Organization[]>({
+      method: 'GET',
+      path: basePath,
+      queryParams: params,
+    });
+  }
+
   public async createOrganization(params: CreateParams) {
     const { publicMetadata, privateMetadata } = params;
     return this._restClient.makeRequest<Organization>({

--- a/packages/sdk-node/README.md
+++ b/packages/sdk-node/README.md
@@ -27,7 +27,7 @@
 
 ## Overview
 
-[Clerk](https://clerk.dev?utm_source=github&utm_medium=clerk_sdk_node) is the easiest way to add authentication and user management to your Node application. To gain a better understanding API and the SDK, refer to 
+[Clerk](https://clerk.dev?utm_source=github&utm_medium=clerk_sdk_node) is the easiest way to add authentication and user management to your Node application. To gain a better understanding API and the SDK, refer to
 the <a href="https://reference.clerk.dev/reference/backend-api-reference" target="_blank">official Backend API documentation</a>.
 
 ## Table of contents


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added a method in the organizations API to retrieve a list of organizations for the instance specified by the API key. 

The method signature is `organizations.getOrganizationList()`.

The results can be paginated and are sorted by descending creation date. Most recent organizations are returned first.

<!-- Fixes # (issue number) -->
