### PR TITLE
feat(nextjs): Add user, session and org load capability to getAuth

### DIFF
--- a/packages/backend-core/src/ClerkClient.ts
+++ b/packages/backend-core/src/ClerkClient.ts
@@ -1,0 +1,38 @@
+import type {
+  AllowlistIdentifierAPI,
+  ClientAPI,
+  EmailAPI,
+  InvitationAPI,
+  OrganizationAPI,
+  SessionAPI,
+  SMSMessageAPI,
+  UserAPI,
+} from './api/endpoints';
+
+export type ClerkClient = {
+  allowlistIdentifiers: AllowlistIdentifierAPI;
+  clients: ClientAPI;
+  emails: EmailAPI;
+  invitations: InvitationAPI;
+  organizations: OrganizationAPI;
+  sessions: SessionAPI;
+  smsMessages: SMSMessageAPI;
+  users: UserAPI;
+};
+
+export type CreateClerkClientParams = { apiKey?: string };
+
+export type CreateClerkClient = (params?: CreateClerkClientParams) => ClerkClient;
+
+export const extractClerkApiFromInstance = (ins: Record<keyof ClerkClient, any>): ClerkClient => {
+  return {
+    allowlistIdentifiers: ins.allowlistIdentifiers,
+    clients: ins.clients,
+    emails: ins.emails,
+    invitations: ins.invitations,
+    organizations: ins.organizations,
+    sessions: ins.sessions,
+    smsMessages: ins.smsMessages,
+    users: ins.users,
+  };
+};

--- a/packages/backend-core/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/backend-core/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -85,6 +85,7 @@ Object {
   "createGetToken": [Function],
   "createSignedOutState": [Function],
   "deserialize": [Function],
+  "extractClerkApiFromInstance": [Function],
   "signedOutGetToken": [Function],
 }
 `;

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './api';
 export * from './Base';
 export * from './util/Logger';
+export * from './ClerkClient';
 
 export { createGetToken, signedOutGetToken, createSignedOutState } from './util/createGetToken';
 export { AuthStatus, AuthErrorReason } from './types';

--- a/packages/edge/src/vercel-edge/ClerkAPI.ts
+++ b/packages/edge/src/vercel-edge/ClerkAPI.ts
@@ -1,8 +1,13 @@
-import { ClerkAPIResponseError, ClerkBackendAPI } from '@clerk/backend-core';
+import {
+  ClerkAPIResponseError,
+  ClerkBackendAPI,
+  CreateClerkClient,
+  extractClerkApiFromInstance,
+} from '@clerk/backend-core';
 
 import { LIB_NAME, LIB_VERSION } from '../info';
 
-export const ClerkAPI = new ClerkBackendAPI({
+const defaultParams = {
   libName: LIB_NAME,
   libVersion: LIB_VERSION,
   apiClient: {
@@ -43,4 +48,12 @@ export const ClerkAPI = new ClerkBackendAPI({
       return data;
     },
   },
-});
+} as ConstructorParameters<typeof ClerkBackendAPI>[0];
+
+export const ClerkAPI = new ClerkBackendAPI(defaultParams);
+
+export const createClerkClient: CreateClerkClient = params => {
+  const { apiKey, ...rest } = params || {};
+  const instance = new ClerkBackendAPI({ apiKey: apiKey || process.env.CLERK_API_KEY, ...defaultParams, ...rest });
+  return extractClerkApiFromInstance(instance);
+};

--- a/packages/edge/src/vercel-edge/index.ts
+++ b/packages/edge/src/vercel-edge/index.ts
@@ -1,5 +1,4 @@
 import { AuthStatus, Base, createGetToken, createSignedOutState } from '@clerk/backend-core';
-import { ClerkJWTClaims } from '@clerk/types';
 import { NextFetchEvent, NextRequest } from 'next/server';
 
 import { ClerkAPI } from './ClerkAPI';
@@ -42,7 +41,6 @@ export const vercelEdgeBase = new Base(importKey, verifySignature, decodeBase64)
 export const verifySessionToken = vercelEdgeBase.verifySessionToken;
 
 /** Export ClerkBackendAPI API client */
-
 const allowlistIdentifiers = ClerkAPI.allowlistIdentifiers;
 const clients = ClerkAPI.clients;
 const emails = ClerkAPI.emails;
@@ -157,7 +155,7 @@ function vercelMiddlewareAuth(
       sessionId,
       userId,
       getToken,
-      claims: sessionClaims as ClerkJWTClaims,
+      claims: sessionClaims,
     });
     return handler(authRequest, event);
   };
@@ -171,4 +169,14 @@ function getCookie(cookies: NextRequest['cookies'], name: string) {
     // @ts-expect-error
     return cookies[name];
   }
+}
+
+export function setClerkApiKey(value: string) {
+  ClerkAPI.apiKey = value;
+}
+
+export function setClerkJwtKey() {
+  // noop
+  // This method exists for parity between edge and sdk-node
+  // The JWT can only be passed as an option to withEdgeMiddlewareAuth/requireEdgeMiddlewareAuth
 }

--- a/packages/nextjs/server.d.ts
+++ b/packages/nextjs/server.d.ts
@@ -1,20 +1,3 @@
-export { AuthData } from './dist/server/types';
-
 export { withClerkMiddleware } from './dist/server/utils/withClerkMiddleware';
-
 export { getAuthEdge as getAuth } from './dist/server/getAuthEdge';
-export { setClerkApiKey as setApiKey } from './dist/api';
-export { setClerkJwtKey as setJwtKey } from './dist/api';
-
-import * as sdk from './dist/api';
-
-export declare namespace clerkApi {
-  export const allowlistIdentifiers: typeof sdk.allowlistIdentifiers;
-  export const clients: typeof sdk.clients;
-  export const emails: typeof sdk.emails;
-  export const invitations: typeof sdk.invitations;
-  export const organizations: typeof sdk.organizations;
-  export const sessions: typeof sdk.sessions;
-  export const smsMessages: typeof sdk.smsMessages;
-  export const users: typeof sdk.users;
-}
+export { createClerkClient, clerkClient } from './dist/api';

--- a/packages/nextjs/server.d.ts
+++ b/packages/nextjs/server.d.ts
@@ -1,3 +1,4 @@
+export { buildClerkProps } from './dist/server/utils/getAuth';
 export { withClerkMiddleware } from './dist/server/utils/withClerkMiddleware';
 export { getAuthEdge as getAuth } from './dist/server/getAuthEdge';
 export { createClerkClient, clerkClient } from './dist/api';

--- a/packages/nextjs/server.d.ts
+++ b/packages/nextjs/server.d.ts
@@ -2,6 +2,19 @@ export { AuthData } from './dist/server/types';
 
 export { withClerkMiddleware } from './dist/server/utils/withClerkMiddleware';
 
-// Export e.g. edge types since api is the same
 export { getAuthEdge as getAuth } from './dist/server/getAuthEdge';
-export * from './dist/api';
+export { setClerkApiKey as setApiKey } from './dist/api';
+export { setClerkJwtKey as setJwtKey } from './dist/api';
+
+import * as sdk from './dist/api';
+
+export declare namespace clerkApi {
+  export const allowlistIdentifiers: typeof sdk.allowlistIdentifiers;
+  export const clients: typeof sdk.clients;
+  export const emails: typeof sdk.emails;
+  export const invitations: typeof sdk.invitations;
+  export const organizations: typeof sdk.organizations;
+  export const sessions: typeof sdk.sessions;
+  export const smsMessages: typeof sdk.smsMessages;
+  export const users: typeof sdk.users;
+}

--- a/packages/nextjs/server.js
+++ b/packages/nextjs/server.js
@@ -1,11 +1,36 @@
+const { setClerkApiKey, setClerkJwtKey } = require('@clerk/clerk-sdk-node/src');
 let exportLib = {};
 
 if (process.env.NEXT_RUNTIME === 'edge') {
-  exportLib = require('./dist/edge-middleware');
+  const sdk = require('./dist/edge-middleware');
+  exportLib.clerkApi = {
+    allowlistIdentifiers: sdk.allowlistIdentifiers,
+    clients: sdk.clients,
+    emails: sdk.emails,
+    invitations: sdk.invitations,
+    organizations: sdk.organizations,
+    sessions: sdk.sessions,
+    smsMessages: sdk.smsMessages,
+    users: sdk.users,
+  };
+  exportLib.setApiKey = sdk.setClerkApiKey;
+  exportLib.setJwtKey = sdk.setClerkJwtKey;
   exportLib.getAuth = require('./dist/server/getAuthEdge').getAuthEdge;
 } else {
   // nodejs runtime assumed
-  exportLib = require('./dist/api');
+  const sdk = require('./dist/api');
+  exportLib.clerkApi = {
+    allowlistIdentifiers: sdk.allowlistIdentifiers,
+    clients: sdk.clients,
+    emails: sdk.emails,
+    invitations: sdk.invitations,
+    organizations: sdk.organizations,
+    sessions: sdk.sessions,
+    smsMessages: sdk.smsMessages,
+    users: sdk.users,
+  };
+  exportLib.setApiKey = sdk.setClerkApiKey;
+  exportLib.setJwtKey = sdk.setClerkJwtKey;
   exportLib.getAuth = require('./dist/server/getAuthNode').getAuthNode;
 }
 

--- a/packages/nextjs/server.js
+++ b/packages/nextjs/server.js
@@ -2,34 +2,14 @@ let exportLib = {};
 
 if (process.env.NEXT_RUNTIME === 'edge') {
   const sdk = require('./dist/edge-middleware');
-  exportLib.clerkApi = {
-    allowlistIdentifiers: sdk.allowlistIdentifiers,
-    clients: sdk.clients,
-    emails: sdk.emails,
-    invitations: sdk.invitations,
-    organizations: sdk.organizations,
-    sessions: sdk.sessions,
-    smsMessages: sdk.smsMessages,
-    users: sdk.users,
-  };
-  exportLib.setApiKey = sdk.setClerkApiKey;
-  exportLib.setJwtKey = sdk.setClerkJwtKey;
+  exportLib.clerkClient = sdk.clerkClient;
+  exportLib.createClerkClient = sdk.createClerkClient;
   exportLib.getAuth = require('./dist/server/getAuthEdge').getAuthEdge;
 } else {
   // nodejs runtime assumed
   const sdk = require('./dist/api');
-  exportLib.clerkApi = {
-    allowlistIdentifiers: sdk.allowlistIdentifiers,
-    clients: sdk.clients,
-    emails: sdk.emails,
-    invitations: sdk.invitations,
-    organizations: sdk.organizations,
-    sessions: sdk.sessions,
-    smsMessages: sdk.smsMessages,
-    users: sdk.users,
-  };
-  exportLib.setApiKey = sdk.setClerkApiKey;
-  exportLib.setJwtKey = sdk.setClerkJwtKey;
+  exportLib.clerkClient = sdk.clerkClient;
+  exportLib.createClerkClient = sdk.createClerkClient;
   exportLib.getAuth = require('./dist/server/getAuthNode').getAuthNode;
 }
 

--- a/packages/nextjs/server.js
+++ b/packages/nextjs/server.js
@@ -1,4 +1,3 @@
-const { setClerkApiKey, setClerkJwtKey } = require('@clerk/clerk-sdk-node/src');
 let exportLib = {};
 
 if (process.env.NEXT_RUNTIME === 'edge') {

--- a/packages/nextjs/server.js
+++ b/packages/nextjs/server.js
@@ -13,6 +13,7 @@ if (process.env.NEXT_RUNTIME === 'edge') {
   exportLib.getAuth = require('./dist/server/getAuthNode').getAuthNode;
 }
 
+exportLib.buildClerkProps = require('./dist/server/utils/getAuth').buildClerkProps;
 exportLib.withClerkMiddleware = require('./dist/server/utils/withClerkMiddleware').withClerkMiddleware;
 
 module.exports = exportLib;

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -16,8 +16,10 @@ type NextClerkProviderProps = {
 export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JSX.Element {
   // @ts-expect-error
   // Allow for overrides without making the type public
-  const { frontendApi, __clerk_ssr_state, clerkJSUrl, ...restProps } = rest;
+  const { frontendApi, __clerk_ssr_state, authServerSideProps, clerkJSUrl, ...restProps } = rest;
   const { push } = useRouter();
+
+  console.log('clerkprovider', __clerk_ssr_state, authServerSideProps);
 
   if (frontendApi == undefined && !process.env.NEXT_PUBLIC_CLERK_FRONTEND_API) {
     throw Error(NO_FRONTEND_API_ERR);
@@ -30,7 +32,9 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
       frontendApi={frontendApi || process.env.NEXT_PUBLIC_CLERK_FRONTEND_API}
       clerkJSUrl={clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS}
       navigate={to => push(to)}
-      initialState={__clerk_ssr_state}
+      // withServerSideAuth automatically injects __clerk_ssr_state
+      // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state
+      initialState={authServerSideProps?.__clerk_ssr_state || __clerk_ssr_state}
       {...restProps}
     >
       {children}

--- a/packages/nextjs/src/middleware/utils/serializeProps.ts
+++ b/packages/nextjs/src/middleware/utils/serializeProps.ts
@@ -1,6 +1,6 @@
-import { GetServerSidePropsResult } from 'next';
+import type { GetServerSidePropsResult } from 'next';
 
-import { AuthData } from '../types';
+import type { AuthData } from '../types';
 
 /**
  *
@@ -11,12 +11,16 @@ import { AuthData } from '../types';
  * @param authData
  */
 export function injectSSRStateIntoProps(callbackResult: any, authData: AuthData): GetServerSidePropsResult<any> {
+  return {
+    ...callbackResult,
+    props: injectSSRStateIntoObject(callbackResult.props, authData),
+  };
+}
+
+export const injectSSRStateIntoObject = (obj: any, authData: AuthData) => {
   // Serializing the state on dev env is a temp workaround for the following issue:
   // https://github.com/vercel/next.js/discussions/11209|Next.js
   const __clerk_ssr_state =
     process.env.NODE_ENV !== 'production' ? JSON.parse(JSON.stringify({ ...authData })) : { ...authData };
-  return {
-    ...callbackResult,
-    props: { ...callbackResult.props, __clerk_ssr_state },
-  };
-}
+  return { ...obj, __clerk_ssr_state };
+};

--- a/packages/nextjs/src/server/getAuthEdge.ts
+++ b/packages/nextjs/src/server/getAuthEdge.ts
@@ -1,4 +1,4 @@
-import { sessions } from '../edge-middleware';
+import { organizations, sessions, users } from '../edge-middleware';
 import { createGetAuth } from './utils/getAuth';
 
-export const getAuthEdge = createGetAuth(sessions);
+export const getAuthEdge = createGetAuth({ sessions, users, organizations });

--- a/packages/nextjs/src/server/getAuthEdge.ts
+++ b/packages/nextjs/src/server/getAuthEdge.ts
@@ -1,4 +1,4 @@
-import { organizations, sessions, users } from '../edge-middleware';
+import { sessions } from '../edge-middleware';
 import { createGetAuth } from './utils/getAuth';
 
-export const getAuthEdge = createGetAuth({ sessions, users, organizations });
+export const getAuthEdge = createGetAuth({ sessions });

--- a/packages/nextjs/src/server/getAuthNode.ts
+++ b/packages/nextjs/src/server/getAuthNode.ts
@@ -1,4 +1,4 @@
-import { organizations, sessions, users } from '../api';
+import { sessions } from '../api';
 import { createGetAuth } from './utils/getAuth';
 
-export const getAuthNode = createGetAuth({ sessions, users, organizations });
+export const getAuthNode = createGetAuth({ sessions });

--- a/packages/nextjs/src/server/getAuthNode.ts
+++ b/packages/nextjs/src/server/getAuthNode.ts
@@ -1,4 +1,4 @@
-import { sessions } from '../api';
+import { organizations, sessions, users } from '../api';
 import { createGetAuth } from './utils/getAuth';
 
-export const getAuthNode = createGetAuth(sessions);
+export const getAuthNode = createGetAuth({ sessions, users, organizations });

--- a/packages/nextjs/src/server/types.ts
+++ b/packages/nextjs/src/server/types.ts
@@ -34,3 +34,5 @@ export const AuthResult = { ...AuthResultExt, ...AuthErrorReason };
 export type AuthResult = typeof AuthResult;
 
 export type SessionsApi = InstanceType<typeof ClerkBackendAPI>['sessions'];
+export type OrganizationsApi = InstanceType<typeof ClerkBackendAPI>['organizations'];
+export type UsersApi = InstanceType<typeof ClerkBackendAPI>['users'];

--- a/packages/nextjs/src/server/utils/getAuth.ts
+++ b/packages/nextjs/src/server/utils/getAuth.ts
@@ -1,48 +1,68 @@
 import { signedOutGetToken } from '@clerk/backend-core';
+import { Organization, Session, User } from '@clerk/clerk-sdk-node';
+import { ClerkJWTClaims } from '@clerk/types';
 
 import type { RequestLike } from '../types';
-import { AuthData, AuthResult, SESSION_COOKIE_NAME, SessionsApi } from '../types';
+import { AuthData, AuthResult, OrganizationsApi, SESSION_COOKIE_NAME, SessionsApi, UsersApi } from '../types';
 import { getAuthDataFromClaims } from './getAuthDataFromClaims';
 import { getAuthResultFromRequest, getCookie, getHeader } from './requestResponseUtils';
 
-export function createGetAuth(sessions: SessionsApi) {
-  return function getAuth(req: RequestLike): AuthData {
+type GetAuthOptions = {
+  loadUser?: boolean;
+  loadSession?: boolean;
+  loadOrg?: boolean;
+};
+
+type GetAuthResult<Options> = AuthData &
+  (Options extends { loadSession: true } ? { session: Session | null } : {}) &
+  (Options extends { loadUser: true } ? { user: User | null } : {}) &
+  (Options extends { loadOrg: true } ? { organization: Organization | null } : {});
+
+export interface GetAuth {
+  (req: RequestLike): GetAuthResult<{}>;
+  (req: RequestLike, opts: Record<string, never>): GetAuthResult<{}>;
+  <Opts extends GetAuthOptions>(req: RequestLike, opts: Opts): Promise<GetAuthResult<Opts>>;
+}
+
+type CreateGetAuthParams = { sessions: SessionsApi; users: UsersApi; organizations: OrganizationsApi };
+
+export const createGetAuth = ({ organizations, sessions, users }: CreateGetAuthParams): GetAuth => {
+  return ((req: RequestLike, opts?: GetAuthOptions) => {
+    const { loadUser, loadSession, loadOrg } = opts || {};
     // When the auth result is set, we trust that the middleware has already run
     // Then, we don't have to re-verify the JWT here,
     // we can just strip out the claims manually.
-
     const authResult = getAuthResultFromRequest(req);
 
     if (!authResult) {
       throw 'You need to use "withClerkMiddleware" in your Next.js middleware.js file. See https://clerk.dev/docs/quickstarts/get-started-with-nextjs.';
     }
 
-    // Signed in case
-    if (authResult === AuthResult.StandardSignedIn) {
-      // Get the token from header or cookie
+    if (authResult !== AuthResult.StandardSignedIn) {
+      // Signed out case assumed
+      return { sessionId: null, userId: null, orgId: null, getToken: signedOutGetToken, claims: null };
+    }
 
-      const headerToken = getHeader(req, 'authorization')?.replace('Bearer ', '');
-      const cookieToken = getCookie(req, SESSION_COOKIE_NAME);
+    // Signed in case, get the token from header or cookie
+    const headerToken = getHeader(req, 'authorization')?.replace('Bearer ', '');
+    const cookieToken = getCookie(req, SESSION_COOKIE_NAME);
+    const token = headerToken || cookieToken || '';
+    const sessionClaims = JSON.parse(atob(token.split('.')[1])) as ClerkJWTClaims;
+    const authData = getAuthDataFromClaims({ sessionClaims, sessions, headerToken, cookieToken });
 
-      const token = headerToken || cookieToken || '';
+    // If a load option is passed in, this function will return a promise instead
+    if (loadUser || loadSession || loadOrg) {
+      const { orgId, sessionId, userId } = authData;
+      const getUser = loadUser && userId ? users.getUser(userId) : Promise.resolve(undefined);
+      const getSession = loadSession && sessionId ? sessions.getSession(sessionId) : Promise.resolve(undefined);
+      const getOrg =
+        loadOrg && orgId ? organizations.getOrganization({ organizationId: orgId }) : Promise.resolve(undefined);
 
-      const sessionClaims = JSON.parse(atob(token.split('.')[1]));
-
-      return getAuthDataFromClaims({
-        sessionClaims,
-        sessions,
-        headerToken,
-        cookieToken,
+      return Promise.all([getUser, getSession, getOrg]).then(([user, session, organization]) => {
+        return { ...authData, user, session, organization };
       });
     }
 
-    // Signed out case assumed
-    return {
-      sessionId: null,
-      userId: null,
-      orgId: null,
-      getToken: signedOutGetToken,
-      claims: null,
-    };
-  };
-}
+    return authData;
+  }) as GetAuth;
+};

--- a/packages/nextjs/src/server/utils/getAuth.ts
+++ b/packages/nextjs/src/server/utils/getAuth.ts
@@ -1,54 +1,21 @@
-import type { Organization, Session, User } from '@clerk/backend-core';
-import { signedOutGetToken } from '@clerk/backend-core';
+import { createGetToken, Organization, Session, signedOutGetToken, User } from '@clerk/backend-core';
 import { ClerkJWTClaims } from '@clerk/types';
 
 import { sanitizeAuthData } from '../../middleware/utils/sanitizeAuthData';
 import { injectSSRStateIntoObject } from '../../middleware/utils/serializeProps';
 import type { RequestLike } from '../types';
-import { AuthData, AuthResult, OrganizationsApi, SESSION_COOKIE_NAME, SessionsApi, UsersApi } from '../types';
+import { AuthData, AuthResult, SESSION_COOKIE_NAME, SessionsApi } from '../types';
 import { getAuthDataFromClaims } from './getAuthDataFromClaims';
 import { getAuthResultFromRequest, getCookie, getHeader } from './requestResponseUtils';
 
-type GetAuthOptions = {
-  loadUser?: boolean;
-  loadSession?: boolean;
-  loadOrg?: boolean;
-};
+type GetAuthResult = AuthData;
 
-type GetAuthResult<Options> = AuthData &
-  (Options extends { loadSession: true } ? { session: Session | null } : {}) &
-  (Options extends { loadUser: true } ? { user: User | null } : {}) &
-  (Options extends { loadOrg: true } ? { organization: Organization | null } : {}) & {
-    /**
-     * To enable Clerk SSR support, include this object to the `props`
-     * returned from `getServerSideProps`. This will automatically make the auth state available to
-     * the Clerk components and hooks during SSR, the hydration phase and CSR.
-     * @example
-     * import { getAuth } from '@clerk/nextjs/server';
-     *
-     * export const getServerSideProps = ({ req }) => {
-     *   const { authServerSideProps } = getAuth(req);
-     *   const myData = getMyData();
-     *
-     *   return {
-     *     props: { myData, authServerSideProps },
-     *   };
-     * };
-     */
-    authServerSideProps: Record<string, unknown>;
-  };
+export type GetAuth = (req: RequestLike) => GetAuthResult;
 
-export interface GetAuth {
-  (req: RequestLike): GetAuthResult<{}>;
-  (req: RequestLike, opts: Record<string, never>): GetAuthResult<{}>;
-  <Opts extends GetAuthOptions>(req: RequestLike, opts: Opts): Promise<GetAuthResult<Opts>>;
-}
+type CreateGetAuthParams = { sessions: SessionsApi };
 
-type CreateGetAuthParams = { sessions: SessionsApi; users: UsersApi; organizations: OrganizationsApi };
-
-export const createGetAuth = ({ organizations, sessions, users }: CreateGetAuthParams): GetAuth => {
-  return ((req: RequestLike, opts?: GetAuthOptions) => {
-    const { loadUser, loadSession, loadOrg } = opts || {};
+export const createGetAuth = ({ sessions }: CreateGetAuthParams): GetAuth => {
+  return ((req: RequestLike) => {
     // When the auth result is set, we trust that the middleware has already run
     // Then, we don't have to re-verify the JWT here,
     // we can just strip out the claims manually.
@@ -64,33 +31,47 @@ export const createGetAuth = ({ organizations, sessions, users }: CreateGetAuthP
     }
 
     // Signed in case, get the token from header or cookie
-    const headerToken = getHeader(req, 'authorization')?.replace('Bearer ', '');
-    const cookieToken = getCookie(req, SESSION_COOKIE_NAME);
-    const token = headerToken || cookieToken || '';
-    const sessionClaims = JSON.parse(atob(token.split('.')[1])) as ClerkJWTClaims;
-    const authData = getAuthDataFromClaims({ sessionClaims, sessions, headerToken, cookieToken });
-
-    // If a load option is passed in, this function will return a promise instead
-    if (loadUser || loadSession || loadOrg) {
-      const { orgId, sessionId, userId } = authData;
-      const getUser = loadUser && userId ? users.getUser(userId) : Promise.resolve(undefined);
-      const getSession = loadSession && sessionId ? sessions.getSession(sessionId) : Promise.resolve(undefined);
-      const getOrg =
-        loadOrg && orgId ? organizations.getOrganization({ organizationId: orgId }) : Promise.resolve(undefined);
-
-      return Promise.all([getUser, getSession, getOrg]).then(([user, session, organization]) => {
-        const authDataWithResources = { ...authData, user, session, organization };
-        return { ...authDataWithResources, authServerSideProps: createAuthServerSideProps(authDataWithResources) };
-      });
-    }
-
-    return { ...authData, authServerSideProps: createAuthServerSideProps(authData) };
+    const { sessionClaims, cookieToken, headerToken } = parseRequest(req);
+    const authData = getAuthDataFromClaims({ sessionClaims });
+    const getToken = createGetToken({
+      headerToken,
+      cookieToken,
+      sessionId: authData.sessionId,
+      fetcher: sessions.getToken,
+    });
+    return { ...authData, getToken, claims: sessionClaims };
   }) as GetAuth;
 };
 
-// TODO: Consolidate the following types between nextjs (edge + node) remix and gatsby
-// The following any's are needed since we have multiple AuthData types for no reason
-const createAuthServerSideProps = (authData: AuthData) => {
-  // return { __clerk_ssr_state: sanitizeAuthData(authData as any) };
-  return injectSSRStateIntoObject({}, sanitizeAuthData(authData as any));
+type BuildClerkPropsInitState = { user?: User | null; session?: Session | null; organization?: Organization | null };
+
+/**
+ * To enable Clerk SSR support, include this object to the `props`
+ * returned from `getServerSideProps`. This will automatically make the auth state available to
+ * the Clerk components and hooks during SSR, the hydration phase and CSR.
+ * @example
+ * import { getAuth } from '@clerk/nextjs/server';
+ *
+ * export const getServerSideProps = ({ req }) => {
+ *   const { authServerSideProps } = getAuth(req);
+ *   const myData = getMyData();
+ *
+ *   return {
+ *     props: { myData, authServerSideProps },
+ *   };
+ * };
+ */
+type BuildClerkProps = (req: RequestLike, authState?: BuildClerkPropsInitState) => Record<string, unknown>;
+
+export const buildClerkProps: BuildClerkProps = (req, initState = {}) => {
+  const { sessionClaims } = parseRequest(req);
+  const authData = getAuthDataFromClaims({ sessionClaims });
+  return injectSSRStateIntoObject({}, sanitizeAuthData({ ...authData, ...initState } as any));
+};
+
+const parseRequest = (req: RequestLike) => {
+  const headerToken = getHeader(req, 'authorization')?.replace('Bearer ', '');
+  const cookieToken = getCookie(req, SESSION_COOKIE_NAME);
+  const sessionClaims = JSON.parse(atob((headerToken || cookieToken || '').split('.')[1])) as ClerkJWTClaims;
+  return { headerToken, cookieToken, sessionClaims };
 };

--- a/packages/nextjs/src/server/utils/getAuthDataFromClaims.ts
+++ b/packages/nextjs/src/server/utils/getAuthDataFromClaims.ts
@@ -1,31 +1,13 @@
-import { createGetToken } from '@clerk/backend-core';
 import { ClerkJWTClaims } from '@clerk/types';
-
-import { AuthData, SessionsApi } from '../types';
 
 type GetAuthDataFromClaimsOpts = {
   sessionClaims: ClerkJWTClaims;
-  sessions: SessionsApi;
-  headerToken: string | undefined;
-  cookieToken: string | undefined;
 };
 
-export function getAuthDataFromClaims({
-  sessionClaims,
-  sessions,
-  headerToken,
-  cookieToken,
-}: GetAuthDataFromClaimsOpts): AuthData {
+export function getAuthDataFromClaims({ sessionClaims }: GetAuthDataFromClaimsOpts) {
   return {
     sessionId: sessionClaims.sid,
     userId: sessionClaims.sub,
     orgId: sessionClaims.org_id || null,
-    getToken: createGetToken({
-      headerToken: headerToken,
-      cookieToken: cookieToken,
-      sessionId: sessionClaims.sid,
-      fetcher: (...args) => sessions.getToken(...args),
-    }),
-    claims: sessionClaims,
   };
 }

--- a/packages/nextjs/src/server/utils/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/utils/withClerkMiddleware.ts
@@ -1,5 +1,5 @@
 import { AuthStatus } from '@clerk/backend-core';
-import { vercelEdgeBaseGetAuthState } from '@clerk/edge/src';
+import { vercelEdgeBase } from '@clerk/edge';
 import { NextMiddleware, NextMiddlewareResult } from 'next/dist/server/web/types';
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
@@ -46,7 +46,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     const cookieToken = cookies.get(SESSION_COOKIE_NAME);
     const headerToken = headers.get('authorization')?.replace('Bearer ', '');
 
-    const { status, errorReason } = await vercelEdgeBaseGetAuthState({
+    const { status, errorReason } = await vercelEdgeBase.getAuthState({
       cookieToken,
       headerToken,
       clientUat: cookies.get('__client_uat'),

--- a/packages/nextjs/src/server/utils/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/utils/withClerkMiddleware.ts
@@ -1,8 +1,8 @@
 import { AuthStatus } from '@clerk/backend-core';
+import { vercelEdgeBaseGetAuthState } from '@clerk/edge/src';
 import { NextMiddleware, NextMiddlewareResult } from 'next/dist/server/web/types';
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
-import { vercelEdgeBase } from '../../edge-middleware';
 import {
   AUTH_RESULT,
   AuthResult,
@@ -46,7 +46,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     const cookieToken = cookies.get(SESSION_COOKIE_NAME);
     const headerToken = headers.get('authorization')?.replace('Bearer ', '');
 
-    const { status, errorReason } = await vercelEdgeBase.getAuthState({
+    const { status, errorReason } = await vercelEdgeBaseGetAuthState({
       cookieToken,
       headerToken,
       clientUat: cookies.get('__client_uat'),

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -21,12 +21,6 @@
     "lint": "eslint ./src --ext .ts",
     "pack": "npm pack"
   },
-  "prettier": {
-    "printWidth": 80,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5"
-  },
   "name": "@clerk/clerk-sdk-node",
   "author": {
     "name": "Clerk, Inc.",

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -73,6 +73,10 @@ export function setClerkApiKey(value: string) {
   Clerk.getInstance().apiKey = value;
 }
 
+export function setClerkJwtKey(value: string) {
+  Clerk.getInstance().jwtKey = value;
+}
+
 export function setClerkServerApiUrl(value: string) {
   Clerk.getInstance().apiUrl = value;
 }

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -1,3 +1,4 @@
+import { ClerkClient, CreateClerkClient, extractClerkApiFromInstance } from '@clerk/backend-core';
 import type { RequestInit } from 'node-fetch';
 
 import Clerk from './instance';
@@ -12,20 +13,12 @@ const sessions = singletonInstance.sessions;
 const smsMessages = singletonInstance.smsMessages;
 const users = singletonInstance.users;
 
+// Export sub-api objects
+// "Old" /api export structure
+export { allowlistIdentifiers, clients, emails, invitations, organizations, sessions, smsMessages, users };
+
 // Export a default singleton instance that should suffice for most use cases
 export default singletonInstance;
-
-// Export sub-api objects
-export {
-  allowlistIdentifiers,
-  clients,
-  emails,
-  invitations,
-  organizations,
-  sessions,
-  smsMessages,
-  users,
-};
 
 // Export resources
 export {
@@ -49,10 +42,8 @@ export {
 
 // Export middleware functions
 
-const ClerkExpressWithAuth =
-  singletonInstance.expressWithAuth.bind(singletonInstance);
-const ClerkExpressRequireAuth =
-  singletonInstance.expressRequireAuth.bind(singletonInstance);
+const ClerkExpressWithAuth = singletonInstance.expressWithAuth.bind(singletonInstance);
+const ClerkExpressRequireAuth = singletonInstance.expressRequireAuth.bind(singletonInstance);
 
 export { ClerkExpressWithAuth, ClerkExpressRequireAuth };
 
@@ -73,10 +64,6 @@ export function setClerkApiKey(value: string) {
   Clerk.getInstance().apiKey = value;
 }
 
-export function setClerkJwtKey(value: string) {
-  Clerk.getInstance().jwtKey = value;
-}
-
 export function setClerkServerApiUrl(value: string) {
   Clerk.getInstance().apiUrl = value;
 }
@@ -88,3 +75,11 @@ export function setClerkApiVersion(value: string) {
 export function setClerkHttpOptions(value: RequestInit) {
   Clerk.getInstance().httpOptions = value;
 }
+
+export const createClerkClient: CreateClerkClient = params => {
+  const { apiKey, ...rest } = params || {};
+  const instance = new Clerk({ apiKey: apiKey || process.env.CLERK_API_KEY, ...rest });
+  return extractClerkApiFromInstance(instance);
+};
+
+export const clerkClient: ClerkClient = createClerkClient();


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR adds the following optional `options` arg to the `getAuth` helper: 
```
type GetAuthOptions = {
  loadUser?: boolean;
  loadSession?: boolean;
  loadOrg?: boolean;
};
```

As usual, depending on the values of `options` the returned value of getAuth changing both during runtime and build time.

#### 1 - no options, getAuth is still sync and returns the usual `AuthData`
![image](https://user-images.githubusercontent.com/1811063/192883308-a636c657-1a74-45cb-bc1e-56661f1edb7f.png)


#### 2 - options passed, getAuth is now async and returns the usual `AuthData` and the corresponding resource. Notice the async/await
![image](https://user-images.githubusercontent.com/1811063/192883206-975979b1-2a60-4420-8544-8c2e25d9cd36.png)
(similarly for loadSession and loadOrg)

This leads as to desired API that correctly supports accessing init clerk state during SSR, hydration and CSR. In essence, this can now replace `withServerSideAuth`

```
import { getAuth } from "@clerk/nextjs/server";

export const getServerSideProps = ({ req }) => {
  const { userId, user, authServerSideProps } =  getAuth(req);

  return {
    props: { foo: "bar", authServerSideProps },
  };
};
```


<!-- Fixes # (issue number) -->
