### PR TITLE
feat(nextjs): Make buildClerkProps return early if not signed in

### DIFF
--- a/packages/nextjs/src/server/utils/getAuth.ts
+++ b/packages/nextjs/src/server/utils/getAuth.ts
@@ -66,6 +66,10 @@ type BuildClerkPropsInitState = { user?: User | null; session?: Session | null; 
 type BuildClerkProps = (req: RequestLike, authState?: BuildClerkPropsInitState) => Record<string, unknown>;
 
 export const buildClerkProps: BuildClerkProps = (req, initState = {}) => {
+  const authResult = getAuthResultFromRequest(req);
+  if (!authResult || authResult !== AuthResult.StandardSignedIn) {
+    return {};
+  }
   const { sessionClaims } = parseRequest(req);
   const authData = getAuthDataFromClaims({ sessionClaims });
   return injectSSRStateIntoObject({}, sanitizeAuthData({ ...authData, ...initState } as any));


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
