### PR TITLE
fix(gatsby-plugin-clerk): Add firefox interstitial parameter reload case

### DIFF
--- a/packages/gatsby-plugin-clerk/src/GatsbyClerkProvider.tsx
+++ b/packages/gatsby-plugin-clerk/src/GatsbyClerkProvider.tsx
@@ -38,9 +38,30 @@ export function ClerkProvider({ children, ...rest }: GatsbyClerkProviderProps) {
 
 const Reload = () => {
   React.useEffect(() => {
-    // TODO: Add fix for firefox edge case
+    function formRedirect() {
+      const form = '<form method="get" action="" name="redirect"></form>';
+      document.body.innerHTML = document.body.innerHTML + form;
+      const formElement = document.querySelector('form[name=redirect]') as HTMLFormElement;
+
+      const searchParams = new URLSearchParams(window.location.search);
+      for (const paramTuple of searchParams) {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = paramTuple[0];
+        input.value = paramTuple[1];
+        formElement.appendChild(input);
+      }
+      const url = new URL(window.location.origin + window.location.pathname + window.location.hash);
+      window.history.pushState({}, '', url);
+
+      formElement.action = window.location.pathname + window.location.hash;
+      formElement.submit();
+    }
+
     if (window.location.href.indexOf('#') === -1) {
       window.location.href = window.location.href;
+    } else if (window.navigator.userAgent.toLowerCase().includes('firefox/')) {
+      formRedirect();
     } else {
       window.location.reload();
     }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [x] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add the firefox redirect form method on gatsby plugin. _(This could have been breaking FF clients with gatsby)_.