### PR TITLE
fix(clerk-sdk-node): Snakecase only top level keys for BAPI calls

### DIFF
--- a/packages/backend-core/src/__tests__/endpoints/InvitationApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/InvitationApi.test.ts
@@ -70,7 +70,7 @@ test('createInvitation() accepts a redirectUrl', async () => {
 test('createInvitation() accepts publicMetadata', async () => {
   const emailAddress = 'test@example.com';
   const publicMetadata = {
-    hello: 'world',
+    helloWorld: 42,
   };
   const resJSON = {
     object: 'invitation',

--- a/packages/backend-core/src/__tests__/endpoints/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/OrganizationApi.test.ts
@@ -127,8 +127,8 @@ test('updateOrganization() updates organization', async () => {
 test('updateOrganizationMetadata() updates organization metadata', async () => {
   const id = 'org_randomid';
   const slug = 'acme-inc';
-  const publicMetadata = { hello: 'world' };
-  const privateMetadata = { goodbye: 'world' };
+  const publicMetadata = { helloWorld: 42 };
+  const privateMetadata = { goodbyeWorld: 42 };
   const resJSON: OrganizationJSON = {
     object: ObjectType.Organization,
     id,

--- a/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
@@ -160,15 +160,25 @@ test('createUser() creates a user', async () => {
 test('updateUser() updates a user', async () => {
   const params = {
     emailAddress: ['boss@clerk.dev'],
-    phoneNumber: ['+15555555555'],
-    username: 'clerk_boss',
-    password: '123456',
     firstName: 'Boss',
-    lastName: 'Clerk',
+    publicMetadata: {
+      topKey: {
+        nestedKey: 42,
+      },
+    },
   };
 
   nock(defaultServerAPIUrl)
-    .patch('/v1/users/user_1oBNj55jOjSK9rOYrT5QHqj7eaK', snakecaseKeys(params))
+    .patch('/v1/users/user_1oBNj55jOjSK9rOYrT5QHqj7eaK', {
+      email_address: ['boss@clerk.dev'],
+      first_name: 'Boss',
+      // The SDK converts only top level keys to snakecase. Nested objects such as metadata are kept with their original key & values.
+      public_metadata: {
+        topKey: {
+          nestedKey: 42,
+        },
+      },
+    })
     .replyWithFile(200, __dirname + '/responses/updateUser.json', {
       'Content-Type': '',
     });

--- a/packages/backend-core/src/api/ClerkBackendApi.ts
+++ b/packages/backend-core/src/api/ClerkBackendApi.ts
@@ -100,10 +100,13 @@ export class ClerkBackendAPI {
       ...requestOptions.headerParams,
     };
 
-    newRequestOptions.bodyParams = snakecaseKeys({
-      ...this.getDefaultBodyParams(),
-      ...requestOptions.bodyParams,
-    });
+    newRequestOptions.bodyParams = snakecaseKeys(
+      {
+        ...this.getDefaultBodyParams(),
+        ...requestOptions.bodyParams,
+      },
+      { deep: false },
+    );
 
     const data = await this.apiClient.request<T>(newRequestOptions);
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

**This fix introduces a breaking change**

Clerk Node SDK has been accidentally snakecasing all keys of the request json payload. As a result public_metadata.fooBar was becoming public_metadata.foo_bar. This isn't happening from other SDKs or direct BAPI calls. The behavior is very confusing and can cause business logic flaws for Clerk applications.

<!-- Fixes # (issue number) -->
