### PR TITLE
chore(clerk-js): Print unexpected FAPI errors in console, not in alerts

### DIFF
--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -1,14 +1,16 @@
+const errorPrefix = 'ClerkJS:';
+
 export function clerkNetworkError(url: string, e: Error): never {
-  throw new Error(`ClerkJS: Network error at "${url}" - ${e}. Please try again or contact support@clerk.dev`);
+  throw new Error(`${errorPrefix} Network error at "${url}" - ${e}. Please try again or contact support@clerk.dev`);
 }
 
 export function clerkErrorInitFailed(): never {
-  throw new Error('ClerkJS: Something went wrong initializing Clerk. Please contact support@clerk.dev');
+  throw new Error(`${errorPrefix} Something went wrong initializing Clerk. Please contact support@clerk.dev`);
 }
 
 export function clerkErrorDevInitFailed(msg?: string): never {
   throw new Error(
-    `ClerkJS: Something went wrong initializing Clerk in development mode${
+    `${errorPrefix} Something went wrong initializing Clerk in development mode${
       msg && ` - ${msg}`
     }. Please contact support@clerk.dev`,
   );
@@ -16,78 +18,87 @@ export function clerkErrorDevInitFailed(msg?: string): never {
 
 export function clerkErrorPathRouterMissingPath(componentName: string): never {
   throw new Error(
-    `ClerkJS: Missing path option. The ${componentName} component was mounted with path routing so you need to specify the path where the component is mounted on e.g. path="/sign-in".`,
+    `${errorPrefix} Missing path option. The ${componentName} component was mounted with path routing so you need to specify the path where the component is mounted on e.g. path="/sign-in".`,
   );
 }
 
 export function clerkErrorNoFrontendApi(): never {
-  throw new Error('ClerkJS: Missing frontendAPI option.');
+  throw new Error(`${errorPrefix} Missing frontendAPI option.`);
 }
 
 export function clerkErrorInvalidFrontendApi(): never {
   throw new Error(
-    'ClerkJS: Invalid frontendAPI option. Go to the instance home page at https://dashboard.clerk.dev and get your Frontend API value.',
+    `${errorPrefix} Invalid frontendAPI option. Go to the instance home page at https://dashboard.clerk.dev and get your Frontend API value.
+    `,
   );
 }
 
 export function clerkErrorInvalidColor(name: string): never {
-  throw new Error(`ClerkJS: You're using an invalid ${name} color. Change the ${name} color from the dashboard.`);
+  throw new Error(`${errorPrefix} You're using an invalid ${name} color. Change the ${name} color from the dashboard.`);
 }
 
 export function clerkCoreErrorContextProviderNotFound(providerName: string): never {
-  throw new Error(`ClerkJS: You must wrap your application in a <${providerName}> component.`);
+  throw new Error(`${errorPrefix} You must wrap your application in a <${providerName}> component.`);
 }
 
 export function clerkCoreErrorUserIsNotDefined(): never {
-  throw new Error('ClerkJS: User is undefined. Try wrapping your component with `withUserGuard`');
+  throw new Error(`${errorPrefix} User is undefined. Try wrapping your component with \`withUserGuard\``);
 }
 
 export function clerkCoreErrorSessionIsNotDefined(): never {
-  throw new Error('ClerkJS: Session is undefined. Try wrapping your component with `withUserGuard`');
+  throw new Error(`${errorPrefix} Session is undefined. Try wrapping your component with \`withUserGuard\``);
 }
 
 export function clerkCoreErrorOrganizationIsNotDefined(): never {
-  throw new Error('ClerkJS: Organization is undefined. Try wrapping your component with `withUserGuard`');
+  throw new Error(`${errorPrefix} Organization is undefined. Try wrapping your component with \`withUserGuard\``);
 }
 
 export function clerkCoreErrorNoClerkSingleton(): never {
-  throw new Error('ClerkJS: Clerk is undefined');
+  throw new Error(`${errorPrefix} Clerk is undefined`);
 }
 
 export function clerkUIErrorDOMElementNotFound(): never {
-  throw new Error('ClerkJS: The target element is empty. Provide a valid DOM element.');
+  throw new Error(`${errorPrefix} The target element is empty. Provide a valid DOM element.`);
 }
 
 export function clerkMissingFapiClientInResources(): never {
-  throw new Error('ClerkJS: Missing FAPI client in resources.');
+  throw new Error(`${errorPrefix} Missing FAPI client in resources.`);
 }
 
 export function clerkCoreErrorExpiredToken(expiresAt: number): never {
-  throw new Error(`ClerkJS: Token has expired (exp='${expiresAt}').`);
+  throw new Error(`${errorPrefix} Token has expired (exp='${expiresAt}').`);
 }
 
 export function clerkCoreErrorTokenRefreshFailed(message: string): never {
-  throw new Error(`ClerkJS: Token refresh failed (error='${message}')`);
+  throw new Error(`${errorPrefix} Token refresh failed (error='${message}')`);
 }
 
 export function clerkOAuthCallbackDidNotCompleteSignInSIgnUp(type: 'sign in' | 'sign up'): never {
-  throw new Error(`ClerkJS: Something went wrong initializing Clerk during the ${type} flow. Please contact support.`);
+  throw new Error(
+    `${errorPrefix} Something went wrong initializing Clerk during the ${type} flow. Please contact support.`,
+  );
 }
 
 export function clerkVerifyEmailAddressCalledBeforeCreate(type: 'SignIn' | 'SignUp'): never {
-  throw new Error(`ClerkJS: You need to start a ${type} flow by calling ${type}.create() first.`);
+  throw new Error(`${errorPrefix} You need to start a ${type} flow by calling ${type}.create() first.`);
 }
 
 export function clerkInvalidStrategy(functionaName: string, strategy: string): never {
-  throw new Error(`ClerkJS: Strategy "${strategy}" is not a valid strategy for ${functionaName}.`);
+  throw new Error(`${errorPrefix} Strategy "${strategy}" is not a valid strategy for ${functionaName}.`);
 }
 
 export function clerkVerifyWeb3WalletCalledBeforeCreate(type: 'SignIn' | 'SignUp'): never {
   throw new Error(
-    `ClerkJS: You need to start a ${type} flow by calling ${type}.create({ identifier: 'your web3 wallet address' }) first`,
+    `${errorPrefix} You need to start a ${type} flow by calling ${type}.create({ identifier: 'your web3 wallet address' }) first`,
   );
 }
 
 export function clerkMissingOptionError(name = ''): never {
-  throw new Error(`ClerkJS: Missing '${name}' option`);
+  throw new Error(`${errorPrefix} Missing '${name}' option`);
+}
+
+export function clerkInvalidFAPIResponse(status: string | null, supportEmail: string): never {
+  throw new Error(
+    `${errorPrefix} Response: ${status || 0} not supported yet.\nFor more information contact us at ${supportEmail}`,
+  );
 }

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -27,6 +27,7 @@ import { AuthenticateWithWeb3Params } from '@clerk/types/src';
 
 import { generateSignatureWithMetamask, getMetamaskIdentifier, windowNavigate } from '../../utils';
 import {
+  clerkInvalidFAPIResponse,
   clerkInvalidStrategy,
   clerkMissingOptionError,
   clerkVerifyEmailAddressCalledBeforeCreate,
@@ -159,9 +160,7 @@ export class SignIn extends BaseResource implements SignInResource {
     if (status === 'unverified' && externalVerificationRedirectURL) {
       windowNavigate(externalVerificationRedirectURL);
     } else {
-      const email = SignIn.fapiClient.buildEmailAddress('support');
-      const message = `Response: ${status} not supported yet.\nFor more information contact us at ${email}`;
-      alert(message);
+      console.error(clerkInvalidFAPIResponse(status, SignIn.fapiClient.buildEmailAddress('support')));
     }
   };
 

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -23,6 +23,7 @@ import type {
 import { generateSignatureWithMetamask, getMetamaskIdentifier, windowNavigate } from '../../utils';
 import { normalizeUnsafeMetadata } from '../../utils/resourceParams';
 import {
+  clerkInvalidFAPIResponse,
   clerkMissingOptionError,
   clerkVerifyEmailAddressCalledBeforeCreate,
   clerkVerifyWeb3WalletCalledBeforeCreate,
@@ -192,10 +193,7 @@ export class SignUp extends BaseResource implements SignUpResource {
     if (status === 'unverified' && !!externalVerificationRedirectURL) {
       windowNavigate(externalVerificationRedirectURL);
     } else {
-      // TODO:
-      const email = SignUp.fapiClient.buildEmailAddress('support');
-      const message = `Response: ${status} not supported yet.\nFor more information contact us at ${email}`;
-      alert(message);
+      console.error(clerkInvalidFAPIResponse(status, SignUp.fapiClient.buildEmailAddress('support')));
     }
   };
 

--- a/packages/clerk-js/src/ui/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInFactorOneCodeForm.tsx
@@ -1,6 +1,7 @@
 import { EmailCodeFactor, PhoneCodeFactor } from '@clerk/types';
 import React from 'react';
 
+import { clerkInvalidFAPIResponse } from '../../core/errors';
 import { useCoreClerk, useCoreSignIn, useSignInContext } from '../../ui/contexts';
 import { useSupportEmail } from '../../ui/hooks/useSupportEmail';
 import { useRouter } from '../../ui/router';
@@ -49,19 +50,18 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
   };
 
   const action: VerificationCodeCardProps['onCodeEntryFinishedAction'] = (code, resolve, reject) => {
-    return signIn
+    signIn
       .attemptFirstFactor({ strategy: props.factor.strategy, code })
       .then(async res => {
         await resolve();
+
         switch (res.status) {
           case 'complete':
             return setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignIn });
           case 'needs_second_factor':
             return navigate('../factor-two');
           default:
-            return alert(
-              `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`,
-            );
+            return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }
       })
       .catch(err => reject(err));

--- a/packages/clerk-js/src/ui/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInFactorOnePasswordCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
+import { clerkInvalidFAPIResponse } from '../../core/errors';
 import { useCoreClerk, useCoreSignIn, useEnvironment, useSignInContext } from '../../ui/contexts';
 import { useSupportEmail } from '../../ui/hooks/useSupportEmail';
 import { useRouter } from '../../ui/router/RouteContext';
-import { descriptors, Flex, Flow, localizationKeys } from '../customizables';
-import { Card, CardAlert, Footer, Form, Header, IdentityPreview } from '../elements';
+import { descriptors, localizationKeys } from '../customizables';
 import { useCardState } from '../elements/contexts';
 import { handleError, useFormControl } from '../utils';
 
@@ -41,9 +41,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
           case 'needs_second_factor':
             return navigate('../factor-two');
           default:
-            return alert(
-              `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`,
-            );
+            return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }
       })
       .catch(err => handleError(err, [passwordControl], card.setError));

--- a/packages/clerk-js/src/ui/SignIn/SignInFactorTwoBackupCodeCard.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInFactorTwoBackupCodeCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { clerkInvalidFAPIResponse } from '../../core/errors';
 import { useCoreClerk, useCoreSignIn, useEnvironment, useSignInContext } from '../contexts';
 import { Col, descriptors, localizationKeys } from '../customizables';
 import { Card, CardAlert, Footer, Form, Header, useCardState } from '../elements';
@@ -33,9 +34,7 @@ export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCa
           case 'complete':
             return setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignIn });
           default:
-            return alert(
-              `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`,
-            );
+            return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }
       })
       .catch(err => handleError(err, [codeControl], card.setError));

--- a/packages/clerk-js/src/ui/SignIn/SignInFactorTwoCodeForm.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInFactorTwoCodeForm.tsx
@@ -1,6 +1,7 @@
 import { PhoneCodeFactor, SignInResource, TOTPFactor } from '@clerk/types';
 import React from 'react';
 
+import { clerkInvalidFAPIResponse } from '../../core/errors';
 import { useCoreClerk, useCoreSignIn, useSignInContext } from '../../ui/contexts';
 import { useSupportEmail } from '../../ui/hooks/useSupportEmail';
 import { LocalizationKey } from '../customizables';
@@ -47,7 +48,7 @@ export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => 
     : undefined;
 
   const action: VerificationCodeCardProps['onCodeEntryFinishedAction'] = (code, resolve, reject) => {
-    return signIn
+    signIn
       .attemptSecondFactor({ strategy: props.factor.strategy, code })
       .then(async res => {
         await resolve();
@@ -55,9 +56,7 @@ export const SignInFactorTwoCodeForm = (props: SignInFactorTwoCodeFormProps) => 
           case 'complete':
             return setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignIn });
           default:
-            return alert(
-              `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`,
-            );
+            return console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
         }
       })
       .catch(err => reject(err));

--- a/packages/clerk-js/src/ui/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInStart.tsx
@@ -1,6 +1,7 @@
 import { ClerkAPIError, SignInCreateParams } from '@clerk/types';
 import React from 'react';
 
+import { clerkInvalidFAPIResponse } from '../../core/errors';
 import { ERROR_CODES, getIdentifierControlDisplayValues } from '../../ui/common/constants';
 import { withRedirectToHome } from '../../ui/common/withRedirectToHome';
 import { useCoreClerk, useCoreSignIn, useEnvironment, useSignInContext } from '../../ui/contexts';
@@ -76,8 +77,8 @@ export function _SignInStart(): JSX.Element {
               beforeEmit: navigateAfterSignIn,
             });
           default: {
-            const msg = `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`;
-            alert(msg);
+            console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
+            return;
           }
         }
       })
@@ -137,8 +138,8 @@ export function _SignInStart(): JSX.Element {
             beforeEmit: navigateAfterSignIn,
           });
         default: {
-          const msg = `Response: ${res.status} not supported yet.\nFor more information contact us at ${supportEmail}`;
-          alert(msg);
+          console.error(clerkInvalidFAPIResponse(res.status, supportEmail));
+          return;
         }
       }
     } catch (e) {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

That way, there will be no alert when ClerkJS components don't talk to an actual FAPI (e.g. in preview mode).


<!-- Fixes # (issue number) -->
