### PR TITLE
feat(clerk-sdk-node,backend-core)!: Upgrade targets to Node.js 14

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -39,5 +39,8 @@
   "bugs": {
     "url": "https://github.com/clerkinc/javascript/issues"
   },
-  "homepage": "https://clerk.dev/"
+  "homepage": "https://clerk.dev/",
+  "engines": {
+    "node": ">=14"
+  }
 }

--- a/packages/backend-core/tsconfig.json
+++ b/packages/backend-core/tsconfig.json
@@ -15,7 +15,7 @@
     "resolveJsonModule": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2019"
+    "target": "ES2020"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -12,7 +12,7 @@
     "package.json"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "build:es5": "node ./scripts/info.js && tsc -p tsconfig.build.json",

--- a/packages/sdk-node/tsconfig.json
+++ b/packages/sdk-node/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "forceConsistentCasingInFileNames": true,
-    "target": "ES2019",
+    "target": "ES2020",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "lib": ["ES2020"]


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Minimum required Node.js version becomes Node 14. Targets have been chosen using https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-14