### PR TITLE
fix(clerk-js): Do not show verification status badges for ext accnts …

### DIFF
--- a/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
@@ -124,11 +124,6 @@ Array [
                     src="https://images.clerk.dev/static/facebook.svg"
                   />
                   peter@gmail.com
-                  <span
-                    className="tag success sm cl-tag"
-                  >
-                    Verified
-                  </span>
                 </div>
               </div>
             </div>

--- a/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.tsx
+++ b/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.tsx
@@ -72,12 +72,8 @@ export function ProfileCard(): JSX.Element {
                   src={svgUrl(externalAccount.provider)}
                   className='cl-left-icon-wrapper'
                 />
-                {externalAccount.emailAddress}
 
-                <VerificationStatusTag
-                  className='cl-tag'
-                  status={externalAccount.verification?.status || 'verified'}
-                />
+                {externalAccount.username || externalAccount.emailAddress}
               </div>
             ))}
           </div>

--- a/packages/clerk-js/src/ui/userProfile/account/profileCard/__snapshots__/ProfileCard.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/account/profileCard/__snapshots__/ProfileCard.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`<ProfileCard/> renders the ProfileCard 1`] = `
 </div>
 `;
 
-exports[`<ProfileCard/> renders the ProfileCard with enabled settings 1`] = `
+exports[`<ProfileCard/> renders the ProfileCard with web3 wallet 1`] = `
 <div
   className="card card cl-themed-card"
 >
@@ -400,6 +400,213 @@ exports[`<ProfileCard/> renders the ProfileCard with enabled settings 1`] = `
         <div
           className="iconContainer"
         />
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<ProfileCard/> renders the profile card with verified external accounts 1`] = `
+<div
+  className="card card cl-themed-card"
+>
+  <div
+    className="titleContainer"
+  >
+    <h1
+      className="title"
+    >
+      Profile
+    </h1>
+    <p
+      className="subtitle"
+    >
+      Manage profile settings
+    </p>
+  </div>
+  <div
+    className="cl-titled-card-list"
+  >
+    <div
+      className="cl-list-item elementContainer"
+      disabled={false}
+    >
+      <div
+        className="title"
+      >
+        Photo
+      </div>
+      <div
+        className="listItem line"
+      >
+        <div
+          className="start"
+        >
+          <div
+            className="uploaderWrapper wrapper"
+            onClick={[Function]}
+          >
+            <img
+              alt=""
+              className="avatar cl-image"
+              height={64}
+              onError={[Function]}
+              src="https://www.gravatar.com/avatar?d=mp"
+              title=""
+              width={64}
+            />
+            <div
+              className="touchContainer"
+            >
+              <svg
+                data-filename="../shared/assets/icons/camera.svg"
+              />
+            </div>
+            <div
+              className="hoverContainer"
+            >
+              <svg
+                data-filename="../shared/assets/icons/camera.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="iconContainer"
+        />
+      </div>
+    </div>
+    <button
+      className="cl-list-item elementContainer button hoverable"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <div
+        className="title"
+      >
+        Email
+      </div>
+      <div
+        className="listItem line"
+      >
+        <div
+          className="start"
+        >
+          <div
+            className="cl-list-item-entry"
+          >
+            <div>
+              clerk@clerk.dev
+              <span
+                className="tag primary sm"
+              >
+                Primary
+              </span>
+              <span
+                className="tag success sm cl-tag"
+              >
+                Verified
+              </span>
+            </div>
+            <div>
+              clerk-unverified@clerk.dev
+              <span
+                className="tag primary sm"
+              >
+                Primary
+              </span>
+              <span
+                className="tag error sm cl-tag"
+              >
+                Unverified
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iconContainer"
+        >
+          <svg
+            data-filename="../shared/assets/icons/arrow-right.svg"
+          />
+        </div>
+      </div>
+    </button>
+    <button
+      className="cl-list-item elementContainer button hoverable"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <div
+        className="title"
+      >
+        Phone number
+      </div>
+      <div
+        className="listItem line"
+      >
+        <div
+          className="start"
+        >
+          <div
+            className="cl-empty-list-item"
+          >
+            None
+          </div>
+        </div>
+        <div
+          className="iconContainer"
+        >
+          <svg
+            data-filename="../shared/assets/icons/arrow-right.svg"
+          />
+        </div>
+      </div>
+    </button>
+    <button
+      className="cl-list-item elementContainer button hoverable"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <div
+        className="title"
+      >
+        Connected accounts
+      </div>
+      <div
+        className="listItem line"
+      >
+        <div
+          className="start"
+        >
+          <div
+            className="cl-list-item-entry"
+          >
+            <div>
+              <img
+                alt="Google"
+                className="cl-left-icon-wrapper"
+                src="https://images.clerk.dev/static/google.svg"
+              />
+              sanjay@gmail.com
+            </div>
+            <div>
+              <img
+                alt="Twitch"
+                className="cl-left-icon-wrapper"
+                src="https://images.clerk.dev/static/twitch.svg"
+              />
+              dhalsim
+            </div>
+          </div>
+        </div>
+        <div
+          className="iconContainer"
+        >
+          <svg
+            data-filename="../shared/assets/icons/arrow-right.svg"
+          />
+        </div>
       </div>
     </button>
   </div>

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/UnverifiedAccountListItem.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/UnverifiedAccountListItem.tsx
@@ -53,6 +53,7 @@ export function UnverifiedAccountListItem({
           src={svgUrl(externalAccount.provider)}
           className='cl-left-icon-wrapper'
         />
+
         {externalAccount.username || externalAccount.emailAddress}
 
         {externalAccount.label && ` (${externalAccount.label})`}


### PR DESCRIPTION
…on the user profile page

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

Showing a verified badge next to an external account that provides unverified emails can give the false impression that the email is verified as well.

To avoid this, the verification status badge will be skipped for now on the user profile page.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/5611795/171169770-cda716fe-b8c1-4ccf-a0b9-4a48629c5716.png)

### After

![image](https://user-images.githubusercontent.com/5611795/171169850-6ae1dbb3-4a41-448d-847f-5a56ffd66b57.png)

## Related issue

https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=531db68c98394e709bafd5b5e1df4add&p=18e0ee3150734aa5b432ecbc79eeb57d
