### PR TITLE
fix(clerk-js): Render SignUp form input errors if missing

### DIFF
--- a/packages/clerk-js/src/ui/signUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpForm.tsx
@@ -85,7 +85,7 @@ export function SignUpForm({
           </Control>
         )}
 
-        {fields.emailAddress?.show && (
+        {fields.emailAddress && (
           <Control
             key='emailAddress'
             htmlFor='emailAddress'
@@ -105,7 +105,7 @@ export function SignUpForm({
           </Control>
         )}
 
-        {fields.phoneNumber?.show && (
+        {fields.phoneNumber && (
           <Control
             key='phoneNumber'
             htmlFor='phoneNumber'

--- a/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/signUp/SignUpStart.tsx
@@ -165,7 +165,7 @@ function _SignUpStart(): JSX.Element {
     e.preventDefault();
 
     const fieldsToSubmit = Object.entries(fields).reduce(
-      (acc, [k, v]) => [...acc, ...(v && formState[k as FormStateKey]?.value ? [formState[k as FormStateKey]] : [])],
+      (acc, [k, v]) => [...acc, ...(v && formState[k as FormStateKey] ? [formState[k as FormStateKey]] : [])],
       [] as Array<FieldState<any>>,
     );
 

--- a/packages/clerk-js/src/ui/signUp/signUpFormHelpers.test.ts
+++ b/packages/clerk-js/src/ui/signUp/signUpFormHelpers.test.ts
@@ -42,11 +42,6 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: true,
             disabled: false,
-            show: true,
-          },
-          phoneNumber: {
-            required: true,
-            show: false,
           },
           firstName: {
             required: true,
@@ -93,14 +88,8 @@ describe('determineActiveFields()', () => {
           },
         },
         {
-          emailAddress: {
-            required: true,
-            disabled: false,
-            show: false,
-          },
           phoneNumber: {
             required: true,
-            show: true,
           },
           firstName: {
             required: true,
@@ -150,11 +139,6 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: true, // email will be toggled on initially
             disabled: false,
-            show: true,
-          },
-          phoneNumber: {
-            required: true,
-            show: false,
           },
           firstName: {
             required: true,
@@ -201,15 +185,6 @@ describe('determineActiveFields()', () => {
           },
         },
         {
-          emailAddress: {
-            required: true,
-            disabled: false,
-            show: false,
-          },
-          phoneNumber: {
-            required: true,
-            show: false,
-          },
           firstName: {
             required: false,
           },
@@ -254,17 +229,7 @@ describe('determineActiveFields()', () => {
             required: false,
           },
         },
-        {
-          emailAddress: {
-            required: true,
-            disabled: false,
-            show: false,
-          },
-          phoneNumber: {
-            required: true,
-            show: false,
-          },
-        },
+        {},
       ],
     ];
 
@@ -365,11 +330,6 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: true,
             disabled: false,
-            show: true,
-          },
-          phoneNumber: {
-            required: false,
-            show: false,
           },
         },
       ],
@@ -389,14 +349,8 @@ describe('determineActiveFields()', () => {
           },
         },
         {
-          emailAddress: {
-            required: false,
-            disabled: false,
-            show: false,
-          },
           phoneNumber: {
             required: true,
-            show: true,
           },
         },
       ],
@@ -419,11 +373,9 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: true,
             disabled: false,
-            show: true,
           },
           phoneNumber: {
             required: true,
-            show: true,
           },
         },
       ],
@@ -446,11 +398,6 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: false, // email will be toggled on initially
             disabled: false,
-            show: true,
-          },
-          phoneNumber: {
-            required: false,
-            show: false,
           },
         },
       ],
@@ -473,11 +420,9 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: true,
             disabled: false,
-            show: true,
           },
           phoneNumber: {
             required: false,
-            show: true,
           },
         },
       ],
@@ -500,11 +445,9 @@ describe('determineActiveFields()', () => {
           emailAddress: {
             required: false,
             disabled: false,
-            show: true,
           },
           phoneNumber: {
             required: true,
-            show: true,
           },
         },
       ],

--- a/packages/clerk-js/src/ui/signUp/signUpFormHelpers.ts
+++ b/packages/clerk-js/src/ui/signUp/signUpFormHelpers.ts
@@ -21,10 +21,6 @@ export type Field = {
    * Denotes if the corresponding input is required to be filled
    */
   required: boolean;
-  /**
-   * Denotes if we have to render the corresponding input
-   */
-  show?: boolean;
 };
 
 export type Fields = {
@@ -152,21 +148,25 @@ function getEmailAddressField({
   hasEmail,
   activeCommIdentifierType,
   isProgressiveSignUp,
-}: FieldDeterminationProps): Field {
+}: FieldDeterminationProps): Field | undefined {
   if (isProgressiveSignUp) {
     // If there is no ticket, or there is a ticket along with an email, and email address is enabled,
     // we have to show it in the SignUp form
-    let show = (!hasTicket || (hasTicket && hasEmail)) && attributes.email_address.enabled;
+    const show = (!hasTicket || (hasTicket && hasEmail)) && attributes.email_address.enabled;
+
+    if (!show) {
+      return;
+    }
+
     // If we are in the case of Email OR Phone, determine if the initial input has to be the email address
     // based on the active identifier type.
-    if (emailOrPhone(attributes, isProgressiveSignUp)) {
-      show = show && activeCommIdentifierType === 'emailAddress';
+    if (emailOrPhone(attributes, isProgressiveSignUp) && activeCommIdentifierType !== 'emailAddress') {
+      return;
     }
 
     return {
       required: attributes.email_address.required,
       disabled: !!hasTicket && !!hasEmail,
-      show,
     };
   }
 
@@ -176,10 +176,13 @@ function getEmailAddressField({
     attributes.email_address.used_for_first_factor &&
     activeCommIdentifierType == 'emailAddress';
 
+  if (!show) {
+    return;
+  }
+
   return {
     required: true, // as far as the FE is concerned the email address is required, if shown
     disabled: !!hasTicket && !!hasEmail,
-    show,
   };
 }
 
@@ -188,19 +191,23 @@ function getPhoneNumberField({
   hasTicket,
   activeCommIdentifierType,
   isProgressiveSignUp,
-}: FieldDeterminationProps): Field {
+}: FieldDeterminationProps): Field | undefined {
   if (isProgressiveSignUp) {
     // If there is no ticket and phone number is enabled, we have to show it in the SignUp form
-    let show = !hasTicket && attributes.phone_number.enabled;
+    const show = !hasTicket && attributes.phone_number.enabled;
+
+    if (!show) {
+      return;
+    }
+
     // If we are in the case of Email OR Phone, determine if the initial input has to be the phone number
     // based on the active identifier type.
-    if (emailOrPhone(attributes, isProgressiveSignUp)) {
-      show = show && activeCommIdentifierType === 'phoneNumber';
+    if (emailOrPhone(attributes, isProgressiveSignUp) && activeCommIdentifierType !== 'phoneNumber') {
+      return;
     }
 
     return {
       required: attributes.phone_number.required,
-      show,
     };
   }
 
@@ -210,9 +217,12 @@ function getPhoneNumberField({
     attributes.phone_number.used_for_first_factor &&
     activeCommIdentifierType == 'phoneNumber';
 
+  if (!show) {
+    return;
+  }
+
   return {
     required: true, // as far as the FE is concerned the phone number is required, if shown
-    show,
   };
 }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This commit fixes a regression introduced in our recent changes for Progressive SignUp. The actual problem was that we filtered out values even with empty string value, for our sign up payload request. This issue, lead the form to not render properly any input error if any of them was required and missing

<!-- Fixes # (issue number) -->
