### PR TITLE
feat(types,clerk-js): Introduce BackupCodeResource and user.createBackupCode() oepration

### DIFF
--- a/packages/clerk-js/src/core/resources/BackupCode.ts
+++ b/packages/clerk-js/src/core/resources/BackupCode.ts
@@ -1,0 +1,27 @@
+import { BackupCodeJSON, BackupCodeResource } from '@clerk/types';
+
+import { unixEpochToDate } from '../../utils/date';
+import { BaseResource } from './internal';
+
+export class BackupCode extends BaseResource implements BackupCodeResource {
+  pathRoot = '/me';
+
+  id!: string;
+  codes: string[] = [];
+  updatedAt: Date | null = null;
+  createdAt: Date | null = null;
+
+  constructor(data: BackupCodeJSON) {
+    super();
+    this.fromJSON(data);
+  }
+
+  protected fromJSON(data: BackupCodeJSON): this {
+    this.id = data.id;
+    this.codes = data.codes;
+    this.updatedAt = unixEpochToDate(data.updated_at);
+    this.createdAt = unixEpochToDate(data.created_at);
+
+    return this;
+  }
+}

--- a/packages/clerk-js/src/core/resources/User.test.ts
+++ b/packages/clerk-js/src/core/resources/User.test.ts
@@ -215,4 +215,30 @@ describe('User', () => {
       path: '/me/totp',
     });
   });
+
+  it('creates backup codes', async () => {
+    const backupCodeJSON = {
+      object: 'backup_code',
+      id: 'bcode_1234',
+      codes: ['1234', '5678'],
+    };
+
+    // @ts-ignore
+    BaseResource._fetch = jest.fn().mockReturnValue(Promise.resolve({ response: backupCodeJSON }));
+
+    const user = new User({
+      email_addresses: [],
+      phone_numbers: [],
+      web3_wallets: [],
+      external_accounts: [],
+    } as unknown as UserJSON);
+
+    await user.createBackupCode();
+
+    // @ts-ignore
+    expect(BaseResource._fetch).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/me/backup_codes/',
+    });
+  });
 });

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -1,4 +1,6 @@
 import type {
+  BackupCodeJSON,
+  BackupCodeResource,
   CreateEmailAddressParams,
   CreatePhoneNumberParams,
   CreateWeb3WalletParams,
@@ -23,6 +25,7 @@ import type {
 
 import { unixEpochToDate } from '../../utils/date';
 import { normalizeUnsafeMetadata } from '../../utils/resourceParams';
+import { BackupCode } from './BackupCode';
 import {
   BaseResource,
   DeletedObject,
@@ -175,6 +178,17 @@ export class User extends BaseResource implements UserResource {
     )?.response as unknown as DeletedObjectJSON;
 
     return new DeletedObject(json);
+  };
+
+  createBackupCode = async (): Promise<BackupCodeResource> => {
+    const json = (
+      await BaseResource._fetch<BackupCodeJSON>({
+        path: this.path() + '/backup_codes/',
+        method: 'POST',
+      })
+    )?.response as unknown as BackupCodeJSON;
+
+    return new BackupCode(json);
   };
 
   update = (params: UpdateUserParams): Promise<UserResource> => {

--- a/packages/types/src/backupCode.ts
+++ b/packages/types/src/backupCode.ts
@@ -1,0 +1,8 @@
+import { ClerkResource } from './resource';
+
+export interface BackupCodeResource extends ClerkResource {
+  id: string;
+  codes: string[];
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from './api';
 export * from './authConfig';
+export * from './backupCode';
 export * from './clerk';
 export * from './client';
 export * from './deletedObject';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -297,6 +297,14 @@ export interface TOTPJSON extends ClerkResourceJSON {
   updated_at: number;
 }
 
+export interface BackupCodeJSON extends ClerkResourceJSON {
+  object: 'backup_code';
+  id: string;
+  codes: string[];
+  created_at: number;
+  updated_at: number;
+}
+
 export interface DeletedObjectJSON {
   object: string;
   id?: string;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,3 +1,4 @@
+import { BackupCodeResource } from './backupCode';
 import { DeletedObjectResource } from './deletedObject';
 import { EmailAddressResource } from './emailAddress';
 import { ExternalAccountResource } from './externalAccount';
@@ -77,6 +78,7 @@ export interface UserResource extends ClerkResource {
   createTOTP: () => Promise<TOTPResource>;
   verifyTOTP: (params: VerifyTOTPParams) => Promise<TOTPResource>;
   disableTOTP: () => Promise<DeletedObjectResource>;
+  createBackupCode: () => Promise<BackupCodeResource>;
   get verifiedExternalAccounts(): ExternalAccountResource[];
   get unverifiedExternalAccounts(): ExternalAccountResource[];
   get hasVerifiedEmailAddress(): boolean;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

- Introduce the new BackupCode resource and the relevant types
- Introduce a new `user.createBackupCode()` method, that generates a set for backup codes for a user

<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/Introduce-new-FAPI-me-backup-codes-endpoints-31f0832bb7544d4d90ba27758cac2a54
