### PR TITLE
fix(clerk-js): Hide form if no required fields exist

### DIFF
--- a/packages/clerk-js/src/ui/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpForm.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ActiveIdentifier, Fields } from 'v4/SignUp/signUpFormHelpers';
 
 import { useAppearance } from '../customizables';
 import { Form } from '../elements';
 import { FormControlState } from '../utils';
+import { ActiveIdentifier, Fields } from './signUpFormHelpers';
 
 type SignUpFormProps = {
   handleSubmit: React.FormEventHandler;

--- a/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
@@ -5,7 +5,7 @@ import { withRedirectToHome } from '../../ui/common/withRedirectToHome';
 import { useCoreClerk, useCoreSignUp, useEnvironment, useSignUpContext } from '../../ui/contexts';
 import { useNavigate } from '../../ui/hooks';
 import { getClerkQueryParam } from '../../utils/getClerkQueryParam';
-import { descriptors, Flex, Flow } from '../customizables';
+import { descriptors, Flex, Flow, useAppearance } from '../customizables';
 import {
   Card,
   CardAlert,
@@ -34,6 +34,7 @@ function _SignUpStart(): JSX.Element {
   const card = useCardState();
   const status = useLoadingStatus();
   const signUp = useCoreSignUp();
+  const { showOptionalFields } = useAppearance().parsedLayout;
   const { userSettings, displayConfig } = useEnvironment();
   const { navigate } = useNavigate();
   const { attributes } = userSettings;
@@ -200,6 +201,9 @@ function _SignUpStart(): JSX.Element {
   const hasSocialOrWeb3Buttons =
     !!userSettings.socialProviderStrategies.length || !!userSettings.web3FirstFactors.length;
 
+  const visibleFields = Object.entries(fields).filter(([_, opts]) => showOptionalFields || opts?.required);
+  const shouldShowForm = showFormFields(userSettings) && visibleFields.length > 0;
+
   return (
     <Flow.Part part='start'>
       <Card>
@@ -215,8 +219,8 @@ function _SignUpStart(): JSX.Element {
         >
           <SocialButtonsReversibleContainer>
             {(!hasTicket || missingRequirementsWithTicket) && <SignUpSocialButtons />}
-            {hasSocialOrWeb3Buttons && showFormFields(userSettings) && <Divider />}
-            {showFormFields(userSettings) && (
+            {hasSocialOrWeb3Buttons && shouldShowForm && <Divider />}
+            {shouldShowForm && (
               <SignUpForm
                 handleSubmit={handleSubmit}
                 fields={fields}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
Properly handles the following scenario: 
- an auth factor is enabled and set to optional (`required: false`)
- no other `required` fields exist
- `appearance.layout.showOptionalFields` is set to `false` (the default)

Before:
 
![image](https://user-images.githubusercontent.com/1811063/188508425-ab765785-7248-4b44-b30b-ad24bbde6dae.png)


After: 

![image](https://user-images.githubusercontent.com/1811063/188508397-99bfc4aa-2a13-46ea-b84c-2930598a44af.png)


<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
