### PR TITLE
chore(repo): Give access to props inside the createVariants callback

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,17 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     'simple-import-sort/imports': 'error',
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['@emotion/*'],
+            message:
+              'Please do not import emotion directly. Import helpers from ./design-system or ./primitives instead.',
+          },
+        ],
+      },
+    ],
   },
 };

--- a/packages/clerk-js/src/v4/styledSystem/StyledSystemProvider.tsx
+++ b/packages/clerk-js/src/v4/styledSystem/StyledSystemProvider.tsx
@@ -1,4 +1,6 @@
+// eslint-disable-next-line no-restricted-imports
 import createCache from '@emotion/cache';
+// eslint-disable-next-line no-restricted-imports
 import { CacheProvider, ThemeProvider, ThemeProviderProps } from '@emotion/react';
 import React from 'react';
 

--- a/packages/clerk-js/src/v4/styledSystem/createCssVariables.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createCssVariables.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import hash from '@emotion/hash';
 
 let varHashId = Date.now();

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.test.ts
@@ -18,7 +18,7 @@ const baseTheme = {
 
 describe('createVariants', () => {
   it('applies base styles', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       base: {
         backgroundColor: theme.colors.primary500,
       },
@@ -35,7 +35,7 @@ describe('createVariants', () => {
   });
 
   it('merges nested pseudo-selector objecst', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       base: {
         backgroundColor: theme.colors.primary500,
         '&:active': {
@@ -67,7 +67,7 @@ describe('createVariants', () => {
   });
 
   it('applies variants based on props', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },
@@ -85,7 +85,7 @@ describe('createVariants', () => {
   });
 
   it('applies boolean-based variants based on props', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },
@@ -105,7 +105,7 @@ describe('createVariants', () => {
   });
 
   it('applies boolean-based variants based on default variants', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },
@@ -129,7 +129,7 @@ describe('createVariants', () => {
   });
 
   it('applies falsy boolean-based variants', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },
@@ -152,7 +152,7 @@ describe('createVariants', () => {
   });
 
   it('applies variants based on props and default variants if found', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },
@@ -176,7 +176,7 @@ describe('createVariants', () => {
   });
 
   it('applies rules from compound variants', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },
@@ -205,7 +205,7 @@ describe('createVariants', () => {
   });
 
   it('correctly overrides styles though compound variants rules', () => {
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },
@@ -235,7 +235,7 @@ describe('createVariants', () => {
 
   it('sanitizes vss variable keys before use', () => {
     const { color } = createCssVariables('color');
-    const { applyVariants } = createVariants<typeof baseTheme>(theme => ({
+    const { applyVariants } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { [color]: theme.colors.primary500, fontSize: baseTheme.fontSizes.sm },
@@ -254,8 +254,21 @@ describe('createVariants', () => {
     });
   });
 
+  it('gives access to props inside the config function', () => {
+    type Props = { size: any; color: any; isLoading: boolean };
+    const { applyVariants } = createVariants<Props, typeof baseTheme>((theme, props) => ({
+      base: {
+        color: props.isLoading ? theme.colors.success500 : theme.colors.primary500,
+      },
+      variants: {},
+    }));
+
+    const res = applyVariants({ isLoading: true } as any)(baseTheme);
+    expect(res).toEqual({ color: baseTheme.colors.success500 });
+  });
+
   it('removes variant keys from passed props', () => {
-    const { filterProps } = createVariants<typeof baseTheme>(theme => ({
+    const { filterProps } = createVariants<any, typeof baseTheme>(theme => ({
       variants: {
         size: {
           small: { fontSize: theme.fontSizes.sm },

--- a/packages/clerk-js/src/v4/styledSystem/createVariants.ts
+++ b/packages/clerk-js/src/v4/styledSystem/createVariants.ts
@@ -40,14 +40,16 @@ type CreateVariantsReturn<T, V extends Variants> = {
 };
 
 interface CreateVariants {
-  <T = Theme, V extends Variants = Variants>(param: (theme: T) => CreateVariantsConfig<V>): CreateVariantsReturn<T, V>;
+  <P, T = Theme, V extends Variants = Variants>(
+    param: (theme: T, props: P) => CreateVariantsConfig<V>,
+  ): CreateVariantsReturn<T, V>;
 }
 
 export const createVariants: CreateVariants = configFn => {
   const applyVariants =
     (props: any = {}) =>
     (theme: any) => {
-      const { base, variants = {}, compoundVariants = [], defaultVariants = {} } = configFn(theme);
+      const { base, variants = {}, compoundVariants = [], defaultVariants = {} } = configFn(theme, props);
       const variantsToApply = calculateVariantsToBeApplied(variants, props, defaultVariants);
       const computedStyles = {};
       applyBaseRules(computedStyles, base);
@@ -63,7 +65,7 @@ export const createVariants: CreateVariants = configFn => {
   // Instead of the theme, we pass an infinite proxy because we only care about
   // the keys of the returned object and not the actual values.
   const fakeProxyTheme = createInfiniteAccessProxy();
-  const variantKeys = Object.keys(configFn(fakeProxyTheme).variants || {});
+  const variantKeys = Object.keys(configFn(fakeProxyTheme, fakeProxyTheme).variants || {});
   const filterProps = (props: any) => getPropsWithoutVariants(props, variantKeys);
   return { applyVariants, filterProps } as any;
 };

--- a/packages/clerk-js/src/v4/styledSystem/index.ts
+++ b/packages/clerk-js/src/v4/styledSystem/index.ts
@@ -1,6 +1,3 @@
-export { CacheProvider, ThemeProvider, keyframes } from '@emotion/react';
-export type { CSSObject, Keyframes } from '@emotion/react';
-
 export * from './types';
 export * from './StyledSystemProvider';
 export * from './createVariants';

--- a/packages/clerk-js/src/v4/styledSystem/types.ts
+++ b/packages/clerk-js/src/v4/styledSystem/types.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Interpolation as _Interpolation, Theme as _Theme } from '@emotion/react';
 import React from 'react';
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Gives access to component props inside the createVariants callback
- Restricts direct imports from `emotion`. This commit will be reverted when design-system is extracted as its own package

<!-- Fixes # (issue number) -->
