### PR TITLE
feat(backend-core): User organization memberships

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -52,6 +52,7 @@ Reference of the methods supported in the Clerk Backend API wrapper. [API refere
   - [updateUser(userId, params)](#updateuseruserid-params)
   - [deleteUser(userId)](#deleteuseruserid)
   - [disableUserMFA(userId)](#disableusermfauserid)
+  - [getOrganizationMembershipList(params)](#getorganizationmembershiplistparams)
 - [Email operations](#email-operations)
   - [createEmail({ fromEmailName, subject, body, emailAddressId })](#createemail-fromemailname-subject-body-emailaddressid-)
 - [SMS Message operations](#sms-message-operations)
@@ -603,6 +604,22 @@ Disables all MFA methods of a user given their id. Throws an error otherwise.
 ```ts
 const userId = 'my-user-id';
 await clerkAPI.users.disableUserMFA(userId);
+```
+
+#### getOrganizationMembershipList(params)
+
+Get a list of organization memberships for the user with the provided `userId`.
+
+The method supports pagination via optional `limit` and `offset` parameters. The method parameters are:
+
+- _userId_ The unique ID of the user to retrieve organization memberships for
+- _limit_ Optionally put a limit on the number of results returned
+- _offset_ Optionally skip some results
+
+```ts
+const memberships = await clerkAPI.users.getOrganizationMemberships({
+  userId: 'user_1o4q123qMeCkKKIXcA9h8',
+});
 ```
 
 ## Email operations

--- a/packages/backend-core/src/api/endpoints/UserApi.ts
+++ b/packages/backend-core/src/api/endpoints/UserApi.ts
@@ -1,5 +1,5 @@
 import { joinPaths } from '../../util/path';
-import { User } from '../resources/User';
+import { OrganizationMembership, User } from '../resources';
 import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/users';
@@ -46,6 +46,12 @@ interface UpdateUserParams extends UserMetadataParams {
   primaryEmailAddressID?: string;
   primaryPhoneNumberID?: string;
 }
+
+type GetOrganizationMembershipListParams = {
+  userId: string;
+  limit?: number;
+  offset?: number;
+};
 
 export class UserAPI extends AbstractAPI {
   public async getUserList(params: UserListParams = {}) {
@@ -121,6 +127,17 @@ export class UserAPI extends AbstractAPI {
     return this.APIClient.request<User>({
       method: 'DELETE',
       path: joinPaths(basePath, userId, 'mfa'),
+    });
+  }
+
+  public async getOrganizationMembershipList(params: GetOrganizationMembershipListParams) {
+    const { userId, limit, offset } = params;
+    this.requireId(userId);
+
+    return this.APIClient.request<OrganizationMembership[]>({
+      method: 'GET',
+      path: joinPaths(basePath, userId, 'organization_memberships'),
+      queryParams: { limit, offset },
     });
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Added a `users.getOrganizationMembershipList()` method to fetch a user's organization memberships.

Results can be paginated with optional limit and offset parameters.

<!-- Fixes # (issue number) -->
