### PR TITLE
feat(clerk-js,clerk-react,types): Add closeUserButton and openUserBut…

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -192,6 +192,14 @@ export default class Clerk implements ClerkInterface {
     this.#components.closeSignUp();
   };
 
+  public openUserButton = () => {
+    return;
+  };
+
+  public closeUserButton = () => {
+    return;
+  };
+
   public mountSignIn = (node: HTMLDivElement, props?: SignInProps): void => {
     this.assertComponentsReady(this.#components);
     this.#components.mountComponent({

--- a/packages/clerk-js/src/ui/userButton/UserButton.tsx
+++ b/packages/clerk-js/src/ui/userButton/UserButton.tsx
@@ -1,6 +1,5 @@
 import { Avatar } from '@clerk/shared/components/avatar';
 import { Portal } from '@clerk/shared/components/portal';
-import { useDetectClickOutside } from '@clerk/shared/hooks';
 import type { UserButtonProps } from '@clerk/types';
 import cn from 'classnames';
 import React from 'react';
@@ -9,6 +8,7 @@ import { useCoreUser, withCoreUserGuard } from 'ui/contexts';
 
 import { PopupVisibilityContext } from './contexts/PopupVisibilityContext';
 import { UserButtonPopup } from './UserButtonPopup';
+import { useUserButtonVisibility } from './useUserButtonVisibility';
 import { determineIdentifier } from './utils';
 
 const userButtonPopperOptions = {
@@ -30,7 +30,8 @@ export const UserButton = withCoreUserGuard(({ showName }: UserButtonProps) => {
 
   const userButtonRef = React.useRef<HTMLButtonElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const { isActive, setIsActive } = useDetectClickOutside(containerRef, false);
+  const { isActive, setIsActive } = useUserButtonVisibility(containerRef);
+
   const { styles, attributes, update } = usePopper(
     userButtonRef.current,
     containerRef.current,

--- a/packages/clerk-js/src/ui/userButton/useUserButtonVisibility.ts
+++ b/packages/clerk-js/src/ui/userButton/useUserButtonVisibility.ts
@@ -1,0 +1,15 @@
+import { useDetectClickOutside } from '@clerk/shared/hooks';
+import React from 'react';
+import { useCoreClerk } from 'ui/contexts';
+
+export function useUserButtonVisibility(userButtonContainer: React.RefObject<HTMLDivElement>) {
+  const clerk = useCoreClerk();
+
+  const { isActive, setIsActive } = useDetectClickOutside(userButtonContainer, false);
+
+  /** Allow programmatic access of the UserButton visibility state */
+  clerk.openUserButton = () => setIsActive(true);
+  clerk.closeUserButton = () => setIsActive(false);
+
+  return { isActive, setIsActive };
+}

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -300,6 +300,18 @@ export default class IsomorphicClerk {
     }
   };
 
+  openUserButton = (): void => {
+    if (this.clerkjs && this.#loaded) {
+      this.clerkjs.openUserButton();
+    }
+  };
+
+  closeUserButton = (): void => {
+    if (this.clerkjs && this.#loaded) {
+      this.clerkjs.closeUserButton();
+    }
+  };
+
   mountSignIn = (node: HTMLDivElement, props: SignInProps): void => {
     if (this.clerkjs && this.#loaded) {
       this.clerkjs.mountSignIn(node, props);

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -73,6 +73,12 @@ export interface Clerk {
   /** Closes the Clerk sign in modal. */
   closeSignIn: () => void;
 
+  /** Open Clerk UserButton component */
+  openUserButton: () => void;
+
+  /** Close Clerk UserButton component */
+  closeUserButton: () => void;
+
   /**
    * Opens the Clerk sign up modal.
    *


### PR DESCRIPTION
…ton methods

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Introduce `closeUserButton` and `openUserButton` methods to programmatically control visibility of the `<UserButton />` component. 
These methods can be used directly from the Clerk object or from the `useClerk` hook _(This object was selected as we already have the openXModal methods there)_ .

https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=7792dc836db24909bd1f89501b5b331f&p=3ec7be1aa49b4c179a6b925b86d3ecb9