### PR TITLE
fix(clerk-js): Control sorting of second factor alternative methods

### DIFF
--- a/packages/clerk-js/src/ui/SignIn/SignInFactorTwoAlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/SignIn/SignInFactorTwoAlternativeMethods.tsx
@@ -5,7 +5,7 @@ import { useCoreSignIn } from '../../ui/contexts/';
 import { Col, descriptors, Flow, LocalizationKey, localizationKeys } from '../customizables';
 import { ArrowBlockButton, Card, CardAlert, Footer, Header } from '../elements';
 import { useCardState } from '../elements/contexts';
-import { formatSafeIdentifier } from '../utils';
+import { backupCodePrefFactorComparator, formatSafeIdentifier } from '../utils';
 import { HavingTrouble } from './HavingTrouble';
 
 export type AlternativeMethodsProps = {
@@ -49,7 +49,7 @@ const AlternativeMethodsList = (props: AlternativeMethodsProps & { onHavingTroub
           gap={8}
         >
           <Col gap={2}>
-            {supportedSecondFactors.map((factor, i) => (
+            {supportedSecondFactors.sort(backupCodePrefFactorComparator).map((factor, i) => (
               <ArrowBlockButton
                 textLocalizationKey={getButtonLabel(factor)}
                 elementDescriptor={descriptors.alternativeMethodsBlockButton}

--- a/packages/clerk-js/src/ui/utils/factorSorting.ts
+++ b/packages/clerk-js/src/ui/utils/factorSorting.ts
@@ -27,6 +27,12 @@ const STRATEGY_SORT_ORDER_ALL_STRATEGIES_BUTTONS = makeSortingOrderMap([
   'password',
 ] as SignInStrategy[]);
 
+const STRATEGY_SORT_ORDER_BACKUP_CODE_PREF = makeSortingOrderMap([
+  'totp',
+  'phone_code',
+  'backup_code',
+] as SignInStrategy[]);
+
 const makeSortingFunction =
   (sortingMap: Record<SignInStrategy, number>) =>
   (a: SignInFactor, b: SignInFactor): number => {
@@ -40,4 +46,5 @@ const makeSortingFunction =
 
 export const passwordPrefFactorComparator = makeSortingFunction(STRATEGY_SORT_ORDER_PASSWORD_PREF);
 export const otpPrefFactorComparator = makeSortingFunction(STRATEGY_SORT_ORDER_OTP_PREF);
+export const backupCodePrefFactorComparator = makeSortingFunction(STRATEGY_SORT_ORDER_BACKUP_CODE_PREF);
 export const allStrategiesButtonsComparator = makeSortingFunction(STRATEGY_SORT_ORDER_ALL_STRATEGIES_BUTTONS);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Instead of relying on the BE for the second factor alternative methods, apply the comparator logic in the component explicitly

### Before

![Screenshot 2022-10-05 at 3 43 43 PM](https://user-images.githubusercontent.com/22435234/194230428-d5a5aebf-b3ed-4016-86c5-b12f28d17c69.png)

### After

![Screenshot 2022-10-05 at 3 44 32 PM](https://user-images.githubusercontent.com/22435234/194230413-fc6b16cb-7e10-46ec-a268-94830293a149.png)

<!-- Fixes # (issue number) -->
