### PR TITLE
chore(clerk-js): Add v4 FormControl system

### DIFF
--- a/packages/clerk-js/src/v4/primitives/Flex.tsx
+++ b/packages/clerk-js/src/v4/primitives/Flex.tsx
@@ -52,7 +52,7 @@ const { applyVariants, filterProps } = createVariants(theme => ({
   },
 }));
 
-type FlexProps = BoxProps & StyleVariants<typeof applyVariants>;
+export type FlexProps = BoxProps & StyleVariants<typeof applyVariants>;
 
 export const Flex = React.forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
   return (

--- a/packages/clerk-js/src/v4/primitives/FormControl.tsx
+++ b/packages/clerk-js/src/v4/primitives/FormControl.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Flex } from './Flex';
+import { FormControlContext, FormControlOptions, useFormControlProvider } from './hooks';
+
+// TODO: Connect with CSS variables
+
+type FormControlProps = {
+  children: React.ReactNode;
+} & FormControlOptions;
+
+const FormControl = (props: FormControlProps) => {
+  const ctx = useFormControlProvider(props);
+  return (
+    <FormControlContext.Provider value={ctx}>
+      <Flex direction='col'>{props.children}</Flex>
+    </FormControlContext.Provider>
+  );
+};
+
+export { FormControl };

--- a/packages/clerk-js/src/v4/primitives/FormErrorText.tsx
+++ b/packages/clerk-js/src/v4/primitives/FormErrorText.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { createVariants, StyleVariants } from '../styledSystem';
+import { useFormControlContext } from './hooks';
+import { Text } from './Text';
+
+// TODO: Connect with CSS variables
+
+const { applyVariants } = createVariants(theme => ({
+  base: {
+    color: theme.colors.$danger500,
+    marginTop: theme.sizes.$2,
+  },
+  variants: {},
+}));
+
+type FormErrorTextProps = StyleVariants<typeof applyVariants> & {
+  children: React.ReactNode;
+};
+
+const FormErrorText = (props: FormErrorTextProps) => {
+  const { hasError, errorMessageId } = useFormControlContext();
+
+  if (!hasError) {
+    return null;
+  }
+
+  return (
+    <Text
+      css={applyVariants(props)}
+      variant='error'
+      aria-live='polite'
+      id={errorMessageId}
+    >
+      {props.children}
+    </Text>
+  );
+};
+
+export { FormErrorText };

--- a/packages/clerk-js/src/v4/primitives/FormLabel.tsx
+++ b/packages/clerk-js/src/v4/primitives/FormLabel.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { createVariants, PrimitiveProps, StyleVariants } from '../styledSystem';
+import { useFormControlContext } from './hooks';
+
+// TODO: Connect with CSS variables
+
+const { applyVariants, filterProps } = createVariants(theme => ({
+  base: {
+    color: theme.colors.$black,
+    fontStyle: theme.fontStyles.$normal,
+    fontWeight: theme.fontWeights.$medium,
+    lineHeight: theme.lineHeights.$none,
+    marginBottom: theme.sizes.$1,
+  },
+  variants: {},
+}));
+
+type FormLabelProps = PrimitiveProps<'label'> &
+  StyleVariants<typeof applyVariants> & {
+    hasError?: boolean;
+    children: React.ReactNode;
+  };
+
+const FormLabel = (props: FormLabelProps) => {
+  const propsWithoutVariants = filterProps(props);
+  const { id } = useFormControlContext();
+
+  return (
+    <label
+      {...propsWithoutVariants}
+      htmlFor={id}
+      css={applyVariants(props)}
+    >
+      {props.children}
+    </label>
+  );
+};
+
+export { FormLabel };

--- a/packages/clerk-js/src/v4/primitives/Input.tsx
+++ b/packages/clerk-js/src/v4/primitives/Input.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { createVariants, PrimitiveProps, StyleVariants } from '../styledSystem';
+import { useFormControlContext } from './hooks';
 import { useInput } from './hooks/useInput';
 
 // TODO: Connect with CSS variables
@@ -30,7 +31,8 @@ type InputProps = PrimitiveProps<'input'> &
   };
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
-  const propsWithoutVariants = filterProps(props);
+  const controlInputProps = useFormControlContext();
+  const propsWithoutVariants = filterProps({ ...props, hasError: props.hasError || controlInputProps.hasError });
   const { onChange } = useInput(propsWithoutVariants.onChange);
   const { isDisabled, hasError, ...rest } = propsWithoutVariants;
   return (
@@ -39,8 +41,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       ref={ref}
       onChange={onChange}
       disabled={isDisabled}
-      aria-invalid={hasError}
-      css={applyVariants(props)}
+      id={props.id || controlInputProps.id}
+      aria-invalid={hasError || controlInputProps.hasError}
+      aria-describedby={controlInputProps.errorMessageId}
+      aria-required={controlInputProps.isRequired}
+      css={applyVariants(propsWithoutVariants)}
     />
   );
 });

--- a/packages/clerk-js/src/v4/primitives/hooks/index.ts
+++ b/packages/clerk-js/src/v4/primitives/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useFormControl';
+export * from './useInput';

--- a/packages/clerk-js/src/v4/primitives/hooks/useFormControl.tsx
+++ b/packages/clerk-js/src/v4/primitives/hooks/useFormControl.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export type FormControlOptions = {
+  /**
+   * If `true`, the form control will be required.
+   * - The form element (e.g, Input) will have `aria-required` set to `true`
+   */
+  isRequired?: boolean;
+  /**
+   * If `true`, the form control will be invalid. This has 2 side effects:
+   * - The form element (e.g, Input) will have `aria-invalid` set to `true`
+   * - The FormErrorText will render
+   */
+  hasError?: boolean;
+
+  /**
+   * The custom `id` to use for the form control. This is passed directly to the form element (e.g, Input).
+   * - The form element (e.g. Input) gets the `id`
+   */
+  id: string;
+};
+
+type FormControlProviderContext = ReturnType<typeof useFormControlProvider>;
+
+export const FormControlContext = React.createContext<FormControlProviderContext | Record<string, never>>({});
+export const useFormControlContext = () => React.useContext(FormControlContext);
+
+export function useFormControlProvider(props: FormControlOptions) {
+  const { id: propsId, isRequired, hasError } = props;
+
+  /**
+   * Track whether the `FormErrorText` has been rendered.
+   * We use this to append its id the `aria-describedby` of the `input`.
+   */
+  const id = `cl-form-control-${propsId}`;
+  const errorMessageId = hasError && `error-${propsId}`;
+
+  return {
+    isRequired,
+    hasError,
+    id,
+    errorMessageId,
+  };
+}

--- a/packages/clerk-js/src/v4/styledSystem/types.ts
+++ b/packages/clerk-js/src/v4/styledSystem/types.ts
@@ -10,6 +10,7 @@ type ElementProps = {
   button: React.HTMLAttributes<HTMLButtonElement>;
   heading: React.HTMLAttributes<HTMLHeadingElement>;
   p: React.HTMLAttributes<HTMLParagraphElement>;
+  label: React.HTMLAttributes<HTMLLabelElement>;
 };
 
 export type Theme = BaseTheme;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
New `FormControl` structure.
When using a FormControl, we need to make sure we keep some markup standards in place _(schematic and wai-aria)_.

For better internal DX the convention designed is something like:
```tsx
        <FormControl hasError id='email'>
          <FormLabel>Email</FormLabel>
          <Input />
          <FormErrorText>Email is required</FormErrorText>
        </FormControl>
        <FormControl isRequired id='username'
        >
          <FormLabel>Username</FormLabel>
          <Input />
          <FormErrorText>Username is required</FormErrorText>
        </FormControl>
```

![image](https://user-images.githubusercontent.com/15251081/170471500-b9d5a8c6-8c06-44c6-9f71-5adf62a45d88.png)
