### PR TITLE
Introduce more v4 primitives

### DIFF
--- a/packages/clerk-js/src/v4/primitives/Button.tsx
+++ b/packages/clerk-js/src/v4/primitives/Button.tsx
@@ -1,4 +1,10 @@
-import { createVariants, PrimitiveProps, StyleVariants } from '../styledSystem';
+import { createCssVariables, createVariants, PrimitiveProps, StyleVariants } from '../styledSystem';
+
+const { accentColor, accentColorActive, accentColorHover } = createCssVariables(
+  'accentColor',
+  'accentColorHover',
+  'accentColorActive',
+);
 
 const { applyVariants, filterProps } = createVariants(theme => ({
   base: {
@@ -6,45 +12,46 @@ const { applyVariants, filterProps } = createVariants(theme => ({
     padding: 0,
     border: 0,
     backgroundColor: 'unset',
-    flexCenter: '',
     cursor: 'pointer',
     borderRadius: theme.radii.$md,
-    my: theme.space.$2x5,
-    '&:disabled': {
-      backgroundColor: theme.colors.$primary200,
-    },
   },
   variants: {
     colorScheme: {
       primary: {
-        '--color': theme.colors.$primary500,
-        '--color-hover': theme.colors.$primary600,
-        '--color-active': theme.colors.$primary300,
+        [accentColorActive]: theme.colors.$primary400,
+        [accentColor]: theme.colors.$primary500,
+        [accentColorHover]: theme.colors.$primary600,
       },
       danger: {
-        '--color': theme.colors.$danger500,
-        '--color-hover': theme.colors.$danger700,
-        '--color-active': theme.colors.$danger300,
+        [accentColorActive]: theme.colors.$danger300,
+        [accentColor]: theme.colors.$danger500,
+        [accentColorHover]: theme.colors.$danger600,
       },
     },
     variant: {
       solid: {
-        backgroundColor: 'var(--color)',
+        backgroundColor: accentColor,
         color: theme.colors.$white,
         '&:hover': {
-          backgroundColor: 'var(--color-hover)',
+          backgroundColor: accentColorHover,
+        },
+        '&:active': {
+          backgroundColor: accentColorActive,
         },
       },
       outline: {
         border: '1px solid',
-        borderColor: 'var(--color)',
-        color: 'var(--color)',
+        borderColor: accentColor,
+        color: accentColor,
         '&:hover': {
-          borderColor: 'var(--color-hover)',
+          borderColor: accentColorHover,
+        },
+        '&:active': {
+          borderColor: accentColorActive,
         },
       },
       ghost: {
-        color: 'var(--color)',
+        color: accentColor,
       },
     },
     size: {

--- a/packages/clerk-js/src/v4/primitives/Flex.tsx
+++ b/packages/clerk-js/src/v4/primitives/Flex.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { createVariants, StyleVariants } from '../styledSystem';
 import { Box, BoxProps } from './Box';
 
-const { applyVariants, filterProps } = createVariants(() => ({
+const { applyVariants, filterProps } = createVariants(theme => ({
   base: {
     display: 'flex',
   },
@@ -31,6 +31,17 @@ const { applyVariants, filterProps } = createVariants(() => ({
       noWrap: { flexWrap: 'nowrap' },
       wrap: { flexWrap: 'wrap' },
       wrapReverse: { flexWrap: 'wrap-reverse' },
+    },
+    gap: {
+      1: { gap: theme.space.$1 },
+      2: { gap: theme.space.$2 },
+      3: { gap: theme.space.$3 },
+      4: { gap: theme.space.$4 },
+      5: { gap: theme.space.$5 },
+      6: { gap: theme.space.$6 },
+      7: { gap: theme.space.$7 },
+      8: { gap: theme.space.$8 },
+      9: { gap: theme.space.$9 },
     },
   },
   defaultVariants: {

--- a/packages/clerk-js/src/v4/primitives/Heading.tsx
+++ b/packages/clerk-js/src/v4/primitives/Heading.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { createVariants, PrimitiveProps, StyleVariants } from '../styledSystem';
-import { Box } from './Box';
 
 const { applyVariants } = createVariants(theme => ({
   base: {
+    boxSizing: 'border-box',
     // TODO: Should this be $text?
     color: theme.colors.$black,
   },
@@ -26,9 +26,10 @@ const { applyVariants } = createVariants(theme => ({
 export type HeadingProps = PrimitiveProps<'div'> & StyleVariants<typeof applyVariants> & { as?: 'h1' };
 
 export const Heading = React.forwardRef<HTMLDivElement, HeadingProps>((props, ref) => {
+  const { as: As = 'h1', ...rest } = props;
   return (
-    <Box
-      {...props}
+    <As
+      {...rest}
       css={applyVariants(props)}
       ref={ref}
     />

--- a/packages/clerk-js/src/v4/primitives/Heading.tsx
+++ b/packages/clerk-js/src/v4/primitives/Heading.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { createVariants, PrimitiveProps, StyleVariants } from '../styledSystem';
+import { Box } from './Box';
+
+const { applyVariants } = createVariants(theme => ({
+  base: {
+    // TODO: Should this be $text?
+    color: theme.colors.$black,
+  },
+  variants: {
+    as: {
+      h1: {
+        fontStyle: 'normal',
+        fontWeight: theme.fontWeights.$semibold,
+        fontSize: theme.fontSizes.$xl,
+        lineHeight: theme.lineHeights.$base,
+      },
+    },
+  },
+  defaultVariants: {
+    as: 'h1',
+  },
+}));
+
+export type HeadingProps = PrimitiveProps<'div'> & StyleVariants<typeof applyVariants> & { as?: 'h1' };
+
+export const Heading = React.forwardRef<HTMLDivElement, HeadingProps>((props, ref) => {
+  return (
+    <Box
+      {...props}
+      css={applyVariants(props)}
+      ref={ref}
+    />
+  );
+});

--- a/packages/clerk-js/src/v4/primitives/index.ts
+++ b/packages/clerk-js/src/v4/primitives/index.ts
@@ -2,3 +2,4 @@ export * from './Card';
 export * from './Box';
 export * from './Button';
 export * from './Flex';
+export * from './Heading';

--- a/packages/clerk-js/src/v4/styledSystem/createCssVariables.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createCssVariables.ts
@@ -1,0 +1,7 @@
+import hash from '@emotion/hash';
+
+let varHashId = Date.now();
+
+export const createCssVariables = <T extends string[]>(...names: T): { [k in T[number]]: string } => {
+  return Object.fromEntries(names.map(name => [name, `var(--${name}-${hash((++varHashId).toString())})`])) as any;
+};

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
@@ -34,6 +34,39 @@ describe('createVariants', () => {
     expect(res).toEqual({ fontSize: baseTheme.fontSizes.sm, backgroundColor: baseTheme.colors.primary500 });
   });
 
+  fit('merges nested pseudo-selector objecst', () => {
+    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+      base: {
+        backgroundColor: theme.colors.primary500,
+        '&:active': {
+          backgroundColor: theme.colors.success500,
+        },
+      },
+      variants: {
+        size: {
+          small: {
+            fontSize: theme.fontSizes.sm,
+            '&:active': {
+              transform: 'scale(0.98)',
+            },
+          },
+          medium: { fontSize: theme.fontSizes.md },
+        },
+      },
+    }));
+
+    const res = applyVariants({ size: 'small' })(baseTheme);
+    console.log(res);
+    expect(res).toEqual({
+      fontSize: baseTheme.fontSizes.sm,
+      backgroundColor: baseTheme.colors.primary500,
+      '&:active': {
+        backgroundColor: baseTheme.colors.success500,
+        transform: 'scale(0.98)',
+      },
+    });
+  });
+
   it('applies variants based on props', () => {
     const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
       variants: {

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
@@ -1,3 +1,4 @@
+import { createCssVariables } from './createCssVariables';
 import { createVariants } from './createVariants';
 
 const baseTheme = {
@@ -197,6 +198,27 @@ describe('createVariants', () => {
     expect(res).toEqual({
       fontSize: baseTheme.fontSizes.md,
       backgroundColor: 'gainsboro',
+    });
+  });
+
+  it('sanitizes vss variable keys before use', () => {
+    const { color } = createCssVariables('color');
+    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+      variants: {
+        size: {
+          small: { [color]: theme.colors.primary500, fontSize: baseTheme.fontSizes.sm },
+        },
+        color: {
+          blue: { backgroundColor: color },
+        },
+      },
+    }));
+
+    const res = applyVariants({ size: 'small', color: 'blue' })(baseTheme);
+    expect(res).toEqual({
+      fontSize: baseTheme.fontSizes.sm,
+      [color.replace('var(', '').replace(')', '')]: baseTheme.colors.primary500,
+      backgroundColor: color,
     });
   });
 

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
@@ -56,7 +56,6 @@ describe('createVariants', () => {
     }));
 
     const res = applyVariants({ size: 'small' })(baseTheme);
-    console.log(res);
     expect(res).toEqual({
       fontSize: baseTheme.fontSizes.sm,
       backgroundColor: baseTheme.colors.primary500,

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
@@ -34,7 +34,7 @@ describe('createVariants', () => {
     expect(res).toEqual({ fontSize: baseTheme.fontSizes.sm, backgroundColor: baseTheme.colors.primary500 });
   });
 
-  fit('merges nested pseudo-selector objecst', () => {
+  it('merges nested pseudo-selector objecst', () => {
     const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
       base: {
         backgroundColor: theme.colors.primary500,

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.ts
@@ -96,7 +96,7 @@ const applyCompoundVariantRules = (
 ) => {
   for (const compoundVariant of compoundVariants) {
     if (conditionMatches(compoundVariant, variantsToApply)) {
-      fastDeepMerge(computedStyles, compoundVariant.styles);
+      fastDeepMerge(compoundVariant.styles, computedStyles);
     }
   }
 };

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.ts
@@ -1,4 +1,5 @@
 import { applyCustomCssUtilities } from './customCssUtilities';
+import { fastDeepMerge } from './fastDeepMerge';
 import { StyleRuleWithCustomCssUtils, Theme } from './types';
 
 type UnwrapBooleanVariant<T> = T extends 'true' | 'false' ? boolean : T;
@@ -84,7 +85,7 @@ const applyBaseRules = (computedStyles: any, base?: StyleRuleWithCustomCssUtils)
 const applyVariantRules = (computedStyles: any, variantsToApply: Variants, variants: Variants) => {
   for (const key in variantsToApply) {
     // @ts-ignore
-    Object.assign(computedStyles, variants[key][variantsToApply[key]]);
+    fastDeepMerge(variants[key][variantsToApply[key]], computedStyles);
   }
 };
 
@@ -95,7 +96,7 @@ const applyCompoundVariantRules = (
 ) => {
   for (const compoundVariant of compoundVariants) {
     if (conditionMatches(compoundVariant, variantsToApply)) {
-      Object.assign(computedStyles, compoundVariant.styles);
+      fastDeepMerge(computedStyles, compoundVariant.styles);
     }
   }
 };

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.ts
@@ -52,6 +52,7 @@ export const createVariants: CreateVariants = configFn => {
       applyBaseRules(computedStyles, base);
       applyVariantRules(computedStyles, variantsToApply, variants);
       applyCompoundVariantRules(computedStyles, variantsToApply, compoundVariants);
+      sanitizeCssVariables(computedStyles);
       applyCustomCssUtilities(computedStyles);
       return computedStyles;
     };
@@ -95,6 +96,15 @@ const applyCompoundVariantRules = (
   for (const compoundVariant of compoundVariants) {
     if (conditionMatches(compoundVariant, variantsToApply)) {
       Object.assign(computedStyles, compoundVariant.styles);
+    }
+  }
+};
+
+const sanitizeCssVariables = (computedStyles: any) => {
+  for (const key in computedStyles) {
+    if (key.startsWith('var(')) {
+      computedStyles[key.slice(4, -1)] = computedStyles[key];
+      delete computedStyles[key];
     }
   }
 };

--- a/packages/clerk-js/src/v4/styledSystem/fastDeepMerge.ts
+++ b/packages/clerk-js/src/v4/styledSystem/fastDeepMerge.ts
@@ -1,0 +1,12 @@
+export const fastDeepMerge = (source: any, target: any) => {
+  for (const key in source) {
+    if (source[key] !== null && typeof source[key] === `object`) {
+      if (target[key] === undefined) {
+        target[key] = new (Object.getPrototypeOf(source[key]).constructor)();
+      }
+      fastDeepMerge(source[key], target[key]);
+    } else {
+      target[key] = source[key];
+    }
+  }
+};

--- a/packages/clerk-js/src/v4/styledSystem/index.ts
+++ b/packages/clerk-js/src/v4/styledSystem/index.ts
@@ -4,3 +4,4 @@ export type { CSSObject, Keyframes } from '@emotion/react';
 export * from './types';
 export * from './StyledSystemProvider';
 export * from './createVariants';
+export * from './createCssVariables';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR introduces more primitives, improvements to the `createVariants` algorithm (allows deep merging of pseudo-selector blocks) and lastrly, introduces `createCssVariables` method. This method makes defining locally-scoped variables inside different variants easy.

In the following example, we have a `colorScheme` variant that sets the color of the  `accentColor` CSS variable. Notice that the `type` variant does not need to defined the colors again - you can simply use the CSS variable we defined earlier.

```ts
const { accentColor } = createCssVariables('accentColor');
const { applyVariants, filterProps } = createVariants(theme => ({
  variants: {
    colorScheme: {
      primary: {
        [accentColor]: theme.colors.$primary500,
      },
      danger: {
        [accentColor]: theme.colors.$danger500,
      },
    },
    type: {
      solid: {
        backgroundColor: accentColor,
      },
      outline: {
        border: '1px solid',
        borderColor: accentColor,
    },
  },
}));
```
In order to avoid conflicts with any user-defined CSS variables or nested styles, the above code will generate unique identifiers for each variable by adding a hash to the variable's name: 
![image](https://user-images.githubusercontent.com/1811063/169927055-b2faa845-151d-4e97-9745-26b73cd73117.png)
<!-- Fixes # (issue number) -->
