### PR TITLE
Handle web3 providers during PSU and correctly handle metamask errors

### DIFF
--- a/packages/clerk-js/src/core/resources/Error.ts
+++ b/packages/clerk-js/src/core/resources/Error.ts
@@ -5,8 +5,24 @@ interface ClerkAPIResponseOptions {
   status: number;
 }
 
-export function isClerkAPIResponseError(object: any): object is ClerkAPIResponseError {
-  return 'clerkError' in object;
+// For a comprehensive Metamask error list, please see
+// https://docs.metamask.io/guide/ethereum-provider.html#errors
+interface MetamaskError extends Error {
+  code: 4001 | 32602 | 32603;
+  message: string;
+  data?: unknown;
+}
+
+export function isKnownError(error: any) {
+  return isClerkAPIResponseError(error) || isMetamaskError(error);
+}
+
+export function isClerkAPIResponseError(err: any): err is ClerkAPIResponseError {
+  return 'clerkError' in err;
+}
+
+export function isMetamaskError(err: any): err is MetamaskError {
+  return 'code' in err && [4001, 32602, 32603].includes(err.code) && 'message' in err;
 }
 
 export function parseErrors(data: ClerkAPIErrorJSON[] = []): ClerkAPIError[] {
@@ -54,8 +70,8 @@ export class MagicLinkError extends Error {
     Object.setPrototypeOf(this, MagicLinkError.prototype);
   }
 }
-
 // Check if the error is a MagicLinkError.
+
 export function isMagicLinkError(err: Error): err is MagicLinkError {
   return err instanceof MagicLinkError;
 }

--- a/packages/clerk-js/src/ui/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInStart.tsx
@@ -198,7 +198,12 @@ export function _SignInStart(): JSX.Element {
           gap={8}
         >
           <SocialButtonsReversibleContainerWithDivider>
-            <SignInSocialButtons />
+            {hasSocialOrWeb3Buttons && (
+              <SignInSocialButtons
+                enableWeb3Providers
+                enableOAuthProviders
+              />
+            )}
             {standardFormAttributes.length ? (
               <Form.Root onSubmit={handleFirstPartySubmit}>
                 <Form.ControlRow>

--- a/packages/clerk-js/src/ui/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInStart.tsx
@@ -11,12 +11,11 @@ import { Col, descriptors, Flow, localizationKeys } from '../customizables';
 import {
   Card,
   CardAlert,
-  Divider,
   Footer,
   Form,
   Header,
   LoadingCard,
-  SocialButtonsReversibleContainer,
+  SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
 } from '../elements';
 import { useCardState } from '../elements/contexts';
@@ -198,9 +197,8 @@ export function _SignInStart(): JSX.Element {
           elementDescriptor={descriptors.main}
           gap={8}
         >
-          <SocialButtonsReversibleContainer>
+          <SocialButtonsReversibleContainerWithDivider>
             <SignInSocialButtons />
-            {hasSocialOrWeb3Buttons && standardFormAttributes.length ? <Divider /> : null}
             {standardFormAttributes.length ? (
               <Form.Root onSubmit={handleFirstPartySubmit}>
                 <Form.ControlRow>
@@ -213,7 +211,7 @@ export function _SignInStart(): JSX.Element {
                 <Form.SubmitButton>Continue</Form.SubmitButton>
               </Form.Root>
             ) : null}
-          </SocialButtonsReversibleContainer>
+          </SocialButtonsReversibleContainerWithDivider>
         </Col>
         <Footer.Root>
           <Footer.Action>

--- a/packages/clerk-js/src/ui/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpContinue.tsx
@@ -140,8 +140,8 @@ function _SignUpContinue() {
   };
 
   const canToggleEmailPhone = emailOrPhone(attributes, isProgressiveSignUp);
-  const showSocialButtons =
-    (!hasVerifiedExternalAccount && oauthOptions.length > 0) || (!hasVerifiedWeb3 && web3Options.length > 0);
+  const showOauthProviders = !hasVerifiedExternalAccount && oauthOptions.length > 0;
+  const showWeb3Providers = !hasVerifiedWeb3 && web3Options.length > 0;
 
   return (
     <Flow.Part part='complete'>
@@ -161,7 +161,12 @@ function _SignUpContinue() {
           gap={8}
         >
           <SocialButtonsReversibleContainerWithDivider>
-            {showSocialButtons && <SignUpSocialButtons />}
+            {(showOauthProviders || showWeb3Providers) && (
+              <SignUpSocialButtons
+                enableOAuthProviders={showOauthProviders}
+                enableWeb3Providers={showWeb3Providers}
+              />
+            )}
             {showFormFields(userSettings) && (
               <SignUpForm
                 handleSubmit={handleSubmit}

--- a/packages/clerk-js/src/ui/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpContinue.tsx
@@ -7,11 +7,10 @@ import { descriptors, Flex, Flow, localizationKeys } from '../customizables';
 import {
   Card,
   CardAlert,
-  Divider,
   Footer,
   Header,
   LoadingCard,
-  SocialButtonsReversibleContainer,
+  SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
 } from '../elements';
 import { useCardState } from '../elements/contexts';
@@ -161,9 +160,8 @@ function _SignUpContinue() {
           elementDescriptor={descriptors.main}
           gap={8}
         >
-          <SocialButtonsReversibleContainer>
+          <SocialButtonsReversibleContainerWithDivider>
             {showSocialButtons && <SignUpSocialButtons />}
-            {showSocialButtons && showFormFields(userSettings) && <Divider />}
             {showFormFields(userSettings) && (
               <SignUpForm
                 handleSubmit={handleSubmit}
@@ -173,7 +171,7 @@ function _SignUpContinue() {
                 handleEmailPhoneToggle={handleChangeActive}
               />
             )}
-          </SocialButtonsReversibleContainer>
+          </SocialButtonsReversibleContainerWithDivider>
         </Flex>
         <Footer.Root>
           <Footer.Action>

--- a/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
@@ -218,11 +218,12 @@ function _SignUpStart(): JSX.Element {
   }
 
   const canToggleEmailPhone = emailOrPhone(attributes, isProgressiveSignUp);
-  const hasSocialOrWeb3Buttons =
-    !!userSettings.socialProviderStrategies.length || !!userSettings.web3FirstFactors.length;
-
   const visibleFields = Object.entries(fields).filter(([_, opts]) => showOptionalFields || opts?.required);
   const shouldShowForm = showFormFields(userSettings) && visibleFields.length > 0;
+
+  const showOauthProviders =
+    (!hasTicket || missingRequirementsWithTicket) && userSettings.socialProviderStrategies.length > 0;
+  const showWeb3Providers = !hasTicket && userSettings.web3FirstFactors.length > 0;
 
   return (
     <Flow.Part part='start'>
@@ -244,7 +245,12 @@ function _SignUpStart(): JSX.Element {
           gap={8}
         >
           <SocialButtonsReversibleContainerWithDivider>
-            {(!hasTicket || missingRequirementsWithTicket) && <SignUpSocialButtons />}
+            {(showOauthProviders || showWeb3Providers) && (
+              <SignUpSocialButtons
+                enableOAuthProviders={showOauthProviders}
+                enableWeb3Providers={showWeb3Providers}
+              />
+            )}
             {shouldShowForm && (
               <SignUpForm
                 handleSubmit={handleSubmit}

--- a/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/SignUp/SignUpStart.tsx
@@ -9,11 +9,10 @@ import { descriptors, Flex, Flow, localizationKeys, useAppearance } from '../cus
 import {
   Card,
   CardAlert,
-  Divider,
   Footer,
   Header,
   LoadingCard,
-  SocialButtonsReversibleContainer,
+  SocialButtonsReversibleContainerWithDivider,
   withCardStateProvider,
 } from '../elements';
 import { useCardState } from '../elements/contexts';
@@ -244,9 +243,8 @@ function _SignUpStart(): JSX.Element {
           elementDescriptor={descriptors.main}
           gap={8}
         >
-          <SocialButtonsReversibleContainer>
+          <SocialButtonsReversibleContainerWithDivider>
             {(!hasTicket || missingRequirementsWithTicket) && <SignUpSocialButtons />}
-            {hasSocialOrWeb3Buttons && shouldShowForm && <Divider />}
             {shouldShowForm && (
               <SignUpForm
                 handleSubmit={handleSubmit}
@@ -256,7 +254,7 @@ function _SignUpStart(): JSX.Element {
                 handleEmailPhoneToggle={handleChangeActive}
               />
             )}
-          </SocialButtonsReversibleContainer>
+          </SocialButtonsReversibleContainerWithDivider>
         </Flex>
         <Footer.Root>
           <Footer.Action>

--- a/packages/clerk-js/src/ui/elements/ReversibleContainer.tsx
+++ b/packages/clerk-js/src/ui/elements/ReversibleContainer.tsx
@@ -1,18 +1,31 @@
 import React from 'react';
 
 import { useAppearance } from '../customizables';
+import { Divider } from './Divider';
 
-export const SocialButtonsReversibleContainer = (props: React.PropsWithChildren<{}>) => {
+export const SocialButtonsReversibleContainerWithDivider = (props: React.PropsWithChildren<{}>) => {
   const appearance = useAppearance();
+  const childrenWithDivider = interleaveElementInArray(React.Children.toArray(props.children), i => (
+    <Divider key={`divider${i}`} />
+  ));
+
   return (
     <ReversibleContainer
-      {...props}
       reverse={appearance.parsedLayout.socialButtonsPlacement === 'bottom'}
-    />
+      {...props}
+    >
+      {childrenWithDivider}
+    </ReversibleContainer>
   );
 };
 
 export const ReversibleContainer = (props: React.PropsWithChildren<{ reverse?: boolean }>) => {
   const { children, reverse } = props;
   return <>{reverse ? React.Children.toArray(children).reverse() : children}</>;
+};
+
+const interleaveElementInArray = <T, A extends T[]>(arr: A, generator: (i: number) => any): A => {
+  return arr.reduce((acc, child, i) => {
+    return i === arr.length - 1 ? [...acc, child] : [...acc, child, generator(i)];
+  }, [] as any);
 };

--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -10,7 +10,10 @@ import { useCardState } from './contexts';
 
 const SOCIAL_BUTTON_BLOCK_THRESHOLD = 2;
 
-export type SocialButtonsProps = React.PropsWithChildren<{}>;
+export type SocialButtonsProps = React.PropsWithChildren<{
+  enableOAuthProviders: boolean;
+  enableWeb3Providers: boolean;
+}>;
 
 type SocialButtonsRootProps = SocialButtonsProps & {
   oauthCallback: (strategy: OAuthStrategy) => Promise<unknown>;
@@ -22,10 +25,12 @@ const isWeb3Strategy = (val: string): val is Web3Strategy => {
 };
 
 export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
-  const { oauthCallback, web3Callback } = props;
-  const { strategies, strategyToDisplayData } = useEnabledThirdPartyProviders();
+  const { oauthCallback, web3Callback, enableOAuthProviders = true, enableWeb3Providers = true } = props;
+  const { web3Strategies, oauthStrategies, strategyToDisplayData } = useEnabledThirdPartyProviders();
   const card = useCardState();
   const { socialButtonsVariant } = useAppearance().parsedLayout;
+
+  const strategies = [...(enableOAuthProviders ? oauthStrategies : []), ...(enableWeb3Providers ? web3Strategies : [])];
 
   if (!strategies.length) {
     return null;

--- a/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
@@ -30,6 +30,8 @@ export const useEnabledThirdPartyProviders = () => {
   const { socialProviderStrategies, web3FirstFactors } = useEnvironment().userSettings;
   return {
     strategies: [...socialProviderStrategies, ...web3FirstFactors],
+    web3Strategies: [...web3FirstFactors],
+    oauthStrategies: [...socialProviderStrategies],
     strategyToDisplayData,
     providerToDisplayData,
   };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR add the ability to show or hide the web3 providers independently of the other oauth providers and completely aligns all related rules in SignInStart, SignUpStart and SignUpContinue to the equivalent rules of the Clerk v3 components.

To avoid duplicating the checks for the Divider, the Divider component is now decleratively added between the children elements of `SocialButtonsReversibleContainerWithDivider`

Lastly, this PR adds error handling for the Metamask plugin errors by showing a global card message (instead of rethrowing).

#### 0. metamask error if user cancels through the plugin
![image](https://user-images.githubusercontent.com/1811063/191355137-0b9fc476-5559-4ed1-9577-31b471801146.png)

#### 1. Google, facebook + metamask + form
![image](https://user-images.githubusercontent.com/1811063/191355301-2eb990a8-66db-4033-aba4-1fe300002c5d.png)

#### 2. Google, facebook + metamask, no form
![image](https://user-images.githubusercontent.com/1811063/191355396-1facd7aa-7868-4782-9471-99e8f14a96b4.png)

#### 3. metamask + no form
![image](https://user-images.githubusercontent.com/1811063/191355467-5c1a0b0e-4cd5-484f-9654-dee0d895ee4d.png)

#### 4. no third party, some required fields
![image](https://user-images.githubusercontent.com/1811063/191355736-c651d89e-2103-43f2-88c6-63bba72ae119.png)

#### 5. Complete PSU flow: metamask -> google -> PSU (required username) -> signed in
https://user-images.githubusercontent.com/1811063/191356228-cae8b8cc-34b7-4cbf-b247-055010c0c8f0.mp4


Note 2:
If no web3, oauth or other methods are enable, the components render nothing: 
![image](https://user-images.githubusercontent.com/1811063/191355565-54387981-2bf7-4d22-bd9a-f0e1248ceedf.png)
However, this state should be made impossible via DAPI.

<!-- Fixes # (issue number) -->
https://www.notion.so/clerkdev/Hide-OAuth-options-during-PSU-in-ClerkJS-v4-b28e68ac20dd43a1a7d1aeb3cfa6d96f