### PR TITLE
Make actorId available to gatsby SSR

### DIFF
--- a/packages/gatsby-plugin-clerk/src/ssr/getAuthData.ts
+++ b/packages/gatsby-plugin-clerk/src/ssr/getAuthData.ts
@@ -1,7 +1,7 @@
 import { AuthStatus, createGetToken, createSignedOutState, Session, User } from '@clerk/backend-core';
 import { isDevelopmentOrStaging } from '@clerk/backend-core/src/util/clerkApiKey';
 import Clerk, { sessions, users } from '@clerk/clerk-sdk-node';
-import { ServerGetToken } from '@clerk/types';
+import { ClerkJWTClaims, ServerGetToken } from '@clerk/types';
 import { GetServerDataProps } from 'gatsby';
 
 import { WithServerAuthOptions } from './types';
@@ -13,6 +13,7 @@ export type AuthData = {
   userId: string | null;
   user: User | undefined | null;
   getToken: ServerGetToken;
+  claims: ClerkJWTClaims | null;
 };
 
 type GetAuthDataReturn =
@@ -71,7 +72,7 @@ export async function getAuthData(
       headerToken,
       fetcher: (...args) => sessions.getToken(...args),
     });
-    return { authData: { sessionId, userId, user, session, getToken } };
+    return { authData: { sessionId, userId, user, session, getToken, claims: sessionClaims } };
   } catch (e) {
     return { authData: createSignedOutState() };
   }

--- a/packages/gatsby-plugin-clerk/src/ssr/utils.ts
+++ b/packages/gatsby-plugin-clerk/src/ssr/utils.ts
@@ -1,3 +1,4 @@
+import { ActJWTClaim, ServerSideAuth } from '@clerk/types';
 import cookie from 'cookie';
 import type { GetServerDataProps } from 'gatsby';
 
@@ -8,10 +9,17 @@ import { GetServerDataPropsWithAuth } from './types';
  * @internal
  */
 export function injectAuthIntoContext(context: GetServerDataProps, authData: AuthData): GetServerDataPropsWithAuth {
-  const { user, session, ...auth } = authData || {};
-  // FIXME: Add auth.claims addition
-  // @ts-ignore
-  return { ...context, auth, user, session };
+  const { user, session, claims, ...auth } = authData || {};
+  return {
+    ...context,
+    auth: {
+      ...auth,
+      claims,
+      actorId: (claims?.act as ActJWTClaim)?.sub || null,
+    } as ServerSideAuth,
+    user: user || null,
+    session: session || null,
+  };
 }
 
 /**

--- a/packages/types/src/jwt.ts
+++ b/packages/types/src/jwt.ts
@@ -65,6 +65,11 @@ export interface ClerkJWTClaims {
   azp?: string;
 
   /**
+   * JWT Actor - [RFC8693](https://www.rfc-editor.org/rfc/rfc8693.html#name-act-actor-claim).
+   */
+  act?: ActJWTClaim;
+
+  /**
    * @deprecated - Add orgs to your session token using the "user.organizations" shortcode in JWT Templates instead
    */
   orgs?: Record<string, MembershipRole>;
@@ -88,6 +93,10 @@ export interface ClerkJWTClaims {
    * Any other JWT Claim Set member.
    */
   [propName: string]: unknown;
+}
+
+export interface ActJWTClaim {
+  sub: string;
 }
 
 export type OrganizationsJWTClaim = Record<string, MembershipRole>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Added the actorId of impersonation sessions to the withServerAuth() function for SSR. See #363 for more context.
<!-- Fixes # (issue number) -->
