### PR TITLE
New `setActive` method to set the active session and organization

### DIFF
--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -219,7 +219,7 @@ describe('Clerk singleton', () => {
       await waitFor(() => {
         expect(mockClientDestroy).toHaveBeenCalled();
         expect(mockSession1.remove).not.toHaveBeenCalled();
-        expect(sut.setActive).toHaveBeenCalledWith({session: null});
+        expect(sut.setActive).toHaveBeenCalledWith({ session: null });
       });
     });
 
@@ -238,7 +238,9 @@ describe('Clerk singleton', () => {
       await waitFor(() => {
         expect(mockSession2.remove).toHaveBeenCalled();
         expect(mockClientDestroy).not.toHaveBeenCalled();
-        expect(sut.setActive).not.toHaveBeenCalledWith(null, undefined);
+        expect(sut.setActive).not.toHaveBeenCalledWith({
+          session: null,
+        });
       });
     });
 
@@ -257,7 +259,7 @@ describe('Clerk singleton', () => {
       await waitFor(() => {
         expect(mockSession1.remove).toHaveBeenCalled();
         expect(mockClientDestroy).not.toHaveBeenCalled();
-        expect(sut.setActive).toHaveBeenCalledWith({session: null});
+        expect(sut.setActive).toHaveBeenCalledWith({ session: null });
       });
     });
   });
@@ -704,8 +706,8 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetActive = jest.fn(async (_: any, callback: () => any) => {
-        await callback();
+      const mockSetActive = jest.fn(async (setActiveOpts: any) => {
+        await setActiveOpts.beforeEmit();
       });
 
       const sut = new Clerk(frontendApi);
@@ -759,8 +761,8 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetActive = jest.fn(async (_: any, callback: () => any) => {
-        await callback();
+      const mockSetActive = jest.fn(async (setActiveOpts: any) => {
+        await setActiveOpts.beforeEmit();
       });
 
       const sut = new Clerk(frontendApi);
@@ -903,7 +905,10 @@ describe('Clerk singleton', () => {
       sut.handleMagicLinkVerification({ redirectUrlComplete });
 
       await waitFor(() => {
-        expect(mockSetActive).toHaveBeenCalledWith(createdSessionId, expect.any(Function));
+        expect(mockSetActive).toHaveBeenCalledWith({
+          session: createdSessionId,
+          beforeEmit: expect.any(Function),
+        });
       });
     });
 
@@ -964,7 +969,10 @@ describe('Clerk singleton', () => {
       sut.handleMagicLinkVerification({ redirectUrlComplete });
 
       await waitFor(() => {
-        expect(mockSetActive).toHaveBeenCalledWith(createdSessionId, expect.any(Function));
+        expect(mockSetActive).toHaveBeenCalledWith({
+          session: createdSessionId,
+          beforeEmit: expect.any(Function),
+        });
       });
     });
 

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -195,12 +195,12 @@ describe('Clerk singleton', () => {
       );
 
       const sut = new Clerk(frontendApi);
-      sut.setSession = jest.fn();
+      sut.setActive = jest.fn();
       await sut.load();
       await sut.signOut();
       await waitFor(() => {
         expect(mockClientDestroy).toHaveBeenCalled();
-        expect(sut.setSession).toHaveBeenCalledWith(null, undefined);
+        expect(sut.setActive).toHaveBeenCalledWith({ session: null });
       });
     });
 
@@ -213,13 +213,13 @@ describe('Clerk singleton', () => {
       );
 
       const sut = new Clerk(frontendApi);
-      sut.setSession = jest.fn();
+      sut.setActive = jest.fn();
       await sut.load();
       await sut.signOut();
       await waitFor(() => {
         expect(mockClientDestroy).toHaveBeenCalled();
         expect(mockSession1.remove).not.toHaveBeenCalled();
-        expect(sut.setSession).toHaveBeenCalledWith(null, undefined);
+        expect(sut.setActive).toHaveBeenCalledWith({session: null});
       });
     });
 
@@ -232,13 +232,13 @@ describe('Clerk singleton', () => {
       );
 
       const sut = new Clerk(frontendApi);
-      sut.setSession = jest.fn();
+      sut.setActive = jest.fn();
       await sut.load();
       await sut.signOut({ sessionId: '2' });
       await waitFor(() => {
         expect(mockSession2.remove).toHaveBeenCalled();
         expect(mockClientDestroy).not.toHaveBeenCalled();
-        expect(sut.setSession).not.toHaveBeenCalledWith(null, undefined);
+        expect(sut.setActive).not.toHaveBeenCalledWith(null, undefined);
       });
     });
 
@@ -251,13 +251,13 @@ describe('Clerk singleton', () => {
       );
 
       const sut = new Clerk(frontendApi);
-      sut.setSession = jest.fn();
+      sut.setActive = jest.fn();
       await sut.load();
       await sut.signOut({ sessionId: '1' });
       await waitFor(() => {
         expect(mockSession1.remove).toHaveBeenCalled();
         expect(mockClientDestroy).not.toHaveBeenCalled();
-        expect(sut.setSession).toHaveBeenCalledWith(null, undefined);
+        expect(sut.setActive).toHaveBeenCalledWith({session: null});
       });
     });
   });
@@ -299,7 +299,7 @@ describe('Clerk singleton', () => {
       mockEnvironmentFetch.mockReset();
     });
 
-    it('creates a new user and calls setSession if the user was not found during sso signup', async () => {
+    it('creates a new user and calls setActive if the user was not found during sso signup', async () => {
       mockEnvironmentFetch.mockReturnValue(
         Promise.resolve({
           authConfig: {},
@@ -335,7 +335,7 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const mockSignUpCreate = jest
         .fn()
         .mockReturnValue(Promise.resolve({ status: 'complete', createdSessionId: '123' }));
@@ -348,13 +348,13 @@ describe('Clerk singleton', () => {
         fail('we should always have a client');
       }
       sut.client.signUp.create = mockSignUpCreate;
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSignUpCreate).toHaveBeenCalledWith({ transfer: true });
-        expect(mockSetSession).toHaveBeenCalled();
+        expect(mockSetActive).toHaveBeenCalled();
       });
     });
 
@@ -457,7 +457,7 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const mockSignInCreate = jest
         .fn()
         .mockReturnValue(Promise.resolve({ status: 'complete', createdSessionId: '123' }));
@@ -470,17 +470,17 @@ describe('Clerk singleton', () => {
         fail('we should always have a client');
       }
       sut.client.signIn.create = mockSignInCreate;
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSignInCreate).toHaveBeenCalledWith({ transfer: true });
-        expect(mockSetSession).toHaveBeenCalled();
+        expect(mockSetActive).toHaveBeenCalled();
       });
     });
 
-    it('signs the user by calling setSession if the user was already signed in during sign up', async () => {
+    it('signs the user by calling setActive if the user was already signed in during sign up', async () => {
       mockEnvironmentFetch.mockReturnValue(
         Promise.resolve({
           authConfig: {},
@@ -516,21 +516,21 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       sut.handleRedirectCallback();
 
       await waitFor(() => {
-        expect(mockSetSession).toHaveBeenCalled();
+        expect(mockSetActive).toHaveBeenCalled();
       });
     });
 
-    it('creates a new user and calls setSession in if the user was found during sign in', async () => {
+    it('creates a new user and calls setActive in if the user was found during sign in', async () => {
       mockEnvironmentFetch.mockReturnValue(
         Promise.resolve({
           authConfig: {},
@@ -562,7 +562,7 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const mockSignUpCreate = jest
         .fn()
         .mockReturnValue(Promise.resolve({ status: 'complete', createdSessionId: '123' }));
@@ -575,13 +575,13 @@ describe('Clerk singleton', () => {
         fail('we should always have a client');
       }
       sut.client.signUp.create = mockSignUpCreate;
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSignUpCreate).toHaveBeenCalledWith({ transfer: true });
-        expect(mockSetSession).toHaveBeenCalled();
+        expect(mockSetActive).toHaveBeenCalled();
       });
     });
 
@@ -704,7 +704,7 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetSession = jest.fn(async (_: any, callback: () => any) => {
+      const mockSetActive = jest.fn(async (_: any, callback: () => any) => {
         await callback();
       });
 
@@ -712,7 +712,7 @@ describe('Clerk singleton', () => {
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession as any;
+      sut.setActive = mockSetActive as any;
 
       sut.handleRedirectCallback({
         redirectUrl: '/custom-sign-in',
@@ -759,7 +759,7 @@ describe('Clerk singleton', () => {
         }),
       );
 
-      const mockSetSession = jest.fn(async (_: any, callback: () => any) => {
+      const mockSetActive = jest.fn(async (_: any, callback: () => any) => {
         await callback();
       });
 
@@ -767,7 +767,7 @@ describe('Clerk singleton', () => {
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession as any;
+      sut.setActive = mockSetActive as any;
 
       sut.handleRedirectCallback({
         afterSignInUrl: '/custom-sign-in',
@@ -891,19 +891,19 @@ describe('Clerk singleton', () => {
           signUp: new SignUp(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       const redirectUrlComplete = '/redirect-to';
       sut.handleMagicLinkVerification({ redirectUrlComplete });
 
       await waitFor(() => {
-        expect(mockSetSession).toHaveBeenCalledWith(createdSessionId, expect.any(Function));
+        expect(mockSetActive).toHaveBeenCalledWith(createdSessionId, expect.any(Function));
       });
     });
 
@@ -919,19 +919,19 @@ describe('Clerk singleton', () => {
           signUp: new SignUp(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       const redirectUrl = '/2fa';
       sut.handleMagicLinkVerification({ redirectUrl });
 
       await waitFor(() => {
-        expect(mockSetSession).not.toHaveBeenCalled();
+        expect(mockSetActive).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith(redirectUrl);
       });
     });
@@ -952,19 +952,19 @@ describe('Clerk singleton', () => {
           signIn: new SignIn(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       const redirectUrlComplete = '/redirect-to';
       sut.handleMagicLinkVerification({ redirectUrlComplete });
 
       await waitFor(() => {
-        expect(mockSetSession).toHaveBeenCalledWith(createdSessionId, expect.any(Function));
+        expect(mockSetActive).toHaveBeenCalledWith(createdSessionId, expect.any(Function));
       });
     });
 
@@ -980,19 +980,19 @@ describe('Clerk singleton', () => {
           signIn: new SignIn(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       const redirectUrl = '/next-up';
       sut.handleMagicLinkVerification({ redirectUrl });
 
       await waitFor(() => {
-        expect(mockSetSession).not.toHaveBeenCalled();
+        expect(mockSetActive).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith(redirectUrl);
       });
     });
@@ -1007,18 +1007,18 @@ describe('Clerk singleton', () => {
           signIn: new SignIn(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       await expect(async () => {
         await sut.handleMagicLinkVerification({});
       }).rejects.toThrow(MagicLinkErrorCode.Expired);
-      expect(mockSetSession).not.toHaveBeenCalled();
+      expect(mockSetActive).not.toHaveBeenCalled();
     });
 
     it('throws an error for failed verification status parameter', async () => {
@@ -1031,18 +1031,18 @@ describe('Clerk singleton', () => {
           signIn: new SignIn(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       await expect(async () => {
         await sut.handleMagicLinkVerification({});
       }).rejects.toThrow(MagicLinkErrorCode.Failed);
-      expect(mockSetSession).not.toHaveBeenCalled();
+      expect(mockSetActive).not.toHaveBeenCalled();
     });
 
     it('runs a callback when verified on other device', async () => {
@@ -1058,19 +1058,19 @@ describe('Clerk singleton', () => {
           signIn: new SignIn(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
       const res = { ping: 'ping' };
       const cb = () => {
         res.ping = 'pong';
       };
       await sut.handleMagicLinkVerification({ onVerifiedOnOtherDevice: cb });
       expect(res.ping).toEqual('pong');
-      expect(mockSetSession).not.toHaveBeenCalled();
+      expect(mockSetActive).not.toHaveBeenCalled();
     });
 
     it('throws an error with no status query parameter', async () => {
@@ -1083,16 +1083,16 @@ describe('Clerk singleton', () => {
           signIn: new SignIn(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
       await expect(async () => {
         await sut.handleMagicLinkVerification({});
       }).rejects.toThrow(MagicLinkErrorCode.Failed);
-      expect(mockSetSession).not.toHaveBeenCalled();
+      expect(mockSetActive).not.toHaveBeenCalled();
     });
 
     it('throws an error for invalid status query parameter', async () => {
@@ -1110,17 +1110,17 @@ describe('Clerk singleton', () => {
           signUp: new SignUp(null),
         }),
       );
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const sut = new Clerk(frontendApi);
       await sut.load({
         navigate: mockNavigate,
       });
-      sut.setSession = mockSetSession;
+      sut.setActive = mockSetActive;
 
       await expect(async () => {
         await sut.handleMagicLinkVerification({});
       }).rejects.toThrow(MagicLinkErrorCode.Failed);
-      expect(mockSetSession).not.toHaveBeenCalled();
+      expect(mockSetActive).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
+++ b/packages/clerk-js/src/ui/common/activeAccountsManager/ActiveAccountsManager.tsx
@@ -29,7 +29,7 @@ export function ActiveAccountsManager({
   userProfileUrl,
   showActiveAccountButtons = true,
 }: ActiveAccountsManagerProps): JSX.Element {
-  const { setSession, signOut } = useCoreClerk();
+  const { setActive, signOut } = useCoreClerk();
   const { id: currentSessionId } = useCoreSession();
   const { authConfig } = useEnvironment();
   const { navigate } = useNavigate();
@@ -68,7 +68,10 @@ export function ActiveAccountsManager({
     // In the future, if the passed session is an expired session, we will allow the
     // user to revive it.
     if (session.status === 'active') {
-      setSession(session as ActiveSessionResource, navigateAfterSwitchSession);
+      setActive({
+        session: session as ActiveSessionResource,
+        beforeEmit: navigateAfterSwitchSession,
+      });
     }
   };
 

--- a/packages/clerk-js/src/ui/common/verifyMagicLink/VerifyMagicLink.test.tsx
+++ b/packages/clerk-js/src/ui/common/verifyMagicLink/VerifyMagicLink.test.tsx
@@ -7,10 +7,10 @@ import { VerifyMagicLink } from 'ui/common';
 const mockHandleMagicLinkVerification = jest.fn();
 
 const mockNavigate = jest.fn();
-const mockSetSession = jest.fn();
+const mockSetActive = jest.fn();
 const mockUseCoreClerk = jest.fn(() => ({
   handleMagicLinkVerification: mockHandleMagicLinkVerification,
-  setSession: mockSetSession,
+  setActive: mockSetActive,
 }));
 
 jest.mock('ui/hooks', () => ({

--- a/packages/clerk-js/src/ui/signIn/SignIn.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignIn.test.tsx
@@ -6,7 +6,7 @@ import { SignIn } from 'ui/signIn/SignIn';
 
 const mockNavigate = jest.fn();
 
-const mockSetSession = jest.fn().mockReturnValue({
+const mockSetActive = jest.fn().mockReturnValue({
   status: 'complete',
 });
 
@@ -37,7 +37,7 @@ jest.mock('ui/contexts', () => {
     useSignUpContext: jest.fn(),
     useClerk: () => {
       return {
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       };
     },
     withCoreSessionSwitchGuard: (a: any) => a,

--- a/packages/clerk-js/src/ui/signIn/SignInAccountSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInAccountSwitcher.test.tsx
@@ -8,7 +8,7 @@ const navigateMock = jest.fn();
 const mockCreateRequest = jest.fn();
 
 const mockFactorOneAttempt = jest.fn();
-const mockSetSession = jest.fn().mockReturnValue({
+const mockSetActive = jest.fn().mockReturnValue({
   status: 'complete',
 });
 
@@ -52,7 +52,7 @@ jest.mock('ui/contexts', () => {
     withCoreUserGuard: (a: any) => a,
     useCoreClerk: () => {
       return {
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       };
     },
     useSignUpContext: () => {

--- a/packages/clerk-js/src/ui/signIn/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorOne.test.tsx
@@ -44,7 +44,7 @@ describe('<SignInFactorOne/>', () => {
 
   describe('successful password based sign in', () => {
     it('renders the sign in screen, enters a password and sets session', async () => {
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const mockAttemptFirstFactor = jest.fn();
 
       (useEnvironment as jest.Mock).mockImplementation(() => ({
@@ -73,7 +73,7 @@ describe('<SignInFactorOne/>', () => {
       }));
 
       (useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -93,15 +93,18 @@ describe('<SignInFactorOne/>', () => {
         });
 
         expect(mockNavigate).toHaveBeenCalledTimes(0);
-        expect(mockSetSession).toHaveBeenCalledTimes(1);
-        expect(mockSetSession).toHaveBeenCalledWith('cafebabe', mockNavigateAfterSignIn);
+        expect(mockSetActive).toHaveBeenCalledTimes(1);
+        expect(mockSetActive).toHaveBeenCalledWith({
+          session: 'cafebabe',
+          beforeEmit: mockNavigateAfterSignIn,
+        });
       });
     });
   });
 
   describe('2SV password based sign in', () => {
     it('redirects to /factor-two', async () => {
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const mockAttemptFirstFactor = jest.fn();
 
       (useEnvironment as jest.Mock).mockImplementation(() => ({
@@ -131,7 +134,7 @@ describe('<SignInFactorOne/>', () => {
       }));
 
       (useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -150,7 +153,7 @@ describe('<SignInFactorOne/>', () => {
           password: 'p@ssW0rD',
         });
 
-        expect(mockSetSession).toHaveBeenCalledTimes(0);
+        expect(mockSetActive).toHaveBeenCalledTimes(0);
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('../factor-two');
       });
@@ -160,7 +163,7 @@ describe('<SignInFactorOne/>', () => {
   describe('successful passwordless sign in', () => {
     it('renders the sign in screen, enters a password and sets session', async () => {
       const mockAttemptFirstFactor = jest.fn();
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       (useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>).mockImplementation(() => ({
         authConfig: { singleSessionMode: false },
@@ -193,7 +196,7 @@ describe('<SignInFactorOne/>', () => {
       );
 
       (useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -219,15 +222,18 @@ describe('<SignInFactorOne/>', () => {
         });
 
         expect(mockNavigate).toHaveBeenCalledTimes(0);
-        expect(mockSetSession).toHaveBeenCalledTimes(1);
-        expect(mockSetSession).toHaveBeenCalledWith('cafebabe', mockNavigateAfterSignIn);
+        expect(mockSetActive).toHaveBeenCalledTimes(1);
+        expect(mockSetActive).toHaveBeenCalledWith({
+          session: 'cafebabe',
+          beforeEmit: mockNavigateAfterSignIn,
+        });
       });
     });
   });
 
   describe('successful magiclink sign in', () => {
     it('renders the magic link sign in screen, and handles an expired first factor verification', async () => {
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const mockStartMagicLinkFlow = jest.fn(() =>
         Promise.resolve({
           status: 'needs_factor_one',
@@ -268,7 +274,7 @@ describe('<SignInFactorOne/>', () => {
       );
 
       (useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -277,13 +283,13 @@ describe('<SignInFactorOne/>', () => {
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledTimes(0);
-        expect(mockSetSession).toHaveBeenCalledTimes(0);
+        expect(mockSetActive).toHaveBeenCalledTimes(0);
         screen.getByText(/expired/);
       });
     });
 
     it('renders the magic link sign in screen, waits for magic link and sets session', async () => {
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       const mockStartMagicLinkFlow = jest.fn(() =>
         Promise.resolve({
           status: 'complete',
@@ -327,7 +333,7 @@ describe('<SignInFactorOne/>', () => {
       );
 
       (useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -340,8 +346,11 @@ describe('<SignInFactorOne/>', () => {
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledTimes(0);
-        expect(mockSetSession).toHaveBeenCalledTimes(1);
-        expect(mockSetSession).toHaveBeenCalledWith('cafebabe', mockNavigateAfterSignIn);
+        expect(mockSetActive).toHaveBeenCalledTimes(1);
+        expect(mockSetActive).toHaveBeenCalledWith({
+          session: 'cafebabe',
+          beforeEmit: mockNavigateAfterSignIn,
+        });
       });
     });
   });
@@ -349,7 +358,7 @@ describe('<SignInFactorOne/>', () => {
   describe('2SV passwordless sign in', () => {
     it('renders the sign in screen, enters a password and sets session', async () => {
       const mockAttemptFirstFactor = jest.fn();
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       mocked(useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>, true).mockImplementation(() => ({
         authConfig: { singleSessionMode: false },
@@ -381,7 +390,7 @@ describe('<SignInFactorOne/>', () => {
       );
 
       mocked(useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>, true).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -406,7 +415,7 @@ describe('<SignInFactorOne/>', () => {
           code: '123456',
         });
 
-        expect(mockSetSession).toHaveBeenCalledTimes(0);
+        expect(mockSetActive).toHaveBeenCalledTimes(0);
         expect(mockNavigate).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('../factor-two');
       });
@@ -417,7 +426,7 @@ describe('<SignInFactorOne/>', () => {
     it('renders the sign in screen and chooses an alternate strategy', async () => {
       const mockAttemptFirstFactor = jest.fn();
       const mockPrepareFirstFactor = jest.fn();
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       mocked(useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>, true).mockImplementation(() => ({
         authConfig: { singleSessionMode: false },
@@ -459,7 +468,7 @@ describe('<SignInFactorOne/>', () => {
         useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>,
         true,
       ).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -483,7 +492,7 @@ describe('<SignInFactorOne/>', () => {
 
     it('goes back to default factorOne screen after hitting back on alternate strategy screen', async () => {
       const mockAttemptFirstFactor = jest.fn();
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
 
       (useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>).mockImplementation(() => ({
         authConfig: { singleSessionMode: false },
@@ -516,7 +525,7 @@ describe('<SignInFactorOne/>', () => {
       );
 
       (useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       render(<SignInFactorOne />);
@@ -531,7 +540,7 @@ describe('<SignInFactorOne/>', () => {
     });
 
     it('renders all available strategies when sso sign is available and no other first factor', () => {
-      const mockSetSession = jest.fn();
+      const mockSetActive = jest.fn();
       mocked(useEnvironment as jest.Mock<PartialDeep<EnvironmentResource>>, true).mockImplementation(() => ({
         authConfig: { singleSessionMode: false },
         displayConfig: {
@@ -561,7 +570,7 @@ describe('<SignInFactorOne/>', () => {
         useCoreClerk as jest.Mock<PartialDeep<LoadedClerk>>,
         true,
       ).mockImplementation(() => ({
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       }));
 
       const { container } = render(<SignInFactorOne />);

--- a/packages/clerk-js/src/ui/signIn/SignInFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorTwo.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { SignInFactorTwo } from './SignInFactorTwo';
 
-const mockSetSession = jest.fn().mockReturnValue({
+const mockSetActive = jest.fn().mockReturnValue({
   status: 'complete',
 });
 const mockFactorOneAttempt = jest.fn();
@@ -57,7 +57,7 @@ jest.mock('ui/contexts', () => {
       prepareSecondFactor: jest.fn(() => Promise.resolve()),
     }),
     useCoreClerk: () => ({
-      setSession: mockSetSession,
+      setActive: mockSetActive,
     }),
   };
 });
@@ -78,7 +78,7 @@ describe('<SignInFactorTwo/>', () => {
     }
 
     await waitFor(() => {
-      expect(mockSetSession).toHaveBeenCalledTimes(1);
+      expect(mockSetActive).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/clerk-js/src/ui/signIn/SignInFactorTwo.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInFactorTwo.tsx
@@ -13,7 +13,7 @@ type SignInUiProps = Pick<SignInResource, 'userData' | 'identifier' | 'supported
 
 function _SignInFactorTwo(): JSX.Element {
   const { navigateAfterSignIn } = useSignInContext();
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const signIn = useCoreSignIn();
   // after successful verification, the server returns a null SIA
   // so to avoid flickering before the navigation completes
@@ -68,7 +68,12 @@ function _SignInFactorTwo(): JSX.Element {
         code: code.value,
       });
       if (response.status === 'complete') {
-        verify(() => setSession(response.createdSessionId, navigateAfterSignIn));
+        verify(() =>
+          setActive({
+            session: response.createdSessionId,
+            beforeEmit: navigateAfterSignIn,
+          }),
+        );
       }
     } catch (err) {
       const globalErr = getGlobalError(err);

--- a/packages/clerk-js/src/ui/signIn/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInStart.test.tsx
@@ -51,13 +51,13 @@ jest.mock('ui/contexts', () => {
       authenticateWithRedirect: mockAuthenticateWithRedirect,
     })),
     useCoreClerk: jest.fn(() => ({
-      setSession: mockSetSession,
+      setActive: mockSetActive,
     })),
   };
 });
 
 const mockFactorOneAttempt = jest.fn();
-const mockSetSession = jest.fn().mockReturnValue({
+const mockSetActive = jest.fn().mockReturnValue({
   status: 'complete',
 });
 
@@ -167,7 +167,7 @@ fdescribe('<SignInStart/>', () => {
           password: '123456',
           strategy: 'password',
         });
-        expect(mockSetSession).toHaveBeenCalledTimes(1);
+        expect(mockSetActive).toHaveBeenCalledTimes(1);
         expect(mockNavigate).not.toHaveBeenCalled();
       });
     });
@@ -215,7 +215,7 @@ fdescribe('<SignInStart/>', () => {
         expect(mockCreateRequest).toHaveBeenCalledWith({
           identifier: 'boss@clerk.dev',
         });
-        expect(mockSetSession).not.toHaveBeenCalled();
+        expect(mockSetActive).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalledWith('factor-one');
       });
     });
@@ -266,7 +266,7 @@ fdescribe('<SignInStart/>', () => {
         expect(mockCreateRequest).toHaveBeenCalledWith({
           identifier: 'boss@clerk.dev',
         });
-        expect(mockSetSession).not.toHaveBeenCalled();
+        expect(mockSetActive).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalledWith('factor-one');
       });
     });
@@ -347,7 +347,10 @@ fdescribe('<SignInStart/>', () => {
           identifier: 'boss@clerk.dev',
         });
         expect(mockNavigate).not.toHaveBeenCalled();
-        expect(mockSetSession).toHaveBeenNthCalledWith(1, 'deadbeef', mockNavigateAfterSignIn);
+        expect(mockSetActive).toHaveBeenNthCalledWith(1, {
+          session: 'deadbeef',
+          beforeEmit: mockNavigateAfterSignIn,
+        });
       });
     });
   });

--- a/packages/clerk-js/src/ui/signIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/signIn/SignInStart.tsx
@@ -29,7 +29,7 @@ import { OAuth, Web3 } from './strategies';
 
 export function _SignInStart(): JSX.Element {
   const { userSettings } = useEnvironment();
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const signIn = useCoreSignIn();
   const { navigate } = useNavigate();
   const { navigateAfterSignIn } = useSignInContext();
@@ -64,7 +64,10 @@ export function _SignInStart(): JSX.Element {
           case 'needs_second_factor':
             return navigate('factor-two');
           case 'complete':
-            return setSession(res.createdSessionId, navigateAfterSignIn);
+            return setActive({
+              session: res.createdSessionId,
+              beforeEmit: navigateAfterSignIn,
+            });
           default: {
             const msg = `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`;
             alert(msg);
@@ -125,7 +128,10 @@ export function _SignInStart(): JSX.Element {
         case 'needs_second_factor':
           return navigate('factor-two');
         case 'complete':
-          return setSession(res.createdSessionId, navigateAfterSignIn);
+          return setActive({
+            session: res.createdSessionId,
+            beforeEmit: navigateAfterSignIn,
+          });
         default: {
           const msg = `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`;
           alert(msg);
@@ -152,7 +158,10 @@ export function _SignInStart(): JSX.Element {
       await signInWithFields(identifier);
     } else if (alreadySignedInError) {
       const sid = alreadySignedInError.meta!.sessionId!;
-      await setSession(sid, navigateAfterSignIn);
+      await setActive({
+        session: sid,
+        beforeEmit: navigateAfterSignIn,
+      });
     } else {
       handleError(e, [identifier, instantPassword], setError);
     }

--- a/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneInputBased.tsx
+++ b/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneInputBased.tsx
@@ -60,7 +60,7 @@ export function SignInFactorOneInputBased({
   setLastUsedFactor,
   handleShowAllStrategies,
 }: SignInFactorOneInputBasedProps): JSX.Element | null {
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const signIn = useCoreSignIn();
   const code = useFieldState('code', '');
   const password = useFieldState('password', '');
@@ -123,7 +123,12 @@ export function SignInFactorOneInputBased({
       const response = await signIn.attemptFirstFactor(params);
 
       if (response.status === 'complete') {
-        verify(() => setSession(response.createdSessionId, navigateAfterSignIn));
+        verify(() =>
+          setActive({
+            session: response.createdSessionId,
+            beforeEmit: navigateAfterSignIn,
+          }),
+        );
         return;
       } else if (response.status === 'needs_second_factor') {
         verify(() => navigate('../factor-two'));

--- a/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneMagicLink.tsx
+++ b/packages/clerk-js/src/ui/signIn/factorOne/SignInFactorOneMagicLink.tsx
@@ -24,7 +24,7 @@ export function SignInFactorOneMagicLink({
 }: SignInFactorOneMagicLinkProps): JSX.Element {
   const signIn = useCoreSignIn();
   const identifierRef = React.useRef(('safeIdentifier' in currentFactor && currentFactor.safeIdentifier) || '');
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const { navigate } = useNavigate();
   const { displayConfig } = useEnvironment();
   const signInContext = useSignInContext();
@@ -69,7 +69,10 @@ export function SignInFactorOneMagicLink({
 
   const completeSignInFlow = async (si: SignInResource) => {
     if (si.status === 'complete') {
-      return setSession(si.createdSessionId, navigateAfterSignIn);
+      return setActive({
+        session: si.createdSessionId,
+        beforeEmit: navigateAfterSignIn,
+      });
     } else if (si.status === 'needs_second_factor') {
       return navigate('../factor-two');
     }

--- a/packages/clerk-js/src/ui/signUp/SignUp.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUp.test.tsx
@@ -8,7 +8,7 @@ const mockNavigate = jest.fn();
 
 jest.mock('ui/router/RouteContext');
 
-const mockSetSession = jest.fn().mockReturnValue({
+const mockSetActive = jest.fn().mockReturnValue({
   status: 'complete',
 });
 
@@ -36,7 +36,7 @@ jest.mock('ui/contexts', () => {
       } as Partial<Session>),
     useCoreClerk: () => ({
       redirectToSignUp: jest.fn(),
-      setSession: mockSetSession,
+      setActive: mockSetActive,
     }),
     useCoreSignIn: jest.fn(),
   };

--- a/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
@@ -8,7 +8,7 @@ import { SignUpContinue } from './SignUpContinue';
 
 const navigateMock = jest.fn();
 const mockUpdateRequest = jest.fn();
-const mockSetSession = jest.fn();
+const mockSetActive = jest.fn();
 let mockUserSettings: UserSettings;
 
 jest.mock('ui/router/RouteContext');
@@ -28,7 +28,7 @@ jest.mock('ui/contexts', () => {
     },
     useCoreClerk: jest.fn(() => ({
       frontendAPI: 'clerk.clerk.dev',
-      setSession: mockSetSession,
+      setActive: mockSetActive,
     })),
     useCoreSignUp: jest.fn(() => ({
       verifications: {

--- a/packages/clerk-js/src/ui/signUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpContinue.tsx
@@ -32,7 +32,7 @@ function _SignUpContinue(): JSX.Element | null {
   const { navigate } = useNavigate();
   const { displayConfig, userSettings } = useEnvironment();
   const { attributes } = userSettings;
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const { navigateAfterSignUp } = useSignUpContext();
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
     getInitialActiveIdentifier(attributes),
@@ -108,7 +108,10 @@ function _SignUpContinue(): JSX.Element | null {
 
   const completeSignUpFlow = (su: SignUpResource) => {
     if (su.status === 'complete') {
-      return setSession(su.createdSessionId, navigateAfterSignUp);
+      return setActive({
+        session: su.createdSessionId,
+        beforeEmit: navigateAfterSignUp,
+      });
     } else if (su.emailAddress && su.verifications.emailAddress.status !== 'verified') {
       return navigate(displayConfig.signUpUrl + '/verify-email-address');
     } else if (su.phoneNumber && su.verifications.phoneNumber.status !== 'verified') {

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
@@ -9,7 +9,7 @@ import { SignUpStart } from './SignUpStart';
 
 const navigateMock = jest.fn();
 const mockCreateRequest = jest.fn();
-const mockSetSession = jest.fn();
+const mockSetActive = jest.fn();
 const mockAuthenticateWithRedirect = jest.fn();
 let mockUserSettings: UserSettings;
 
@@ -39,7 +39,7 @@ jest.mock('ui/contexts', () => {
     },
     useCoreClerk: jest.fn(() => ({
       frontendAPI: 'clerk.clerk.dev',
-      setSession: mockSetSession,
+      setActive: mockSetActive,
     })),
     useCoreSignUp: jest.fn(() => ({
       create: mockCreateRequest,
@@ -365,7 +365,7 @@ describe('<SignUpStart/>', () => {
           render(<SignUpStart />);
 
           await waitFor(() => {
-            expect(mockSetSession).toHaveBeenCalled();
+            expect(mockSetActive).toHaveBeenCalled();
           });
         });
 
@@ -414,7 +414,7 @@ describe('<SignUpStart/>', () => {
           );
           render(<SignUpStart />);
           await waitFor(() => {
-            expect(mockSetSession).not.toHaveBeenCalled();
+            expect(mockSetActive).not.toHaveBeenCalled();
             // Required and optional fields are rendered
             screen.getByText(/First name/);
             screen.getByText(/Last name/);
@@ -484,7 +484,7 @@ describe('<SignUpStart/>', () => {
           render(<SignUpStart />);
 
           await waitFor(() => {
-            expect(mockSetSession).not.toHaveBeenCalled();
+            expect(mockSetActive).not.toHaveBeenCalled();
             screen.getByText(/First name/);
             screen.getByText(/Last name/);
             expect(screen.queryByText('Password')).not.toBeInTheDocument();
@@ -493,7 +493,7 @@ describe('<SignUpStart/>', () => {
           // Submit the form
           userEvent.click(screen.getByRole('button', { name: 'Sign up' }));
           await waitFor(() => {
-            expect(mockSetSession).toHaveBeenCalled();
+            expect(mockSetActive).toHaveBeenCalled();
           });
         });
 

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -35,7 +35,7 @@ function _SignUpStart(): JSX.Element {
   const { navigate } = useNavigate();
   const { userSettings } = useEnvironment();
   const { attributes } = userSettings;
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const { navigateAfterSignUp } = useSignUpContext();
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
     getInitialActiveIdentifier(attributes),
@@ -175,7 +175,10 @@ function _SignUpStart(): JSX.Element {
 
   const completeSignUpFlow = (su: SignUpResource) => {
     if (su.status === 'complete') {
-      return setSession(su.createdSessionId, navigateAfterSignUp);
+      return setActive({
+        session: su.createdSessionId,
+        beforeEmit: navigateAfterSignUp,
+      });
     } else if (su.emailAddress && su.verifications.emailAddress.status !== 'verified') {
       return navigate('verify-email-address');
     } else if (su.phoneNumber && su.verifications.phoneNumber.status !== 'verified') {

--- a/packages/clerk-js/src/ui/signUp/SignUpVerify.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpVerify.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { SignUpVerifyEmailAddress, SignUpVerifyPhoneNumber } from './SignUpVerify';
 
 const navigateMock = jest.fn();
-const mockSetSession = jest.fn();
+const mockSetActive = jest.fn();
 const mockAttemptVerification = jest.fn();
 const mockStartMagicLinkFlow = jest.fn(() => {
   return Promise.resolve({
@@ -74,7 +74,7 @@ jest.mock('ui/contexts', () => {
     withCoreUserGuard: (a: any) => a,
     useCoreClerk: () => {
       return {
-        setSession: mockSetSession,
+        setActive: mockSetActive,
       };
     },
     useSignUpContext: () => {

--- a/packages/clerk-js/src/ui/signUp/SignUpVerify.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpVerify.tsx
@@ -34,7 +34,7 @@ function _SignUpVerifyPhoneNumber(): JSX.Element {
 
 function VerifyWithOtp({ field }: { field: 'emailAddress' | 'phoneNumber' }): JSX.Element {
   const { navigateAfterSignUp } = useSignUpContext();
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const signUp = useCoreSignUp();
   const identifierRef = React.useRef(signUp[field] || '');
   const codeState = useFieldState('code', '');
@@ -79,7 +79,12 @@ function VerifyWithOtp({ field }: { field: 'emailAddress' | 'phoneNumber' }): JS
         : attemptEmailAddressVerification());
 
       if (res.status === 'complete') {
-        verify(() => setSession(res.createdSessionId, navigateAfterSignUp));
+        verify(() =>
+          setActive({
+            session: res.createdSessionId,
+            beforeEmit: navigateAfterSignUp,
+          }),
+        );
       }
     } catch (err) {
       const globalErr = getGlobalError(err);

--- a/packages/clerk-js/src/ui/signUp/SignUpVerifyEmailAddressWithMagicLink.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpVerifyEmailAddressWithMagicLink.tsx
@@ -16,7 +16,7 @@ import { useMagicLink } from 'ui/hooks';
 export function SignUpVerifyEmailAddressWithMagicLink(): JSX.Element {
   const signUp = useCoreSignUp();
   const renderHappenedAfterTheDamnedSetSessionFlow = signUp.status === null;
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const identifierRef = React.useRef(signUp.emailAddress);
   const { displayConfig } = useEnvironment();
   const signUpContext = useSignUpContext();
@@ -63,7 +63,10 @@ export function SignUpVerifyEmailAddressWithMagicLink(): JSX.Element {
 
   const completeSignUpFlow = async (su: SignUpResource) => {
     if (su.status === 'complete') {
-      return setSession(su.createdSessionId, navigateAfterSignUp);
+      return setActive({
+        session: su.createdSessionId,
+        beforeEmit: navigateAfterSignUp,
+      });
     }
   };
 

--- a/packages/clerk-js/src/ui/userButton/UserButtonPopup.test.tsx
+++ b/packages/clerk-js/src/ui/userButton/UserButtonPopup.test.tsx
@@ -37,7 +37,7 @@ jest.mock('ui/contexts', () => {
     },
     useCoreClerk: () => {
       return {
-        setSession: jest.fn(),
+        setActive: jest.fn(),
         signOut: jest.fn(),
         signOutOne: jest.fn(),
       };

--- a/packages/clerk-js/src/v4/signIn/SignInStart.tsx
+++ b/packages/clerk-js/src/v4/signIn/SignInStart.tsx
@@ -14,7 +14,7 @@ import { getClerkQueryParam } from '../../utils/getClerkQueryParam';
 
 export function _SignInStart(): JSX.Element {
   const { userSettings } = useEnvironment();
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const signIn = useCoreSignIn();
   const { navigate } = useNavigate();
   const { navigateAfterSignIn } = useSignInContext();
@@ -49,7 +49,10 @@ export function _SignInStart(): JSX.Element {
           case 'needs_second_factor':
             return navigate('factor-two');
           case 'complete':
-            return setSession(res.createdSessionId, navigateAfterSignIn);
+            return setActive({
+              session: res.createdSessionId,
+              beforeEmit: navigateAfterSignIn,
+            });
           default: {
             const msg = `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`;
             alert(msg);
@@ -110,7 +113,10 @@ export function _SignInStart(): JSX.Element {
         case 'needs_second_factor':
           return navigate('factor-two');
         case 'complete':
-          return setSession(res.createdSessionId, navigateAfterSignIn);
+          return setActive({
+            session: res.createdSessionId,
+            beforeEmit: navigateAfterSignIn,
+          });
         default: {
           const msg = `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`;
           alert(msg);
@@ -137,7 +143,10 @@ export function _SignInStart(): JSX.Element {
       await signInWithFields(identifier);
     } else if (alreadySignedInError) {
       const sid = alreadySignedInError.meta!.sessionId!;
-      await setSession(sid, navigateAfterSignIn);
+      await setActive({
+        session: sid,
+        beforeEmit: navigateAfterSignIn,
+      });
     } else {
       handleError(e, [identifier, instantPassword], setError);
     }

--- a/packages/react/src/hooks/useSessionList.ts
+++ b/packages/react/src/hooks/useSessionList.ts
@@ -1,11 +1,11 @@
-import { SessionResource, SetSession } from '@clerk/types';
+import { SetActive, SessionResource, SetSession } from '@clerk/types';
 
 import { useClientContext } from '../contexts/ClientContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 
 type UseSessionListReturn =
-  | { isLoaded: false; sessions: undefined; setSession: undefined }
-  | { isLoaded: true; sessions: SessionResource[]; setSession: SetSession };
+  | { isLoaded: false; sessions: undefined; setSession: undefined; setActive: undefined }
+  | { isLoaded: true; sessions: SessionResource[]; setSession: SetSession; setActive: SetActive };
 
 type UseSessionList = () => UseSessionListReturn;
 
@@ -14,8 +14,13 @@ export const useSessionList: UseSessionList = () => {
   const client = useClientContext();
 
   if (!client) {
-    return { isLoaded: false, sessions: undefined, setSession: undefined };
+    return { isLoaded: false, sessions: undefined, setSession: undefined, setActive: undefined };
   }
 
-  return { isLoaded: true, sessions: client.sessions, setSession: isomorphicClerk.setSession };
+  return {
+    isLoaded: true,
+    sessions: client.sessions,
+    setSession: isomorphicClerk.setSession,
+    setActive: isomorphicClerk.setActive,
+  };
 };

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -1,11 +1,11 @@
-import { SetSession, SignInResource } from '@clerk/types';
+import { SetActive, SetSession, SignInResource } from '@clerk/types';
 
 import { useClientContext } from '../contexts/ClientContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 
 type UseSignInReturn =
-  | { isLoaded: false; signIn: undefined; setSession: undefined }
-  | { isLoaded: true; signIn: SignInResource; setSession: SetSession };
+  | { isLoaded: false; signIn: undefined; setSession: undefined; setActive: undefined }
+  | { isLoaded: true; signIn: SignInResource; setSession: SetSession; setActive: SetActive };
 
 type UseSignIn = () => UseSignInReturn;
 
@@ -14,8 +14,13 @@ export const useSignIn: UseSignIn = () => {
   const client = useClientContext();
 
   if (!client) {
-    return { isLoaded: false, signIn: undefined, setSession: undefined };
+    return { isLoaded: false, signIn: undefined, setSession: undefined, setActive: undefined };
   }
 
-  return { isLoaded: true, signIn: client.signIn, setSession: isomorphicClerk.setSession };
+  return {
+    isLoaded: true,
+    signIn: client.signIn,
+    setSession: isomorphicClerk.setSession,
+    setActive: isomorphicClerk.setActive,
+  };
 };

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -1,11 +1,11 @@
-import { SetSession, SignUpResource } from '@clerk/types';
+import { SetActive, SetSession, SignUpResource } from '@clerk/types';
 
 import { useClientContext } from '../contexts/ClientContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 
 type UseSignUpReturn =
-  | { isLoaded: false; signUp: undefined; setSession: undefined }
-  | { isLoaded: true; signUp: SignUpResource; setSession: SetSession };
+  | { isLoaded: false; signUp: undefined; setSession: undefined; setActive: undefined }
+  | { isLoaded: true; signUp: SignUpResource; setSession: SetSession; setActive: SetActive };
 
 type UseSignUp = () => UseSignUpReturn;
 
@@ -14,8 +14,13 @@ export const useSignUp: UseSignUp = () => {
   const client = useClientContext();
 
   if (!client) {
-    return { isLoaded: false, signUp: undefined, setSession: undefined };
+    return { isLoaded: false, signUp: undefined, setSession: undefined, setActive: undefined };
   }
 
-  return { isLoaded: true, signUp: client.signUp, setSession: isomorphicClerk.setSession };
+  return {
+    isLoaded: true,
+    signUp: client.signUp,
+    setSession: isomorphicClerk.setSession,
+    setActive: isomorphicClerk.setActive,
+  };
 };

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -9,6 +9,7 @@ import type {
   OrganizationResource,
   RedirectOptions,
   Resources,
+  SetActiveParams,
   SignInProps,
   SignOut,
   SignOutCallback,
@@ -238,15 +239,20 @@ export default class IsomorphicClerk {
     }
   }
 
+  setActive = ({ session, organization, beforeEmit }: SetActiveParams): Promise<void> => {
+    if (this.clerkjs) {
+      return this.clerkjs.setActive({ session, organization, beforeEmit });
+    } else {
+      return Promise.reject();
+    }
+  };
+
+  /** @deprecated Use `setActive` instead */
   setSession = (
     session: ActiveSessionResource | string | null,
     beforeEmit?: (session: ActiveSessionResource | null) => void | Promise<any>,
   ): Promise<void> => {
-    if (this.clerkjs) {
-      return this.clerkjs.setActive({ session, beforeEmit });
-    } else {
-      return Promise.reject();
-    }
+    return this.setActive({ session, beforeEmit });
   };
 
   openSignIn = (props?: SignInProps): void => {

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -243,7 +243,7 @@ export default class IsomorphicClerk {
     beforeEmit?: (session: ActiveSessionResource | null) => void | Promise<any>,
   ): Promise<void> => {
     if (this.clerkjs) {
-      return this.clerkjs.setSession(session, beforeEmit);
+      return this.clerkjs.setActive({ session, beforeEmit });
     } else {
       return Promise.reject();
     }

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -322,10 +322,16 @@ export type RedirectOptions = {
 
 export type SetActiveParams = {
   /**
-   * The session resource or session id (string version).
+   * The session resource or session id (string version) to be set as active.
    * If `null`, the current session is deleted.
    */
   session?: ActiveSessionResource | string | null;
+
+  /**
+   * The organization id to be set as active in the current session.
+   * If `null`, the currently active organization is removed as active.
+   */
+  organization?: string | null;
 
   /**
    * Callback run just before the active session and/or organization is set to the passed object.

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -161,6 +161,14 @@ export interface Clerk {
   addListener: (callback: ListenerCallback) => UnsubscribeCallback;
 
   /**
+   * Set the active session and organization explicitly.
+   *
+   * If the session param is `null`, the active session is deleted.
+   * In a similar fashion, if the organization param is `null`, the current organization is removed as active.
+   */
+  setActive: (params: SetActiveParams) => Promise<void>;
+
+  /**
    * Set the current session explicitly.
    *
    * Setting the session to `null` deletes the active session.
@@ -310,6 +318,20 @@ export type RedirectOptions = {
    * to the same value.
    */
   redirectUrl?: string | null;
+};
+
+export type SetActiveParams = {
+  /**
+   * The session resource or session id (string version).
+   * If `null`, the current session is deleted.
+   */
+  session?: ActiveSessionResource | string | null;
+
+  /**
+   * Callback run just before the active session and/or organization is set to the passed object.
+   * Can be used to hook up for pre-navigation actions.
+   */
+  beforeEmit?: BeforeEmitCallback;
 };
 
 export type SignInProps = {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -166,7 +166,7 @@ export interface Clerk {
    * If the session param is `null`, the active session is deleted.
    * In a similar fashion, if the organization param is `null`, the current organization is removed as active.
    */
-  setActive: (params: SetActiveParams) => Promise<void>;
+  setActive: SetActive;
 
   /**
    * Set the current session explicitly.
@@ -339,6 +339,8 @@ export type SetActiveParams = {
    */
   beforeEmit?: BeforeEmitCallback;
 };
+
+export type SetActive = (params: SetActiveParams) => Promise<void>;
 
 export type SignInProps = {
   /*


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This PR introduces a new method called `setActive`. 
This basically replaces the older `setSession` which is now deprecated.

In addition to setting the active session, it can also be used to set the active organization for the session.
Its signature is:
```
export type SetActiveParams = {
  session?: ActiveSessionResource | string | null;
  organization?: string | null;
  beforeEmit?: BeforeEmitCallback;
};

setActive: (SetActiveParams) => Promise<void>;
```

The session parameter can accept either an `ActiveSessionResource` or the id of such a session. It also accepts `null` in which case the current session will be removed.

The organization parameter accepts the id that we want to set as active in the session.
If no session parameter is passed, the currently active session will be used. Otherwise, the organization will be set as active in the passed session.
Please note that passing a `null` organization id means that the currently active organization will be removed as active.

<!-- Fixes # (issue number) -->
