### PR TITLE
fix(clerk-js): Render both errors in case of emailOrPhone in sign up form

### DIFF
--- a/packages/clerk-js/src/ui/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpContinue.tsx
@@ -88,6 +88,16 @@ function _SignUpContinue() {
       [] as Array<FormControlState>,
     );
 
+    // In case of emailOrPhone (both email & phone are optional) and neither of them is provided,
+    // add both to the submitted fields to trigger and render an error for both respective inputs
+    const emailAddressProvided = !!(fieldsToSubmit.find(f => f.id === 'emailAddress')?.value || '');
+    const phoneNumberProvided = !!(fieldsToSubmit.find(f => f.id === 'phoneNumber')?.value || '');
+
+    if (!emailAddressProvided && !phoneNumberProvided && emailOrPhone(attributes, isProgressiveSignUp)) {
+      fieldsToSubmit.push(formState['emailAddress']);
+      fieldsToSubmit.push(formState['phoneNumber']);
+    }
+
     card.setLoading();
     card.setError(undefined);
     return signUp

--- a/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
@@ -159,6 +159,16 @@ function _SignUpStart(): JSX.Element {
       fieldsToSubmit.push({ id: 'strategy', value: 'ticket' } as any);
     }
 
+    // In case of emailOrPhone (both email & phone are optional) and neither of them is provided,
+    // add both to the submitted fields to trigger and render an error for both respective inputs
+    const emailAddressProvided = !!(fieldsToSubmit.find(f => f.id === 'emailAddress')?.value || '');
+    const phoneNumberProvided = !!(fieldsToSubmit.find(f => f.id === 'phoneNumber')?.value || '');
+
+    if (!emailAddressProvided && !phoneNumberProvided && emailOrPhone(attributes, isProgressiveSignUp)) {
+      fieldsToSubmit.push(formState['emailAddress']);
+      fieldsToSubmit.push(formState['phoneNumber']);
+    }
+
     card.setLoading();
     card.setError(undefined);
     return signUp


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This fixes a bug in the sign up form in the special case of email or phone. When email & phone are both optional and neither of them is provided the form rendered an error only in the input of the active identifier. We change this behavior to also render the respective error in the 'inactive' identifier input as well.

### Before

https://user-images.githubusercontent.com/22435234/187421188-9680b2f9-2b23-49f5-b045-567d3b80c76e.mov

### After

https://user-images.githubusercontent.com/22435234/187421206-8b769001-7044-4297-95f3-cc929f6b4178.mov

_Note: There is some code duplication in the two SignUpStart & SignUpContinue components which we will tackle in a separate PR_

<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/Return-error-for-missing-phone-in-email-or-phone-case-where-no-phone-is-submitted-69492036ccf542cda8e6d020113abe2b
