### PR TITLE
fix(edge,nextjs,remix,clerk-sdk-node,types): Correct SSR claims typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35348,6 +35348,7 @@
       "license": "MIT",
       "dependencies": {
         "@clerk/backend-core": "^1.9.2",
+        "@clerk/types": "^2.16.0",
         "@peculiar/webcrypto": "^1.2.3",
         "next": "^12.0.7"
       },
@@ -37290,6 +37291,7 @@
       "version": "file:packages/edge",
       "requires": {
         "@clerk/backend-core": "^1.9.2",
+        "@clerk/types": "*",
         "@peculiar/webcrypto": "^1.2.3",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.12",

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@clerk/backend-core": "^1.9.2",
+    "@clerk/types": "^2.16.0",
     "@peculiar/webcrypto": "^1.2.3",
     "next": "^12.0.7"
   },

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -1,4 +1,5 @@
 import { AuthStatus, Base, createGetToken, createSignedOutState } from '@clerk/backend-core';
+import { ClerkJWTClaims } from '@clerk/types';
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
 import { ClerkAPI } from './ClerkAPI';
@@ -129,7 +130,7 @@ export function withEdgeMiddlewareAuth(
       sessionId,
       userId,
       getToken,
-      claims: sessionClaims as Record<string, unknown>,
+      claims: sessionClaims as ClerkJWTClaims,
     });
     return handler(authRequest, event);
   };

--- a/packages/edge/src/vercel-edge/types.ts
+++ b/packages/edge/src/vercel-edge/types.ts
@@ -1,5 +1,5 @@
 import type { Session, User } from '@clerk/backend-core';
-import { ServerGetToken } from '@clerk/types';
+import { ClerkJWTClaims, ServerGetToken } from '@clerk/types';
 import type { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
 export type WithEdgeMiddlewareAuthOptions = {
@@ -37,7 +37,7 @@ export type EdgeMiddlewareAuth = {
   sessionId: string | null;
   userId: string | null;
   getToken: ServerGetToken;
-  claims: Record<string, unknown> | null;
+  claims: ClerkJWTClaims | null;
 };
 
 export type AuthData = {
@@ -46,5 +46,5 @@ export type AuthData = {
   userId: string | null;
   user: User | undefined | null;
   getToken: ServerGetToken;
-  claims: Record<string, unknown> | null;
+  claims: ClerkJWTClaims | null;
 };

--- a/packages/nextjs/src/middleware/types.ts
+++ b/packages/nextjs/src/middleware/types.ts
@@ -1,5 +1,5 @@
 import type { Session, User } from '@clerk/clerk-sdk-node';
-import { ServerSideAuth } from '@clerk/types';
+import { ClerkJWTClaims, ServerSideAuth } from '@clerk/types';
 import { GetServerSidePropsContext } from 'next';
 
 // TODO: Remove when we're using TS >=4.5
@@ -24,7 +24,7 @@ export type AuthData = {
   userId: string | null;
   user: User | undefined | null;
   getToken: (...args: any) => Promise<string | null>;
-  claims: Record<string, unknown> | null;
+  claims: ClerkJWTClaims | null;
 };
 
 export type ContextWithAuth<Options extends WithServerSideAuthOptions = any> = GetServerSidePropsContext & {

--- a/packages/remix/src/ssr/getAuthData.ts
+++ b/packages/remix/src/ssr/getAuthData.ts
@@ -1,6 +1,6 @@
 import { AuthStatus, createGetToken, createSignedOutState, Session, User } from '@clerk/backend-core';
 import Clerk, { sessions, users } from '@clerk/clerk-sdk-node';
-import { ServerGetToken } from '@clerk/types';
+import { ClerkJWTClaims, ServerGetToken } from '@clerk/types';
 
 import { RootAuthLoaderOptions } from './types';
 import { parseCookies } from './utils';
@@ -11,7 +11,7 @@ export type AuthData = {
   userId: string | null;
   user: User | undefined | null;
   getToken: ServerGetToken;
-  claims: Record<string, unknown> | null;
+  claims: ClerkJWTClaims | null;
 };
 
 /**

--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -42,7 +42,7 @@ export type WithAuthProp<T> = T & {
     sessionId: string | null;
     userId: string | null;
     getToken: ServerGetToken;
-    claims: Record<string, unknown> | null;
+    claims: ClerkJWTClaims | null;
   };
 };
 
@@ -51,7 +51,7 @@ export type RequireAuthProp<T> = T & {
     sessionId: string;
     userId: string;
     getToken: ServerGetToken;
-    claims: Record<string, unknown>;
+    claims: ClerkJWTClaims;
   };
 };
 

--- a/packages/types/src/ssr.ts
+++ b/packages/types/src/ssr.ts
@@ -1,4 +1,5 @@
 import { SessionJSON, UserJSON } from './json';
+import { ClerkJWTClaims } from './jwt';
 import { SessionResource } from './session';
 import { UserResource } from './user';
 
@@ -9,7 +10,7 @@ export type ServerSideAuth = {
   sessionId: string | null;
   userId: string | null;
   getToken: ServerGetToken;
-  claims: Record<string, unknown> | null;
+  claims: ClerkJWTClaims | null;
 };
 
 type SsrSessionState<SessionType> =


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Add the correct claims type on all `claims` attributes. Mostly used on SSR and API routes.

### Before
![Screenshot 2022-06-23 at 11 03 16 AM](https://user-images.githubusercontent.com/15251081/175249018-20482ce4-1627-4f9f-8c5c-b6b2db62ed37.png)

### After
![Screenshot 2022-06-23 at 11 01 52 AM](https://user-images.githubusercontent.com/15251081/175248988-512a927c-62ba-400f-bd91-76a8b4099e48.png)


<!-- Fixes # (issue number) -->
