### PR TITLE
fix(clerk-js): Clear session token cache when switching organizations

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -68,6 +68,7 @@ import {
   OrganizationMembership,
 } from './resources/internal';
 import { AuthenticationService } from './services';
+import { SessionTokenCache } from './tokenCache';
 
 export type ClerkCoreBroadcastChannelEvent = { type: 'signout' };
 
@@ -310,6 +311,8 @@ export default class Clerk implements ClerkInterface {
       } else {
         session.lastActiveOrganizationId = organization.id;
       }
+
+      SessionTokenCache.clear();
     }
 
     this.#authService?.setAuthCookiesFromSession(session);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Using the setActive() call from useOrganization() correctly sets the CSR version of the organization.
However, the session sent to the server page does not yet include the active organization as the previous __session JWT is still cached.

<!-- Fixes # (issue number) -->