### PR TITLE
feat(backend-core): Get organization by ID or slug

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -21,6 +21,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
 - [Organization operations](#organization-operations)
   - [getOrganizationList()](#getorganizationlist)
   - [createOrganization(params)](#createorganizationparams)
+  - [getOrganization(params)](#getorganizationparams)
   - [updateOrganization(organizationId, params)](#updateorganizationorganizationid-params)
   - [updateOrganizationMetadata(organizationId, params)](#updateorganizationmetadataorganizationid-params)
   - [deleteOrganization(organizationId)](#deleteorganizationorganizationid)
@@ -192,6 +193,29 @@ const organization = await clerkAPI.organizations.createOrganization({
   name: 'Acme Inc',
   slug: 'acme-inc',
   createdBy: 'user_1o4q123qMeCkKKIXcA9h8',
+});
+```
+
+#### getOrganization(params)
+
+Fetch an organization whose ID or slug matches the one provided in the parameters.
+
+The method accepts either the organization ID or slug in the parameters, but not both at the same time. See the snippet below for a usage example.
+
+The instance that the organization belongs to is determined by the API key you've provided when configuring the API. You can either set the `CLERK_API_KEY` environment variable, or provide the `apiKey` property explicitly when configuring the API client.
+
+Available parameters:
+
+- _organizationId_ The ID of the organization.
+- _slug_ Alternatively, you can provide the slug of the organization.
+
+```ts
+const organizationBySlug = await clerkAPI.organizations.getOrganization({
+  slug: 'acme-inc',
+});
+
+const organizationById = await clerkAPI.organizations.getOrganization({
+  organizationId: 'org_1o4q123qMeCkKKIXcA9h8',
 });
 ```
 

--- a/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/apis/OrganizationApi.test.ts
@@ -79,6 +79,50 @@ test('createOrganization() creates an organization', async () => {
   );
 });
 
+test('getOrganization() fetches an organization', async () => {
+  const id = 'org_randomid';
+  const slug = 'acme-inc';
+  const resJSON = {
+    object: 'organization',
+    id,
+    slug,
+    name: 'Acme Inc',
+    public_metadata: {},
+    private_metadata: {},
+    created_at: 1611948436,
+    updated_at: 1611948436,
+  };
+
+  nock('https://api.clerk.dev').get(`/v1/organizations/${id}`).reply(200, resJSON);
+
+  let organization = await TestBackendAPIClient.organizations.getOrganization({ organizationId: id });
+  expect(organization).toEqual(
+    new Organization({
+      id,
+      name: resJSON.name,
+      slug: resJSON.slug,
+      publicMetadata: resJSON.public_metadata,
+      privateMetadata: resJSON.private_metadata,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    }),
+  );
+
+  nock('https://api.clerk.dev').get(`/v1/organizations/${slug}`).reply(200, resJSON);
+  organization = await TestBackendAPIClient.organizations.getOrganization({ slug });
+  expect(organization).toEqual(
+    new Organization({
+      id,
+      name: resJSON.name,
+      slug: resJSON.slug,
+      publicMetadata: resJSON.public_metadata,
+      privateMetadata: resJSON.private_metadata,
+      createdAt: resJSON.created_at,
+      updatedAt: resJSON.updated_at,
+    }),
+  );
+});
+
 test('updateOrganization() updates organization', async () => {
   const id = 'org_randomid';
   const name = 'New name';

--- a/packages/backend-core/src/api/collection/OrganizationApi.ts
+++ b/packages/backend-core/src/api/collection/OrganizationApi.ts
@@ -25,6 +25,8 @@ type OrganizationMetadataRequestBody = {
   privateMetadata?: string;
 };
 
+type GetOrganizationParams = { organizationId: string } | { slug: string };
+
 type UpdateParams = {
   name?: string;
 };
@@ -91,6 +93,16 @@ export class OrganizationApi extends AbstractApi {
           privateMetadata,
         }),
       },
+    });
+  }
+
+  public async getOrganization(params: GetOrganizationParams) {
+    const organizationIdOrSlug = 'organizationId' in params ? params.organizationId : params.slug;
+    this.requireId(organizationIdOrSlug);
+
+    return this._restClient.makeRequest<Organization>({
+      method: 'GET',
+      path: `${basePath}/${organizationIdOrSlug}`,
     });
   }
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Added a method on the organizations API to retrieve an organization by either ID or slug. 

The signature is `organizations.getOrganization({ organizationIdOrSlug: "acme-inc" })`.

<!-- Fixes # (issue number) -->
