### PR TITLE
fix(clerk-js): Handle the case of unverified primary email/phone in UserProfile

### DIFF
--- a/packages/clerk-js/src/ui/UserProfile/EmailSection.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/EmailSection.tsx
@@ -54,10 +54,19 @@ const EmailAccordion = ({ email }: { email: EmailAddressResource }) => {
       badge={isPrimary ? <Badge>Primary</Badge> : undefined}
     >
       <Col gap={4}>
-        {isPrimary && (
+        {isPrimary && isVerified && (
           <LinkButtonWithDescription
             title='Primary email address'
             subtitle='This email address is the primary email address'
+          />
+        )}
+        {isPrimary && !isVerified && (
+          <LinkButtonWithDescription
+            title='Primary email address'
+            titleLabel={<Badge colorScheme='warning'>Unverified</Badge>}
+            subtitle='This email address is the primary email address'
+            actionLabel='Complete verification'
+            onClick={() => navigate(`email-address/${email.id}`)}
           />
         )}
         {!isPrimary && isVerified && (

--- a/packages/clerk-js/src/ui/UserProfile/PhoneSection.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/PhoneSection.tsx
@@ -65,10 +65,19 @@ const PhoneAccordion = ({ phone }: { phone: PhoneNumberResource }) => {
       badge={isPrimary ? <Badge>Primary</Badge> : undefined}
     >
       <Col gap={4}>
-        {isPrimary && (
+        {isPrimary && isVerified && (
           <LinkButtonWithDescription
             title='Primary phone number'
             subtitle='This phone number is the primary phone number'
+          />
+        )}
+        {isPrimary && !isVerified && (
+          <LinkButtonWithDescription
+            title='Primary phone number'
+            titleLabel={<Badge colorScheme='warning'>Unverified</Badge>}
+            subtitle='This phone number is the primary phone number'
+            actionLabel='Complete verification'
+            onClick={() => navigate(`phone-number/${phone.id}`)}
           />
         )}
         {!isPrimary && isVerified && (


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

For PSU instances, where isn't required to verify the email/phone to sign up, we should handle the case of a primary unverified email/phone as well. Right now the user can't do anything and thus can't verify it via the UserProfile

### Before

https://user-images.githubusercontent.com/22435234/189301885-cef2a4d0-820e-45e2-b4ec-5770f67e98a6.mov

### After

https://user-images.githubusercontent.com/22435234/189301901-3e29133a-c58a-4838-8996-7a72434134e3.mov

<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/In-UserProfile-handle-case-of-unverified-primary-email-phone-bd048eba7bb34c3abcafbcb163f89c76
