### PR TITLE
Organization membership metadata

### DIFF
--- a/packages/backend-core/src/__tests__/endpoints/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/OrganizationApi.test.ts
@@ -209,6 +209,8 @@ test('createOrganizationMembership() creates a membership for an organization', 
   const resJSON: OrganizationMembershipJSON = {
     object: ObjectType.OrganizationMembership,
     id: 'orgmem_randomid',
+    public_metadata: {},
+    private_metadata: {},
     role,
     organization: {
       object: ObjectType.Organization,
@@ -261,6 +263,8 @@ test('updateOrganizationMembership() updates an organization membership', async 
       created_at: 1612378465,
       updated_at: 1612378465,
     },
+    public_metadata: {},
+    private_metadata: {},
     public_user_data: {
       first_name: 'John',
       last_name: 'Doe',
@@ -278,6 +282,55 @@ test('updateOrganizationMembership() updates an organization membership', async 
     organizationId,
     userId,
     role,
+  });
+  expect(orgMembership).toEqual(OrganizationMembership.fromJSON(resJSON));
+});
+
+test('updateOrganizationMembershipMetadata() updates organization metadata', async () => {
+  const organizationId = 'org_randomid';
+  const userId = 'user_randomid';
+  const publicMetadata = { helloWorld: 42 };
+  const privateMetadata = { goodbyeWorld: 42 };
+  const resJSON: OrganizationMembershipJSON = {
+    object: ObjectType.OrganizationMembership,
+    id: 'orgmem_randomid',
+    role: 'basic_member',
+    organization: {
+      object: ObjectType.Organization,
+      id: organizationId,
+      logo_url: null,
+      name: 'Acme Inc',
+      slug: 'acme-inc',
+      public_metadata: {},
+      private_metadata: {},
+      created_at: 1612378465,
+      updated_at: 1612378465,
+    },
+    public_metadata: publicMetadata,
+    private_metadata: privateMetadata,
+    public_user_data: {
+      first_name: 'John',
+      last_name: 'Doe',
+      profile_image_url: 'https://url-to-image.png',
+      identifier: 'johndoe@example.com',
+      user_id: userId,
+    },
+    created_at: 1612378465,
+    updated_at: 1612378465,
+  };
+
+  nock(defaultServerAPIUrl)
+    .patch(`/v1/organizations/${organizationId}/memberships/${userId}/metadata`, {
+      public_metadata: publicMetadata,
+      private_metadata: privateMetadata,
+    })
+    .reply(200, resJSON);
+
+  const orgMembership = await TestClerkAPI.organizations.updateOrganizationMembershipMetadata({
+    organizationId,
+    userId,
+    publicMetadata,
+    privateMetadata,
   });
   expect(orgMembership).toEqual(OrganizationMembership.fromJSON(resJSON));
 });

--- a/packages/backend-core/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend-core/src/api/endpoints/OrganizationApi.ts
@@ -5,7 +5,7 @@ import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/organizations';
 
-type OrganizationMetadataParams = {
+type MetadataParams = {
   publicMetadata?: Record<string, unknown>;
   privateMetadata?: Record<string, unknown>;
 };
@@ -20,7 +20,7 @@ type CreateParams = {
   slug?: string;
   /* The User id for the user creating the organization. The user will become an administrator for the organization. */
   createdBy: string;
-} & OrganizationMetadataParams;
+} & MetadataParams;
 
 type GetOrganizationParams = { organizationId: string } | { slug: string };
 
@@ -28,7 +28,7 @@ type UpdateParams = {
   name?: string;
 };
 
-type UpdateMetadataParams = OrganizationMetadataParams;
+type UpdateMetadataParams = MetadataParams;
 
 type GetOrganizationMembershipListParams = {
   organizationId: string;
@@ -43,6 +43,11 @@ type CreateOrganizationMembershipParams = {
 };
 
 type UpdateOrganizationMembershipParams = CreateOrganizationMembershipParams;
+
+type UpdateOrganizationMembershipMetadataParams = {
+  organizationId: string;
+  userId: string;
+} & MetadataParams;
 
 type DeleteOrganizationMembershipParams = {
   organizationId: string;
@@ -156,6 +161,19 @@ export class OrganizationAPI extends AbstractAPI {
       path: joinPaths(basePath, organizationId, 'memberships', userId),
       bodyParams: {
         role,
+      },
+    });
+  }
+
+  public async updateOrganizationMembershipMetadata(params: UpdateOrganizationMembershipMetadataParams) {
+    const { organizationId, userId, publicMetadata, privateMetadata } = params;
+
+    return this.APIClient.request<OrganizationMembership>({
+      method: 'PATCH',
+      path: joinPaths(basePath, organizationId, 'memberships', userId, 'metadata'),
+      bodyParams: {
+        publicMetadata,
+        privateMetadata,
       },
     });
   }

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -134,6 +134,8 @@ export interface OrganizationInvitationJSON extends ClerkResourceJSON {
 export interface OrganizationMembershipJSON extends ClerkResourceJSON {
   object: ObjectType.OrganizationMembership;
   organization: OrganizationJSON;
+  public_metadata: Record<string, unknown>;
+  private_metadata?: Record<string, unknown>;
   public_user_data: OrganizationMembershipPublicUserDataJSON;
   role: OrganizationMembershipRole;
   created_at: number;

--- a/packages/backend-core/src/api/resources/OrganizationMembership.ts
+++ b/packages/backend-core/src/api/resources/OrganizationMembership.ts
@@ -6,6 +6,8 @@ export class OrganizationMembership {
   constructor(
     readonly id: string,
     readonly role: OrganizationMembershipRole,
+    readonly publicMetadata: Record<string, unknown> = {},
+    readonly privateMetadata: Record<string, unknown> = {},
     readonly createdAt: number,
     readonly updatedAt: number,
     readonly organization: Organization,
@@ -16,6 +18,8 @@ export class OrganizationMembership {
     return new OrganizationMembership(
       data.id,
       data.role,
+      data.public_metadata,
+      data.private_metadata,
       data.created_at,
       data.updated_at,
       Organization.fromJSON(data.organization),

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.test.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.test.ts
@@ -18,6 +18,9 @@ describe('OrganizationMembership', () => {
         created_at: 12345,
         updated_at: 67890,
       },
+      public_metadata: {
+        foo: 'bar',
+      },
       public_user_data: {
         object: 'public_user_data',
         first_name: 'test_first_name',

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -10,6 +10,7 @@ import { BaseResource, Organization } from './internal';
 
 export class OrganizationMembership extends BaseResource implements OrganizationMembershipResource {
   id!: string;
+  publicMetadata: Record<string, unknown> = {};
   publicUserData!: PublicUserData;
   organization!: Organization;
   role!: MembershipRole;
@@ -55,6 +56,7 @@ export class OrganizationMembership extends BaseResource implements Organization
   protected fromJSON(data: OrganizationMembershipJSON): this {
     this.id = data.id;
     this.organization = new Organization(data.organization);
+    this.publicMetadata = data.public_metadata;
     if (data.public_user_data) {
       this.publicUserData = {
         firstName: data.public_user_data.first_name,

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -27,6 +27,9 @@ OrganizationMembership {
     "updatedAt": 1970-01-01T00:01:07.890Z,
   },
   "pathRoot": "",
+  "publicMetadata": Object {
+    "foo": "bar",
+  },
   "publicUserData": Object {
     "firstName": "test_first_name",
     "identifier": "test@identifier.gr",

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -261,6 +261,7 @@ export interface OrganizationMembershipJSON extends ClerkResourceJSON {
   object: 'organization_membership';
   id: string;
   organization: OrganizationJSON;
+  public_metadata: Record<string, unknown>;
   public_user_data: PublicUserDataJSON;
   role: MembershipRole;
   created_at: number;

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -7,7 +7,7 @@ declare global {
   /**
    * If you want to provide custom types for the organization.publicMetadata object,
    * simply redeclare this rule in the global namespace.
-   * Every user object will use the provided type.
+   * Every organization object will use the provided type.
    */
   interface OrganizationPublicMetadata {
     [k: string]: unknown;

--- a/packages/types/src/organizationMembership.ts
+++ b/packages/types/src/organizationMembership.ts
@@ -1,9 +1,21 @@
 import { OrganizationResource } from './organization';
 import { PublicUserData } from './session';
 
+declare global {
+  /**
+   * If you want to provide custom types for the organizationMembership.publicMetadata
+   * object, simply redeclare this rule in the global namespace.
+   * Every organizationMembership object will use the provided type.
+   */
+  interface OrganizationMembershipPublicMetadata {
+    [k: string]: unknown;
+  }
+}
+
 export interface OrganizationMembershipResource {
   id: string;
   organization: OrganizationResource;
+  publicMetadata: OrganizationMembershipPublicMetadata;
   publicUserData: PublicUserData;
   role: MembershipRole;
   createdAt: Date;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

We've recently added public and private metadata fields for organization memberships. Both metadata fields can be  accessed from the Backend API, but public metadata can only be read from the Frontend API.

This PR adds support for the organization metadata fields by:
- Adding `publicMetadata` in the `OrganizationMembershipResource` type.
- Adding `publicMetadata` in the `OrganizationMembership` resource in clerkJS.
- Adding support for updating an organization membership's public and private metadata in backend-core and exposing it to our Node SDK.

The new backend-core method for the organizations API is `organizations.updateOrganizationMembershipMetadata()`.

<!-- Fixes # (issue number) -->
