### PR TITLE
feat(types,clerk-js): Expand existing MFA methods with backup codes

### DIFF
--- a/packages/clerk-js/src/core/resources/PhoneNumber.ts
+++ b/packages/clerk-js/src/core/resources/PhoneNumber.ts
@@ -16,6 +16,7 @@ export class PhoneNumber extends BaseResource implements PhoneNumberResource {
   defaultSecondFactor = false;
   linkedTo: IdentificationLinkResource[] = [];
   verification!: VerificationResource;
+  backupCodes?: string[];
 
   public constructor(data: Partial<PhoneNumberJSON>, pathRoot: string);
   public constructor(data: PhoneNumberJSON, pathRoot: string) {
@@ -76,6 +77,7 @@ export class PhoneNumber extends BaseResource implements PhoneNumberResource {
     this.defaultSecondFactor = data.default_second_factor;
     this.verification = new Verification(data.verification);
     this.linkedTo = (data.linked_to || []).map(link => new IdentificationLink(link));
+    this.backupCodes = data.backup_codes;
     return this;
   }
 }

--- a/packages/clerk-js/src/core/resources/TOTP.ts
+++ b/packages/clerk-js/src/core/resources/TOTP.ts
@@ -10,6 +10,7 @@ export class TOTP extends BaseResource implements TOTPResource {
   secret?: string;
   uri?: string;
   verified = false;
+  backupCodes?: string[];
   updatedAt: Date | null = null;
   createdAt: Date | null = null;
 
@@ -23,6 +24,7 @@ export class TOTP extends BaseResource implements TOTPResource {
     this.secret = data.secret;
     this.uri = data.uri;
     this.verified = data.verified;
+    this.backupCodes = data.backup_codes;
     this.updatedAt = unixEpochToDate(data.updated_at);
     this.createdAt = unixEpochToDate(data.created_at);
 

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeCreatePage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeCreatePage.tsx
@@ -49,7 +49,11 @@ export const MfaBackupCodeCreatePage = () => {
         localizationKey={text}
         variant='regularRegular'
       />
-      <MfaBackupCodeList backupCodes={backupCode.codes} />
+
+      <MfaBackupCodeList
+        subtitle={'Store them securely and keep them secret.'}
+        backupCodes={backupCode.codes}
+      />
 
       <FormButtonContainer>
         <NavigateToFlowStartButton

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeList.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeList.tsx
@@ -2,18 +2,19 @@ import React from 'react';
 
 import { PrintableComponent, usePrintable } from '../common';
 import { useCoreUser, useEnvironment } from '../contexts';
-import { Button, Col, Flex, Grid, Heading, Text } from '../customizables';
+import { Button, Col, Flex, Grid, Heading, LocalizationKey, Text } from '../customizables';
 import { useClipboard } from '../hooks';
 import { mqu } from '../styledSystem';
 import { getIdentifier } from '../utils';
 import { MfaBackupCodeTile } from './MfaBackupCodeTile';
 
 type MfaBackupCodeListProps = {
+  subtitle: LocalizationKey;
   backupCodes?: string[];
 };
 
 export const MfaBackupCodeList = (props: MfaBackupCodeListProps) => {
-  const { backupCodes } = props;
+  const { subtitle, backupCodes } = props;
   const { applicationName } = useEnvironment().displayConfig;
   const user = useCoreUser();
   const { print, printableProps } = usePrintable();
@@ -43,7 +44,7 @@ export const MfaBackupCodeList = (props: MfaBackupCodeListProps) => {
           variant='regularMedium'
         />
         <Text
-          localizationKey={'Store them securely and keep them secret.'}
+          localizationKey={subtitle}
           variant='smallRegular'
           colorScheme='neutral'
         />

--- a/packages/clerk-js/src/ui/UserProfile/MfaPhoneCodePage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaPhoneCodePage.tsx
@@ -39,10 +39,12 @@ export const MfaPhoneCodePage = withCardStateProvider(() => {
           wizard.goToStep(1);
         }}
         title={title}
+        resourceRef={ref}
       />
       <SuccessPage
         title={title}
         text={`SMS code two-step verification is now enabled for this phone number. When signing in, you will need to enter a verification code sent to this phone number as an additional step.`}
+        backupCodes={ref.current?.backupCodes}
       />
     </Wizard>
   );
@@ -53,10 +55,11 @@ type AddMfaProps = {
   onUnverifiedPhoneClick: (phone: PhoneNumberResource) => void;
   onSuccess: () => void;
   title: string;
+  resourceRef: React.MutableRefObject<PhoneNumberResource | undefined>;
 };
 
 const AddMfa = (props: AddMfaProps) => {
-  const { onSuccess, title, onAddPhoneClick, onUnverifiedPhoneClick } = props;
+  const { onSuccess, title, onAddPhoneClick, onUnverifiedPhoneClick, resourceRef } = props;
   const card = useCardState();
   const user = useCoreUser();
   const availableMethods = user.phoneNumbers.filter(p => !p.reservedForSecondFactor);
@@ -74,6 +77,8 @@ const AddMfa = (props: AddMfaProps) => {
         onSuccess();
       })
       .catch(err => handleError(err, [], card.setError));
+
+    resourceRef.current = phone;
   };
 
   return (

--- a/packages/clerk-js/src/ui/UserProfile/MfaTOTPPage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaTOTPPage.tsx
@@ -1,3 +1,4 @@
+import { TOTPResource } from '@clerk/types';
 import React from 'react';
 
 import { useWizard, Wizard } from '../common';
@@ -9,6 +10,7 @@ import { VerifyTOTP } from './VerifyTOTP';
 export const MfaTOTPPage = withCardStateProvider(() => {
   const title = 'Add authenticator app';
   const wizard = useWizard();
+  const ref = React.useRef<TOTPResource>();
 
   return (
     <Wizard {...wizard.props}>
@@ -20,11 +22,13 @@ export const MfaTOTPPage = withCardStateProvider(() => {
       <VerifyTOTP
         title={title}
         onVerified={wizard.nextStep}
+        resourceRef={ref}
       />
 
       <SuccessPage
         title={title}
         text={`Two-step verification is now enabled. When signing in, you will need to enter a verification code from this authenticator as an additional step.`}
+        backupCodes={ref.current?.backupCodes}
       />
     </Wizard>
   );

--- a/packages/clerk-js/src/ui/UserProfile/SuccessPage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/SuccessPage.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 
 import { LocalizationKey, localizationKeys, Text } from '../customizables';
 import { FormButtonContainer } from './FormButtons';
+import { MfaBackupCodeList } from './MfaBackupCodeList';
 import { NavigateToFlowStartButton } from './NavigateToFlowStartButton';
 import { ContentPage } from './Page';
 
 type SuccessPageProps = {
   title: LocalizationKey;
   text: LocalizationKey;
+  backupCodes?: string[];
 };
 
 export const SuccessPage = (props: SuccessPageProps) => {
-  const { text, title } = props;
+  const { text, title, backupCodes } = props;
 
   return (
     <ContentPage.Root headerTitle={title}>
@@ -19,6 +21,16 @@ export const SuccessPage = (props: SuccessPageProps) => {
         localizationKey={text}
         variant='regularRegular'
       />
+
+      {backupCodes && (
+        <MfaBackupCodeList
+          subtitle={
+            'You can use one of these to sign in to your account, if you lose access to your authentication device.'
+          }
+          backupCodes={backupCodes}
+        />
+      )}
+
       <FormButtonContainer>
         <NavigateToFlowStartButton
           variant='solid'

--- a/packages/clerk-js/src/ui/UserProfile/VerifyTOTP.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/VerifyTOTP.tsx
@@ -1,3 +1,4 @@
+import { TOTPResource } from '@clerk/types';
 import React from 'react';
 
 import { useCoreUser } from '../contexts';
@@ -13,10 +14,11 @@ import { ContentPage } from './Page';
 type VerifyTOTPProps = {
   title: string;
   onVerified: () => void;
+  resourceRef: React.MutableRefObject<TOTPResource | undefined>;
 };
 
 export const VerifyTOTP = (props: VerifyTOTPProps) => {
-  const { title, onVerified } = props;
+  const { title, onVerified, resourceRef } = props;
   const card = useCardState();
   const user = useCoreUser();
   const status = useLoadingStatus();
@@ -24,8 +26,9 @@ export const VerifyTOTP = (props: VerifyTOTPProps) => {
   const codeControlState = useFormControl('code', '');
   const codeControl = useCodeControl(codeControlState);
 
-  const resolve = async () => {
+  const resolve = async (totp: TOTPResource) => {
     setSuccess(true);
+    resourceRef.current = totp;
     await sleep(750);
     onVerified();
   };
@@ -42,7 +45,7 @@ export const VerifyTOTP = (props: VerifyTOTPProps) => {
     codeControlState.setError(undefined);
     return user
       .verifyTOTP({ code })
-      .then(() => resolve())
+      .then((totp: TOTPResource) => resolve(totp))
       .catch(reject);
   });
 

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -129,6 +129,7 @@ export interface PhoneNumberJSON extends ClerkResourceJSON {
   default_second_factor: boolean;
   linked_to: IdentificationLinkJSON[];
   verification: VerificationJSON | null;
+  backup_codes?: string[];
 }
 
 export interface Web3WalletJSON extends ClerkResourceJSON {
@@ -294,6 +295,7 @@ export interface TOTPJSON extends ClerkResourceJSON {
   secret?: string;
   uri?: string;
   verified: boolean;
+  backup_codes?: string[];
   created_at: number;
   updated_at: number;
 }

--- a/packages/types/src/phoneNumber.ts
+++ b/packages/types/src/phoneNumber.ts
@@ -24,6 +24,7 @@ export interface PhoneNumberResource extends ClerkResource {
   reservedForSecondFactor: boolean;
   defaultSecondFactor: boolean;
   linkedTo: IdentificationLinkResource[];
+  backupCodes?: string[];
   toString: () => string;
   prepareVerification: () => Promise<PhoneNumberResource>;
   attemptVerification: (params: AttemptPhoneNumberVerificationParams) => Promise<PhoneNumberResource>;

--- a/packages/types/src/totp.ts
+++ b/packages/types/src/totp.ts
@@ -5,6 +5,7 @@ export interface TOTPResource extends ClerkResource {
   secret?: string;
   uri?: string;
   verified: boolean;
+  backupCodes?: string[];
   createdAt: Date | null;
   updatedAt: Date | null;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

**Must be merged after https://github.com/clerkinc/javascript/pull/393**

When a user enables a new MFA method for the first time also list the generated backup codes when applicable

https://user-images.githubusercontent.com/22435234/192973575-b9effcea-088e-46fe-a74f-2cfc84cfc5e2.mov

<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/Expand-existing-MFA-methods-phone-code-TOTP-and-generate-backup-codes-as-well-ca0a5ca55d664652b511de7f23df2fa4
