### PR TITLE
fix(clerk-js): Replace setSession with setActive

### DIFF
--- a/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
@@ -37,7 +37,7 @@ function _SignUpStart(): JSX.Element {
   const { userSettings, displayConfig } = useEnvironment();
   const { navigate } = useNavigate();
   const { attributes } = userSettings;
-  const { setSession } = useCoreClerk();
+  const { setActive } = useCoreClerk();
   const { navigateAfterSignUp, signInUrl } = useSignUpContext();
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
     getInitialActiveIdentifier(attributes, userSettings.signUp.progressive),
@@ -89,7 +89,7 @@ function _SignUpStart(): JSX.Element {
           signUp,
           verifyEmailPath: 'verify-email-address',
           verifyPhonePath: 'verify-phone-number',
-          handleComplete: () => setSession(signUp.createdSessionId, navigateAfterSignUp),
+          handleComplete: () => setActive({ session: signUp.createdSessionId, beforeEmit: navigateAfterSignUp }),
           navigate,
         });
       })
@@ -168,7 +168,7 @@ function _SignUpStart(): JSX.Element {
           signUp: res,
           verifyEmailPath: 'verify-email-address',
           verifyPhonePath: 'verify-phone-number',
-          handleComplete: () => setSession(res.createdSessionId, navigateAfterSignUp),
+          handleComplete: () => setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignUp }),
           navigate,
         }),
       )


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Replace 2 setSession invocations with the latest setActive api
<!-- Fixes # (issue number) -->
