### PR TITLE
fix(clerk-js): If organization is `null`, set the active org as null

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -331,9 +331,12 @@ export default class Clerk implements ClerkInterface {
     }
 
     this.session = session;
-    this.organization = (this.session?.user.organizationMemberships || [])
-      .map(om => om.organization)
-      .find(org => org.id === this.session?.lastActiveOrganizationId);
+    this.organization =
+      organization === null
+        ? null
+        : (this.session?.user.organizationMemberships || [])
+            .map(om => om.organization)
+            .find(org => org.id === this.session?.lastActiveOrganizationId);
     this.user = this.session ? this.session.user : null;
 
     this.#emit();


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This commit fixes `setActive` to set the active organization as `null` if the organization parameter that was passed in `setActive` is `null`.

<!-- Fixes # (issue number) -->
