### PR TITLE
Non standard browser mode

### DIFF
--- a/packages/clerk-js/src/utils/index.ts
+++ b/packages/clerk-js/src/utils/index.ts
@@ -15,7 +15,6 @@ export * from './jwt';
 export * from './pageLifecycle';
 export * from './path';
 export * from './querystring';
-export * from './runtime';
 export * from './runWithExponentialBackOff';
 export * from './safeLock';
 export * from './script';

--- a/packages/clerk-js/src/utils/runtime.ts
+++ b/packages/clerk-js/src/utils/runtime.ts
@@ -1,3 +1,0 @@
-export function isReactNative(): boolean {
-  return typeof navigator != 'undefined' && navigator.product === 'ReactNative';
-}

--- a/packages/expo/src/ClerkProvider.tsx
+++ b/packages/expo/src/ClerkProvider.tsx
@@ -4,6 +4,7 @@ import { ClerkProvider as ClerkReactProvider, ClerkProviderProps as ClerkReactPr
 import React from 'react';
 
 import type { TokenCache } from './cache';
+import { isReactNative } from './runtime';
 import { buildClerk } from './singleton';
 
 export type ClerkProviderProps = ClerkReactProviderProps & {
@@ -32,6 +33,7 @@ export function ClerkProvider(props: ClerkProviderProps): JSX.Element {
     <ClerkReactProvider
       {...rest}
       Clerk={getClerk()}
+      standardBrowser={!isReactNative()}
     >
       {children}
     </ClerkReactProvider>

--- a/packages/expo/src/runtime.ts
+++ b/packages/expo/src/runtime.ts
@@ -1,0 +1,3 @@
+export function isReactNative(): boolean {
+  return typeof navigator != 'undefined' && navigator.product === 'ReactNative';
+}

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -303,13 +303,15 @@ export type CustomNavigation = (to: string) => Promise<unknown> | void;
 export type ClerkThemeOptions = DeepSnakeToCamel<DeepPartial<DisplayThemeJSON>>;
 
 export interface ClerkOptions {
+  appearance?: Appearance;
   navigate?: (to: string) => Promise<unknown> | unknown;
   polling?: boolean;
-  touchSession?: boolean;
   selectInitialSession?: (client: ClientResource) => ActiveSessionResource | null;
-  appearance?: Appearance;
+  /** Controls if ClerkJS will load with the standard browser setup using Clerk cookies */
+  standardBrowser?: boolean;
   /** Optional support email for display in authentication screens */
   supportEmail?: string;
+  touchSession?: boolean;
 }
 
 export interface Resources {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR introduces the necessary frontend infrastructure in order to support Capacitor.js, browser extensions and similar stacks.

The new `standardBrowser` option controls if ClerkJS will load with the standard browser setup using Clerk cookies. Nonstandard browser stacks are browser extensions or hybrid frameworks such as Capacitor or Cordova.