### PR TITLE
fix(nextjs): Remove organization private metadata from __NEXT_DATA__

### DIFF
--- a/packages/nextjs/src/middleware/utils/sanitizeAuthData.ts
+++ b/packages/nextjs/src/middleware/utils/sanitizeAuthData.ts
@@ -2,7 +2,7 @@ import { AuthData } from '../types';
 
 /**
  *
- * Removes sensitive data from User and Session
+ * Removes sensitive data from User and Organization
  * This allows for sensitive fields like `user.privateMetadata` to be available
  * inside the `withServerSideAuth` callback, while ensuring that these fields
  * will not get serialized into the client-accessible __NEXT_DATA__ script
@@ -15,5 +15,12 @@ export function sanitizeAuthData(authData: AuthData): any {
     // @ts-expect-error;
     delete user['privateMetadata'];
   }
-  return { ...authData, user };
+
+  const organization = authData.organization ? { ...authData.organization } : authData.organization;
+  if (organization) {
+    // @ts-expect-error;
+    delete organization['privateMetadata'];
+  }
+
+  return { ...authData, user, organization };
 }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This allows for sensitive fields like `organization.privateMetadata` to be available inside the `withServerSideAuth` callback while ensuring that these fields will not get serialized into the client-accessible __NEXT_DATA__ script.
