### PR TITLE
feat(nextjs,edge,backend-core): Expose clerkApi, getAuth & runClerkMi…

### DIFF
--- a/packages/backend-core/src/Base.ts
+++ b/packages/backend-core/src/Base.ts
@@ -269,7 +269,7 @@ export class Base {
     // }
 
     if (clientUat === '0') {
-      return { status: AuthStatus.SignedOut, errorReason: AuthErrorReason.StandardOut };
+      return { status: AuthStatus.SignedOut, errorReason: AuthErrorReason.StandardSignedOut };
     }
 
     if (isProductionKey && clientUat && !cookieToken) {

--- a/packages/backend-core/src/__tests__/Base.test.ts
+++ b/packages/backend-core/src/__tests__/Base.test.ts
@@ -1,6 +1,7 @@
 import { Base } from '../Base';
 import { AuthErrorReason, AuthStateParams, AuthStatus } from '../types';
 import { TokenVerificationError } from '../util/errors';
+
 const mockCrossOrigin = jest.fn();
 const mockFetchInterstitial = jest.fn();
 const mockIsDevelopmentOrStaging = jest.fn();
@@ -188,7 +189,7 @@ describe('Base getAuthState', () => {
     const testBase = new Base(mockImportKey, mockVerifySignature, mockBase64Decode, mockLoadCryptoKeyFunction);
     mockIsProduction.mockImplementationOnce(() => true);
     const authStateResult = await testBase.getAuthState({ ...defaultAuthState, clientUat: '0' });
-    expect(authStateResult).toEqual({ status: AuthStatus.SignedOut, errorReason: AuthErrorReason.StandardOut });
+    expect(authStateResult).toEqual({ status: AuthStatus.SignedOut, errorReason: AuthErrorReason.StandardSignedOut });
   });
 
   it('returns interstitial when on production and have a valid clientUat value without cookieToken', async () => {

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -2,6 +2,6 @@ export * from './api';
 export * from './Base';
 export * from './util/Logger';
 
-export { createGetToken, createSignedOutState } from './util/createGetToken';
+export { createGetToken, signedOutGetToken, createSignedOutState } from './util/createGetToken';
 export { AuthStatus, AuthErrorReason } from './types';
 export type { Session } from './api/resources/Session';

--- a/packages/backend-core/src/types/core.ts
+++ b/packages/backend-core/src/types/core.ts
@@ -30,7 +30,7 @@ export type TokenType = 'cookie' | 'header';
 export type AuthState = {
   status: AuthStatus;
   session?: Session;
-  /* Interstitial is returned as null when the client will handle the interstitial logic */
+  /* Interstitial is returned as null when the interstitial endpoint will be rewritten to instead of being rendered directly */
   interstitial?: string | null;
   sessionClaims?: ClerkJWTClaims;
   /* Error reason for signed-out and interstitial states. Would probably be set on the `Auth-Result` response header. */

--- a/packages/backend-core/src/types/errors.ts
+++ b/packages/backend-core/src/types/errors.ts
@@ -13,7 +13,7 @@ export enum AuthErrorReason {
   UATMissing = 'uat-missing',
   CrossOriginReferrer = 'cross-origin-referrer',
   CookieAndUATMissing = 'cookie-and-uat-missing',
-  StandardOut = 'standard-out',
+  StandardSignedOut = 'standard-signed-out',
   CookieMissing = 'cookie-missing',
   CookieExpired = 'cookie-expired',
   CookieEarly = 'cookie-early',

--- a/packages/backend-core/src/util/createGetToken.ts
+++ b/packages/backend-core/src/util/createGetToken.ts
@@ -31,7 +31,7 @@ export const createGetToken: CreateGetToken = params => {
   };
 };
 
-const signedOutGetToken = createGetToken({
+export const signedOutGetToken = createGetToken({
   sessionId: undefined,
   cookieToken: undefined,
   headerToken: undefined,

--- a/packages/clerk-js/src/ui/common/PrintableComponent.tsx
+++ b/packages/clerk-js/src/ui/common/PrintableComponent.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+type OnPrintCallback = () => void;
+type UsePrintableReturn = {
+  print: () => void;
+  printableProps: { onPrint: (cb: OnPrintCallback) => void };
+};
+
+export const usePrintable = (): UsePrintableReturn => {
+  const callbacks: OnPrintCallback[] = [];
+  const onPrint = (cb: OnPrintCallback) => callbacks.push(cb);
+  const print = () => callbacks.forEach(cb => cb());
+  return { print, printableProps: { onPrint } };
+};
+
+export const PrintableComponent = (props: UsePrintableReturn['printableProps'] & React.PropsWithChildren<{}>) => {
+  const { children, onPrint } = props;
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  onPrint(() => {
+    printContentsOfElementViaIFrame(ref);
+  });
+
+  return (
+    <div
+      ref={ref}
+      style={{ position: 'fixed', left: '-9999px', top: 0, display: 'none' }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const copyStyles = (iframe: HTMLIFrameElement, selector = '[data-emotion=cl-internal]') => {
+  if (!iframe.contentDocument) {
+    return;
+  }
+  const allStyleText = [...document.head.querySelectorAll(selector)].map(a => a.innerHTML).join('\n');
+  const styleEl = iframe.contentDocument.createElement('style');
+  styleEl.innerHTML = allStyleText;
+  iframe.contentDocument.head.prepend(styleEl);
+};
+
+const setPrintingStyles = (iframe: HTMLIFrameElement) => {
+  if (!iframe.contentDocument) {
+    return;
+  }
+  // A web-safe font that's universally supported
+  iframe.contentDocument.body.style.fontFamily = 'Arial';
+  // Make the printing dialog display the background colors by default
+  iframe.contentDocument.body.style.cssText = `* {\n-webkit-print-color-adjust: exact !important;\ncolor-adjust: exact !important;\nprint-color-adjust: exact !important;\n}`;
+};
+
+const printContentsOfElementViaIFrame = (elementRef: React.MutableRefObject<HTMLElement | null>) => {
+  const content = elementRef.current;
+  if (!content) {
+    return;
+  }
+
+  const frame = document.createElement('iframe');
+  frame.style.position = 'fixed';
+  frame.style.right = '-2000px';
+  frame.style.bottom = '-2000px';
+  // frame.style.width = '500px';
+  // frame.style.height = '500px';
+  // frame.style.border = '0px';
+
+  frame.onload = () => {
+    copyStyles(frame);
+    setPrintingStyles(frame);
+    if (frame.contentDocument && frame.contentWindow) {
+      frame.contentDocument.body.innerHTML = content.innerHTML;
+      frame.contentWindow.print();
+    }
+  };
+
+  // TODO: Cleaning this iframe is not always possible because
+  // .print() will not block. Leaving this iframe inside the DOM
+  // shouldn't be an issue, but is there any reliable way to remove it?
+  window.document.body.appendChild(frame);
+};

--- a/packages/clerk-js/src/ui/common/index.ts
+++ b/packages/clerk-js/src/ui/common/index.ts
@@ -8,3 +8,4 @@ export * from './SSOCallback';
 export * from './EmailLinkVerify';
 export * from './EmailLinkStatusCard';
 export * from './Wizard';
+export * from './PrintableComponent';

--- a/packages/nextjs/src/server/types.ts
+++ b/packages/nextjs/src/server/types.ts
@@ -1,4 +1,4 @@
-import { AuthErrorReason, ClerkBackendAPI, Organization, Session, User } from '@clerk/backend-core';
+import { AuthErrorReason, ClerkBackendAPI } from '@clerk/backend-core';
 import { ClerkJWTClaims, ServerGetToken } from '@clerk/types';
 import { IncomingMessage } from 'http';
 import { NextApiRequest } from 'next';
@@ -18,20 +18,16 @@ export const NEXT_REWRITE_HEADER = 'x-middleware-rewrite';
 export const NEXT_RESUME_HEADER = 'x-middleware-next';
 export const NEXT_REDIRECT_HEADER = 'Location';
 
-// TODO consolidate AuthData declarations across repo
 export type AuthData = {
   sessionId: string | null;
-  session: Session | undefined | null;
   userId: string | null;
-  user: User | undefined | null;
   orgId: string | null | undefined;
-  organization: Organization | undefined | null;
   getToken: ServerGetToken;
   claims: ClerkJWTClaims | null;
 };
 
 enum AuthResultExt {
-  StandardIn = 'standard-in',
+  StandardSignedIn = 'standard-signed-in',
 }
 
 export const AuthResult = { ...AuthResultExt, ...AuthErrorReason };

--- a/packages/nextjs/src/server/utils/getAuth.ts
+++ b/packages/nextjs/src/server/utils/getAuth.ts
@@ -1,4 +1,4 @@
-import { createSignedOutState } from '@clerk/backend-core';
+import { signedOutGetToken } from '@clerk/backend-core';
 
 import type { RequestLike } from '../types';
 import { AuthData, AuthResult, SESSION_COOKIE_NAME, SessionsApi } from '../types';
@@ -14,11 +14,11 @@ export function createGetAuth(sessions: SessionsApi) {
     const authResult = getAuthResultFromRequest(req);
 
     if (!authResult) {
-      throw 'You need to use "withClerkMiddleware" in your Next.js middleware.js file. See https://nextjs.org/docs/advanced-features/middleware.';
+      throw 'You need to use "withClerkMiddleware" in your Next.js middleware.js file. See https://clerk.dev/docs/quickstarts/get-started-with-nextjs.';
     }
 
     // Signed in case
-    if (authResult === AuthResult.StandardIn) {
+    if (authResult === AuthResult.StandardSignedIn) {
       // Get the token from header or cookie
 
       const headerToken = getHeader(req, 'authorization')?.replace('Bearer ', '');
@@ -37,6 +37,12 @@ export function createGetAuth(sessions: SessionsApi) {
     }
 
     // Signed out case assumed
-    return createSignedOutState();
+    return {
+      sessionId: null,
+      userId: null,
+      orgId: null,
+      getToken: signedOutGetToken,
+      claims: null,
+    };
   };
 }

--- a/packages/nextjs/src/server/utils/getAuthDataFromClaims.ts
+++ b/packages/nextjs/src/server/utils/getAuthDataFromClaims.ts
@@ -18,11 +18,8 @@ export function getAuthDataFromClaims({
 }: GetAuthDataFromClaimsOpts): AuthData {
   return {
     sessionId: sessionClaims.sid,
-    session: undefined, // currently not loaded here
     userId: sessionClaims.sub,
-    user: undefined, // currently not loaded here
     orgId: sessionClaims.org_id,
-    organization: undefined, // currently not loaded here
     getToken: createGetToken({
       headerToken: headerToken,
       cookieToken: cookieToken,

--- a/packages/nextjs/src/server/utils/requestResponseUtils.ts
+++ b/packages/nextjs/src/server/utils/requestResponseUtils.ts
@@ -24,15 +24,21 @@ function getQueryParam(req: RequestLike, name: string): string | null | undefine
 
   // Check if the request contains a parsed query object
   // NextApiRequest does, but the IncomingMessage in the GetServerSidePropsContext case does not
+
+  let queryParam: string | null | undefined;
+
   if ('query' in req) {
-    return req.query[name] as string | undefined;
+    queryParam = req.query[name] as string | undefined;
   }
 
   // Fall back to query string
-  const qs = (req.url || '').split('?')[1];
-  const searchParams = new URLSearchParams(qs);
+  if (!queryParam) {
+    const qs = (req.url || '').split('?')[1];
+    const searchParams = new URLSearchParams(qs);
+    queryParam = searchParams.get(name);
+  }
 
-  return searchParams.get(name);
+  return queryParam;
 }
 
 export function getHeader(req: RequestLike, name: string): string | null | undefined {


### PR DESCRIPTION
…ddleware in @clerk/nextjs/server

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [X] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [X] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [X] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

Draft PR combining @igneel64 draft & @colinclerk's POC

# Related issue(s)

https://github.com/clerkinc/javascript/issues/299

Aims:

- support for next.js 12.2+ middlewares
- challenge: request is now immutable, req.auth injection is not an option any more
- challenge: middleware can no longer render a response (e.g. the intestitial), req needs to be rewritten to interstitial endpoint
- new approach for getting auth data: run middleware first, call getAuth in API route to consume auth data (no more function wrappers or withAuth going forward)
- additive only, don't remove any existing functionality
