### PR TITLE
fix(clerk-js): Image create returns a wrapped response

### DIFF
--- a/packages/clerk-js/src/core/resources/Image.test.ts
+++ b/packages/clerk-js/src/core/resources/Image.test.ts
@@ -1,0 +1,25 @@
+import { Image } from './Image';
+import { BaseResource } from './internal';
+
+describe('Image', () => {
+  it('.create returns the newly created image', async () => {
+    const mockResponse = {
+      id: 'img_123',
+      name: 'the-image',
+      public_url: 'https://example.com',
+    };
+
+    // @ts-ignore
+    BaseResource._fetch = jest.fn().mockReturnValue(
+      Promise.resolve({
+        client: {},
+        response: mockResponse,
+      }),
+    );
+
+    const image = await Image.create('the-path', { file: 'whatever' });
+    expect(image.name).toEqual(mockResponse.name);
+    expect(image.publicUrl).toEqual(mockResponse.public_url);
+    expect(image.id).toEqual(mockResponse.id);
+  });
+});

--- a/packages/clerk-js/src/core/resources/Image.ts
+++ b/packages/clerk-js/src/core/resources/Image.ts
@@ -15,11 +15,13 @@ export class Image extends BaseResource implements ImageResource {
       fd.append('file', body['file']);
     }
 
-    const json = (await BaseResource._fetch<ImageJSON>({
-      path,
-      method: 'POST',
-      body: fd,
-    })) as unknown as ImageJSON;
+    const json = (
+      await BaseResource._fetch<ImageJSON>({
+        path,
+        method: 'POST',
+        body: fd,
+      })
+    )?.response as unknown as ImageJSON;
 
     return new Image(json);
   }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

When calling `Image.create` it performs a POST request to FAPI to create an image resource. 

Since it's a FAPI request, the response will be wrapped with the current client. 

So, the actual image JSON representation will be under the "response" key.

Before this fix, calling `Image.create` would return an image JSON object with all attributes set to `undefined`.

<!-- Fixes # (issue number) -->
