### PR TITLE
Introduce touchSession Clerk option and onAfterResponseCallbacks improvements

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -78,7 +78,7 @@ declare global {
   }
 }
 
-const defaultOptions: ClerkOptions & { polling: boolean } = { polling: true };
+const defaultOptions: ClerkOptions = { polling: true, touchSession: true };
 
 export default class Clerk implements ClerkInterface {
   public static Components?: typeof Components;
@@ -857,7 +857,7 @@ export default class Clerk implements ClerkInterface {
 
   // TODO: Be more conservative about touches. Throttle, don't touch when only one user, etc
   #touchLastActiveSession = (session: ActiveSessionResource | null): Promise<unknown> => {
-    if (!session) {
+    if (!session || !this.#options.touchSession) {
       return Promise.resolve();
     }
     return session.touch().catch(noop);

--- a/packages/clerk-js/src/core/services/authentication/AuthenticationService.ts
+++ b/packages/clerk-js/src/core/services/authentication/AuthenticationService.ts
@@ -18,7 +18,7 @@ export class AuthenticationService {
   constructor(private clerk: Clerk) {}
 
   public initAuth = (opts: InitParams): void => {
-    this.enablePolling = opts.enablePolling || true;
+    this.enablePolling = opts.enablePolling ?? true;
     this.setAuthCookiesFromSession(this.clerk.session);
     this.setClientUatCookieForDevelopmentInstances();
     this.clearLegacyAuthV1Cookies();

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -292,6 +292,7 @@ export type ClerkThemeOptions = DeepSnakeToCamel<DeepPartial<DisplayThemeJSON>>;
 export interface ClerkOptions {
   navigate?: (to: string) => Promise<unknown> | unknown;
   polling?: boolean;
+  touchSession?: boolean;
   selectInitialSession?: (client: ClientResource) => ActiveSessionResource | null;
   theme?: ClerkThemeOptions;
   /** Optional support email for display in authentication screens */


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
