### PR TITLE
chore(types,clerk-js): Logo and favicon URLs

### DIFF
--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -1,10 +1,4 @@
-import type {
-  DisplayConfigJSON,
-  DisplayConfigResource,
-  DisplayThemeJSON,
-  ImageJSON,
-  PreferredSignInStrategy,
-} from '@clerk/types';
+import type { DisplayConfigJSON, DisplayConfigResource, DisplayThemeJSON, PreferredSignInStrategy } from '@clerk/types';
 
 import { BaseResource } from './internal';
 
@@ -19,10 +13,10 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   applicationName!: string;
   backendHost!: string;
   branded!: boolean;
-  faviconImage!: ImageJSON;
   homeUrl!: string;
   instanceEnvironmentType!: string;
-  logoImage!: ImageJSON;
+  logoUrl!: string;
+  faviconUrl!: string;
   preferredSignInStrategy!: PreferredSignInStrategy;
   signInUrl!: string;
   signUpUrl!: string;
@@ -42,8 +36,8 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.applicationName = data.application_name;
     this.theme = data.theme;
     this.preferredSignInStrategy = data.preferred_sign_in_strategy;
-    this.logoImage = data.logo_image;
-    this.faviconImage = data.favicon_image;
+    this.logoUrl = data.logo_url;
+    this.faviconUrl = data.favicon_url;
     this.backendHost = data.backend_host;
     this.homeUrl = data.home_url;
     this.signInUrl = data.sign_in_url;

--- a/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
+++ b/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
@@ -28,10 +28,10 @@ type ApplicationLogoProps = PropsOfComponent<typeof Flex>;
 export const ApplicationLogo = (props: ApplicationLogoProps) => {
   const imageRef = React.useRef<HTMLImageElement>(null);
   const [loaded, setLoaded] = React.useState(false);
-  const { logoImage, applicationName } = useEnvironment().displayConfig;
+  const { logoUrl, applicationName } = useEnvironment().displayConfig;
   const { parsedLayout } = useAppearance();
   // TODO: Should we throw an error if logoImageUrl is not a valid url?
-  const imageSrc = parsedLayout.logoImageUrl || logoImage?.public_url;
+  const imageSrc = parsedLayout.logoImageUrl || logoUrl;
 
   if (!imageSrc) {
     return null;

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -1,4 +1,4 @@
-import { DisplayThemeJSON, ImageJSON } from './json';
+import { DisplayThemeJSON } from './json';
 import { ClerkResource } from './resource';
 
 export type PreferredSignInStrategy = 'password' | 'otp';
@@ -15,10 +15,10 @@ export interface DisplayConfigJSON {
   application_name: string;
   backend_host: string;
   branded: boolean;
-  favicon_image: ImageJSON;
   home_url: string;
   instance_environment_type: string;
-  logo_image: ImageJSON;
+  logo_url: string;
+  favicon_url: string;
   preferred_sign_in_strategy: PreferredSignInStrategy;
   sign_in_url: string;
   sign_up_url: string;
@@ -39,10 +39,10 @@ export interface DisplayConfigResource extends ClerkResource {
   applicationName: string;
   backendHost: string;
   branded: boolean;
-  faviconImage: ImageJSON;
   homeUrl: string;
   instanceEnvironmentType: string;
-  logoImage: ImageJSON;
+  logoUrl: string;
+  faviconUrl: string;
   preferredSignInStrategy: PreferredSignInStrategy;
   signInUrl: string;
   signUpUrl: string;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Instead of relying on the full serialized image response for display config logo and favicon, get the URLs directly.

The Clerk API will include these URLs in the responses alongside the existing nested objects for the images. Since the objects are deprecated and will be removed in the future, this is the first step to ease out the transition.

<!-- Fixes # (issue number) -->
