### PR TITLE
fix(clerk-js): Fix navigation when an error occurs during progressive sign up flow

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -628,12 +628,12 @@ export default class Clerk implements ClerkInterface {
       }
     }
 
-    if (su.externalAccountStatus === 'verified' && su.status == 'missing_requirements') {
-      return navigateToContinueSignUp();
-    }
-
     if (hasExternalAccountSignUpError(signUp)) {
       return navigateToSignUp();
+    }
+
+    if (su.externalAccountStatus === 'verified' && su.status === 'missing_requirements') {
+      return navigateToContinueSignUp();
     }
 
     return navigateToSignIn();


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This commit fixes a logical error in our redirect logic during an OAuth flow and progressive sign up. If the external account was verified and were still missing requirements for sign up to complete, we redirected to the sign-up continue url. Although the right thing to do, is to first check if there is an error on the external account verification. Image a scenario where an instance uses sign-up restrictions for emails. The user tries to sign-up using an OAuth account whose email is not listed on the allowlist. We should redirect them back on the sign-up url and preview the error, instead of the sign up continue path

https://www.notion.so/clerkdev/PSU-asks-for-email-after-OAuth-flow-although-it-s-already-provided-when-Allowlists-are-on-e8129bd8b7ca488abc5f07ef5b382a93
