### PR TITLE
feat(nextjs,edge,backend-core): Add getAuth and runClerkMiddleware pr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5702,12 +5702,6 @@
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "peer": true
     },
-    "node_modules/@next/env": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
-      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g==",
-      "dev": true
-    },
     "node_modules/@next/swc-android-arm-eabi": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.0.tgz",
@@ -5723,54 +5717,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
-      "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
-      "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
-      "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-freebsd-x64": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
@@ -5781,134 +5727,6 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
-      "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
-      "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
-      "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
-      "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
-      "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
-      "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
-      "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
-      "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -25636,79 +25454,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
-    "node_modules/next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
-      "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
-      "dev": true,
-      "dependencies": {
-        "@next/env": "12.0.10",
-        "caniuse-lite": "^1.0.30001283",
-        "postcss": "8.4.5",
-        "styled-jsx": "5.0.0",
-        "use-subscription": "1.5.1"
-      },
-      "bin": {
-        "next": "dist/bin/next"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "optionalDependencies": {
-        "@next/swc-android-arm64": "12.0.10",
-        "@next/swc-darwin-arm64": "12.0.10",
-        "@next/swc-darwin-x64": "12.0.10",
-        "@next/swc-linux-arm-gnueabihf": "12.0.10",
-        "@next/swc-linux-arm64-gnu": "12.0.10",
-        "@next/swc-linux-arm64-musl": "12.0.10",
-        "@next/swc-linux-x64-gnu": "12.0.10",
-        "@next/swc-linux-x64-musl": "12.0.10",
-        "@next/swc-win32-arm64-msvc": "12.0.10",
-        "@next/swc-win32-ia32-msvc": "12.0.10",
-        "@next/swc-win32-x64-msvc": "12.0.10"
-      },
-      "peerDependencies": {
-        "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
-        "sass": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "fibers": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "peer": true
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
-      "dev": true,
-      "dependencies": {
-        "nanoid": "^3.1.30",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -32393,26 +32143,6 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/styled-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
-      "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || 18.x.x"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/stylehacks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
@@ -33981,18 +33711,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -35762,6 +35480,7 @@
       "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
+        "@clerk/backend-core": "^1.13.0",
         "@clerk/clerk-react": "^3.5.0",
         "@clerk/clerk-sdk-node": "^3.8.6",
         "@clerk/edge": "^1.6.1",
@@ -35774,7 +35493,7 @@
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
         "jest": "^27.4.7",
-        "next": "^12.0.10",
+        "next": "^12.2.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
@@ -35787,11 +35506,330 @@
         "next": ">=10"
       }
     },
+    "packages/nextjs/node_modules/@next/env": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.2.tgz",
+      "integrity": "sha512-BqDwE4gDl1F608TpnNxZqrCn6g48MBjvmWFEmeX5wEXDXh3IkAOw6ASKUgjT8H4OUePYFqghDFUss5ZhnbOUjw==",
+      "dev": true
+    },
+    "packages/nextjs/node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.2.tgz",
+      "integrity": "sha512-VHjuCHeq9qCprUZbsRxxM/VqSW8MmsUtqB5nEpGEgUNnQi/BTm/2aK8tl7R4D0twGKRh6g1AAeFuWtXzk9Z/vQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-android-arm64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.2.tgz",
+      "integrity": "sha512-v5EYzXUOSv0r9mO/2PX6mOcF53k8ndlu9yeFHVAWW1Dhw2jaJcvTRcCAwYYN8Q3tDg0nH3NbEltJDLKmcJOuVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-darwin-arm64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.2.tgz",
+      "integrity": "sha512-JCoGySHKGt+YBk7xRTFGx1QjrnCcwYxIo3yGepcOq64MoiocTM3yllQWeOAJU2/k9MH0+B5E9WUSme4rOCBbpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-darwin-x64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.2.tgz",
+      "integrity": "sha512-dztDtvfkhUqiqpXvrWVccfGhLe44yQ5tQ7B4tBfnsOR6vxzI9DNPHTlEOgRN9qDqTAcFyPxvg86mn4l8bB9Jcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
+      "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.2.tgz",
+      "integrity": "sha512-XeYC/qqPLz58R4pjkb+x8sUUxuGLnx9QruC7/IGkK68yW4G17PHwKI/1njFYVfXTXUukpWjcfBuauWwxp9ke7Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.2.tgz",
+      "integrity": "sha512-d6jT8xgfKYFkzR7J0OHo2D+kFvY/6W8qEo6/hmdrTt6AKAqxs//rbbcdoyn3YQq1x6FVUUd39zzpezZntg9Naw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.2.tgz",
+      "integrity": "sha512-rIZRFxI9N/502auJT1i7coas0HTHUM+HaXMyJiCpnY8Rimbo0495ir24tzzHo3nQqJwcflcPTwEh/DV17sdv9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.2.tgz",
+      "integrity": "sha512-ir1vNadlUDj7eQk15AvfhG5BjVizuCHks9uZwBfUgT5jyeDCeRvaDCo1+Q6+0CLOAnYDR/nqSCvBgzG2UdFh9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.2.tgz",
+      "integrity": "sha512-bte5n2GzLN3O8JdSFYWZzMgEgDHZmRz5wiispiiDssj4ik3l8E7wq/czNi8RmIF+ioj2sYVokUNa/ekLzrESWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.2.tgz",
+      "integrity": "sha512-ZUGCmcDmdPVSAlwJ/aD+1F9lYW8vttseiv4n2+VCDv5JloxiX9aY32kYZaJJO7hmTLNrprvXkb4OvNuHdN22Jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.2.tgz",
+      "integrity": "sha512-v7ykeEDbr9eXiblGSZiEYYkWoig6sRhAbLKHUHQtk8vEWWVEqeXFcxmw6LRrKu5rCN1DY357UlYWToCGPQPCRA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.2.tgz",
+      "integrity": "sha512-2D2iinWUL6xx8D9LYVZ5qi7FP6uLAoWymt8m8aaG2Ld/Ka8/k723fJfiklfuAcwOxfufPJI+nRbT5VcgHGzHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/nextjs/node_modules/@swc/helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
+      "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "packages/nextjs/node_modules/@types/node": {
       "version": "16.11.22",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.22.tgz",
       "integrity": "sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==",
       "dev": true
+    },
+    "packages/nextjs/node_modules/next": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.2.2.tgz",
+      "integrity": "sha512-zAYFY45aBry/PlKONqtlloRFqU/We3zWYdn2NoGvDZkoYUYQSJC8WMcalS5C19MxbCZLUVCX7D7a6gTGgl2yLg==",
+      "dev": true,
+      "dependencies": {
+        "@next/env": "12.2.2",
+        "@swc/helpers": "0.4.2",
+        "caniuse-lite": "^1.0.30001332",
+        "postcss": "8.4.5",
+        "styled-jsx": "5.0.2",
+        "use-sync-external-store": "1.1.0"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-android-arm-eabi": "12.2.2",
+        "@next/swc-android-arm64": "12.2.2",
+        "@next/swc-darwin-arm64": "12.2.2",
+        "@next/swc-darwin-x64": "12.2.2",
+        "@next/swc-freebsd-x64": "12.2.2",
+        "@next/swc-linux-arm-gnueabihf": "12.2.2",
+        "@next/swc-linux-arm64-gnu": "12.2.2",
+        "@next/swc-linux-arm64-musl": "12.2.2",
+        "@next/swc-linux-x64-gnu": "12.2.2",
+        "@next/swc-linux-x64-musl": "12.2.2",
+        "@next/swc-win32-arm64-msvc": "12.2.2",
+        "@next/swc-win32-ia32-msvc": "12.2.2",
+        "@next/swc-win32-x64-msvc": "12.2.2"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^6.0.0 || ^7.0.0",
+        "react": "^17.0.2 || ^18.0.0-0",
+        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "packages/nextjs/node_modules/next/node_modules/styled-jsx": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "packages/nextjs/node_modules/postcss": {
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+      "dev": true,
+      "dependencies": {
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "packages/nextjs/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "packages/react": {
       "name": "@clerk/clerk-react",
@@ -37678,6 +37716,7 @@
     "@clerk/nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
+        "@clerk/backend-core": "*",
         "@clerk/clerk-react": "^3.5.0",
         "@clerk/clerk-sdk-node": "^3.8.6",
         "@clerk/edge": "^1.6.1",
@@ -37687,7 +37726,7 @@
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
         "jest": "^27.4.7",
-        "next": "^12.0.10",
+        "next": "^12.2.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
@@ -37695,11 +37734,169 @@
         "typescript": "^4.6.4"
       },
       "dependencies": {
+        "@next/env": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.2.tgz",
+          "integrity": "sha512-BqDwE4gDl1F608TpnNxZqrCn6g48MBjvmWFEmeX5wEXDXh3IkAOw6ASKUgjT8H4OUePYFqghDFUss5ZhnbOUjw==",
+          "dev": true
+        },
+        "@next/swc-android-arm-eabi": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.2.tgz",
+          "integrity": "sha512-VHjuCHeq9qCprUZbsRxxM/VqSW8MmsUtqB5nEpGEgUNnQi/BTm/2aK8tl7R4D0twGKRh6g1AAeFuWtXzk9Z/vQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-android-arm64": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.2.tgz",
+          "integrity": "sha512-v5EYzXUOSv0r9mO/2PX6mOcF53k8ndlu9yeFHVAWW1Dhw2jaJcvTRcCAwYYN8Q3tDg0nH3NbEltJDLKmcJOuVA==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-darwin-arm64": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.2.tgz",
+          "integrity": "sha512-JCoGySHKGt+YBk7xRTFGx1QjrnCcwYxIo3yGepcOq64MoiocTM3yllQWeOAJU2/k9MH0+B5E9WUSme4rOCBbpA==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-darwin-x64": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.2.tgz",
+          "integrity": "sha512-dztDtvfkhUqiqpXvrWVccfGhLe44yQ5tQ7B4tBfnsOR6vxzI9DNPHTlEOgRN9qDqTAcFyPxvg86mn4l8bB9Jcw==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-freebsd-x64": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
+          "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-arm-gnueabihf": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.2.tgz",
+          "integrity": "sha512-XeYC/qqPLz58R4pjkb+x8sUUxuGLnx9QruC7/IGkK68yW4G17PHwKI/1njFYVfXTXUukpWjcfBuauWwxp9ke7Q==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-arm64-gnu": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.2.tgz",
+          "integrity": "sha512-d6jT8xgfKYFkzR7J0OHo2D+kFvY/6W8qEo6/hmdrTt6AKAqxs//rbbcdoyn3YQq1x6FVUUd39zzpezZntg9Naw==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-arm64-musl": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.2.tgz",
+          "integrity": "sha512-rIZRFxI9N/502auJT1i7coas0HTHUM+HaXMyJiCpnY8Rimbo0495ir24tzzHo3nQqJwcflcPTwEh/DV17sdv9A==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.2.tgz",
+          "integrity": "sha512-ir1vNadlUDj7eQk15AvfhG5BjVizuCHks9uZwBfUgT5jyeDCeRvaDCo1+Q6+0CLOAnYDR/nqSCvBgzG2UdFh9A==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-linux-x64-musl": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.2.tgz",
+          "integrity": "sha512-bte5n2GzLN3O8JdSFYWZzMgEgDHZmRz5wiispiiDssj4ik3l8E7wq/czNi8RmIF+ioj2sYVokUNa/ekLzrESWw==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-win32-arm64-msvc": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.2.tgz",
+          "integrity": "sha512-ZUGCmcDmdPVSAlwJ/aD+1F9lYW8vttseiv4n2+VCDv5JloxiX9aY32kYZaJJO7hmTLNrprvXkb4OvNuHdN22Jg==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-win32-ia32-msvc": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.2.tgz",
+          "integrity": "sha512-v7ykeEDbr9eXiblGSZiEYYkWoig6sRhAbLKHUHQtk8vEWWVEqeXFcxmw6LRrKu5rCN1DY357UlYWToCGPQPCRA==",
+          "dev": true,
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.2.tgz",
+          "integrity": "sha512-2D2iinWUL6xx8D9LYVZ5qi7FP6uLAoWymt8m8aaG2Ld/Ka8/k723fJfiklfuAcwOxfufPJI+nRbT5VcgHGzHAQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@swc/helpers": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.2.tgz",
+          "integrity": "sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
         "@types/node": {
           "version": "16.11.22",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.22.tgz",
           "integrity": "sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==",
           "dev": true
+        },
+        "next": {
+          "version": "12.2.2",
+          "resolved": "https://registry.npmjs.org/next/-/next-12.2.2.tgz",
+          "integrity": "sha512-zAYFY45aBry/PlKONqtlloRFqU/We3zWYdn2NoGvDZkoYUYQSJC8WMcalS5C19MxbCZLUVCX7D7a6gTGgl2yLg==",
+          "dev": true,
+          "requires": {
+            "@next/env": "12.2.2",
+            "@next/swc-android-arm-eabi": "12.2.2",
+            "@next/swc-android-arm64": "12.2.2",
+            "@next/swc-darwin-arm64": "12.2.2",
+            "@next/swc-darwin-x64": "12.2.2",
+            "@next/swc-freebsd-x64": "12.2.2",
+            "@next/swc-linux-arm-gnueabihf": "12.2.2",
+            "@next/swc-linux-arm64-gnu": "12.2.2",
+            "@next/swc-linux-arm64-musl": "12.2.2",
+            "@next/swc-linux-x64-gnu": "12.2.2",
+            "@next/swc-linux-x64-musl": "12.2.2",
+            "@next/swc-win32-arm64-msvc": "12.2.2",
+            "@next/swc-win32-ia32-msvc": "12.2.2",
+            "@next/swc-win32-x64-msvc": "12.2.2",
+            "@swc/helpers": "0.4.2",
+            "caniuse-lite": "^1.0.30001332",
+            "postcss": "8.4.5",
+            "styled-jsx": "5.0.2",
+            "use-sync-external-store": "1.1.0"
+          },
+          "dependencies": {
+            "styled-jsx": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+              "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+              "dev": true,
+              "requires": {}
+            }
+          }
+        },
+        "postcss": {
+          "version": "8.4.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+          "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
+          "dev": true,
+          "requires": {
+            "nanoid": "^3.1.30",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -40827,99 +41024,16 @@
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "peer": true
     },
-    "@next/env": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
-      "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g==",
-      "dev": true
-    },
     "@next/swc-android-arm-eabi": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.0.tgz",
       "integrity": "sha512-hbneH8DNRB2x0Nf5fPCYoL8a0osvdTCe4pvOc9Rv5CpDsoOlf8BWBs2OWpeP0U2BktGvIsuUhmISmdYYGyrvTw==",
       "optional": true
     },
-    "@next/swc-android-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
-      "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
-      "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
-      "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
-      "dev": true,
-      "optional": true
-    },
     "@next/swc-freebsd-x64": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
       "integrity": "sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==",
-      "optional": true
-    },
-    "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
-      "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
-      "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
-      "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
-      "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
-      "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
-      "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
-      "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
-      "dev": true,
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
-      "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
-      "dev": true,
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -55945,43 +56059,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
-    "next": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
-      "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
-      "dev": true,
-      "requires": {
-        "@next/env": "12.0.10",
-        "@next/swc-android-arm64": "12.0.10",
-        "@next/swc-darwin-arm64": "12.0.10",
-        "@next/swc-darwin-x64": "12.0.10",
-        "@next/swc-linux-arm-gnueabihf": "12.0.10",
-        "@next/swc-linux-arm64-gnu": "12.0.10",
-        "@next/swc-linux-arm64-musl": "12.0.10",
-        "@next/swc-linux-x64-gnu": "12.0.10",
-        "@next/swc-linux-x64-musl": "12.0.10",
-        "@next/swc-win32-arm64-msvc": "12.0.10",
-        "@next/swc-win32-ia32-msvc": "12.0.10",
-        "@next/swc-win32-x64-msvc": "12.0.10",
-        "caniuse-lite": "^1.0.30001283",
-        "postcss": "8.4.5",
-        "styled-jsx": "5.0.0",
-        "use-subscription": "1.5.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "8.4.5",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
-          "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
-          "dev": true,
-          "requires": {
-            "nanoid": "^3.1.30",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.1"
-          }
-        }
-      }
-    },
     "next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
@@ -61032,13 +61109,6 @@
         "schema-utils": "^3.0.0"
       }
     },
-    "styled-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
-      "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==",
-      "dev": true,
-      "requires": {}
-    },
     "stylehacks": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
@@ -62176,15 +62246,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "peer": true
-    },
-    "use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1"
-      }
     },
     "use-sync-external-store": {
       "version": "1.1.0",

--- a/packages/backend-core/src/types/core.ts
+++ b/packages/backend-core/src/types/core.ts
@@ -21,7 +21,7 @@ export type VerifySessionTokenOptions = {
 export type BuildAuthenticatedStateOptions = {
   jwtKey?: string;
   authorizedParties?: string[];
-  fetchInterstitial: () => Promise<string>;
+  fetchInterstitial: () => Promise<string> | null;
   tokenType: TokenType;
 };
 
@@ -30,7 +30,8 @@ export type TokenType = 'cookie' | 'header';
 export type AuthState = {
   status: AuthStatus;
   session?: Session;
-  interstitial?: string;
+  /* Interstitial is returned as null when the client will handle the interstitial logic */
+  interstitial?: string | null;
   sessionClaims?: ClerkJWTClaims;
   /* Error reason for signed-out and interstitial states. Would probably be set on the `Auth-Result` response header. */
   errorReason?: AuthErrorReason;
@@ -59,8 +60,11 @@ export type AuthStateParams = {
   userAgent?: string | null;
   /* A list of authorized parties to validate against the session token azp claim */
   authorizedParties?: string[];
-  /* HTTP utility for fetching a text/html string */
-  fetchInterstitial: () => Promise<string>;
+  /*
+   * HTTP utility for fetching a text/html string.
+   * If explicitly `null` it will only return the status for the client to handle as it may
+   */
+  fetchInterstitial: () => Promise<string> | null;
   /* Value corresponding to the JWT verification key */
   jwtKey?: string;
 };

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -35,7 +35,7 @@ const decodeBase64 = (base64: string) => atob(base64);
 
 /** Base initialization */
 
-const vercelEdgeBase = new Base(importKey, verifySignature, decodeBase64);
+export const vercelEdgeBase = new Base(importKey, verifySignature, decodeBase64);
 
 /** Export standalone verifySessionToken */
 
@@ -51,11 +51,11 @@ const organizations = ClerkAPI.organizations;
 const sessions = ClerkAPI.sessions;
 const smsMessages = ClerkAPI.smsMessages;
 const users = ClerkAPI.users;
-
+const clerkApi = ClerkAPI;
 // Export sub-api objects
-export { allowlistIdentifiers, clients, emails, invitations, organizations, sessions, smsMessages, users };
+export { allowlistIdentifiers, clients, emails, invitations, organizations, sessions, smsMessages, users, clerkApi };
 
-async function fetchInterstitial() {
+export async function fetchInterstitial() {
   return ClerkAPI.fetchInterstitial();
 }
 

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -32,6 +32,7 @@
     "dev": "tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
+    "@clerk/backend-core": "^1.13.0",
     "@clerk/clerk-react": "^3.5.0",
     "@clerk/clerk-sdk-node": "^3.8.6",
     "@clerk/edge": "^1.6.1",
@@ -44,7 +45,7 @@
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "jest": "^27.4.7",
-    "next": "^12.0.10",
+    "next": "^12.2.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ts-jest": "^27.1.3",

--- a/packages/nextjs/server.js
+++ b/packages/nextjs/server.js
@@ -1,0 +1,11 @@
+let exportLib = {};
+exportLib.runClerkMiddleware = require('./dist/server/runClerkMiddleware').runClerkMiddleware;
+if (process.env.NEXT_RUNTIME === 'edge') {
+  exportLib.getAuth = require('./dist/server/getAuthEdge').getAuthEdge;
+  exportLib.clerkApi = require('./dist/edge-middleware').clerkApi;
+} else {
+  exportLib.getAuth = require('./dist/server/getAuthNode').getAuthNode;
+  exportLib.clerkApi = require('./dist/api').default;
+}
+
+module.exports = exportLib;

--- a/packages/nextjs/src/server/getAuthEdge.ts
+++ b/packages/nextjs/src/server/getAuthEdge.ts
@@ -1,0 +1,4 @@
+import { sessions } from '../edge-middleware';
+import { createGetAuth } from './utils/getAuth';
+
+export const getAuthEdge = createGetAuth(sessions);

--- a/packages/nextjs/src/server/getAuthNode.ts
+++ b/packages/nextjs/src/server/getAuthNode.ts
@@ -1,0 +1,4 @@
+import { sessions } from '../api';
+import { createGetAuth } from './utils/getAuth';
+
+export const getAuthNode = createGetAuth(sessions);

--- a/packages/nextjs/src/server/runClerkMiddleware.ts
+++ b/packages/nextjs/src/server/runClerkMiddleware.ts
@@ -1,0 +1,73 @@
+import { AuthStatus, createGetToken } from '@clerk/backend-core';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { sessions, vercelEdgeBase } from '../edge-middleware';
+
+const DEFAULT_API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
+const DEFAULT_API_VERSION = process.env.CLERK_API_VERSION || 'v1';
+
+const INTERSTITIAL_URL = `${DEFAULT_API_URL}/${DEFAULT_API_VERSION}/internal/interstitial`;
+
+type RunClerkMiddlewareOptions = {
+  jwtKey?: string;
+  authorizedParties?: string[];
+};
+
+export async function runClerkMiddleware(req: NextRequest, opts: RunClerkMiddlewareOptions = {}): Promise<any> {
+  const { headers, cookies } = req;
+  const { jwtKey, authorizedParties } = opts;
+
+  try {
+    const cookieToken = cookies.get('__session');
+    const headerToken = headers.get('authorization')?.replace('Bearer ', '');
+    const { status, sessionClaims } = await vercelEdgeBase.getAuthState({
+      cookieToken,
+      headerToken,
+      clientUat: cookies.get('__client_uat'),
+      origin: headers.get('origin'),
+      host: headers.get('host') as string,
+      forwardedPort: headers.get('x-forwarded-port'),
+      forwardedHost: headers.get('x-forwarded-host'),
+      referrer: headers.get('referer'),
+      userAgent: headers.get('user-agent'),
+      fetchInterstitial: () => null,
+      jwtKey,
+      authorizedParties,
+    });
+
+    const auth = {
+      sessionId: sessionClaims?.sid,
+      userId: sessionClaims?.sub,
+      getToken: createGetToken({
+        headerToken,
+        cookieToken,
+        sessionId: sessionClaims?.sid,
+        fetcher: (...args) => sessions.getToken(...args),
+      }),
+      claims: sessionClaims,
+    };
+
+    if (status === AuthStatus.Interstitial) {
+      return {
+        response: NextResponse.rewrite(INTERSTITIAL_URL, {
+          headers: {
+            Authorization: `Bearer ${process.env.CLERK_API_KEY}`,
+          },
+        }),
+        auth,
+      };
+    }
+
+    const response = NextResponse.next();
+    response.headers.append(
+      'Clerk-Auth-Middleware',
+      JSON.stringify({ status, ...auth, getToken: undefined, cookieToken, headerToken }),
+    );
+    return {
+      response,
+      auth,
+    };
+  } catch (err) {
+    return { response: null, auth: null };
+  }
+}

--- a/packages/nextjs/src/server/utils/getAuth.ts
+++ b/packages/nextjs/src/server/utils/getAuth.ts
@@ -1,0 +1,28 @@
+import type { ClerkBackendAPI } from '@clerk/backend-core';
+import { createGetToken } from '@clerk/backend-core';
+import { ServerResponse } from 'http';
+
+type SessionsApi = InstanceType<typeof ClerkBackendAPI>['sessions'];
+
+export function createGetAuth(sessionsApi: SessionsApi) {
+  return function (res: ServerResponse) {
+    const authHeader = res.getHeader('clerk-auth-middleware');
+    res.removeHeader('clerk-auth-middleware');
+    if (!authHeader) {
+      throw 'You need to use "runClerkMiddleware" on your Next.js middleware file.';
+    }
+
+    const authData = JSON.parse(authHeader as string);
+    return {
+      ...authData,
+      getToken: createGetToken({
+        headerToken: authData.headerToken,
+        cookieToken: authData.cookieToken,
+        sessionId: authData.sessionId,
+        fetcher: (...args) => sessionsApi.getToken(...args),
+      }),
+      headerToken: undefined,
+      cookieToken: undefined,
+    };
+  };
+}


### PR DESCRIPTION
Draft proposal

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
## Integration strategy proposal for Next.js 12.2 compatible APIs

This PR adds 2 new methods for use in the new `middleware` structure of Next.js > 12.2.
- `runClerkMiddleware` should be run on the middleware file
- `getAuth` can be run on both `gssp` and `Node.js API routes`
- API calls work for`gssp`, `middleware` and Node.js API routes from the same import.

```ts
// gssp
import { getAuth, clerkApi } from "@clerk/nextjs/server";

export default function Home() {
  return ();
}

export async function getServerSideProps(ctx) {
  const auth = getAuth(ctx.res);

  const sessions = await clerkApi.sessions.getSessionList();
  console.log("gssp sessions: ", sessions);
  return { props: {} };
}

// middleware
import { NextRequest } from "next/server";
import { runClerkMiddleware, clerkApi } from "@clerk/nextjs/server";

export async function middleware(request: NextRequest) {
  const { auth, response } = await runClerkMiddleware(request);
  const sessions = await clerkApi.sessions.getSessionList();
  console.log("sessions middleware", sessions);
  return response;
}
```

The proposal uses a header(Clerk-Auth-Middleware) which is passed from the middleware file down to `gssp` and API routes. There `getAuth` retrieves the values from the decoded key  etc., adds the appropriate `getToken` version and removes it from the client. In the worst case scenario where the client does not use `getAuth`, the header retrieved on the client is the decoded JWT.

## Issues/12.2 stuff
- Intersitital rewrite does not receive the `Authorization` header properly. Using `NextResponse.rewrite` does calls a proxy request on the Next.js server but does not seem to add any additional headers on the request, it only adds them on the final response. See more [here](https://github.com/vercel/next.js/blob/9a1b756defbdc735a136504aae7fa1a6212eefb4/packages/next/server/next-server.ts#L502). The only place I found which can add data on the original request is the query string which persists for the final rewrite request. **This is a blocker for interstitial.**
- As it [seems from GH](https://github.com/vercel/next.js/discussions/38650) the `req` object is immutable from the middleware so the `getAuth` method cannot retrieve data from the `req` but from the `res` object.
- The `experimental-edge` API routes seem to run before the middleware file which seems unintuitive to me. Using experimental-edge API together with `middleware` seems to be having these issues.

### WIP
- Typings.
- Testing more cases.
- Add options on `getAuth` which were present on the wrappers such as `authorizedParties` etc.
- Check if we can throw at some point when we detect no removal of `Clerk-Auth-Middleware`

<!-- Fixes # (issue number) -->
Based on: https://www.notion.so/clerkdev/Next-js-12-2-New-integration-strategy-move-auth-to-middleware-ts-0293c1f53a134dc08ed9b4cfee7b06fd