### PR TITLE
chore(clerk-sdk-node): Align dist directory structure

### DIFF
--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -1,12 +1,11 @@
 {
   "version": "4.2.1",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "esm/index.js",
-  "typings": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "typings": "dist/cjs/index.d.ts",
   "files": [
     "dist",
-    "esm",
     "instance.js",
     "instance.d.ts",
     "package.json"

--- a/packages/sdk-node/tsconfig.build.json
+++ b/packages/sdk-node/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist",
+    "outDir": "dist/cjs",
     "module": "commonjs"
   },
   "include": ["src/**/*"]

--- a/packages/sdk-node/tsconfig.esm.json
+++ b/packages/sdk-node/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "esm",
+    "outDir": "dist/esm",
     "module": "ES6"
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
…packages

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This package used to generate a `dist` and a `esm` *top level* directories. Our main build script deletes all `dist` directories prior to building but the `esm` dir in sdk-node remained in place,  resulting in repeated issues in case-sensitive filesystems.

To avoid further confusion in the future, this PR aligns the dist directory structure for the `clerk-sdk-node` package with everything else. 
<!-- Fixes # (issue number) -->
