### PR TITLE
feat(types,clerk-js): Add support for backup code operations in UserProfille

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -117,7 +117,7 @@
     "files": [
       {
         "path": "./dist/clerk.browser.js",
-        "maxSize": "152kB"
+        "maxSize": "155kB"
       },
       {
         "path": "./dist/clerk.headless.js",

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -64,6 +64,7 @@ export class User extends BaseResource implements UserResource {
   profileImageUrl = '';
   twoFactorEnabled = false;
   totpEnabled = false;
+  backupCodeEnabled = false;
   publicMetadata: Record<string, unknown> = {};
   unsafeMetadata: Record<string, unknown> = {};
   lastSignInAt: Date | null = null;
@@ -272,6 +273,7 @@ export class User extends BaseResource implements UserResource {
     this.unsafeMetadata = data.unsafe_metadata;
 
     this.totpEnabled = data.totp_enabled;
+    this.backupCodeEnabled = data.backup_code_enabled;
     this.twoFactorEnabled = data.two_factor_enabled;
 
     if (data.last_sign_in_at) {

--- a/packages/clerk-js/src/ui/UserProfile/Content.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/Content.tsx
@@ -5,6 +5,7 @@ import { Route, Switch, useRouter } from '../router';
 import { common, mqu } from '../styledSystem';
 import { ConnectedAccountsPage } from './ConnectedAccountsPage';
 import { EmailPage } from './EmailPage';
+import { MfaBackupCodeCreatePage } from './MfaBackupCodeCreatePage';
 import { MfaPage } from './MfaPage';
 import { PasswordPage } from './PasswordPage';
 import { PhonePage } from './PhonePage';
@@ -93,6 +94,9 @@ export const Content = React.forwardRef<HTMLDivElement>((_, ref) => {
           <Switch>
             <Route path='totp/remove'>
               <RemoveMfaTOTPPage />
+            </Route>
+            <Route path='backup_code/add'>
+              <MfaBackupCodeCreatePage />
             </Route>
             <Route path=':id/remove'>
               <RemoveMfaPhoneCodePage />

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeAccordion.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeAccordion.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { Col, Icon } from '../customizables';
+import { useNavigate } from '../hooks';
+import { DotCircle } from '../icons';
+import { LinkButtonWithDescription } from './LinkButtonWithDescription';
+import { UserProfileAccordion } from './UserProfileAccordion';
+
+export const MfaBackupCodeAccordion = () => {
+  const { navigate } = useNavigate();
+
+  return (
+    <UserProfileAccordion
+      icon={
+        <Icon
+          icon={DotCircle}
+          sx={theme => ({ color: theme.colors.$blackAlpha700 })}
+        />
+      }
+      title='Backup code'
+    >
+      <Col gap={4}>
+        <LinkButtonWithDescription
+          title='Regenerate backup codes'
+          subtitle='Get a fresh set of secure backup codes. Prior backup codes will be deleted and cannot be used.'
+          actionLabel='Regenerate codes'
+          onClick={() => navigate('multi-factor/backup_code/add')}
+        />
+      </Col>
+    </UserProfileAccordion>
+  );
+};

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeCreatePage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeCreatePage.tsx
@@ -1,0 +1,63 @@
+import { BackupCodeResource } from '@clerk/types';
+import React from 'react';
+
+import { useCoreUser } from '../contexts';
+import { localizationKeys, Spinner, Text } from '../customizables';
+import { useCardState } from '../elements';
+import { handleError } from '../utils';
+import { FormButtonContainer } from './FormButtons';
+import { MfaBackupCodeList } from './MfaBackupCodeList';
+import { NavigateToFlowStartButton } from './NavigateToFlowStartButton';
+import { ContentPage } from './Page';
+
+export const MfaBackupCodeCreatePage = () => {
+  const user = useCoreUser();
+  const card = useCardState();
+  const [backupCode, setBackupCode] = React.useState<BackupCodeResource | undefined>(undefined);
+
+  const title = 'Add multi-factor authentication';
+  const text =
+    'Backup codes are now enabled. You can use one of these to sign in to your account, if you lose access to your authentication device. Each code can only be used once.';
+
+  React.useEffect(() => {
+    if (backupCode) {
+      return;
+    }
+
+    void user
+      .createBackupCode()
+      .then((backupCode: BackupCodeResource) => setBackupCode(backupCode))
+      .catch(err => handleError(err, [], card.setError));
+  }, []);
+
+  if (card.error) {
+    return <ContentPage.Root headerTitle={title} />;
+  }
+
+  if (!backupCode) {
+    return (
+      <Spinner
+        colorScheme='primary'
+        size='lg'
+      />
+    );
+  }
+
+  return (
+    <ContentPage.Root headerTitle={title}>
+      <Text
+        localizationKey={text}
+        variant='regularRegular'
+      />
+      <MfaBackupCodeList backupCodes={backupCode.codes} />
+
+      <FormButtonContainer>
+        <NavigateToFlowStartButton
+          variant='solid'
+          autoFocus
+          localizationKey={localizationKeys('userProfile.formButtonPrimary__finish')}
+        />
+      </FormButtonContainer>
+    </ContentPage.Root>
+  );
+};

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeList.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeList.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import { PrintableComponent, usePrintable } from '../common';
+import { useCoreUser, useEnvironment } from '../contexts';
+import { Button, Col, Flex, Grid, Heading, Text } from '../customizables';
+import { useClipboard } from '../hooks';
+import { mqu } from '../styledSystem';
+import { getIdentifier } from '../utils';
+import { MfaBackupCodeTile } from './MfaBackupCodeTile';
+
+type MfaBackupCodeListProps = {
+  backupCodes?: string[];
+};
+
+export const MfaBackupCodeList = (props: MfaBackupCodeListProps) => {
+  const { backupCodes } = props;
+  const { applicationName } = useEnvironment().displayConfig;
+  const user = useCoreUser();
+  const { print, printableProps } = usePrintable();
+  const { onCopy, hasCopied } = useClipboard(backupCodes?.join(',') || '');
+  const userIdentifier = getIdentifier(user);
+
+  const onDownloadTxtFile = () => {
+    const element = document.createElement('a');
+    const file = new Blob([txtFileContent(backupCodes, applicationName, userIdentifier)], {
+      type: 'text/plain',
+    });
+    element.href = URL.createObjectURL(file);
+    element.download = `${applicationName}_backup_codes.txt`;
+    document.body.appendChild(element);
+    element.click();
+  };
+
+  if (!backupCodes) {
+    return null;
+  }
+
+  return (
+    <>
+      <Col gap={1}>
+        <Text
+          localizationKey={'Backup codes'}
+          variant='regularMedium'
+        />
+        <Text
+          localizationKey={'Store them securely and keep them secret.'}
+          variant='smallRegular'
+          colorScheme='neutral'
+        />
+      </Col>
+      <Grid
+        gap={2}
+        sx={t => ({
+          gridTemplateColumns: `repeat(5, minmax(${t.sizes.$12}, 1fr))`,
+          [mqu.sm]: {
+            gridTemplateColumns: `repeat(2, minmax(${t.sizes.$12}, 1fr))`,
+          },
+        })}
+      >
+        {backupCodes.map((code, i) => (
+          <MfaBackupCodeTile
+            key={i}
+            code={code}
+          />
+        ))}
+      </Grid>
+
+      <Flex gap={6}>
+        <Button
+          variant='link'
+          colorScheme='primary'
+          onClick={onCopy}
+        >
+          {!hasCopied ? 'Copy all' : 'Copied!'}
+        </Button>
+
+        <Button
+          variant='link'
+          colorScheme='primary'
+          onClick={onDownloadTxtFile}
+        >
+          Download .txt
+        </Button>
+
+        <Button
+          variant='link'
+          colorScheme='primary'
+          onClick={print}
+        >
+          Print
+        </Button>
+      </Flex>
+
+      <PrintableComponent {...printableProps}>
+        <Heading>
+          Your backup codes for {applicationName} account {userIdentifier}:
+        </Heading>
+        <Col gap={2}>
+          {backupCodes.map((code, i) => (
+            <MfaBackupCodeTile
+              key={i}
+              code={code}
+            />
+          ))}
+        </Col>
+      </PrintableComponent>
+    </>
+  );
+};
+
+function txtFileContent(backupCodes: string[] | undefined, applicationName: string, userIdentifier: string): string {
+  const sanitizedBackupCodes = backupCodes?.join('\n');
+  return `These are your backup codes for ${applicationName} account ${userIdentifier}.\nStore them securely and keep them secret. Each code can only be used once.\n\n${sanitizedBackupCodes}`;
+}

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodePage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodePage.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { useWizard, Wizard } from '../common';
+import { Button, Text } from '../customizables';
+import { withCardStateProvider } from '../elements';
+import { FormButtonContainer } from './FormButtons';
+import { MfaBackupCodeCreatePage } from './MfaBackupCodeCreatePage';
+import { NavigateToFlowStartButton } from './NavigateToFlowStartButton';
+import { ContentPage } from './Page';
+
+export const MfaBackupCodePage = withCardStateProvider(() => {
+  const wizard = useWizard();
+
+  return (
+    <Wizard {...wizard.props}>
+      <AddBackupCode
+        title={'Add multi-factor authentication'}
+        onContinue={wizard.nextStep}
+      />
+
+      <MfaBackupCodeCreatePage />
+    </Wizard>
+  );
+});
+
+type AddBackupCodeProps = {
+  title: string;
+  onContinue: () => void;
+};
+
+const AddBackupCode = (props: AddBackupCodeProps) => {
+  const { title, onContinue } = props;
+
+  return (
+    <ContentPage.Root headerTitle={title}>
+      <Text>Backup codes will be enabled for this account.</Text>
+      <Text>
+        Keep the backup codes secret and store them securely. You may regenerate backup codes if you suspect they have
+        been compromised.
+      </Text>
+      <FormButtonContainer sx={{ marginTop: 0 }}>
+        <Button
+          textVariant='buttonExtraSmallBold'
+          onClick={onContinue}
+        >
+          Continue
+        </Button>
+
+        <NavigateToFlowStartButton>Cancel</NavigateToFlowStartButton>
+      </FormButtonContainer>
+    </ContentPage.Root>
+  );
+};

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeTile.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeTile.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Flex, Text } from '../customizables';
+
+export const MfaBackupCodeTile = (props: { code: string }) => {
+  const { code } = props;
+
+  return (
+    <Flex
+      center
+      sx={t => ({
+        backgroundColor: t.colors.$blackAlpha50,
+        padding: `${t.space.$1} ${t.space.$4}`,
+        borderRadius: t.radii.$sm,
+      })}
+    >
+      <Text>{code}</Text>
+    </Flex>
+  );
+};

--- a/packages/clerk-js/src/ui/UserProfile/MfaPage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaPage.tsx
@@ -4,9 +4,10 @@ import React from 'react';
 import { useCoreUser, useEnvironment } from '../contexts';
 import { Col, Grid, localizationKeys, Text } from '../customizables';
 import { TileButton, useCardState, withCardStateProvider } from '../elements';
-import { AuthApp, Mobile } from '../icons';
+import { AuthApp, DotCircle, Mobile } from '../icons';
 import { mqu } from '../styledSystem';
 import { FormButtonContainer } from './FormButtons';
+import { MfaBackupCodePage } from './MfaBackupCodePage';
 import { MfaPhoneCodePage } from './MfaPhoneCodePage';
 import { MfaTOTPPage } from './MfaTOTPPage';
 import { NavigateToFlowStartButton } from './NavigateToFlowStartButton';
@@ -53,6 +54,14 @@ export const MfaPage = withCardStateProvider(() => {
     return <MfaTOTPPage />;
   }
 
+  // If only backup_code is available, just render that. Otherwise, check if selected
+  if (
+    (secondFactorsAvailableToAdd.length === 1 && secondFactorsAvailableToAdd[0] === 'backup_code') ||
+    selectedMethod === 'backup_code'
+  ) {
+    return <MfaBackupCodePage />;
+  }
+
   return (
     <ContentPage.Root headerTitle={title}>
       <Col gap={4}>
@@ -67,19 +76,32 @@ export const MfaPage = withCardStateProvider(() => {
             },
           })}
         >
-          <TileButton
-            icon={AuthApp}
-            onClick={() => setSelectedMethod('totp')}
-          >
-            Authenticator application
-          </TileButton>
+          {secondFactorsAvailableToAdd.includes('totp') && (
+            <TileButton
+              icon={AuthApp}
+              onClick={() => setSelectedMethod('totp')}
+            >
+              Authenticator application
+            </TileButton>
+          )}
 
-          <TileButton
-            icon={Mobile}
-            onClick={() => setSelectedMethod('phone_code')}
-          >
-            SMS code
-          </TileButton>
+          {secondFactorsAvailableToAdd.includes('phone_code') && (
+            <TileButton
+              icon={Mobile}
+              onClick={() => setSelectedMethod('phone_code')}
+            >
+              SMS code
+            </TileButton>
+          )}
+
+          {secondFactorsAvailableToAdd.includes('backup_code') && (
+            <TileButton
+              icon={DotCircle}
+              onClick={() => setSelectedMethod('backup_code')}
+            >
+              Backup code
+            </TileButton>
+          )}
         </Grid>
       </Col>
 

--- a/packages/clerk-js/src/ui/UserProfile/MfaPage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaPage.tsx
@@ -36,30 +36,9 @@ export const MfaPage = withCardStateProvider(() => {
     return <ContentPage.Root headerTitle={title} />;
   }
 
-  // If only phone_code is available, just render that
-  // Otherwise check if selected
-  if (
-    (secondFactorsAvailableToAdd.length === 1 && secondFactorsAvailableToAdd[0] === 'phone_code') ||
-    selectedMethod === 'phone_code'
-  ) {
-    return <MfaPhoneCodePage />;
-  }
-
-  // If only totp is available, just render that
-  // Otherwise check if selected
-  if (
-    (secondFactorsAvailableToAdd.length === 1 && secondFactorsAvailableToAdd[0] === 'totp') ||
-    selectedMethod === 'totp'
-  ) {
-    return <MfaTOTPPage />;
-  }
-
-  // If only backup_code is available, just render that. Otherwise, check if selected
-  if (
-    (secondFactorsAvailableToAdd.length === 1 && secondFactorsAvailableToAdd[0] === 'backup_code') ||
-    selectedMethod === 'backup_code'
-  ) {
-    return <MfaBackupCodePage />;
+  // If there is only an available method or one has been selected, render the dedicated page instead
+  if (secondFactorsAvailableToAdd.length === 1 || selectedMethod) {
+    return <MfaPageIfSingleOrCurrent method={selectedMethod || secondFactorsAvailableToAdd[0]} />;
   }
 
   return (
@@ -76,32 +55,13 @@ export const MfaPage = withCardStateProvider(() => {
             },
           })}
         >
-          {secondFactorsAvailableToAdd.includes('totp') && (
-            <TileButton
-              icon={AuthApp}
-              onClick={() => setSelectedMethod('totp')}
-            >
-              Authenticator application
-            </TileButton>
-          )}
-
-          {secondFactorsAvailableToAdd.includes('phone_code') && (
-            <TileButton
-              icon={Mobile}
-              onClick={() => setSelectedMethod('phone_code')}
-            >
-              SMS code
-            </TileButton>
-          )}
-
-          {secondFactorsAvailableToAdd.includes('backup_code') && (
-            <TileButton
-              icon={DotCircle}
-              onClick={() => setSelectedMethod('backup_code')}
-            >
-              Backup code
-            </TileButton>
-          )}
+          {secondFactorsAvailableToAdd.map((method, i) => (
+            <MfaAvailableMethodToAdd
+              method={method}
+              setSelectedMethod={setSelectedMethod}
+              key={i}
+            />
+          ))}
         </Grid>
       </Col>
 
@@ -111,3 +71,55 @@ export const MfaPage = withCardStateProvider(() => {
     </ContentPage.Root>
   );
 });
+
+type MfaPageIfSingleOrCurrentProps = {
+  method: string;
+};
+
+const MfaPageIfSingleOrCurrent = (props: MfaPageIfSingleOrCurrentProps) => {
+  const { method } = props;
+
+  switch (method) {
+    case 'phone_code':
+      return <MfaPhoneCodePage />;
+    case 'totp':
+      return <MfaTOTPPage />;
+    case 'backup_code':
+      return <MfaBackupCodePage />;
+    default:
+      return null;
+  }
+};
+
+type MfaAvailableMethodToAddProps = {
+  method: string;
+  setSelectedMethod: (method: VerificationStrategy | undefined) => void;
+};
+
+const MfaAvailableMethodToAdd = (props: MfaAvailableMethodToAddProps) => {
+  const { method, setSelectedMethod } = props;
+
+  let icon: React.ComponentType;
+  let text: string;
+  if (method === 'phone_code') {
+    icon = Mobile;
+    text = 'SMS code';
+  } else if (method === 'totp') {
+    icon = AuthApp;
+    text = 'Authenticator application';
+  } else if (method === 'backup_code') {
+    icon = DotCircle;
+    text = 'Backup code';
+  } else {
+    return null;
+  }
+
+  return (
+    <TileButton
+      icon={icon}
+      onClick={() => setSelectedMethod(method)}
+    >
+      {text}
+    </TileButton>
+  );
+};

--- a/packages/clerk-js/src/ui/UserProfile/MfaSection.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaSection.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useCoreUser, useEnvironment } from '../contexts';
 import { localizationKeys } from '../customizables';
 import { useNavigate } from '../hooks';
+import { MfaBackupCodeAccordion } from './MfaBackupCodeAccordion';
 import { MfaPhoneCodeAccordion } from './MfaPhoneCodeAccordion';
 import { MfaTOTPAccordion } from './MfaTOTPAccordion';
 import { ProfileSection } from './Section';
@@ -20,6 +21,7 @@ export const MfaSection = () => {
   const secondFactorsAvailableToAdd = getSecondFactorsAvailableToAdd(attributes, user);
 
   const showTOTP = secondFactors.includes('totp') && user.totpEnabled;
+  const showBackupCode = secondFactors.includes('backup_code') && user.backupCodeEnabled;
 
   const mfaPhones = user.phoneNumbers
     .filter(ph => ph.verification.status === 'verified')
@@ -41,6 +43,8 @@ export const MfaSection = () => {
             showTOTP={showTOTP}
           />
         ))}
+
+      {showBackupCode && <MfaBackupCodeAccordion />}
 
       {secondFactorsAvailableToAdd.length > 0 && (
         <AddBlockButton

--- a/packages/clerk-js/src/ui/icons/dot-circle-horizontal.svg
+++ b/packages/clerk-js/src/ui/icons/dot-circle-horizontal.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM5 7H3V9H5V7ZM13 7H11V9H13V7ZM7 7H9V9H7V7Z" fill="currentColor"/>
+</svg>

--- a/packages/clerk-js/src/ui/icons/index.ts
+++ b/packages/clerk-js/src/ui/icons/index.ts
@@ -29,3 +29,4 @@ export { default as DeviceMobile } from './device-mobile.svg';
 export { default as DeviceLaptop } from './device-laptop.svg';
 export { default as Menu } from './menu.svg';
 export { default as Eye } from './eye.svg';
+export { default as DotCircle } from './dot-circle-horizontal.svg';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -174,6 +174,7 @@ export interface UserJSON extends ClerkResourceJSON {
   first_name: string;
   last_name: string;
   totp_enabled: boolean;
+  backup_code_enabled: boolean;
   two_factor_enabled: boolean;
   public_metadata: Record<string, unknown>;
   unsafe_metadata: Record<string, unknown>;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -54,6 +54,7 @@ export interface UserResource extends ClerkResource {
   organizationMemberships: OrganizationMembershipResource[];
   passwordEnabled: boolean;
   totpEnabled: boolean;
+  backupCodeEnabled: boolean;
   twoFactorEnabled: boolean;
   publicMetadata: UserPublicMetadata;
   unsafeMetadata: UserUnsafeMetadata;

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -10,9 +10,10 @@ type Attribute =
   | 'last_name'
   | 'password'
   | 'web3_wallet'
-  | 'authenticator_app';
+  | 'authenticator_app'
+  | 'backup_code';
 
-export type VerificationStrategy = 'email_link' | 'email_code' | 'phone_code' | 'totp';
+export type VerificationStrategy = 'email_link' | 'email_code' | 'phone_code' | 'totp' | 'backup_code';
 
 export type OAuthProviderSettings = {
   enabled: boolean;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add the supported operations for backup codes in UserProfile. Users can select and generate a new set of backup codes if not already set and any other multi-factor method is enabled. Can also regenerate to get a new fresh set anytime they want. Users can copy in clipboard, download as txt file and print the codes

### Before
Not supported

### After

https://user-images.githubusercontent.com/22435234/192485087-14380056-fbb8-4570-81ba-d0fb249e9ba5.mov

<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/Introduce-backup-code-operations-in-UserProfile-fdec6cbc1ffc4c5aa66456f3ca348b5e