### PR TITLE
fix(clerk-js): Render email/phone input in case of both are optional

### DIFF
--- a/packages/clerk-js/src/ui/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpForm.tsx
@@ -18,6 +18,12 @@ export const SignUpForm = (props: SignUpFormProps) => {
   const { showOptionalFields } = useAppearance().parsedLayout;
 
   const shouldShow = (name: keyof typeof fields) => {
+    // In case both email & phone are optional, then don't take into account the
+    // Layout showOptionalFields prop and the required field.
+    if ((name === 'emailAddress' || name === 'phoneNumber') && canToggleEmailPhone) {
+      return !!fields[name];
+    }
+
     return !!fields[name] && (showOptionalFields || fields[name]?.required);
   };
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This fixes a bug in the sign up form in the special case of email or phone. When email & phone are both optional, actually at least one must be provided for the sign up to complete, thus we have to render the special input instead of hiding it based on the layout showOptionalFields prop

###Before

https://user-images.githubusercontent.com/22435234/187372278-55012584-fbe4-4ab2-8faf-4161d1e06cc0.mov

### After

https://user-images.githubusercontent.com/22435234/187372314-e0448de1-6ac6-43d9-ab33-f6a90ef8b5c0.mov

<!-- Fixes # (issue number) -->

Part of https://www.notion.so/clerkdev/Return-error-for-missing-phone-in-email-or-phone-case-where-no-phone-is-submitted-69492036ccf542cda8e6d020113abe2b
