### PR TITLE
fix(clerk-js): Fix magic link verification in <UserProfile/> when used as a modal

### DIFF
--- a/packages/clerk-js/src/ui/UserProfile/UserProfile.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/UserProfile.tsx
@@ -16,7 +16,7 @@ const _UserProfile = (_: UserProfileProps) => {
       <Flow.Part>
         <Switch>
           {/* PublicRoutes */}
-          <Route path={'verify'}>
+          <Route path='verify'>
             <VerificationSuccessPage />
           </Route>
           <Route>


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The following workaround is used in order to make magic links work when the `<UserProfile/>` is used as a modal. In modals, the routing is virtual. For magic links the flow needs to end by invoking the `/verify` path of the `<UserProfile/>` that renders the `<VerificationSuccessPage/>`. So, we use the `userProfileUrl` that defaults to Clerk Hosted Pages `/user` as a fallback.

<img width="1440" alt="Screenshot 2022-09-14 at 4 23 26 PM" src="https://user-images.githubusercontent.com/1352422/190383867-99b94ded-6498-491f-b0a9-76449a09dac7.png">


