### PR TITLE
feat(clerk-js): Session touch includes the active organization

### DIFF
--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -49,6 +49,7 @@ export class Session extends BaseResource implements SessionResource {
   touch = (): Promise<SessionResource> => {
     return this._basePost({
       action: 'touch',
+      body: { active_organization_id: this.lastActiveOrganizationId },
     });
   };
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

When we do a session touch, we should include the active orgnization id if there is one.
This ensures that when we move from tab to tab where each tab has the same session but different organizations, each tab keeps the correct active organization.

<!-- Fixes # (issue number) -->
