### PR TITLE
fix(clerk-js): Phone code takes priority over backup code as second factor

### DIFF
--- a/packages/clerk-js/src/ui/SignIn/utils.ts
+++ b/packages/clerk-js/src/ui/SignIn/utils.ts
@@ -111,6 +111,7 @@ export function factorHasLocalStrategy(factor: SignInFactor | undefined | null):
   return localStrategies.includes(factor.strategy);
 }
 
+// The priority of second factors is: TOTP -> Phone code -> any other factor
 export function determineStartingSignInSecondFactor(secondFactors: SignInFactor[]): SignInFactor | null {
   if (!secondFactors || secondFactors.length === 0) {
     return null;
@@ -119,6 +120,11 @@ export function determineStartingSignInSecondFactor(secondFactors: SignInFactor[
   const totpFactor = secondFactors.find(f => f.strategy === 'totp');
   if (totpFactor) {
     return totpFactor;
+  }
+
+  const phoneCodeFactor = secondFactors.find(f => f.strategy === 'phone_code');
+  if (phoneCodeFactor) {
+    return phoneCodeFactor;
   }
 
   return secondFactors[0];

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeAccordion.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeAccordion.tsx
@@ -17,7 +17,7 @@ export const MfaBackupCodeAccordion = () => {
           sx={theme => ({ color: theme.colors.$blackAlpha700 })}
         />
       }
-      title='Backup code'
+      title='Backup codes'
     >
       <Col gap={4}>
         <LinkButtonWithDescription


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Phone code should take priority over backup code when determining and calculating the starting sign in second factor. That means the user should land on the phone OTP screen first instead of the backup code one

### Before

https://user-images.githubusercontent.com/22435234/193761202-94b3321e-e41c-4ca0-a469-56526cbcc6e8.mov

### After

https://user-images.githubusercontent.com/22435234/193761215-b3a8fb39-5c73-4bdc-81da-73caaa684efe.mov

<!-- Fixes # (issue number) -->
