### PR TITLE
fix(types,clerk-js): Same component navigate after OAuth flow with missing requirements

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -497,7 +497,8 @@ export default class Clerk implements ClerkInterface {
     );
 
     const navigateToContinueSignUp = makeNavigate(
-      buildURL({ base: displayConfig.signUpUrl, hashPath: '/continue' }, { stringify: true }),
+      params.continueSignUpUrl ||
+        buildURL({ base: displayConfig.signUpUrl, hashPath: '/continue' }, { stringify: true }),
     );
 
     const userExistsButNeedsToSignIn =

--- a/packages/clerk-js/src/ui/signUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUp.tsx
@@ -35,6 +35,7 @@ function SignUpRoutes(): JSX.Element {
           afterSignInUrl={signUpContext.afterSignInUrl}
           redirectUrl={signUpContext.redirectUrl}
           secondFactorUrl={signUpContext.secondFactorUrl}
+          continueSignUpUrl='../continue'
         />
       </Route>
       <Route path='verify'>

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -275,6 +275,11 @@ export type HandleOAuthCallbackParams = {
    * if 2FA is enabled.
    */
   secondFactorUrl?: string;
+
+  /**
+   * Full URL or path to navigate after an incomplete sign up.
+   */
+  continueSignUpUrl?: string | null;
 };
 
 // TODO: Make sure Isomorphic Clerk navigate can work with the correct type:


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This commit fixes a navigation bug, after a successful OAuth flow but the sign up still missing some requirements to complete. We navigate to SignUpContinue form and as this is a same component navigation, it didn't properly work before

<!-- Fixes # (issue number) -->
