### PR TITLE
fix(backend-core): Remove unneeded stringifyMetadata function

### DIFF
--- a/packages/backend-core/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend-core/src/api/endpoints/OrganizationApi.ts
@@ -21,11 +21,6 @@ type CreateParams = {
   createdBy: string;
 } & OrganizationMetadataParams;
 
-type OrganizationMetadataRequestBody = {
-  publicMetadata?: string;
-  privateMetadata?: string;
-};
-
 type GetOrganizationParams = { organizationId: string } | { slug: string };
 
 type UpdateParams = {
@@ -83,17 +78,10 @@ export class OrganizationAPI extends AbstractAPI {
   }
 
   public async createOrganization(params: CreateParams) {
-    const { publicMetadata, privateMetadata } = params;
     return this.APIClient.request<Organization>({
       method: 'POST',
       path: basePath,
-      bodyParams: {
-        ...params,
-        ...stringifyMetadataParams({
-          publicMetadata,
-          privateMetadata,
-        }),
-      },
+      bodyParams: params,
     });
   }
 
@@ -122,7 +110,7 @@ export class OrganizationAPI extends AbstractAPI {
     return this.APIClient.request<Organization>({
       method: 'PATCH',
       path: joinPaths(basePath, organizationId, 'metadata'),
-      bodyParams: stringifyMetadataParams(params),
+      bodyParams: params,
     });
   }
 
@@ -215,20 +203,4 @@ export class OrganizationAPI extends AbstractAPI {
       },
     });
   }
-}
-
-function stringifyMetadataParams(
-  params: OrganizationMetadataParams & {
-    [key: string]: Record<string, unknown> | undefined;
-  },
-): OrganizationMetadataRequestBody {
-  return ['publicMetadata', 'privateMetadata'].reduce(
-    (res: Record<string, string>, key: string): Record<string, string> => {
-      if (params[key]) {
-        res[key] = JSON.stringify(params[key]);
-      }
-      return res;
-    },
-    {},
-  );
 }

--- a/packages/backend-core/src/api/endpoints/UserApi.ts
+++ b/packages/backend-core/src/api/endpoints/UserApi.ts
@@ -19,8 +19,6 @@ type UserListParams = UserCountParams & {
   orderBy?: 'created_at' | 'updated_at' | '+created_at' | '+updated_at' | '-created_at' | '-updated_at';
 };
 
-const userMetadataKeys = ['publicMetadata', 'privateMetadata', 'unsafeMetadata'];
-
 type UserMetadataParams = {
   publicMetadata?: Record<string, unknown>;
   privateMetadata?: Record<string, unknown>;
@@ -48,12 +46,6 @@ interface UpdateUserParams extends UserMetadataParams {
   primaryPhoneNumberID?: string;
 }
 
-type UserMetadataRequestBody = {
-  publicMetadata?: string;
-  privateMetadata?: string;
-  unsafeMetadata?: string;
-};
-
 export class UserAPI extends AbstractAPI {
   public async getUserList(params: UserListParams = {}) {
     return this.APIClient.request<Array<User>>({
@@ -72,36 +64,20 @@ export class UserAPI extends AbstractAPI {
   }
 
   public async createUser(params: CreateUserParams): Promise<User> {
-    const { publicMetadata, privateMetadata, unsafeMetadata } = params;
     return this.APIClient.request({
       method: 'POST',
       path: basePath,
-      bodyParams: {
-        ...params,
-        ...stringifyMetadataParams({
-          publicMetadata,
-          privateMetadata,
-          unsafeMetadata,
-        }),
-      },
+      bodyParams: params,
     });
   }
 
   public async updateUser(userId: string, params: UpdateUserParams = {}) {
     this.requireId(userId);
-    const { publicMetadata, privateMetadata, unsafeMetadata } = params;
 
     return this.APIClient.request<User>({
       method: 'PATCH',
       path: joinPaths(basePath, userId),
-      bodyParams: {
-        ...params,
-        ...stringifyMetadataParams({
-          publicMetadata,
-          privateMetadata,
-          unsafeMetadata,
-        }),
-      },
+      bodyParams: params,
     });
   }
 
@@ -111,7 +87,7 @@ export class UserAPI extends AbstractAPI {
     return this.APIClient.request<User>({
       method: 'PATCH',
       path: joinPaths(basePath, userId, 'metadata'),
-      bodyParams: stringifyMetadataParams(params),
+      bodyParams: params,
     });
   }
 
@@ -138,17 +114,4 @@ export class UserAPI extends AbstractAPI {
       path: joinPaths(basePath, userId, 'oauth_access_tokens', provider),
     });
   }
-}
-
-function stringifyMetadataParams(
-  params: UserMetadataParams & {
-    [key: string]: Record<string, unknown> | undefined;
-  },
-): UserMetadataRequestBody {
-  return userMetadataKeys.reduce((res: Record<string, string>, key: string): Record<string, string> => {
-    if (params[key]) {
-      res[key] = JSON.stringify(params[key]);
-    }
-    return res;
-  }, {});
 }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Fixed issue with unneeded metadata param stringification. With the current changes, metadata parameters were stringified twice, resulting in errors on api's like `users.createUser`. 

- Removed unneeded stringification.