### PR TITLE
fix(clerk-react): Correct annotations in isomorphicClerk for setSession

### DIFF
--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -247,6 +247,12 @@ export default class IsomorphicClerk {
     }
   }
 
+  /**
+   * `setActive` can be used to set the active session and/or organization.
+   * It will eventually replace `setSession`.
+   *
+   * @experimental
+   */
   setActive = ({ session, organization, beforeEmit }: SetActiveParams): Promise<void> => {
     if (this.clerkjs) {
       return this.clerkjs.setActive({ session, organization, beforeEmit });
@@ -255,7 +261,6 @@ export default class IsomorphicClerk {
     }
   };
 
-  /** @deprecated Use `setActive` instead */
   setSession = (
     session: ActiveSessionResource | string | null,
     beforeEmit?: (session: ActiveSessionResource | null) => void | Promise<any>,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Fixes the correct annotation for `setSession`, `setActive` .

Before:
![image](https://user-images.githubusercontent.com/15251081/171818153-7dc58f9a-363c-42cf-9995-744e9e339306.png)

After:

![image](https://user-images.githubusercontent.com/15251081/171818082-32a9cc1e-934b-4892-8120-be0248bd9a83.png)
