### PR TITLE
fix(clerk-js): Use provider name instead of id in SocialButtons

### DIFF
--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -63,6 +63,7 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
         <ButtonElement
           key={strategy}
           id={strategyToDisplayData[strategy].id}
+          providerName={strategyToDisplayData[strategy].name}
           onClick={startOauth(strategy)}
           isLoading={card.loadingMetadata === strategy}
           isDisabled={card.isLoading}
@@ -114,6 +115,7 @@ const ButtonRows = (props: React.PropsWithChildren<any>) => {
 type SocialButtonProps = PropsOfComponent<typeof Button> & {
   icon: React.ReactElement;
   id: OAuthProvider | Web3Provider;
+  providerName: string;
   label?: string;
 };
 
@@ -137,7 +139,7 @@ const SocialButtonIcon = (props: SocialButtonProps): JSX.Element => {
 };
 
 const SocialButtonBlock = (props: SocialButtonProps): JSX.Element => {
-  const { label, id, ...rest } = props;
+  const { label, id, providerName, ...rest } = props;
 
   return (
     <ArrowBlockButton
@@ -145,7 +147,7 @@ const SocialButtonBlock = (props: SocialButtonProps): JSX.Element => {
       elementId={descriptors.socialButtonsBlockButton.setId(id)}
       textElementDescriptor={descriptors.socialButtonsBlockButtonText}
       textElementId={descriptors.socialButtonsBlockButtonText.setId(id)}
-      textLocalizationKey={localizationKeys('socialButtonsBlockButton', { provider: id })}
+      textLocalizationKey={localizationKeys('socialButtonsBlockButton', { provider: providerName })}
       arrowElementDescriptor={descriptors.socialButtonsBlockButtonArrow}
       arrowElementId={descriptors.socialButtonsBlockButtonArrow.setId(id)}
       {...rest}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Use the actual name of the 3rd party provider instead of the provider id in `SocialButtons`
![image](https://user-images.githubusercontent.com/1811063/192344959-1f8a2268-51b4-4801-bdce-46e959fb79bd.png)

<!-- Fixes # (issue number) -->
