### PR TITLE
fix(clerk-js,types): Typo for MetaMask web3 provider name

### DIFF
--- a/packages/clerk-js/src/ui/common/constants.ts
+++ b/packages/clerk-js/src/ui/common/constants.ts
@@ -57,7 +57,7 @@ type Web3Providers = {
 export const WEB3_PROVIDERS: Web3Providers = Object.freeze({
   metamask: {
     id: 'metamask',
-    name: 'Metamask',
+    name: 'MetaMask',
   },
 });
 

--- a/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/__snapshots__/UserProfile.test.tsx.snap
@@ -3567,7 +3567,7 @@ Array [
                   src="https://images.clerk.dev/static/metamask.svg"
                 />
                 Connect 
-                Metamask
+                MetaMask
                  wallet
               </div>
             </div>

--- a/packages/clerk-js/src/ui/userProfile/web3Wallets/__snapshots__/AddNewWeb3Wallet.test.tsx.snap
+++ b/packages/clerk-js/src/ui/userProfile/web3Wallets/__snapshots__/AddNewWeb3Wallet.test.tsx.snap
@@ -63,7 +63,7 @@ Array [
                 src="https://images.clerk.dev/static/metamask.svg"
               />
               Connect 
-              Metamask
+              MetaMask
                wallet
             </div>
           </div>

--- a/packages/types/src/web3.ts
+++ b/packages/types/src/web3.ts
@@ -14,7 +14,7 @@ export const WEB3_PROVIDERS: Web3ProviderData[] = [
   {
     provider: 'metamask',
     strategy: 'web3_metamask_signature',
-    name: 'Metamask',
+    name: 'MetaMask',
   },
 ];
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Rename `Metamask` to `MetaMask` as the provider name

<!-- Fixes # (issue number) -->
