### PR TITLE
fix(clerk-js): Explicitly pass the user in SignInAccountSwitcher instead of calling useCoreUser

### DIFF
--- a/packages/clerk-js/src/ui/SignIn/SignInAccountSwitcher.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInAccountSwitcher.tsx
@@ -22,6 +22,7 @@ const _SignInAccountSwitcher = () => {
       navigateAfterSwitchSession: navigateAfterSignIn,
       userProfileUrl,
       signInUrl,
+      user: undefined,
     });
 
   return (
@@ -32,7 +33,6 @@ const _SignInAccountSwitcher = () => {
           <Header.Title>Signed out</Header.Title>
           <Header.Subtitle>Select account to continue to {applicationName}</Header.Subtitle>
         </Header.Root>
-        {/*TODO: extract main in its own component */}
         <Col
           elementDescriptor={descriptors.main}
           gap={8}
@@ -51,7 +51,7 @@ const _SignInAccountSwitcher = () => {
               isDisabled={card.isLoading}
               icon={
                 <Icon
-                  size={'sm'}
+                  size='sm'
                   icon={Plus}
                   sx={theme => ({ color: theme.colors.$blackAlpha500 })}
                 />

--- a/packages/clerk-js/src/ui/UserButton/UserButtonPopover.tsx
+++ b/packages/clerk-js/src/ui/UserButton/UserButtonPopover.tsx
@@ -15,9 +15,9 @@ type UserButtonPopoverProps = { isOpen: boolean; close: () => void } & PropsOfCo
 
 export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopoverProps>((props, ref) => {
   const { isOpen, close, ...rest } = props;
-  const user = useCoreUser();
   const session = useCoreSession() as ActiveSessionResource;
   const { authConfig } = useEnvironment();
+  const user = useCoreUser();
   const {
     handleAddAccountClicked,
     handleManageAccountClicked,
@@ -25,7 +25,7 @@ export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopo
     handleSignOutAllClicked,
     handleSignOutSessionClicked,
     otherSessions,
-  } = useMultisessionActions({ ...useUserButtonContext(), actionCompleteCallback: close });
+  } = useMultisessionActions({ ...useUserButtonContext(), actionCompleteCallback: close, user });
 
   if (!isOpen) {
     return null;

--- a/packages/clerk-js/src/ui/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/UserButton/useMultisessionActions.tsx
@@ -1,13 +1,14 @@
-import { ActiveSessionResource, UserButtonProps } from '@clerk/types';
+import { ActiveSessionResource, UserButtonProps, UserResource } from '@clerk/types';
 import React from 'react';
 
 import { windowNavigate } from '../../utils/windowNavigate';
-import { useCoreClerk, useCoreSessionList, useCoreUser } from '../contexts';
+import { useCoreClerk, useCoreSessionList } from '../contexts';
 import { useCardState } from '../elements';
 import { useNavigate } from '../hooks';
 import { sleep } from '../utils';
 
 type UseMultisessionActionsParams = {
+  user: UserResource | undefined;
   actionCompleteCallback?: () => void;
   navigateAfterSignOut?: () => any;
   navigateAfterMultiSessionSingleSignOut?: () => any;
@@ -21,9 +22,8 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
   const card = useCardState();
   const sessions = useCoreSessionList();
   const { navigate } = useNavigate();
-  const user = useCoreUser();
   const activeSessions = sessions.filter(s => s.status === 'active') as ActiveSessionResource[];
-  const otherSessions = activeSessions.filter(s => s.user?.id !== user.id);
+  const otherSessions = activeSessions.filter(s => s.user?.id !== opts.user?.id);
 
   const handleSignOutSessionClicked = (session: ActiveSessionResource) => () => {
     if (otherSessions.length === 0) {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The useCoreUser hook still throws if it's called while the user is not defined. If a user signs out from a single session in a multisession app with multiple active sessions, the signOut() call will set the Clerk.user to null, so we cannot call useCoreUser while navigating to SignInAccountSwitcher.tsx


https://user-images.githubusercontent.com/1811063/191474081-1b24df4b-2fc4-424d-a017-f9e64b3b5778.mp4



<!-- Fixes # (issue number) -->
https://www.notion.so/clerkdev/a853f869f69c414b85e6d5290a2c4172?v=b253a2f980c641de8992cc63ed416fa0&p=6a4b6b180ac64f76a1e31d7947386867&pm=s