### PR TITLE
feat(types,clerk-js): Support required flag for email & phone numbers

### DIFF
--- a/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
@@ -99,6 +99,9 @@ describe('<SignUpContinue/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
   });
 
@@ -264,6 +267,9 @@ describe('<SignUpContinue/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
 
     mockUpdateRequest.mockImplementation(() =>
@@ -367,6 +373,9 @@ describe('<SignUpContinue/>', () => {
           enabled: true,
           strategy: 'oauth_facebook',
         },
+      },
+      sign_up: {
+        progressive: false,
       },
     } as UserSettingsJSON);
 

--- a/packages/clerk-js/src/ui/signUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpContinue.tsx
@@ -20,7 +20,7 @@ import { SignInLink } from './SignInLink';
 import {
   ActiveIdentifier,
   determineActiveFields,
-  emailOrPhoneUsedForFF,
+  emailOrPhone,
   getInitialActiveIdentifier,
   minimizeFieldsForExistingSignup,
   showFormFields,
@@ -35,7 +35,7 @@ function _SignUpContinue(): JSX.Element | null {
   const { setSession } = useCoreClerk();
   const { navigateAfterSignUp } = useSignUpContext();
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
-    getInitialActiveIdentifier(attributes),
+    getInitialActiveIdentifier(attributes, userSettings.signUp.progressive),
   );
   const signUp = useCoreSignUp();
 
@@ -65,12 +65,14 @@ function _SignUpContinue(): JSX.Element | null {
   const hasEmail = !!formState.emailAddress.value;
   const hasVerifiedExternalAccount = signUp.verifications?.externalAccount?.status == 'verified';
   const hasVerifiedWeb3 = signUp.verifications?.web3Wallet?.status == 'verified';
+  const isProgressiveSignUp = userSettings.signUp.progressive;
 
   const fields = determineActiveFields({
     attributes,
     hasEmail,
     activeCommIdentifierType,
     signUp,
+    isProgressiveSignUp,
   });
 
   minimizeFieldsForExistingSignup(fields, signUp);
@@ -81,7 +83,7 @@ function _SignUpContinue(): JSX.Element | null {
   const handleChangeActive = (type: ActiveIdentifier) => (e: React.MouseEvent) => {
     e.preventDefault();
 
-    if (!emailOrPhoneUsedForFF(attributes)) {
+    if (!emailOrPhone(attributes, isProgressiveSignUp)) {
       return;
     }
 
@@ -162,7 +164,7 @@ function _SignUpContinue(): JSX.Element | null {
             <SignUpForm
               fields={fields}
               formState={formState}
-              toggleEmailPhone={emailOrPhoneUsedForFF(attributes)}
+              toggleEmailPhone={emailOrPhone(attributes, isProgressiveSignUp)}
               handleSubmit={handleSubmit}
               handleChangeActive={handleChangeActive}
             />

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
@@ -126,6 +126,9 @@ describe('<SignUpStart/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
   });
 
@@ -254,6 +257,9 @@ describe('<SignUpStart/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
 
     render(<SignUpStart />);
@@ -347,6 +353,9 @@ describe('<SignUpStart/>', () => {
                 required: false,
               },
             },
+            sign_up: {
+              progressive: false,
+            },
           } as UserSettingsJSON);
         });
 
@@ -398,6 +407,9 @@ describe('<SignUpStart/>', () => {
                 enabled: true,
                 required: true,
               },
+            },
+            sign_up: {
+              progressive: false,
             },
           } as UserSettingsJSON);
 
@@ -472,6 +484,9 @@ describe('<SignUpStart/>', () => {
                 required: false,
               },
             },
+            sign_up: {
+              progressive: false,
+            },
           } as UserSettingsJSON);
 
           mockCreateRequest.mockImplementation(() =>
@@ -524,6 +539,9 @@ describe('<SignUpStart/>', () => {
                 enabled: true,
                 required: false,
               },
+            },
+            sign_up: {
+              progressive: false,
             },
           } as UserSettingsJSON);
 
@@ -580,10 +598,136 @@ describe('<SignUpStart/>', () => {
           strategy: 'oauth_google',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
 
     render(<SignUpStart />);
     expect(screen.queryByRole('button', { name: 'Sign up' })).not.toBeInTheDocument();
     expect(screen.queryByText('Password')).not.toBeInTheDocument();
+  });
+});
+
+describe('<SignUpStart/> Progressive Sign Up', () => {
+  const mockUserSettingsProgressive = {
+    attributes: {
+      password: {
+        enabled: true,
+        required: false,
+      },
+      username: {
+        enabled: false,
+        required: false,
+      },
+      first_name: {
+        enabled: false,
+        required: false,
+      },
+      last_name: {
+        enabled: false,
+        required: false,
+      },
+    },
+    sign_up: {
+      progressive: true,
+    },
+  } as UserSettingsJSON;
+
+  it('renders email input if required', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: true,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+    expect(screen.queryByText('Phone number')).not.toBeInTheDocument();
+  });
+
+  it('renders phone input if required', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: true,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.queryByText('Email address')).not.toBeInTheDocument();
+    expect(screen.getByText('Phone number')).toBeInTheDocument();
+  });
+
+  it('renders both email & phone inputs if required', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+    expect(screen.getByText('Phone number')).toBeInTheDocument();
+  });
+
+  it('renders optional email/phone input if email OR phone', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: true,
+        },
+        phone_number: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: true,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Use phone instead'));
+    expect(screen.getByText('Phone number')).toBeInTheDocument();
   });
 });

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -24,7 +24,7 @@ import { SignUpForm } from './SignUpForm';
 import {
   ActiveIdentifier,
   determineActiveFields,
-  emailOrPhoneUsedForFF,
+  emailOrPhone,
   getInitialActiveIdentifier,
   showFormFields,
 } from './signUpFormHelpers';
@@ -38,7 +38,7 @@ function _SignUpStart(): JSX.Element {
   const { setSession } = useCoreClerk();
   const { navigateAfterSignUp } = useSignUpContext();
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
-    getInitialActiveIdentifier(attributes),
+    getInitialActiveIdentifier(attributes, userSettings.signUp.progressive),
   );
   const signUp = useCoreSignUp();
   const [isLoading, setIsLoading] = React.useState(false);
@@ -62,12 +62,14 @@ function _SignUpStart(): JSX.Element {
   const [error, setError] = React.useState<string | undefined>();
   const hasTicket = !!formState.ticket.value;
   const hasEmail = !!formState.emailAddress.value;
+  const isProgressiveSignUp = userSettings.signUp.progressive;
 
   const fields = determineActiveFields({
     attributes,
     hasTicket,
     hasEmail,
     activeCommIdentifierType,
+    isProgressiveSignUp,
   });
 
   const oauthOptions = userSettings.socialProviderStrategies;
@@ -138,7 +140,7 @@ function _SignUpStart(): JSX.Element {
   const handleChangeActive = (type: ActiveIdentifier) => (e: React.MouseEvent) => {
     e.preventDefault();
 
-    if (!emailOrPhoneUsedForFF(attributes)) {
+    if (!emailOrPhone(attributes, isProgressiveSignUp)) {
       return;
     }
 
@@ -218,7 +220,7 @@ function _SignUpStart(): JSX.Element {
             <SignUpForm
               fields={fields}
               formState={formState}
-              toggleEmailPhone={emailOrPhoneUsedForFF(attributes)}
+              toggleEmailPhone={emailOrPhone(attributes, isProgressiveSignUp)}
               handleSubmit={handleSubmit}
               handleChangeActive={handleChangeActive}
             />

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -41,6 +41,7 @@ export type SignInData = {
 
 export type SignUpData = {
   allowlist_only: boolean;
+  progressive: boolean;
 };
 
 export type OAuthProviders = {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This PR adds support in the Sign Up form, for the required/optional attribute flag used by the upcoming Progressive Sign up feature. The main difference is that now both email and phone can be set as required which means the SignUp form will render both inputs. All the other functionality should remain the same as before

![Screenshot 2022-05-25 at 4 13 18 PM](https://user-images.githubusercontent.com/22435234/170270990-e64aa511-7d5c-4023-ac11-b597b815a6a6.png)

<!-- Fixes # (issue number) -->
