### PR TITLE
feat(edge,nextjs): Compatibility with API middleware experimental edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5705,7 +5705,23 @@
     "node_modules/@next/env": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
-      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
+      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g==",
+      "dev": true
+    },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.0.tgz",
+      "integrity": "sha512-hbneH8DNRB2x0Nf5fPCYoL8a0osvdTCe4pvOc9Rv5CpDsoOlf8BWBs2OWpeP0U2BktGvIsuUhmISmdYYGyrvTw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@next/swc-android-arm64": {
       "version": "12.0.10",
@@ -5714,6 +5730,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -5729,6 +5746,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5744,9 +5762,25 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
+      "integrity": "sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
       ],
       "engines": {
         "node": ">= 10"
@@ -5759,6 +5793,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5774,6 +5809,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5789,6 +5825,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5804,6 +5841,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5819,6 +5857,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5834,6 +5873,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5849,6 +5889,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5864,6 +5905,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -25607,6 +25649,7 @@
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
       "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
+      "dev": true,
       "dependencies": {
         "@next/env": "12.0.10",
         "caniuse-lite": "^1.0.30001283",
@@ -25662,6 +25705,7 @@
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
       "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "dev": true,
       "dependencies": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
@@ -32358,6 +32402,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
       "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==",
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -33947,11 +33992,20 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
       "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+      "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -35350,7 +35404,7 @@
         "@clerk/backend-core": "^1.10.0",
         "@clerk/types": "^2.17.0",
         "@peculiar/webcrypto": "^1.2.3",
-        "next": "^12.0.7"
+        "next": "^12.2.0"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
@@ -35363,11 +35417,282 @@
         "node": ">=12"
       }
     },
+    "packages/edge/node_modules/@next/env": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.0.tgz",
+      "integrity": "sha512-/FCkDpL/8SodJEXvx/DYNlOD5ijTtkozf4PPulYPtkPOJaMPpBSOkzmsta4fnrnbdH6eZjbwbiXFdr6gSQCV4w=="
+    },
+    "packages/edge/node_modules/@next/swc-android-arm64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.0.tgz",
+      "integrity": "sha512-1eEk91JHjczcJomxJ8X0XaUeNcp5Lx1U2Ic7j15ouJ83oRX+3GIslOuabW2oPkSgXbHkThMClhirKpvG98kwZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-darwin-arm64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.0.tgz",
+      "integrity": "sha512-x5U5gJd7ZvrEtTFnBld9O2bUlX8opu7mIQUqRzj7KeWzBwPhrIzTTsQXAiNqsaMuaRPvyHBVW/5d/6g6+89Y8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-darwin-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.0.tgz",
+      "integrity": "sha512-iwMNFsrAPjfedjKDv9AXPAV16PWIomP3qw/FfPaxkDVRbUls7BNdofBLzkQmqxqWh93WrawLwaqyXpJuAaiwJA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.0.tgz",
+      "integrity": "sha512-/TJZkxaIpeEwnXh6A40trgwd40C5+LJroLUOEQwMOJdavLl62PjCA6dGl1pgooWLCIb5YdBQ0EG4ylzvLwS2+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.0.tgz",
+      "integrity": "sha512-++WAB4ElXCSOKG9H8r4ENF8EaV+w0QkrpjehmryFkQXmt5juVXz+nKDVlCRMwJU7A1O0Mie82XyEoOrf6Np1pA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.0.tgz",
+      "integrity": "sha512-XrqkHi/VglEn5zs2CYK6ofJGQySrd+Lr4YdmfJ7IhsCnMKkQY1ma9Hv5THwhZVof3e+6oFHrQ9bWrw9K4WTjFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.0.tgz",
+      "integrity": "sha512-MyhHbAKVjpn065WzRbqpLu2krj4kHLi6RITQdD1ee+uxq9r2yg5Qe02l24NxKW+1/lkmpusl4Y5Lks7rBiJn4w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.0.tgz",
+      "integrity": "sha512-Tz1tJZ5egE0S/UqCd5V6ZPJsdSzv/8aa7FkwFmIJ9neLS8/00za+OY5pq470iZQbPrkTwpKzmfTTIPRVD5iqDg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.0.tgz",
+      "integrity": "sha512-0iRO/CPMCdCYUzuH6wXLnsfJX1ykBX4emOOvH0qIgtiZM0nVYbF8lkEyY2ph4XcsurpinS+ziWuYCXVqrOSqiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.0.tgz",
+      "integrity": "sha512-8A26RJVcJHwIKm8xo/qk2ePRquJ6WCI2keV2qOW/Qm+ZXrPXHMIWPYABae/nKN243YFBNyPiHytjX37VrcpUhg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.0.tgz",
+      "integrity": "sha512-OI14ozFLThEV3ey6jE47zrzSTV/6eIMsvbwozo+XfdWqOPwQ7X00YkRx4GVMKMC0rM44oGS2gmwMKYpe4EblnA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/edge/node_modules/@swc/helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
+      "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "packages/edge/node_modules/@types/node": {
       "version": "16.11.22",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.22.tgz",
       "integrity": "sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==",
       "dev": true
+    },
+    "packages/edge/node_modules/next": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.2.0.tgz",
+      "integrity": "sha512-B4j7D3SHYopLYx6/Ark0fenwIar9tEaZZFAaxmKjgcMMexhVJzB3jt7X+6wcdXPPMeUD6r09weUtnDpjox/vIA==",
+      "dependencies": {
+        "@next/env": "12.2.0",
+        "@swc/helpers": "0.4.2",
+        "caniuse-lite": "^1.0.30001332",
+        "postcss": "8.4.5",
+        "styled-jsx": "5.0.2",
+        "use-sync-external-store": "1.1.0"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-android-arm-eabi": "12.2.0",
+        "@next/swc-android-arm64": "12.2.0",
+        "@next/swc-darwin-arm64": "12.2.0",
+        "@next/swc-darwin-x64": "12.2.0",
+        "@next/swc-freebsd-x64": "12.2.0",
+        "@next/swc-linux-arm-gnueabihf": "12.2.0",
+        "@next/swc-linux-arm64-gnu": "12.2.0",
+        "@next/swc-linux-arm64-musl": "12.2.0",
+        "@next/swc-linux-x64-gnu": "12.2.0",
+        "@next/swc-linux-x64-musl": "12.2.0",
+        "@next/swc-win32-arm64-msvc": "12.2.0",
+        "@next/swc-win32-ia32-msvc": "12.2.0",
+        "@next/swc-win32-x64-msvc": "12.2.0"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^6.0.0 || ^7.0.0",
+        "react": "^17.0.2 || ^18.0.0-0",
+        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "packages/edge/node_modules/postcss": {
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "dependencies": {
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "packages/edge/node_modules/styled-jsx": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "packages/edge/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
@@ -37296,16 +37621,142 @@
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.12",
         "jest": "^27.4.7",
-        "next": "^12.0.7",
+        "next": "^12.2.0",
         "ts-jest": "^27.1.3",
         "typescript": "^4.6.4"
       },
       "dependencies": {
+        "@next/env": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.0.tgz",
+          "integrity": "sha512-/FCkDpL/8SodJEXvx/DYNlOD5ijTtkozf4PPulYPtkPOJaMPpBSOkzmsta4fnrnbdH6eZjbwbiXFdr6gSQCV4w=="
+        },
+        "@next/swc-android-arm64": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.0.tgz",
+          "integrity": "sha512-1eEk91JHjczcJomxJ8X0XaUeNcp5Lx1U2Ic7j15ouJ83oRX+3GIslOuabW2oPkSgXbHkThMClhirKpvG98kwZg==",
+          "optional": true
+        },
+        "@next/swc-darwin-arm64": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.0.tgz",
+          "integrity": "sha512-x5U5gJd7ZvrEtTFnBld9O2bUlX8opu7mIQUqRzj7KeWzBwPhrIzTTsQXAiNqsaMuaRPvyHBVW/5d/6g6+89Y8g==",
+          "optional": true
+        },
+        "@next/swc-darwin-x64": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.0.tgz",
+          "integrity": "sha512-iwMNFsrAPjfedjKDv9AXPAV16PWIomP3qw/FfPaxkDVRbUls7BNdofBLzkQmqxqWh93WrawLwaqyXpJuAaiwJA==",
+          "optional": true
+        },
+        "@next/swc-linux-arm-gnueabihf": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.0.tgz",
+          "integrity": "sha512-/TJZkxaIpeEwnXh6A40trgwd40C5+LJroLUOEQwMOJdavLl62PjCA6dGl1pgooWLCIb5YdBQ0EG4ylzvLwS2+Q==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-gnu": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.0.tgz",
+          "integrity": "sha512-++WAB4ElXCSOKG9H8r4ENF8EaV+w0QkrpjehmryFkQXmt5juVXz+nKDVlCRMwJU7A1O0Mie82XyEoOrf6Np1pA==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-musl": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.0.tgz",
+          "integrity": "sha512-XrqkHi/VglEn5zs2CYK6ofJGQySrd+Lr4YdmfJ7IhsCnMKkQY1ma9Hv5THwhZVof3e+6oFHrQ9bWrw9K4WTjFA==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.0.tgz",
+          "integrity": "sha512-MyhHbAKVjpn065WzRbqpLu2krj4kHLi6RITQdD1ee+uxq9r2yg5Qe02l24NxKW+1/lkmpusl4Y5Lks7rBiJn4w==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-musl": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.0.tgz",
+          "integrity": "sha512-Tz1tJZ5egE0S/UqCd5V6ZPJsdSzv/8aa7FkwFmIJ9neLS8/00za+OY5pq470iZQbPrkTwpKzmfTTIPRVD5iqDg==",
+          "optional": true
+        },
+        "@next/swc-win32-arm64-msvc": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.0.tgz",
+          "integrity": "sha512-0iRO/CPMCdCYUzuH6wXLnsfJX1ykBX4emOOvH0qIgtiZM0nVYbF8lkEyY2ph4XcsurpinS+ziWuYCXVqrOSqiw==",
+          "optional": true
+        },
+        "@next/swc-win32-ia32-msvc": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.0.tgz",
+          "integrity": "sha512-8A26RJVcJHwIKm8xo/qk2ePRquJ6WCI2keV2qOW/Qm+ZXrPXHMIWPYABae/nKN243YFBNyPiHytjX37VrcpUhg==",
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.0.tgz",
+          "integrity": "sha512-OI14ozFLThEV3ey6jE47zrzSTV/6eIMsvbwozo+XfdWqOPwQ7X00YkRx4GVMKMC0rM44oGS2gmwMKYpe4EblnA==",
+          "optional": true
+        },
+        "@swc/helpers": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
+          "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
         "@types/node": {
           "version": "16.11.22",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.22.tgz",
           "integrity": "sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==",
           "dev": true
+        },
+        "next": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/next/-/next-12.2.0.tgz",
+          "integrity": "sha512-B4j7D3SHYopLYx6/Ark0fenwIar9tEaZZFAaxmKjgcMMexhVJzB3jt7X+6wcdXPPMeUD6r09weUtnDpjox/vIA==",
+          "requires": {
+            "@next/env": "12.2.0",
+            "@next/swc-android-arm-eabi": "12.2.0",
+            "@next/swc-android-arm64": "12.2.0",
+            "@next/swc-darwin-arm64": "12.2.0",
+            "@next/swc-darwin-x64": "12.2.0",
+            "@next/swc-freebsd-x64": "12.2.0",
+            "@next/swc-linux-arm-gnueabihf": "12.2.0",
+            "@next/swc-linux-arm64-gnu": "12.2.0",
+            "@next/swc-linux-arm64-musl": "12.2.0",
+            "@next/swc-linux-x64-gnu": "12.2.0",
+            "@next/swc-linux-x64-musl": "12.2.0",
+            "@next/swc-win32-arm64-msvc": "12.2.0",
+            "@next/swc-win32-ia32-msvc": "12.2.0",
+            "@next/swc-win32-x64-msvc": "12.2.0",
+            "@swc/helpers": "0.4.2",
+            "caniuse-lite": "^1.0.30001332",
+            "postcss": "8.4.5",
+            "styled-jsx": "5.0.2",
+            "use-sync-external-store": "1.1.0"
+          }
+        },
+        "postcss": {
+          "version": "8.4.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+          "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+          "requires": {
+            "nanoid": "^3.1.30",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.1"
+          }
+        },
+        "styled-jsx": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+          "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+          "requires": {}
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -40464,72 +40915,96 @@
     "@next/env": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
-      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
+      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g==",
+      "dev": true
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.0.tgz",
+      "integrity": "sha512-hbneH8DNRB2x0Nf5fPCYoL8a0osvdTCe4pvOc9Rv5CpDsoOlf8BWBs2OWpeP0U2BktGvIsuUhmISmdYYGyrvTw==",
+      "optional": true
     },
     "@next/swc-android-arm64": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
       "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-darwin-arm64": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
       "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-darwin-x64": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
       "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
+      "dev": true,
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
+      "integrity": "sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
       "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
       "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
       "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
       "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
       "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
       "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
       "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
+      "dev": true,
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
       "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
+      "dev": true,
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -55619,6 +56094,7 @@
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
       "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
+      "dev": true,
       "requires": {
         "@next/env": "12.0.10",
         "@next/swc-android-arm64": "12.0.10",
@@ -55642,6 +56118,7 @@
           "version": "8.4.5",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
           "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+          "dev": true,
           "requires": {
             "nanoid": "^3.1.30",
             "picocolors": "^1.0.0",
@@ -60700,6 +61177,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
       "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==",
+      "dev": true,
       "requires": {}
     },
     "stylehacks": {
@@ -61844,9 +62322,16 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
       "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.1"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -39,7 +39,7 @@
     "@clerk/backend-core": "^1.10.0",
     "@clerk/types": "^2.17.0",
     "@peculiar/webcrypto": "^1.2.3",
-    "next": "^12.0.7"
+    "next": "^12.2.0"
   },
   "engines": {
     "node": ">=12"

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -76,12 +76,12 @@ export function withEdgeMiddlewareAuth(
 ): any {
   return async function clerkAuth(req: NextRequest, event: NextFetchEvent) {
     const { loadUser, loadSession, jwtKey, authorizedParties } = options;
-    const cookieToken = req.cookies['__session'];
+    const cookieToken = req.cookies.get('__session');
     const headerToken = req.headers.get('authorization');
     const { status, interstitial, sessionClaims, errorReason } = await vercelEdgeBase.getAuthState({
       cookieToken,
       headerToken,
-      clientUat: req.cookies['__client_uat'],
+      clientUat: req.cookies.get('__client_uat'),
       origin: req.headers.get('origin'),
       host: req.headers.get('host') as string,
       userAgent: req.headers.get('user-agent'),

--- a/packages/nextjs/api.d.ts
+++ b/packages/nextjs/api.d.ts
@@ -1,1 +1,2 @@
+// TODO: Dynamic typings based on process
 export * from './dist/api';

--- a/packages/nextjs/api.js
+++ b/packages/nextjs/api.js
@@ -1,1 +1,9 @@
-module.exports = require('./dist/api');
+let exportLib;
+if (process.env.NEXT_RUNTIME === 'edge') {
+  exportLib = require('./dist/edge-middleware');
+  exportLib.withAuth = exportLib.withEdgeMiddlewareAuth;
+} else {
+  exportLib = require('./dist/api');
+}
+
+module.exports = exportLib;


### PR DESCRIPTION
Compatibility with API middleware experimental edge runtime.

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
With the release of Next.js 12.2, many changes came forth on the experimental edge middleware support as it now becomes GA.

The changes on 12.2 affect us in the following ways:
1. Middleware files _(now at a different location)_ cannot return a response.
2. API routes can experimentaly use the `edge` runtime.
3. Breaking API changes for edge runtimes.

In this PR:
1. We address the breaking changes on our `@clerk/nextjs/edge-middleware` and `@clerk/edge/vercel-edge` functions.
2. We allow for seamless change in API experimental edge runtime in the following fashion:
```ts
// Normal middleware
import { withAuth } from "@clerk/nextjs/api";

export default withAuth(handler);

// Edge middleware. Works exactly as is without the need for the developer to change import paths
import { withAuth } from "@clerk/nextjs/api";

export default withAuth(handler);

export const config = {
 runtime: 'experimental-edge'
}
```

## Important considerations for (2)
1. There is no complete parity between the node-sdk exports and the clerk-edge exports. E.g. how would we handle `requireAuth` which is not valid for edge middleware ? 
2. Typings are still being worked on if we want them to work seamlessly, if possible.

Personally I am really skeptical if (2) this  is worth it at this point. The developer would need to change his handlers either way, as `edge` runtime handlers have different APIs than `nodejs`. I think we are bearing unneeded complexity for minimal increase in DX, if any at all, as confusion may also incur.