### PR TITLE
Introduce user.totp_enabled field and totp_secret optional param for create user operation

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -557,6 +557,7 @@ Available parameters are:
 - _password_ The plaintext password to give the user.
 - _firstName_ User's first name.
 - _lastName_ User's last name.
+- _totpSecret_ User's secret for TOTP. Useful while migrating users with enabled 2FA Authenticator Apps.
 - _publicMetadata_ Metadata saved on the user, that is visible to both your Frontend and Backend APIs.
 - _privateMetadata_ Metadata saved on the user, that is only visible to your Backend API.
 - _unsafeMetadata_ Metadata saved on the user, that can be updated from both the Frontend and Backend APIs. Note: Since this data can be modified from the frontend, it is not guaranteed to be safe.

--- a/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
@@ -145,6 +145,7 @@ test('createUser() creates a user', async () => {
     password: '123456',
     firstName: 'Boss',
     lastName: 'Clerk',
+    totpSecret: 'AICJ3HCXKO4KOY6NDH6RII4E3ZYL5ZBH',
   };
 
   nock(defaultServerAPIUrl)

--- a/packages/backend-core/src/api/endpoints/UserApi.ts
+++ b/packages/backend-core/src/api/endpoints/UserApi.ts
@@ -35,6 +35,7 @@ type CreateUserParams = {
   lastName?: string;
   skipPasswordChecks?: boolean;
   skipPasswordRequirement?: boolean;
+  totpSecret?: string;
 } & UserMetadataParams;
 
 interface UpdateUserParams extends UserMetadataParams {

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -240,6 +240,7 @@ export interface UserJSON extends ClerkResourceJSON {
   primary_phone_number_id: string;
   primary_web3_wallet_id: string;
   password_enabled: boolean;
+  totp_enabled: boolean;
   two_factor_enabled: boolean;
   email_addresses: EmailAddressJSON[];
   phone_numbers: PhoneNumberJSON[];

--- a/packages/backend-core/src/api/resources/User.ts
+++ b/packages/backend-core/src/api/resources/User.ts
@@ -8,6 +8,7 @@ export class User {
   constructor(
     readonly id: string,
     readonly passwordEnabled: boolean,
+    readonly totpEnabled: boolean,
     readonly twoFactorEnabled: boolean,
     readonly createdAt: number,
     readonly updatedAt: number,
@@ -35,6 +36,7 @@ export class User {
     return new User(
       data.id,
       data.password_enabled,
+      data.totp_enabled,
       data.two_factor_enabled,
       data.created_at,
       data.updated_at,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR introduces 2 related TOTP fields for user operations:
- A `user.totp_enabled` field that denotes if the user has enabled & verified TOTP
- A new optional parameter `totp_secret` for create user operation

<!-- Fixes # (issue number) -->
