### PR TITLE
fix(clerk-js): Introduce FullHeightLoader element and replace Spinner in UserProfile

### DIFF
--- a/packages/clerk-js/src/ui/UserProfile/ActiveDevicesSection.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/ActiveDevicesSection.tsx
@@ -3,7 +3,8 @@ import { SessionWithActivitiesResource } from '@clerk/types';
 import React from 'react';
 
 import { useCoreSession, useCoreUser } from '../contexts';
-import { Badge, Col, descriptors, Flex, Icon, localizationKeys, Spinner, Text } from '../customizables';
+import { Badge, Col, descriptors, Flex, Icon, localizationKeys, Text } from '../customizables';
+import { FullHeightLoader } from '../elements';
 import { DeviceLaptop, DeviceMobile } from '../icons';
 import { mqu } from '../styledSystem';
 import { LinkButtonWithDescription } from './LinkButtonWithDescription';
@@ -25,12 +26,7 @@ export const ActiveDevicesSection = () => {
       title={localizationKeys('userProfile.start.activeDevicesSection.title')}
       id='activeDevices'
     >
-      {!sessionsWithActivities.length && (
-        <Spinner
-          colorScheme='primary'
-          size='lg'
-        />
-      )}
+      {!sessionsWithActivities.length && <FullHeightLoader />}
       {!!sessionsWithActivities.length &&
         sessionsWithActivities.sort(currentSessionFirst(session?.id)).map(sa => (
           <DeviceAccordion

--- a/packages/clerk-js/src/ui/UserProfile/AddAuthenticatorApp.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/AddAuthenticatorApp.tsx
@@ -3,8 +3,8 @@ import { QRCodeSVG } from 'qrcode.react';
 import React from 'react';
 
 import { useCoreUser } from '../contexts';
-import { Button, Col, Spinner, Text } from '../customizables';
-import { ClipboardInput, useCardState } from '../elements';
+import { Button, Col, Text } from '../customizables';
+import { ClipboardInput, FullHeightLoader, useCardState } from '../elements';
 import { handleError } from '../utils';
 import { FormButtonContainer } from './FormButtons';
 import { NavigateToFlowStartButton } from './NavigateToFlowStartButton';
@@ -39,12 +39,7 @@ export const AddAuthenticatorApp = (props: AddAuthenticatorAppProps) => {
 
   return (
     <ContentPage.Root headerTitle={title}>
-      {!totp && (
-        <Spinner
-          colorScheme='primary'
-          size='lg'
-        />
-      )}
+      {!totp && <FullHeightLoader />}
 
       {totp && (
         <>

--- a/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeCreatePage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/MfaBackupCodeCreatePage.tsx
@@ -2,8 +2,8 @@ import { BackupCodeResource } from '@clerk/types';
 import React from 'react';
 
 import { useCoreUser } from '../contexts';
-import { localizationKeys, Spinner, Text } from '../customizables';
-import { useCardState } from '../elements';
+import { localizationKeys, Text } from '../customizables';
+import { FullHeightLoader, useCardState } from '../elements';
 import { handleError } from '../utils';
 import { FormButtonContainer } from './FormButtons';
 import { MfaBackupCodeList } from './MfaBackupCodeList';
@@ -34,34 +34,31 @@ export const MfaBackupCodeCreatePage = () => {
     return <ContentPage.Root headerTitle={title} />;
   }
 
-  if (!backupCode) {
-    return (
-      <Spinner
-        colorScheme='primary'
-        size='lg'
-      />
-    );
-  }
-
   return (
     <ContentPage.Root headerTitle={title}>
-      <Text
-        localizationKey={text}
-        variant='regularRegular'
-      />
+      {!backupCode ? (
+        <FullHeightLoader />
+      ) : (
+        <>
+          <Text
+            localizationKey={text}
+            variant='regularRegular'
+          />
 
-      <MfaBackupCodeList
-        subtitle={'Store them securely and keep them secret.'}
-        backupCodes={backupCode.codes}
-      />
+          <MfaBackupCodeList
+            subtitle={'Store them securely and keep them secret.'}
+            backupCodes={backupCode.codes}
+          />
 
-      <FormButtonContainer>
-        <NavigateToFlowStartButton
-          variant='solid'
-          autoFocus
-          localizationKey={localizationKeys('userProfile.formButtonPrimary__finish')}
-        />
-      </FormButtonContainer>
+          <FormButtonContainer>
+            <NavigateToFlowStartButton
+              variant='solid'
+              autoFocus
+              localizationKey={localizationKeys('userProfile.formButtonPrimary__finish')}
+            />
+          </FormButtonContainer>
+        </>
+      )}
     </ContentPage.Root>
   );
 };

--- a/packages/clerk-js/src/ui/elements/FullHeightLoader.tsx
+++ b/packages/clerk-js/src/ui/elements/FullHeightLoader.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { Flex, Spinner } from '../customizables';
+
+export const FullHeightLoader = (): JSX.Element => {
+  return (
+    <Flex
+      center
+      sx={{ height: '100%' }}
+    >
+      <Spinner
+        colorScheme='primary'
+        size='lg'
+      />
+    </Flex>
+  );
+};

--- a/packages/clerk-js/src/ui/elements/index.ts
+++ b/packages/clerk-js/src/ui/elements/index.ts
@@ -27,3 +27,4 @@ export * from './RootBox';
 export * from './InvisibleRootBox';
 export * from './ClipboardInput';
 export * from './TileButton';
+export * from './FullHeightLoader';


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Replace the regular Spinner component with the new FullHeightLoader component in the following UserProfile places:
- Generate backup code page
- Adding TOTP page
- Active session section

### Before

https://user-images.githubusercontent.com/22435234/194555006-16c13bd9-077a-4e60-b24e-b13aff1d3bdf.mov

### After

https://user-images.githubusercontent.com/22435234/194555037-5ed31634-c26c-4ac8-8703-8d1e8e8d57dc.mov

<!-- Fixes # (issue number) -->
