### PR TITLE
Improve UserProfile removal page copyright & render connected account section only if at least one OAuth provider is enabled

### DIFF
--- a/packages/clerk-js/src/ui/userProfile/EditableListFieldRemoveCard.tsx
+++ b/packages/clerk-js/src/ui/userProfile/EditableListFieldRemoveCard.tsx
@@ -6,8 +6,9 @@ import { handleError } from 'ui/common';
 import { Alert } from 'ui/common/alert';
 
 interface EditableListFieldRemoveCardProps {
-  type: 'phone' | 'email' | 'external_account' | 'web3_wallet';
+  type: 'phone' | 'email' | 'connected_account' | 'web3_wallet';
   label: string;
+  buttonLabel: string;
   onCancel: () => void;
   onRemove: () => Promise<any>;
   onRemoved?: () => void;
@@ -16,11 +17,11 @@ interface EditableListFieldRemoveCardProps {
 export const EditableListFieldRemoveCard: React.FC<EditableListFieldRemoveCardProps> = ({
   type,
   label,
+  buttonLabel,
   onCancel,
   onRemove,
   onRemoved,
 }) => {
-  const lowerLabel = label.toLowerCase();
   const [error, setError] = React.useState<string | undefined>();
 
   const updateFieldSubmit = async () => {
@@ -39,7 +40,6 @@ export const EditableListFieldRemoveCard: React.FC<EditableListFieldRemoveCardPr
   return (
     <TitledCard
       title={`Remove ${formattedType}`}
-      subtitle='Confirm removal'
       className='cl-themed-card cl-verifiable-field-card'
     >
       <Alert type='error'>{error}</Alert>
@@ -49,10 +49,10 @@ export const EditableListFieldRemoveCard: React.FC<EditableListFieldRemoveCardPr
           {type === 'phone' ? (
             <PhoneViewer
               className='cl-identifier'
-              phoneNumber={lowerLabel}
+              phoneNumber={label.toLowerCase()}
             />
           ) : (
-            <span className='cl-identifier'>{lowerLabel}</span>
+            <span className='cl-identifier'>{label}</span>
           )}{' '}
           will be removed from this account.
         </p>
@@ -68,11 +68,15 @@ export const EditableListFieldRemoveCard: React.FC<EditableListFieldRemoveCardPr
             yourself.
           </p>
         )}
-        {type === 'external_account' && <p>You will no longer be able to sign in using this connected account.</p>}
+        {type === 'connected_account' && (
+          <p>Unlink your {label} account, and remove associated personal information.</p>
+        )}
         {type === 'web3_wallet' && <p>Remove the connection between this app and your Web3 wallet</p>}
       </div>
       <div className='cl-form-button-group'>
-        <Button onClick={updateFieldSubmit}>Remove {formattedType}</Button>
+        <Button onClick={updateFieldSubmit}>
+          {buttonLabel} {formattedType}
+        </Button>
         <Button
           flavor='text'
           type='reset'

--- a/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
@@ -3509,7 +3509,7 @@ Array [
         <svg
           data-filename="../shared/assets/icons/bin.svg"
         />
-        Remove
+        Unlink
       </button>
     </div>
     <div
@@ -3794,7 +3794,7 @@ Array [
         <svg
           data-filename="../shared/assets/icons/bin.svg"
         />
-        Disconnect
+        Unlink
       </button>
     </div>
     <div

--- a/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.test.tsx
+++ b/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.test.tsx
@@ -109,7 +109,7 @@ const userWithExtAccounts = (): PartialDeep<UserResource> => {
   };
 };
 
-const envWithoutWeb3wallet = () => ({
+const envWithEmailPhone = () => ({
   displayConfig: {},
   userSettings: {
     attributes: {
@@ -124,6 +124,37 @@ const envWithoutWeb3wallet = () => ({
       },
       web3_wallet: {
         enabled: false,
+      },
+    },
+  },
+});
+
+const envWithExternalAccount = () => ({
+  displayConfig: {},
+  userSettings: {
+    attributes: {
+      email_address: {
+        enabled: true,
+      },
+      phone_number: {
+        enabled: true,
+      },
+      username: {
+        enabled: false,
+      },
+      web3_wallet: {
+        enabled: false,
+      },
+    },
+    social: {
+      oauth_google: {
+        enabled: true,
+      },
+      oauth_twitch: {
+        enabled: true,
+      },
+      oauth_facebook: {
+        enabled: true,
       },
     },
   },
@@ -155,7 +186,7 @@ describe('<ProfileCard/>', () => {
   });
 
   it('renders the ProfileCard', () => {
-    (useEnvironment as jest.Mock).mockImplementation(envWithoutWeb3wallet);
+    (useEnvironment as jest.Mock).mockImplementation(envWithEmailPhone);
     (useCoreUser as jest.Mock).mockImplementation(userWithoutExtAccounts);
 
     const tree = renderJSON(<ProfileCard />);
@@ -171,7 +202,7 @@ describe('<ProfileCard/>', () => {
   });
 
   it('renders the profile card with verified external accounts', () => {
-    (useEnvironment as jest.Mock).mockImplementation(envWithoutWeb3wallet);
+    (useEnvironment as jest.Mock).mockImplementation(envWithExternalAccount);
     (useCoreUser as jest.Mock).mockImplementation(userWithExtAccounts);
 
     const tree = renderJSON(<ProfileCard />);

--- a/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.tsx
+++ b/packages/clerk-js/src/ui/userProfile/account/profileCard/ProfileCard.tsx
@@ -13,7 +13,7 @@ import { ProfileWeb3Wallets } from './ProfileWeb3Wallets';
 
 export function ProfileCard(): JSX.Element {
   const { userSettings } = useEnvironment();
-  const { attributes } = userSettings;
+  const { attributes, social } = userSettings;
   const user = useCoreUser();
   const { navigate } = useNavigate();
 
@@ -78,10 +78,11 @@ export function ProfileCard(): JSX.Element {
     </List.Item>
   );
 
-  const showWebWallet = attributes.web3_wallet.enabled;
   const showUsername = attributes.username.enabled;
   const showEmail = attributes.email_address.enabled;
   const showPhone = attributes.phone_number.enabled;
+  const showConnectedAccount = social && Object.values(social).filter(p => p.enabled).length > 0;
+  const showWebWallet = attributes.web3_wallet.enabled;
 
   return (
     <TitledCard
@@ -94,7 +95,7 @@ export function ProfileCard(): JSX.Element {
         {showUsername && buildUsernameRow()}
         {showEmail && <ProfileEmailAddresses />}
         {showPhone && <ProfilePhoneNumbers />}
-        {buildConnectedAccountsRow()}
+        {showConnectedAccount && buildConnectedAccountsRow()}
         {showWebWallet && <ProfileWeb3Wallets />}
       </List>
     </TitledCard>

--- a/packages/clerk-js/src/ui/userProfile/account/profileCard/__snapshots__/ProfileCard.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/account/profileCard/__snapshots__/ProfileCard.test.tsx.snap
@@ -157,37 +157,6 @@ exports[`<ProfileCard/> renders the ProfileCard 1`] = `
         </div>
       </div>
     </button>
-    <button
-      className="cl-list-item elementContainer button hoverable"
-      disabled={false}
-      onClick={[Function]}
-    >
-      <div
-        className="title"
-      >
-        Connected accounts
-      </div>
-      <div
-        className="listItem line"
-      >
-        <div
-          className="start"
-        >
-          <div
-            className="cl-empty-list-item"
-          >
-            None
-          </div>
-        </div>
-        <div
-          className="iconContainer"
-        >
-          <svg
-            data-filename="../shared/assets/icons/arrow-right.svg"
-          />
-        </div>
-      </div>
-    </button>
   </div>
 </div>
 `;
@@ -327,37 +296,6 @@ exports[`<ProfileCard/> renders the ProfileCard with web3 wallet 1`] = `
         className="title"
       >
         Phone number
-      </div>
-      <div
-        className="listItem line"
-      >
-        <div
-          className="start"
-        >
-          <div
-            className="cl-empty-list-item"
-          >
-            None
-          </div>
-        </div>
-        <div
-          className="iconContainer"
-        >
-          <svg
-            data-filename="../shared/assets/icons/arrow-right.svg"
-          />
-        </div>
-      </div>
-    </button>
-    <button
-      className="cl-list-item elementContainer button hoverable"
-      disabled={false}
-      onClick={[Function]}
-    >
-      <div
-        className="title"
-      >
-        Connected accounts
       </div>
       <div
         className="listItem line"

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountDetail.test.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountDetail.test.tsx
@@ -86,11 +86,11 @@ describe('<ConnectedAccountDetail/>', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('Disconnect Google Connected Account', () => {
+  it('Unlink Google Connected Account', () => {
     render(<ConnectedAccountDetail />);
 
-    userEvent.click(screen.getByText('Disconnect'));
-    userEvent.click(screen.getByText('Remove external account', { selector: 'button' }));
+    userEvent.click(screen.getByText('Unlink'));
+    userEvent.click(screen.getByText('Unlink connected account', { selector: 'button' }));
     expect(mockGoogleDestroy).toHaveBeenCalled();
   });
 });

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountDetail.tsx
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/ConnectedAccountDetail.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@clerk/shared/components/avatar';
 import { Button } from '@clerk/shared/components/button';
 import { List } from '@clerk/shared/components/list';
 import { TitledCard } from '@clerk/shared/components/titledCard';
+import { titleize } from '@clerk/shared/utils';
 import React from 'react';
 import { svgUrl } from 'ui/common/constants';
 import { useCoreUser } from 'ui/contexts';
@@ -76,8 +77,9 @@ export function ConnectedAccountDetail(): JSX.Element | null {
 
   const disconnectExternalAccountScreen = (
     <EditableListFieldRemoveCard
-      type='external_account'
-      label={externalAccount.providerTitle()}
+      type='connected_account'
+      label={titleize(externalAccount.providerSlug())}
+      buttonLabel='Unlink'
       onCancel={() => {
         setShowRemovalPage(false);
       }}
@@ -124,7 +126,7 @@ export function ConnectedAccountDetail(): JSX.Element | null {
             hoverable
           >
             <BinIcon />
-            Disconnect
+            Unlink
           </Button>
         </TitledCard>
       )}

--- a/packages/clerk-js/src/ui/userProfile/connectedAccounts/__snapshots__/ConnectedAccountDetail.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/connectedAccounts/__snapshots__/ConnectedAccountDetail.test.tsx.snap
@@ -122,7 +122,7 @@ Array [
       <svg
         data-filename="../shared/assets/icons/bin.svg"
       />
-      Disconnect
+      Unlink
     </button>
   </div>,
 ]

--- a/packages/clerk-js/src/ui/userProfile/emailAdressess/EmailDetail.tsx
+++ b/packages/clerk-js/src/ui/userProfile/emailAdressess/EmailDetail.tsx
@@ -60,6 +60,7 @@ export function EmailDetail(): JSX.Element | null {
     <EditableListFieldRemoveCard
       type='email'
       label={email.emailAddress}
+      buttonLabel='Remove'
       onCancel={() => {
         setShowRemovalPage(false);
       }}

--- a/packages/clerk-js/src/ui/userProfile/phoneNumbers/PhoneDetail.tsx
+++ b/packages/clerk-js/src/ui/userProfile/phoneNumbers/PhoneDetail.tsx
@@ -109,6 +109,7 @@ export const PhoneDetail = (): JSX.Element => {
     <EditableListFieldRemoveCard
       type='phone'
       label={phoneIdent.phoneNumber}
+      buttonLabel='Remove'
       onCancel={() => {
         setShowRemovalPage(false);
       }}

--- a/packages/clerk-js/src/ui/userProfile/web3Wallets/Web3WalletDetail.tsx
+++ b/packages/clerk-js/src/ui/userProfile/web3Wallets/Web3WalletDetail.tsx
@@ -51,6 +51,7 @@ export function Web3WalletDetail(): JSX.Element | null {
     <EditableListFieldRemoveCard
       type='web3_wallet'
       label={web3Wallet.web3Wallet}
+      buttonLabel='Unlink'
       onCancel={() => {
         setShowRemovalPage(false);
       }}
@@ -132,7 +133,7 @@ export function Web3WalletDetail(): JSX.Element | null {
             hoverable
           >
             <BinIcon />
-            Remove
+            Unlink
           </Button>
         </TitledCard>
       )}

--- a/packages/clerk-js/src/ui/userProfile/web3Wallets/__snapshots__/Web3WalletDetail.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/web3Wallets/__snapshots__/Web3WalletDetail.test.tsx.snap
@@ -138,7 +138,7 @@ Array [
       <svg
         data-filename="../shared/assets/icons/bin.svg"
       />
-      Remove
+      Unlink
     </button>
   </div>,
 ]


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This PR includes:
- Improve connected account & web3 wallet removal page copyright
- Don't render connected account UserProfile section, if there isn't any OAuth provider enabled

### Before

![Screenshot 2022-06-01 at 9 10 49 PM](https://user-images.githubusercontent.com/22435234/171484693-9203ccc7-b796-478d-a1b5-9da96d454eef.png)

![Screenshot 2022-06-01 at 11 43 55 PM](https://user-images.githubusercontent.com/22435234/171498169-d42a7dc6-5835-4858-8751-4c97221ffcc0.png)

### After

![Screenshot 2022-06-01 at 9 27 50 PM](https://user-images.githubusercontent.com/22435234/171484713-99c9542e-c5f4-4d37-8437-ede290f92043.png)

![Screenshot 2022-06-01 at 11 41 11 PM](https://user-images.githubusercontent.com/22435234/171498200-03b346fa-53d6-4094-9425-5a653741a64f.png)

<!-- Fixes # (issue number) -->
