### PR TITLE
fix(clerk-js): Handle error while deleting user's last identification

### DIFF
--- a/packages/clerk-js/src/ui/UserProfile/RemoveResourcePage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/RemoveResourcePage.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 import { useWizard, Wizard } from '../common';
 import { useCoreUser } from '../contexts';
 import { Text } from '../customizables';
-import { Form } from '../elements';
+import { Form, useCardState, withCardStateProvider } from '../elements';
 import { useEnabledThirdPartyProviders } from '../hooks';
 import { useRouter } from '../router';
+import { handleError } from '../utils';
 import { FormButtons } from './FormButtons';
 import { ContentPage } from './Page';
 import { SuccessPage } from './SuccessPage';
@@ -134,13 +135,23 @@ type RemovePageProps = {
   deleteResource: () => Promise<any>;
 };
 
-const RemoveResourcePage = (props: RemovePageProps) => {
+const RemoveResourcePage = withCardStateProvider((props: RemovePageProps) => {
   const { title, messageLine1, messageLine2, successMessage, deleteResource } = props;
   const wizard = useWizard();
+  const card = useCardState();
+
+  const handleSubmit = async () => {
+    try {
+      await deleteResource().then(() => wizard.nextStep());
+    } catch (e) {
+      handleError(e, [], card.setError);
+    }
+  };
+
   return (
     <Wizard {...wizard.props}>
       <ContentPage.Root headerTitle={title}>
-        <Form.Root onSubmit={() => deleteResource().then(() => wizard.nextStep())}>
+        <Form.Root onSubmit={handleSubmit}>
           <Text variant='regularRegular'>{messageLine1}</Text>
           <Text variant='regularRegular'>{messageLine2}</Text>
           <FormButtons colorScheme={'danger'} />
@@ -153,4 +164,4 @@ const RemoveResourcePage = (props: RemovePageProps) => {
       />
     </Wizard>
   );
-};
+});


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Handle error while deleting user's last identification from UserProfile component

### Before

https://user-images.githubusercontent.com/22435234/186377734-b78e6482-b3a8-4218-a5aa-b2c572dd335a.mov

### After


https://user-images.githubusercontent.com/22435234/186377767-5c98fbdc-d2d1-434f-8edd-9ea0bfc20fcd.mov



<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/Handle-error-while-deleting-last-user-identification-in-accounts-d590e08cb21b4efe996f64031fcaa7df
