### PR TITLE
feat(types,clerk-js): Support required/optional email/phone for Progressive sign up instances

### DIFF
--- a/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
@@ -99,6 +99,9 @@ describe('<SignUpContinue/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
   });
 
@@ -161,6 +164,29 @@ describe('<SignUpContinue/>', () => {
   });
 
   it('patches the existing signup when user submits the form', async () => {
+    (useCoreSignUp as jest.Mock).mockImplementation(() => {
+      return {
+        id: 'su_perman',
+        update: mockUpdateRequest,
+        verifications: {
+          externalAccount: {
+            status: 'verified',
+          },
+          emailAddress: {
+            status: 'unverified',
+          },
+          phoneNumber: {
+            status: 'verified',
+          },
+        },
+        firstName: null,
+        lastName: null,
+        emailAddress: 'bryan@taken.com',
+        phoneNumber: '+12125551001',
+        username: 'bryanmills',
+      };
+    });
+
     mockUpdateRequest.mockImplementation(() =>
       Promise.resolve({
         firstName: 'Bryan',
@@ -264,6 +290,9 @@ describe('<SignUpContinue/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
 
     mockUpdateRequest.mockImplementation(() =>
@@ -276,6 +305,27 @@ describe('<SignUpContinue/>', () => {
         },
       }),
     );
+
+    (useCoreSignUp as jest.Mock).mockImplementation(() => {
+      return {
+        id: 'su_perman',
+        update: mockUpdateRequest,
+        verifications: {
+          externalAccount: {
+            status: 'verified',
+          },
+          emailAddress: {
+            status: 'verified',
+          },
+          phoneNumber: {
+            status: 'unverified',
+          },
+        },
+        emailAddress: 'bryan@taken.com',
+        phoneNumber: '+15615551001',
+        username: 'bryanmills',
+      };
+    });
 
     render(<SignUpContinue />);
 
@@ -367,6 +417,9 @@ describe('<SignUpContinue/>', () => {
           enabled: true,
           strategy: 'oauth_facebook',
         },
+      },
+      sign_up: {
+        progressive: false,
       },
     } as UserSettingsJSON);
 

--- a/packages/clerk-js/src/ui/signUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpContinue.tsx
@@ -20,7 +20,7 @@ import { SignInLink } from './SignInLink';
 import {
   ActiveIdentifier,
   determineActiveFields,
-  emailOrPhoneUsedForFF,
+  emailOrPhone,
   getInitialActiveIdentifier,
   minimizeFieldsForExistingSignup,
   showFormFields,
@@ -35,9 +35,10 @@ function _SignUpContinue(): JSX.Element | null {
   const { setActive } = useCoreClerk();
   const { navigateAfterSignUp } = useSignUpContext();
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
-    getInitialActiveIdentifier(attributes),
+    getInitialActiveIdentifier(attributes, userSettings.signUp.progressive),
   );
   const signUp = useCoreSignUp();
+  const isProgressiveSignUp = userSettings.signUp.progressive;
 
   // Redirect to sign-up if there is no persisted sign-up
 
@@ -71,6 +72,7 @@ function _SignUpContinue(): JSX.Element | null {
     hasEmail,
     activeCommIdentifierType,
     signUp,
+    isProgressiveSignUp,
   });
 
   minimizeFieldsForExistingSignup(fields, signUp);
@@ -81,7 +83,7 @@ function _SignUpContinue(): JSX.Element | null {
   const handleChangeActive = (type: ActiveIdentifier) => (e: React.MouseEvent) => {
     e.preventDefault();
 
-    if (!emailOrPhoneUsedForFF(attributes)) {
+    if (!emailOrPhone(attributes, isProgressiveSignUp)) {
       return;
     }
 
@@ -165,7 +167,7 @@ function _SignUpContinue(): JSX.Element | null {
             <SignUpForm
               fields={fields}
               formState={formState}
-              toggleEmailPhone={emailOrPhoneUsedForFF(attributes)}
+              toggleEmailPhone={emailOrPhone(attributes, isProgressiveSignUp)}
               handleSubmit={handleSubmit}
               handleChangeActive={handleChangeActive}
             />

--- a/packages/clerk-js/src/ui/signUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpForm.tsx
@@ -85,14 +85,14 @@ export function SignUpForm({
           </Control>
         )}
 
-        {fields.emailAddress && (
+        {fields.emailAddress?.show && (
           <Control
             key='emailAddress'
             htmlFor='emailAddress'
             label='Email address'
             error={formState.emailAddress.error}
-            hint={toggleEmailPhone ? 'Use phone instead' : undefined}
-            hintOnClickHandler={handleChangeActive('phoneNumber')}
+            hint={toggleEmailPhone ? 'Use phone instead' : fields.emailAddress.required ? undefined : 'Optional'}
+            hintOnClickHandler={toggleEmailPhone ? handleChangeActive('phoneNumber') : undefined}
           >
             <Input
               id='emailAddress'
@@ -105,14 +105,14 @@ export function SignUpForm({
           </Control>
         )}
 
-        {fields.phoneNumber && (
+        {fields.phoneNumber?.show && (
           <Control
             key='phoneNumber'
             htmlFor='phoneNumber'
             label='Phone number'
             error={formState.phoneNumber.error}
-            hint={toggleEmailPhone ? 'Use email instead' : undefined}
-            hintOnClickHandler={handleChangeActive('emailAddress')}
+            hint={toggleEmailPhone ? 'Use email instead' : fields.phoneNumber.required ? undefined : 'Optional'}
+            hintOnClickHandler={toggleEmailPhone ? handleChangeActive('emailAddress') : undefined}
           >
             <PhoneInput
               id='phoneNumber'

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
@@ -126,6 +126,9 @@ describe('<SignUpStart/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
   });
 
@@ -254,6 +257,9 @@ describe('<SignUpStart/>', () => {
           strategy: 'oauth_facebook',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
 
     render(<SignUpStart />);
@@ -347,6 +353,9 @@ describe('<SignUpStart/>', () => {
                 required: false,
               },
             },
+            sign_up: {
+              progressive: false,
+            },
           } as UserSettingsJSON);
         });
 
@@ -398,6 +407,9 @@ describe('<SignUpStart/>', () => {
                 enabled: true,
                 required: true,
               },
+            },
+            sign_up: {
+              progressive: false,
             },
           } as UserSettingsJSON);
 
@@ -472,6 +484,9 @@ describe('<SignUpStart/>', () => {
                 required: false,
               },
             },
+            sign_up: {
+              progressive: false,
+            },
           } as UserSettingsJSON);
 
           mockCreateRequest.mockImplementation(() =>
@@ -524,6 +539,9 @@ describe('<SignUpStart/>', () => {
                 enabled: true,
                 required: false,
               },
+            },
+            sign_up: {
+              progressive: false,
             },
           } as UserSettingsJSON);
 
@@ -580,10 +598,160 @@ describe('<SignUpStart/>', () => {
           strategy: 'oauth_google',
         },
       },
+      sign_up: {
+        progressive: false,
+      },
     } as UserSettingsJSON);
 
     render(<SignUpStart />);
     expect(screen.queryByRole('button', { name: 'Sign up' })).not.toBeInTheDocument();
     expect(screen.queryByText('Password')).not.toBeInTheDocument();
+  });
+});
+
+describe('<SignUpStart/> Progressive Sign Up', () => {
+  const mockUserSettingsProgressive = {
+    attributes: {
+      password: {
+        enabled: true,
+        required: false,
+      },
+      username: {
+        enabled: false,
+        required: false,
+      },
+      first_name: {
+        enabled: false,
+        required: false,
+      },
+      last_name: {
+        enabled: false,
+        required: false,
+      },
+    },
+    sign_up: {
+      progressive: true,
+    },
+  } as UserSettingsJSON;
+
+  it('renders email input if required', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: false,
+          required: false,
+          used_for_first_factor: true,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+    expect(screen.queryByText('Phone number')).not.toBeInTheDocument();
+  });
+
+  it('renders phone input if required', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: false,
+          required: false,
+          used_for_first_factor: true,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.queryByText('Email address')).not.toBeInTheDocument();
+    expect(screen.getByText('Phone number')).toBeInTheDocument();
+  });
+
+  it('renders both email & phone inputs if required', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: false,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+    expect(screen.getByText('Phone number')).toBeInTheDocument();
+  });
+
+  it('renders optional email/phone input if email OR phone', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: true,
+        },
+        phone_number: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: true,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Use phone instead'));
+    expect(screen.getByText('Phone number')).toBeInTheDocument();
+  });
+  it('renders required phone & optional email inputs', () => {
+    mockUserSettings = new UserSettings({
+      ...mockUserSettingsProgressive,
+      attributes: {
+        ...mockUserSettingsProgressive.attributes,
+        email_address: {
+          enabled: true,
+          required: false,
+          used_for_first_factor: true,
+        },
+        phone_number: {
+          enabled: true,
+          required: true,
+          used_for_first_factor: true,
+        },
+      },
+    } as UserSettingsJSON);
+
+    render(<SignUpStart />);
+
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+    expect(screen.getByText('Optional')).toBeInTheDocument();
+    expect(screen.getByText('Phone number')).toBeInTheDocument();
   });
 });

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -24,7 +24,7 @@ import { SignUpForm } from './SignUpForm';
 import {
   ActiveIdentifier,
   determineActiveFields,
-  emailOrPhoneUsedForFF,
+  emailOrPhone,
   getInitialActiveIdentifier,
   showFormFields,
 } from './signUpFormHelpers';
@@ -38,7 +38,7 @@ function _SignUpStart(): JSX.Element {
   const { setActive } = useCoreClerk();
   const { navigateAfterSignUp } = useSignUpContext();
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
-    getInitialActiveIdentifier(attributes),
+    getInitialActiveIdentifier(attributes, userSettings.signUp.progressive),
   );
   const signUp = useCoreSignUp();
   const [isLoading, setIsLoading] = React.useState(false);
@@ -62,12 +62,14 @@ function _SignUpStart(): JSX.Element {
   const [error, setError] = React.useState<string | undefined>();
   const hasTicket = !!formState.ticket.value;
   const hasEmail = !!formState.emailAddress.value;
+  const isProgressiveSignUp = userSettings.signUp.progressive;
 
   const fields = determineActiveFields({
     attributes,
     hasTicket,
     hasEmail,
     activeCommIdentifierType,
+    isProgressiveSignUp,
   });
 
   const oauthOptions = userSettings.socialProviderStrategies;
@@ -138,7 +140,7 @@ function _SignUpStart(): JSX.Element {
   const handleChangeActive = (type: ActiveIdentifier) => (e: React.MouseEvent) => {
     e.preventDefault();
 
-    if (!emailOrPhoneUsedForFF(attributes)) {
+    if (!emailOrPhone(attributes, isProgressiveSignUp)) {
       return;
     }
 
@@ -149,7 +151,7 @@ function _SignUpStart(): JSX.Element {
     e.preventDefault();
 
     const fieldsToSubmit = Object.entries(fields).reduce(
-      (acc, [k, v]) => [...acc, ...(v && formState[k as FormStateKey] ? [formState[k as FormStateKey]] : [])],
+      (acc, [k, v]) => [...acc, ...(v && formState[k as FormStateKey]?.value ? [formState[k as FormStateKey]] : [])],
       [] as Array<FieldState<any>>,
     );
 
@@ -221,7 +223,7 @@ function _SignUpStart(): JSX.Element {
             <SignUpForm
               fields={fields}
               formState={formState}
-              toggleEmailPhone={emailOrPhoneUsedForFF(attributes)}
+              toggleEmailPhone={emailOrPhone(attributes, isProgressiveSignUp)}
               handleSubmit={handleSubmit}
               handleChangeActive={handleChangeActive}
             />

--- a/packages/clerk-js/src/ui/signUp/signUpFormHelpers.test.ts
+++ b/packages/clerk-js/src/ui/signUp/signUpFormHelpers.test.ts
@@ -5,6 +5,7 @@ describe('determineActiveFields()', () => {
   // and the current Instance User settings options
   describe('returns first party field based on auth config', () => {
     type Scenario = [string, any, any];
+    const isProgressiveSignUp = false;
 
     const scenaria: Scenario[] = [
       [
@@ -41,6 +42,11 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: true,
             disabled: false,
+            show: true,
+          },
+          phoneNumber: {
+            required: true,
+            show: false,
           },
           firstName: {
             required: true,
@@ -87,8 +93,14 @@ describe('determineActiveFields()', () => {
           },
         },
         {
+          emailAddress: {
+            required: true,
+            disabled: false,
+            show: false,
+          },
           phoneNumber: {
             required: true,
+            show: true,
           },
           firstName: {
             required: true,
@@ -138,6 +150,11 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: true, // email will be toggled on initially
             disabled: false,
+            show: true,
+          },
+          phoneNumber: {
+            required: true,
+            show: false,
           },
           firstName: {
             required: true,
@@ -184,6 +201,15 @@ describe('determineActiveFields()', () => {
           },
         },
         {
+          emailAddress: {
+            required: true,
+            disabled: false,
+            show: false,
+          },
+          phoneNumber: {
+            required: true,
+            show: false,
+          },
           firstName: {
             required: false,
           },
@@ -228,7 +254,17 @@ describe('determineActiveFields()', () => {
             required: false,
           },
         },
-        {},
+        {
+          emailAddress: {
+            required: true,
+            disabled: false,
+            show: false,
+          },
+          phoneNumber: {
+            required: true,
+            show: false,
+          },
+        },
       ],
     ];
 
@@ -236,7 +272,8 @@ describe('determineActiveFields()', () => {
       expect(
         determineActiveFields({
           attributes: attributes,
-          activeCommIdentifierType: getInitialActiveIdentifier(attributes),
+          activeCommIdentifierType: getInitialActiveIdentifier(attributes, isProgressiveSignUp),
+          isProgressiveSignUp,
         }),
       ).toEqual(result);
     });
@@ -255,7 +292,8 @@ describe('determineActiveFields()', () => {
       const res = determineActiveFields({
         attributes: attributes,
         hasTicket: true,
-        activeCommIdentifierType: getInitialActiveIdentifier(attributes),
+        activeCommIdentifierType: getInitialActiveIdentifier(attributes, isProgressiveSignUp),
+        isProgressiveSignUp,
       });
 
       expect(res).toMatchObject(expected);
@@ -276,10 +314,210 @@ describe('determineActiveFields()', () => {
         attributes: attributes,
         hasTicket: true,
         hasEmail: true,
-        activeCommIdentifierType: getInitialActiveIdentifier(attributes),
+        activeCommIdentifierType: getInitialActiveIdentifier(attributes, isProgressiveSignUp),
+        isProgressiveSignUp,
       });
 
       expect(res).toMatchObject(expected);
+    });
+  });
+
+  describe('calculates active fields based on user settings for Progressive Sign up', () => {
+    type Scenario = [string, any, any];
+    const isProgressiveSignUp = true;
+
+    const mockDefaultAttributesProgressive = {
+      first_name: {
+        enabled: false,
+        required: false,
+      },
+      last_name: {
+        enabled: false,
+        required: false,
+      },
+      password: {
+        enabled: false,
+        required: false,
+      },
+      username: {
+        enabled: false,
+        required: false,
+      },
+    };
+
+    const scenarios: Scenario[] = [
+      [
+        'email required',
+        {
+          ...mockDefaultAttributesProgressive,
+          email_address: {
+            enabled: true,
+            required: true,
+            used_for_first_factor: false,
+          },
+          phone_number: {
+            enabled: false,
+            required: false,
+            used_for_first_factor: true,
+          },
+        },
+        {
+          emailAddress: {
+            required: true,
+            disabled: false,
+            show: true,
+          },
+          phoneNumber: {
+            required: false,
+            show: false,
+          },
+        },
+      ],
+      [
+        'phone required',
+        {
+          ...mockDefaultAttributesProgressive,
+          email_address: {
+            enabled: false,
+            required: false,
+            used_for_first_factor: true,
+          },
+          phone_number: {
+            enabled: true,
+            required: true,
+            used_for_first_factor: false,
+          },
+        },
+        {
+          emailAddress: {
+            required: false,
+            disabled: false,
+            show: false,
+          },
+          phoneNumber: {
+            required: true,
+            show: true,
+          },
+        },
+      ],
+      [
+        'email & phone required',
+        {
+          ...mockDefaultAttributesProgressive,
+          phone_number: {
+            enabled: true,
+            required: true,
+            used_for_first_factor: false,
+          },
+          email_address: {
+            enabled: true,
+            required: true,
+            used_for_first_factor: false,
+          },
+        },
+        {
+          emailAddress: {
+            required: true,
+            disabled: false,
+            show: true,
+          },
+          phoneNumber: {
+            required: true,
+            show: true,
+          },
+        },
+      ],
+      [
+        'email OR phone',
+        {
+          ...mockDefaultAttributesProgressive,
+          phone_number: {
+            enabled: true,
+            required: false,
+            used_for_first_factor: true,
+          },
+          email_address: {
+            enabled: true,
+            required: false,
+            used_for_first_factor: true,
+          },
+        },
+        {
+          emailAddress: {
+            required: false, // email will be toggled on initially
+            disabled: false,
+            show: true,
+          },
+          phoneNumber: {
+            required: false,
+            show: false,
+          },
+        },
+      ],
+      [
+        'email required, phone optional',
+        {
+          ...mockDefaultAttributesProgressive,
+          phone_number: {
+            enabled: true,
+            required: false,
+            used_for_first_factor: true,
+          },
+          email_address: {
+            enabled: true,
+            required: true,
+            used_for_first_factor: true,
+          },
+        },
+        {
+          emailAddress: {
+            required: true,
+            disabled: false,
+            show: true,
+          },
+          phoneNumber: {
+            required: false,
+            show: true,
+          },
+        },
+      ],
+      [
+        'phone required, email optional',
+        {
+          ...mockDefaultAttributesProgressive,
+          phone_number: {
+            enabled: true,
+            required: true,
+            used_for_first_factor: true,
+          },
+          email_address: {
+            enabled: true,
+            required: false,
+            used_for_first_factor: true,
+          },
+        },
+        {
+          emailAddress: {
+            required: false,
+            disabled: false,
+            show: true,
+          },
+          phoneNumber: {
+            required: true,
+            show: true,
+          },
+        },
+      ],
+    ];
+
+    it.each(scenarios)('%s', (___, attributes, result) => {
+      expect(
+        determineActiveFields({
+          attributes: attributes,
+          activeCommIdentifierType: getInitialActiveIdentifier(attributes, isProgressiveSignUp),
+          isProgressiveSignUp,
+        }),
+      ).toEqual(result);
     });
   });
 });

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -41,6 +41,7 @@ export type SignInData = {
 
 export type SignUpData = {
   allowlist_only: boolean;
+  progressive: boolean;
 };
 
 export type OAuthProviders = {


### PR DESCRIPTION


## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Add support in signUp form, for required/optional email address & phone number inputs. The feature is only supported for instances opt-in to upcoming Progressive sign up feature.

Below you can find some new scenarios that this PR adds ability for

### Required email & phone

![Screenshot 2022-05-31 at 12 50 17 PM](https://user-images.githubusercontent.com/22435234/171147443-467a61ec-f72c-4f3d-8de3-c808dce0bd1e.png)

### Required email/phone & optional phone/email

![Screenshot 2022-05-31 at 12 50 32 PM](https://user-images.githubusercontent.com/22435234/171147464-d3278380-07c8-40bc-b69f-771bbd2af61f.png)

<!-- Fixes # (issue number) -->
