### PR TITLE
fix(nextjs): Throw new Error instead of string in @clerk/nextjs/serve…

### DIFF
--- a/packages/nextjs/src/server/utils/getAuth.ts
+++ b/packages/nextjs/src/server/utils/getAuth.ts
@@ -22,7 +22,9 @@ export const createGetAuth = ({ sessions }: CreateGetAuthParams): GetAuth => {
     const authResult = getAuthResultFromRequest(req);
 
     if (!authResult) {
-      throw 'You need to use "withClerkMiddleware" in your Next.js middleware file. See https://clerk.dev/docs/quickstarts/get-started-with-nextjs';
+      throw new Error(
+        'You need to use "withClerkMiddleware" in your Next.js middleware file. See https://clerk.dev/docs/quickstarts/get-started-with-nextjs',
+      );
     }
 
     if (authResult !== AuthResult.StandardSignedIn) {

--- a/packages/nextjs/src/server/utils/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/utils/withClerkMiddleware.ts
@@ -40,7 +40,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
 
     // throw an error if the request already includes an auth result, because that means it has been spoofed
     if (getAuthResultFromRequest(req)) {
-      throw 'withClerkMiddleware: Auth violation detected';
+      throw new Error('withClerkMiddleware: Auth violation detected');
     }
 
     // get auth state, check if we need to return an interstitial
@@ -77,7 +77,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     const authResult = status === AuthStatus.SignedIn ? AuthResult.StandardSignedIn : errorReason;
 
     if (!authResult) {
-      throw 'withClerkMiddleware: Auth result could not be determined';
+      throw new Error('withClerkMiddleware: Auth result could not be determined');
     }
 
     // Set auth result on request in a private property so that middleware can read it too


### PR DESCRIPTION
…r for better debuggability

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [X] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description

Throwing an error instead of a string results in the error message actually being logged in stderr / stdout.