### PR TITLE
fix(backend-core): Don't stringify invitations metadata

### DIFF
--- a/packages/backend-core/src/__tests__/endpoints/InvitationApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/InvitationApi.test.ts
@@ -84,7 +84,7 @@ test('createInvitation() accepts publicMetadata', async () => {
   nock(defaultServerAPIUrl)
     .post('/v1/invitations', {
       email_address: emailAddress,
-      public_metadata: JSON.stringify(publicMetadata),
+      public_metadata: publicMetadata,
     })
     .reply(200, resJSON);
 

--- a/packages/backend-core/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend-core/src/api/endpoints/InvitationApi.ts
@@ -22,10 +22,7 @@ export class InvitationAPI extends AbstractAPI {
     return this.APIClient.request<Invitation>({
       method: 'POST',
       path: basePath,
-      bodyParams: {
-        ...params,
-        publicMetadata: JSON.stringify(params.publicMetadata),
-      },
+      bodyParams: params,
     });
   }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

In the invitations API `createInvitation()` method, we were stringifying the value of the `publicMetadata` property. 

Since `publicMetadata` is already a JSON object, the additional stringify call is redundant.


<!-- Fixes # (issue number) -->
Fixes #338