### PR TITLE
fix(clerk-js): Slightly increase the base font size for smaller elements

### DIFF
--- a/packages/clerk-js/src/ui/elements/Header.tsx
+++ b/packages/clerk-js/src/ui/elements/Header.tsx
@@ -28,7 +28,7 @@ const Subtitle = React.memo((props: React.PropsWithChildren<any>): JSX.Element =
     <Text
       elementDescriptor={descriptors.headerSubtitle}
       {...props}
-      variant='regularRegular'
+      variant='headingRegularRegular'
       colorScheme='neutral'
     />
   );

--- a/packages/clerk-js/src/ui/foundations/typography.ts
+++ b/packages/clerk-js/src/ui/foundations/typography.ts
@@ -6,12 +6,13 @@ const fontWeights = Object.freeze({
 
 const lineHeights = Object.freeze({
   normal: 'normal',
-  none: '1',
+  none: 1,
+  shortest: 1.1,
   shorter: 1.25,
   short: 1.375,
   base: 1.5,
   tall: 1.625,
-  taller: '2',
+  taller: 2,
 } as const);
 
 const letterSpacings = Object.freeze({

--- a/packages/clerk-js/src/ui/foundations/typography.ts
+++ b/packages/clerk-js/src/ui/foundations/typography.ts
@@ -24,8 +24,8 @@ const letterSpacings = Object.freeze({
 } as const);
 
 const fontSizes = Object.freeze({
-  '2xs': '0.625rem',
-  xs: '0.75rem',
+  '2xs': '0.6875rem',
+  xs: '0.8125rem',
   sm: '0.875rem',
   md: '1rem',
   lg: '1.125rem',

--- a/packages/clerk-js/src/ui/styledSystem/common.ts
+++ b/packages/clerk-js/src/ui/styledSystem/common.ts
@@ -76,7 +76,7 @@ const textVariants = (t: InternalTheme) => {
   const buttonSmallRegular = {
     ...smallRegular,
     fontFamily: t.fonts.$buttons,
-    lineHeight: t.lineHeights.$none,
+    lineHeight: t.lineHeights.$shortest,
   };
 
   const buttonRegularRegular = {

--- a/packages/clerk-js/src/ui/styledSystem/common.ts
+++ b/packages/clerk-js/src/ui/styledSystem/common.ts
@@ -91,7 +91,13 @@ const textVariants = (t: InternalTheme) => {
     lineHeight: t.lineHeights.$none,
   };
 
+  const headingRegularRegular = {
+    ...regularRegular,
+    fontSize: t.fontSizes.$md,
+  } as const;
+
   return {
+    headingRegularRegular,
     buttonExtraSmallBold,
     buttonSmallRegular,
     buttonRegularRegular,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
Slightly increase the font sizes of all smaller elements according to the latest Figma designs.

### After

![image](https://user-images.githubusercontent.com/1811063/187511590-025c5065-9082-412d-8b86-4e050fc0f805.png)
![image](https://user-images.githubusercontent.com/1811063/187511606-554e1118-7139-4fb8-b016-f509c52c78eb.png)
![image](https://user-images.githubusercontent.com/1811063/187511636-c9df4f71-7e17-4e5a-923b-f9a05d41478b.png)
![image](https://user-images.githubusercontent.com/1811063/187511653-d39c8ed7-9ba9-4107-9269-2a9085d5e81c.png)



<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
