### PR TITLE
feat(remix): Pass options to remix getAuth

### DIFF
--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -2,17 +2,17 @@ import { json } from '@remix-run/server-runtime';
 
 import { getAuthInterstitialErrorRendered, noRequestPassedInGetAuth } from '../errors';
 import { getAuthData } from './getAuthData';
-import { GetAuthReturn, LoaderFunctionArgs } from './types';
+import { GetAuthReturn, LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
 import { sanitizeAuthData } from './utils';
 
 const EMPTY_INTERSTITIAL_RESPONSE = { message: getAuthInterstitialErrorRendered };
 
-export async function getAuth(argsOrReq: Request | LoaderFunctionArgs): GetAuthReturn {
+export async function getAuth(argsOrReq: Request | LoaderFunctionArgs, options?: RootAuthLoaderOptions): GetAuthReturn {
   if (!argsOrReq) {
     throw new Error(noRequestPassedInGetAuth);
   }
   const request = 'request' in argsOrReq ? argsOrReq.request : argsOrReq;
-  const { authData, showInterstitial } = await getAuthData(request);
+  const { authData, showInterstitial } = await getAuthData(request, options);
 
   if (showInterstitial || !authData) {
     throw json(EMPTY_INTERSTITIAL_RESPONSE, { status: 401 });

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -7,11 +7,18 @@ import { sanitizeAuthData } from './utils';
 
 const EMPTY_INTERSTITIAL_RESPONSE = { message: getAuthInterstitialErrorRendered };
 
-export async function getAuth(argsOrReq: Request | LoaderFunctionArgs, options?: RootAuthLoaderOptions): GetAuthReturn {
+export async function getAuth(
+  argsOrReq: Request | LoaderFunctionArgs,
+  _options?: RootAuthLoaderOptions,
+): GetAuthReturn {
   if (!argsOrReq) {
     throw new Error(noRequestPassedInGetAuth);
   }
   const request = 'request' in argsOrReq ? argsOrReq.request : argsOrReq;
+  const options =
+    'context' in argsOrReq && 'requestId' in argsOrReq.context
+      ? { ..._options, requestId: argsOrReq.context.requestId }
+      : _options;
   const { authData, showInterstitial } = await getAuthData(request, options);
 
   if (showInterstitial || !authData) {

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -10,6 +10,7 @@ export type RootAuthLoaderOptions = {
   loadSession?: boolean;
   jwtKey?: string;
   authorizedParties?: [];
+  requestId?: string;
 };
 
 export type RootAuthLoaderCallback<Options> = (


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Just like how the NextJS package allows passing in `getAuthData` options to `withServerSideAuth` ([link](https://clerk.dev/docs/get-started/nextjs#enabling-full-server-side-rendering)), extend the Remix package's `getAuth` to accept `options` too.

I find myself doing `getAuth(args).then(({userId}) => users.getUser(userId))` in several of my loaders, which this would make easier

<!-- Fixes # (issue number) -->
