### PR TITLE
feat(clerk-js): Support multiple unverified identifiers during Sign up flow

### DIFF
--- a/packages/clerk-js/src/ui/common/verifyMagicLink/VerifyMagicLink.test.tsx
+++ b/packages/clerk-js/src/ui/common/verifyMagicLink/VerifyMagicLink.test.tsx
@@ -32,6 +32,9 @@ jest.mock('ui/contexts', () => {
         branded: true,
       },
     })),
+    useCoreSignUp: jest.fn(() => ({
+      status: 'complete',
+    })),
   };
 });
 

--- a/packages/clerk-js/src/ui/common/verifyMagicLink/VerifyMagicLink.tsx
+++ b/packages/clerk-js/src/ui/common/verifyMagicLink/VerifyMagicLink.tsx
@@ -2,36 +2,42 @@ import { isMagicLinkError, MagicLinkErrorCode } from 'core/resources/internal';
 import React, { useEffect, useState } from 'react';
 import type { MagicLinkVerificationStatusModalProps } from 'ui/common';
 import { MagicLinkVerificationStatusModal } from 'ui/common';
-import { useCoreClerk } from 'ui/contexts';
+import { useCoreClerk, useCoreSignUp } from 'ui/contexts';
 import { useNavigate } from 'ui/hooks';
+import { completeSignUpFlow } from 'ui/signUp/util';
 import type { VerificationStatus } from 'utils/getClerkQueryParam';
 
 type VerifyMagicLinkProps = Pick<MagicLinkVerificationStatusModalProps, 'successHeader'> & {
   redirectUrlComplete?: string;
   redirectUrl?: string;
+  verifyEmailPath?: string;
+  verifyPhonePath?: string;
 };
 
 export function VerifyMagicLink({
   successHeader,
   redirectUrlComplete,
   redirectUrl,
+  verifyEmailPath,
+  verifyPhonePath,
 }: VerifyMagicLinkProps): JSX.Element | null {
   const { handleMagicLinkVerification } = useCoreClerk();
   const { navigate } = useNavigate();
-
+  const signUp = useCoreSignUp();
   const [verificationStatus, setVerificationStatus] = useState<VerificationStatus>('loading');
 
   useEffect(() => {
     const verify = async () => {
       try {
-        await handleMagicLinkVerification(
-          {
-            redirectUrlComplete,
-            redirectUrl,
-          },
-          navigate,
-        );
+        await handleMagicLinkVerification({ redirectUrlComplete, redirectUrl }, navigate);
         setVerificationStatus('verified');
+
+        return completeSignUpFlow({
+          signUp,
+          verifyEmailPath,
+          verifyPhonePath,
+          navigate,
+        });
       } catch (err) {
         let status: VerificationStatus = 'failed';
         if (isMagicLinkError(err) && err.code === MagicLinkErrorCode.Expired) {

--- a/packages/clerk-js/src/ui/signUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUp.tsx
@@ -39,7 +39,11 @@ function SignUpRoutes(): JSX.Element {
         />
       </Route>
       <Route path='verify'>
-        <VerifyMagicLink redirectUrlComplete={signUpContext.afterSignUpUrl || signUpContext.redirectUrl || undefined} />
+        <VerifyMagicLink
+          redirectUrlComplete={signUpContext.afterSignUpUrl || signUpContext.redirectUrl || undefined}
+          verifyEmailPath='../verify-email-address'
+          verifyPhonePath='../verify-phone-number'
+        />
       </Route>
       <Route path='continue'>
         <SignUpContinue />

--- a/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpContinue.test.tsx
@@ -8,7 +8,7 @@ import { SignUpContinue } from './SignUpContinue';
 
 const navigateMock = jest.fn();
 const mockUpdateRequest = jest.fn();
-const mockSetActive = jest.fn();
+const mockSetSession = jest.fn();
 let mockUserSettings: UserSettings;
 
 jest.mock('ui/router/RouteContext');
@@ -28,7 +28,7 @@ jest.mock('ui/contexts', () => {
     },
     useCoreClerk: jest.fn(() => ({
       frontendAPI: 'clerk.clerk.dev',
-      setActive: mockSetActive,
+      setSession: mockSetSession,
     })),
     useCoreSignUp: jest.fn(() => ({
       verifications: {
@@ -192,11 +192,8 @@ describe('<SignUpContinue/>', () => {
         firstName: 'Bryan',
         lastName: 'Mills',
         emailAddress: 'bryan@taken.com',
-        verifications: {
-          emailAddress: {
-            status: 'unverified',
-          },
-        },
+        status: 'missing_requirements',
+        unverifiedFields: ['email_address'],
       }),
     );
 
@@ -220,7 +217,7 @@ describe('<SignUpContinue/>', () => {
         email_address: 'bryan@taken.com',
       });
       expect(navigateMock).toHaveBeenCalledTimes(1);
-      expect(navigateMock).toHaveBeenCalledWith('http://test.host/sign-up/verify-email-address');
+      expect(navigateMock).toHaveBeenCalledWith('../verify-email-address');
     });
   });
 
@@ -298,11 +295,8 @@ describe('<SignUpContinue/>', () => {
     mockUpdateRequest.mockImplementation(() =>
       Promise.resolve({
         phoneNumber: '+15615551001',
-        verifications: {
-          phoneNumber: {
-            status: 'unverified',
-          },
-        },
+        status: 'missing_requirements',
+        unverifiedFields: ['phone_number'],
       }),
     );
 
@@ -341,7 +335,7 @@ describe('<SignUpContinue/>', () => {
         phone_number: '+15615551001',
       });
       expect(navigateMock).toHaveBeenCalledTimes(1);
-      expect(navigateMock).toHaveBeenCalledWith('http://test.host/sign-up/verify-phone-number');
+      expect(navigateMock).toHaveBeenCalledWith('../verify-phone-number');
     });
   });
 

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.test.tsx
@@ -9,7 +9,7 @@ import { SignUpStart } from './SignUpStart';
 
 const navigateMock = jest.fn();
 const mockCreateRequest = jest.fn();
-const mockSetActive = jest.fn();
+const mockSetSession = jest.fn();
 const mockAuthenticateWithRedirect = jest.fn();
 let mockUserSettings: UserSettings;
 
@@ -39,7 +39,7 @@ jest.mock('ui/contexts', () => {
     },
     useCoreClerk: jest.fn(() => ({
       frontendAPI: 'clerk.clerk.dev',
-      setActive: mockSetActive,
+      setSession: mockSetSession,
     })),
     useCoreSignUp: jest.fn(() => ({
       create: mockCreateRequest,
@@ -80,11 +80,8 @@ describe('<SignUpStart/>', () => {
     mockCreateRequest.mockImplementation(() =>
       Promise.resolve({
         emailAddress: 'jdoe@example.com',
-        verifications: {
-          emailAddress: {
-            status: 'unverified',
-          },
-        },
+        status: 'missing_requirements',
+        unverifiedFields: ['email_address'],
       }),
     );
 
@@ -374,7 +371,7 @@ describe('<SignUpStart/>', () => {
           render(<SignUpStart />);
 
           await waitFor(() => {
-            expect(mockSetActive).toHaveBeenCalled();
+            expect(mockSetSession).toHaveBeenCalled();
           });
         });
 
@@ -426,7 +423,7 @@ describe('<SignUpStart/>', () => {
           );
           render(<SignUpStart />);
           await waitFor(() => {
-            expect(mockSetActive).not.toHaveBeenCalled();
+            expect(mockSetSession).not.toHaveBeenCalled();
             // Required and optional fields are rendered
             screen.getByText(/First name/);
             screen.getByText(/Last name/);
@@ -499,7 +496,7 @@ describe('<SignUpStart/>', () => {
           render(<SignUpStart />);
 
           await waitFor(() => {
-            expect(mockSetActive).not.toHaveBeenCalled();
+            expect(mockSetSession).not.toHaveBeenCalled();
             screen.getByText(/First name/);
             screen.getByText(/Last name/);
             expect(screen.queryByText('Password')).not.toBeInTheDocument();
@@ -508,7 +505,7 @@ describe('<SignUpStart/>', () => {
           // Submit the form
           userEvent.click(screen.getByRole('button', { name: 'Sign up' }));
           await waitFor(() => {
-            expect(mockSetActive).toHaveBeenCalled();
+            expect(mockSetSession).toHaveBeenCalled();
           });
         });
 

--- a/packages/clerk-js/src/ui/signUp/SignUpVerify.test.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpVerify.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderJSON } from '@clerk/shared/testUtils';
+import { renderJSON } from '@clerk/shared/testUtils';
 import { AttributeData, SessionResource, SignUpResource, UserSettingsJSON } from '@clerk/types';
 import { UserSettings } from 'core/resources/internal';
 import React from 'react';
@@ -6,7 +6,7 @@ import React from 'react';
 import { SignUpVerifyEmailAddress, SignUpVerifyPhoneNumber } from './SignUpVerify';
 
 const navigateMock = jest.fn();
-const mockSetActive = jest.fn();
+const mockSetSession = jest.fn();
 const mockAttemptVerification = jest.fn();
 const mockStartMagicLinkFlow = jest.fn(() => {
   return Promise.resolve({
@@ -74,7 +74,7 @@ jest.mock('ui/contexts', () => {
     withCoreUserGuard: (a: any) => a,
     useCoreClerk: () => {
       return {
-        setActive: mockSetActive,
+        setSession: mockSetSession,
       };
     },
     useSignUpContext: () => {

--- a/packages/clerk-js/src/ui/signUp/SignUpVerifyEmailAddressWithMagicLink.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpVerifyEmailAddressWithMagicLink.tsx
@@ -11,15 +11,17 @@ import {
 } from 'ui/common';
 import { Alert } from 'ui/common/alert';
 import { useCoreClerk, useCoreSignUp, useEnvironment, useSignUpContext } from 'ui/contexts';
-import { useMagicLink } from 'ui/hooks';
+import { useMagicLink, useNavigate } from 'ui/hooks';
+import { completeSignUpFlow } from 'ui/signUp/util';
 
 export function SignUpVerifyEmailAddressWithMagicLink(): JSX.Element {
   const signUp = useCoreSignUp();
   const renderHappenedAfterTheDamnedSetSessionFlow = signUp.status === null;
-  const { setActive } = useCoreClerk();
+  const { setSession } = useCoreClerk();
   const identifierRef = React.useRef(signUp.emailAddress);
   const { displayConfig } = useEnvironment();
   const signUpContext = useSignUpContext();
+  const { navigate } = useNavigate();
   const { navigateAfterSignUp } = signUpContext;
   const [error, setError] = React.useState<string | undefined>();
   const [showVerifyModal, setShowVerifyModal] = React.useState(false);
@@ -57,15 +59,12 @@ export function SignUpVerifyEmailAddressWithMagicLink(): JSX.Element {
     } else if (ver.verifiedFromTheSameClient()) {
       showMagicLinkVerificationModal();
     } else {
-      await completeSignUpFlow(su);
-    }
-  };
-
-  const completeSignUpFlow = async (su: SignUpResource) => {
-    if (su.status === 'complete') {
-      return setActive({
-        session: su.createdSessionId,
-        beforeEmit: navigateAfterSignUp,
+      await completeSignUpFlow({
+        signUp: su,
+        verifyEmailPath: '../verify-email-address',
+        verifyPhonePath: '../verify-phone-number',
+        handleComplete: () => setSession(su.createdSessionId, navigateAfterSignUp),
+        navigate,
       });
     }
   };

--- a/packages/clerk-js/src/ui/signUp/util.test.ts
+++ b/packages/clerk-js/src/ui/signUp/util.test.ts
@@ -1,0 +1,79 @@
+import { SignUpResource } from '@clerk/types';
+
+import { completeSignUpFlow } from './util';
+
+const mockHandleComplete = jest.fn();
+const mockNavigate = jest.fn();
+
+describe('completeSignUpFlow', () => {
+  beforeEach(() => {
+    mockHandleComplete.mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it('calls handleComplete if sign up is complete', async () => {
+    const mockSignUp = {
+      status: 'complete',
+    } as SignUpResource;
+
+    await completeSignUpFlow({
+      signUp: mockSignUp,
+      handleComplete: mockHandleComplete,
+      navigate: mockNavigate,
+    });
+
+    expect(mockHandleComplete).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to verify email page if email still unverified', async () => {
+    const mockSignUp = {
+      status: 'missing_requirements',
+      unverifiedFields: ['email_address', 'phone_number'],
+    } as SignUpResource;
+
+    await completeSignUpFlow({
+      signUp: mockSignUp,
+      verifyEmailPath: 'verify-email',
+      handleComplete: mockHandleComplete,
+      navigate: mockNavigate,
+    });
+
+    expect(mockHandleComplete).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('verify-email');
+  });
+
+  it('navigates to verify phone page if phone still unverified', async () => {
+    const mockSignUp = {
+      status: 'missing_requirements',
+      unverifiedFields: ['phone_number'],
+    } as SignUpResource;
+
+    await completeSignUpFlow({
+      signUp: mockSignUp,
+      verifyPhonePath: 'verify-phone',
+      handleComplete: mockHandleComplete,
+      navigate: mockNavigate,
+    });
+
+    expect(mockHandleComplete).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('verify-phone');
+  });
+
+  it('does nothing in any other case', async () => {
+    const mockSignUp = {
+      status: 'missing_requirements',
+    } as SignUpResource;
+
+    await completeSignUpFlow({
+      signUp: mockSignUp,
+      handleComplete: mockHandleComplete,
+      navigate: mockNavigate,
+    });
+
+    expect(mockHandleComplete).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/clerk-js/src/ui/signUp/util.ts
+++ b/packages/clerk-js/src/ui/signUp/util.ts
@@ -1,0 +1,29 @@
+import { SignUpResource } from '@clerk/types';
+
+type CompleteSignUpFlowProps = {
+  signUp: SignUpResource;
+  verifyEmailPath?: string;
+  verifyPhonePath?: string;
+  navigate: (to: string) => Promise<void>;
+  handleComplete?: () => Promise<void>;
+};
+
+export const completeSignUpFlow = ({
+  signUp,
+  verifyEmailPath,
+  verifyPhonePath,
+  navigate,
+  handleComplete,
+}: CompleteSignUpFlowProps): Promise<void> | undefined => {
+  if (signUp.status === 'complete') {
+    return handleComplete && handleComplete();
+  } else if (signUp.status === 'missing_requirements') {
+    if (signUp.unverifiedFields?.includes('email_address') && verifyEmailPath) {
+      return navigate(verifyEmailPath);
+    }
+    if (signUp.unverifiedFields?.includes('phone_number') && verifyPhonePath) {
+      return navigate(verifyPhonePath);
+    }
+  }
+  return;
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

During a signUp, might there be more than one identifier that need verification (e.g email & phone). Support the above flow, by teaching our accounts components to properly redirect to the corresponding screens

<!-- Fixes # (issue number) -->
