### PR TITLE
Authentication context for impersonation sessions

### DIFF
--- a/packages/clerk-js/src/core/resources/Session.test.ts
+++ b/packages/clerk-js/src/core/resources/Session.test.ts
@@ -1,0 +1,55 @@
+import { PublicUserDataJSON, SessionJSON, TokenJSON, UserJSON } from '@clerk/types';
+
+import { Session } from './Session';
+
+describe('Session', () => {
+  describe('isImpersonated()', () => {
+    it('returns true for session with actorId', () => {
+      const json = {
+        object: 'session',
+        id: 'sess_123',
+        status: 'active',
+        expire_at: 123,
+        abandon_at: 123,
+        last_active_at: 123,
+        last_active_organization_id: null,
+        last_active_token: null as unknown as TokenJSON,
+        user: {
+          object: 'user',
+          id: 'test',
+          external_id: 'test',
+          primary_email_address_id: 'test',
+          primary_phone_number_id: 'test',
+          primary_web3_wallet_id: 'test',
+          profile_image_url: 'test',
+          username: 'test',
+          email_addresses: [],
+          phone_numbers: [],
+          web3_wallets: [],
+          external_accounts: [],
+          organization_memberships: [],
+          password_enabled: false,
+          password: 'test',
+          profile_image_id: 'test',
+          first_name: 'test',
+          last_name: 'test',
+          totp_enabled: false,
+          two_factor_enabled: false,
+          public_metadata: {},
+          unsafe_metadata: {},
+          last_sign_in_at: 123,
+          updated_at: 123,
+          created_at: 123,
+        } as UserJSON,
+        public_user_data: null as unknown as PublicUserDataJSON,
+        created_at: 123,
+        updated_at: 123,
+      };
+      let session = new Session({ ...json, actor_id: 'the-id' } as SessionJSON);
+      expect(session.isImpersonated()).toEqual(true);
+
+      session = new Session({ ...json, actor_id: null } as SessionJSON);
+      expect(session.isImpersonated()).toEqual(false);
+    });
+  });
+});

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -14,6 +14,7 @@ export class Session extends BaseResource implements SessionResource {
   lastActiveAt!: Date;
   lastActiveToken!: Token | null;
   lastActiveOrganizationId!: string | null;
+  actorId!: string | null;
   user!: UserResource | null;
   publicUserData!: PublicUserData;
   expireAt!: Date;
@@ -87,6 +88,10 @@ export class Session extends BaseResource implements SessionResource {
     return tokenResolver.then(res => res.getRawString());
   };
 
+  isImpersonated = (): boolean => {
+    return !!this.actorId;
+  };
+
   #hydrateCache = (token: Token | null) => {
     if (token && SessionTokenCache.size() === 0) {
       SessionTokenCache.set({
@@ -130,6 +135,7 @@ export class Session extends BaseResource implements SessionResource {
     this.abandonAt = unixEpochToDate(data.abandon_at);
     this.lastActiveAt = unixEpochToDate(data.last_active_at);
     this.lastActiveOrganizationId = data.last_active_organization_id;
+    this.actorId = data.actor_id;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     this.user = new User(data.user);

--- a/packages/nextjs/src/middleware/utils/injectAuthIntoRequest.ts
+++ b/packages/nextjs/src/middleware/utils/injectAuthIntoRequest.ts
@@ -8,7 +8,13 @@ import { AuthData, ContextWithAuth } from '../types';
  */
 export function injectAuthIntoRequest(ctx: GetServerSidePropsContext, authData: AuthData): ContextWithAuth {
   const { user, session, userId, sessionId, getToken, claims, organization } = authData;
-  (ctx.req as any).auth = { userId, sessionId, getToken, claims };
+  (ctx.req as any).auth = {
+    userId,
+    sessionId,
+    getToken,
+    claims,
+    actorId: claims?.act?.sub || null,
+  };
   (ctx.req as any).user = user;
   (ctx.req as any).session = session;
   (ctx.req as any).organization = organization;

--- a/packages/react/src/contexts/AuthContext.ts
+++ b/packages/react/src/contexts/AuthContext.ts
@@ -3,4 +3,5 @@ import { makeContextAndHook } from '../utils/makeContextAndHook';
 export const [AuthContext, useAuthContext] = makeContextAndHook<{
   userId: string | null | undefined;
   sessionId: string | null | undefined;
+  actorId: string | null;
 }>('AuthContext');

--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -47,19 +47,26 @@ export function ClerkContextProvider(props: ClerkContextProvider): JSX.Element |
   const clerkCtx = React.useMemo(() => ({ value: clerk }), [clerkLoaded]);
   const clientCtx = React.useMemo(() => ({ value: state.client }), [state.client]);
 
+  const { sessionId, session, userId, user } = derivedState;
+  const actorId = session?.actorId || null;
+
   const authCtx = React.useMemo(() => {
     return {
-      value: { sessionId: derivedState.sessionId, userId: derivedState.userId },
+      value: {
+        sessionId,
+        userId,
+        actorId,
+      },
     };
-  }, [derivedState.sessionId, derivedState.userId]);
+  }, [sessionId, userId, actorId]);
 
   const userCtx = React.useMemo(() => {
-    return { value: derivedState.user };
-  }, [derivedState.userId, derivedState.user]);
+    return { value: user };
+  }, [userId, user]);
 
   const sessionCtx = React.useMemo(() => {
-    return { value: derivedState.session };
-  }, [derivedState.sessionId, derivedState.session]);
+    return { value: session };
+  }, [sessionId, session]);
 
   const organizationCtx = React.useMemo(() => {
     return {

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -11,6 +11,7 @@ type UseAuthReturn =
       isSignedIn: undefined;
       userId: undefined;
       sessionId: undefined;
+      actorId: null;
       signOut: SignOut;
       getToken: GetToken;
     }
@@ -19,6 +20,7 @@ type UseAuthReturn =
       isSignedIn: false;
       userId: null;
       sessionId: null;
+      actorId: null;
       signOut: SignOut;
       getToken: GetToken;
     }
@@ -27,6 +29,7 @@ type UseAuthReturn =
       isSignedIn: true;
       userId: string;
       sessionId: string;
+      actorId: string | null;
       signOut: SignOut;
       getToken: GetToken;
     };
@@ -73,7 +76,7 @@ type UseAuth = () => UseAuthReturn;
  * }
  */
 export const useAuth: UseAuth = () => {
-  const { sessionId, userId } = useAuthContext();
+  const { sessionId, userId, actorId } = useAuthContext();
   const isomorphicClerk = useIsomorphicClerkContext();
 
   const getToken: GetToken = createGetToken(isomorphicClerk);
@@ -85,6 +88,7 @@ export const useAuth: UseAuth = () => {
       isSignedIn: undefined,
       sessionId,
       userId,
+      actorId: null,
       signOut,
       getToken,
     };
@@ -96,6 +100,7 @@ export const useAuth: UseAuth = () => {
       isSignedIn: false,
       sessionId,
       userId,
+      actorId: null,
       signOut,
       getToken,
     };
@@ -107,6 +112,7 @@ export const useAuth: UseAuth = () => {
       isSignedIn: true,
       sessionId,
       userId,
+      actorId,
       signOut,
       getToken,
     };

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -9,8 +9,13 @@ import { LoaderFunctionArgs, LoaderFunctionArgsWithAuth } from './types';
  * @internal
  */
 export function injectAuthIntoRequest(args: LoaderFunctionArgs, authData: AuthData): LoaderFunctionArgsWithAuth {
-  const { user, session, userId, sessionId, getToken } = authData;
-  (args.request as any).auth = { userId, sessionId, getToken };
+  const { user, session, userId, sessionId, getToken, claims } = authData;
+  (args.request as any).auth = {
+    userId,
+    sessionId,
+    getToken,
+    actorId: claims?.act?.sub || null,
+  };
   (args.request as any).user = user;
   (args.request as any).session = session;
   return args as LoaderFunctionArgsWithAuth;

--- a/packages/sdk-node/src/Clerk.ts
+++ b/packages/sdk-node/src/Clerk.ts
@@ -36,6 +36,7 @@ export type LooseAuthProp = {
   auth: {
     sessionId: string | null;
     userId: string | null;
+    actorId: string | null;
     getToken: ServerGetToken;
     claims: ClerkJWTClaims | null;
   };
@@ -47,6 +48,7 @@ export type StrictAuthProp = {
   auth: {
     sessionId: string;
     userId: string;
+    actorId: string | null;
     getToken: ServerGetToken;
     claims: ClerkJWTClaims;
   };
@@ -305,6 +307,7 @@ export default class Clerk extends ClerkBackendAPI {
           req.auth = {
             sessionId: sessionClaims?.sid,
             userId: sessionClaims?.sub,
+            actorId: sessionClaims?.act?.sub || null,
             getToken: createGetToken({
               headerToken,
               cookieToken,
@@ -326,6 +329,7 @@ export default class Clerk extends ClerkBackendAPI {
         req.auth = {
           userId: null,
           sessionId: null,
+          actorId: null,
           getToken: createSignedOutState().getToken,
           claims: null,
         } as WithAuthProp<Request>;

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -101,6 +101,7 @@ export interface SessionJSON extends ClerkResourceJSON {
   last_active_at: number;
   last_active_token: TokenJSON;
   last_active_organization_id: string | null;
+  actor_id: string | null;
   user: UserJSON;
   public_user_data: PublicUserDataJSON;
   created_at: number;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -9,6 +9,7 @@ export interface SessionResource extends ClerkResource {
   abandonAt: Date;
   lastActiveToken: TokenResource | null;
   lastActiveOrganizationId: string | null;
+  actorId: string | null;
   user: UserResource | null;
   publicUserData: PublicUserData;
   end: () => Promise<SessionResource>;

--- a/packages/types/src/ssr.ts
+++ b/packages/types/src/ssr.ts
@@ -9,6 +9,7 @@ export type ServerGetToken = (options?: ServerGetTokenOptions) => Promise<string
 export type ServerSideAuth = {
   sessionId: string | null;
   userId: string | null;
+  actorId: string | null;
   getToken: ServerGetToken;
   claims: ClerkJWTClaims | null;
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Provide a way to determine whether the current session is impersonated by another user. 

The impersonating user is the "actor" and the user that's appeared to be signed in the session is the "subject".

- Add `Session.actorId` and `Session.isImpersonated()` in clerk-js.
```js
const session = useSession();
if (session.isImpersonated()) {
  console.log(`The real user is ${session.actorId}`);
}
```

- Make the `actorId` available in the react `useAuth()` hook.
```js
const { userId, actorId } = useAuth();
if (actorId) {
  console.log(`User ${actorId} is logged in as user ${userId}`);
}
```

- Make `actorId` available in sdk-node withAuth middleware.
```js
withAuth((req, res) => {
  const { userId, actorId } = req.auth;
  console.log(`User ${actorId} is logged in as user ${userId}`);
});
```

- Make `actorId` available in nextjs SSR middleware.
```js
export const getServerSideProps = withServerSideAuth(
  async ({ req }) => {
    const { userId, actorId } = req.auth;

    return {
      props: { userId, actorId },
    };
  },
);

function MyComponent({ userId, actorId }) {
  return <div>User {actorId} is signed in as user {userId}</div>;
} 
```

- Make `actorId` available in remix root loader.
```js
export const loader = (args) => {
  return rootAuthLoader(
    args,
    ({ request }) => {
      const { userId, actorId } = request.auth;
      return { userId, actorId };
    },
   );
};

function App() {
  const { userId, actorId } = useLoaderData();
  return <div>User {actorId} is logged in as user {userId}</div>;
}
```

I'm having a bit of trouble setting up and testing Gatsby, Expo and Edge, so I thought I'd leave these libraries for a follow-up PR.

It might be easier to review the changes commit-by-commit. The changeset is small for each package.

<!-- Fixes # (issue number) -->
