### PR TITLE
fix(clerk-js): Handle undefined global errors in errorHandler

### DIFF
--- a/packages/clerk-js/src/core/resources/Error.ts
+++ b/packages/clerk-js/src/core/resources/Error.ts
@@ -7,7 +7,7 @@ interface ClerkAPIResponseOptions {
 
 // For a comprehensive Metamask error list, please see
 // https://docs.metamask.io/guide/ethereum-provider.html#errors
-interface MetamaskError extends Error {
+export interface MetamaskError extends Error {
   code: 4001 | 32602 | 32603;
   message: string;
   data?: unknown;

--- a/packages/clerk-js/tsconfig.json
+++ b/packages/clerk-js/tsconfig.json
@@ -20,6 +20,7 @@
     "declaration": false,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react"
+    // "noUncheckedIndexedAccess": true // TODO: Enable and progressively fix related errors
   },
   "include": [
     "src/index.ts",


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Found a small issue while testing the latest staging changes. Specifically: 
```
globalErrors[0].longMessage
```
could potentially throw an error, since the [0] element can be undefined. 

I'd like to enable the `noUncheckedIndexedAccess` strict TSC check but it results in many unhandled errors right now. Let's enable it periodically and progressively fix the errors from now on.

<!-- Fixes # (issue number) -->
