### PR TITLE
feat(nextjs): Add loadOrg to edgeWithAuth for parity with withAuth

### DIFF
--- a/packages/edge/src/vercel-edge/types.ts
+++ b/packages/edge/src/vercel-edge/types.ts
@@ -1,4 +1,4 @@
-import type { Session, User } from '@clerk/backend-core';
+import type { Organization, Session, User } from '@clerk/backend-core';
 import { ClerkJWTClaims, ServerGetToken } from '@clerk/types';
 import type { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
@@ -24,7 +24,8 @@ export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 export type RequestWithAuth<Options extends WithEdgeMiddlewareAuthOptions = any> = NextRequest & {
   auth: EdgeMiddlewareAuth;
 } & (Options extends { loadSession: true } ? { session: Session | null } : {}) &
-  (Options extends { loadUser: true } ? { user: User | null } : {});
+  (Options extends { loadUser: true } ? { user: User | null } : {}) &
+  (Options extends { loadOrg: true } ? { organization: Organization | null } : {});
 
 type NextMiddlewareReturnOptions = NextResponse | Response | null | undefined;
 export type NextMiddlewareResult = NextMiddlewareReturnOptions;
@@ -48,4 +49,5 @@ export type AuthData = {
   user: User | undefined | null;
   getToken: ServerGetToken;
   claims: ClerkJWTClaims | null;
+  organization: Organization | undefined | null;
 };

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -19,8 +19,6 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
   const { frontendApi, __clerk_ssr_state, authServerSideProps, clerkJSUrl, ...restProps } = rest;
   const { push } = useRouter();
 
-  console.log('clerkprovider', __clerk_ssr_state, authServerSideProps);
-
   if (frontendApi == undefined && !process.env.NEXT_PUBLIC_CLERK_FRONTEND_API) {
     throw Error(NO_FRONTEND_API_ERR);
   }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
