### PR TITLE
fix(clerk-js): Stop infinite TOTP re-renders

### DIFF
--- a/packages/clerk-js/src/ui/UserProfile/AddAuthenticatorApp.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/AddAuthenticatorApp.tsx
@@ -31,7 +31,7 @@ export const AddAuthenticatorApp = (props: AddAuthenticatorAppProps) => {
       .createTOTP()
       .then((totp: TOTPResource) => setTOTP(totp))
       .catch(err => handleError(err, [], card.setError));
-  }, [user]);
+  }, []);
 
   if (card.error) {
     return <ContentPage.Root headerTitle={title} />;


### PR DESCRIPTION
…e dep array

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
A user reported that the TOTP UserProfile component infinitely renders, causing the QR code to change for every new request.

We couldn't successfully reproduce this behavior, but it's most likely cause by the `[user]` dependency which we removed. 

<!-- Fixes # (issue number) -->
