### PR TITLE
feat(backend-core): Introduce operation to disable user's MFA methods

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -51,6 +51,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [createUser(params)](#createuserparams)
   - [updateUser(userId, params)](#updateuseruserid-params)
   - [deleteUser(userId)](#deleteuseruserid)
+  - [disableUserMFA(userId)](#disableusermfauserid)
 - [Email operations](#email-operations)
   - [createEmail({ fromEmailName, subject, body, emailAddressId })](#createemail-fromemailname-subject-body-emailaddressid-)
 - [SMS Message operations](#sms-message-operations)
@@ -593,6 +594,15 @@ Deletes a user given their id, if the id is valid. Throws an error otherwise.
 ```ts
 const userId = 'my-user-id';
 const user = await clerkAPI.users.deleteUser(userId);
+```
+
+#### disableUserMFA(userId)
+
+Disables all MFA methods of a user given their id. Throws an error otherwise.
+
+```ts
+const userId = 'my-user-id';
+await clerkAPI.users.disableUserMFA(userId);
 ```
 
 ## Email operations

--- a/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
@@ -205,3 +205,15 @@ test('getCount() returns a valid number response', async () => {
   const userCount = await TestClerkAPI.users.getCount();
   expect(userCount).toEqual(1);
 });
+
+test('disableUserMFA() throws an error without user ID', async () => {
+  await expect(TestClerkAPI.users.disableUserMFA('')).rejects.toThrow('A valid resource ID is required.');
+});
+
+test('disableUserMFA() disables all MFA methods of a user', async () => {
+  const id = 'user_1oBNj55jOjSK9rOYrT5QHqj7eaK';
+
+  nock(defaultServerAPIUrl).delete(`/v1/users/${id}/mfa`).reply(200, { user_id: 'user_1oBNj55jOjSK9rOYrT5QHqj7eaK' });
+
+  await TestClerkAPI.users.disableUserMFA(id);
+});

--- a/packages/backend-core/src/api/endpoints/UserApi.ts
+++ b/packages/backend-core/src/api/endpoints/UserApi.ts
@@ -115,4 +115,12 @@ export class UserAPI extends AbstractAPI {
       path: joinPaths(basePath, userId, 'oauth_access_tokens', provider),
     });
   }
+
+  public async disableUserMFA(userId: string) {
+    this.requireId(userId);
+    return this.APIClient.request<User>({
+      method: 'DELETE',
+      path: joinPaths(basePath, userId, 'mfa'),
+    });
+  }
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Introduce a new user operation `DisableUserMFA` which disables all user's MFA methods

<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/Deactivate-2FA-from-BAPI-c9c85987e8ce464baa703dcc77ea0360

