### PR TITLE
fix(clerk-js): Implement tabs components

### DIFF
--- a/packages/clerk-js/src/ui/UserProfile/RootPage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/RootPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useEnvironment } from '../contexts';
 import { Col, descriptors, localizationKeys } from '../customizables';
-import { Header } from '../elements';
+import { Header, Tab, TabPanel, TabPanels, Tabs, TabsList } from '../elements';
 import { ActiveDevicesSection } from './ActiveDevicesSection';
 import { ConnectedAccountsSection } from './ConnectedAccountsSection';
 import { EmailsSection } from './EmailSection';
@@ -44,6 +44,20 @@ export const RootPage = () => {
           <Header.Subtitle localizationKey={localizationKeys('userProfile.start.headerSubtitle__account')} />
         </Header.Root>
         <UserProfileSection />
+
+        <Tabs>
+          <TabsList>
+            <Tab>Active</Tab>
+            <Tab>Invited</Tab>
+            <Tab>Danger</Tab>
+          </TabsList>
+          <TabPanels>
+            <TabPanel>section 1</TabPanel>
+            <TabPanel>section 2</TabPanel>
+            <TabPanel>section 3</TabPanel>
+          </TabPanels>
+        </Tabs>
+
         {showUsername && <UsernameSection />}
         {showEmail && <EmailsSection />}
         {showPhone && <PhoneSection />}

--- a/packages/clerk-js/src/ui/UserProfile/RootPage.tsx
+++ b/packages/clerk-js/src/ui/UserProfile/RootPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useEnvironment } from '../contexts';
 import { Col, descriptors, localizationKeys } from '../customizables';
-import { Header, Tab, TabPanel, TabPanels, Tabs, TabsList } from '../elements';
+import { Header } from '../elements';
 import { ActiveDevicesSection } from './ActiveDevicesSection';
 import { ConnectedAccountsSection } from './ConnectedAccountsSection';
 import { EmailsSection } from './EmailSection';
@@ -44,19 +44,6 @@ export const RootPage = () => {
           <Header.Subtitle localizationKey={localizationKeys('userProfile.start.headerSubtitle__account')} />
         </Header.Root>
         <UserProfileSection />
-
-        <Tabs>
-          <TabsList>
-            <Tab>Active</Tab>
-            <Tab>Invited</Tab>
-            <Tab>Danger</Tab>
-          </TabsList>
-          <TabPanels>
-            <TabPanel>section 1</TabPanel>
-            <TabPanel>section 2</TabPanel>
-            <TabPanel>section 3</TabPanel>
-          </TabPanels>
-        </Tabs>
 
         {showUsername && <UsernameSection />}
         {showEmail && <EmailsSection />}

--- a/packages/clerk-js/src/ui/elements/Tabs.tsx
+++ b/packages/clerk-js/src/ui/elements/Tabs.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+
+import * as Primitives from '../../ui/primitives';
+import { Button, Flex } from '../customizables';
+import { createContextAndHook, getValidChildren } from '../utils';
+
+const { Box } = Primitives;
+
+type TabsContextValue = {
+  selectedIndex: number;
+  setSelectedIndex: (item: number) => void;
+  focusedIndex: number;
+  setFocusedIndex: (item: number) => void;
+};
+export const [TabsContext, useTabsContext] = createContextAndHook<TabsContextValue>('TabsContext');
+export const TabsContextProvider = (props: React.PropsWithChildren<{ value: TabsContextValue }>) => {
+  const ctxValue = React.useMemo(
+    () => ({ value: props.value }),
+    [props.value.selectedIndex, props.value.setFocusedIndex],
+  );
+  return <TabsContext.Provider value={ctxValue}>{props.children}</TabsContext.Provider>;
+};
+
+/**
+ * TabsProps
+ */
+type TabsProps = {
+  children: React.ReactNode;
+  defaultIndex?: number | null;
+};
+
+export const Tabs = ({ children, ...props }: TabsProps) => {
+  const { defaultIndex = null } = props;
+  const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex ?? 0);
+  const [focusedIndex, setFocusedIndex] = React.useState(defaultIndex ?? 0);
+
+  return (
+    <TabsContextProvider value={{ selectedIndex, setSelectedIndex, focusedIndex, setFocusedIndex }}>
+      <Box>{children}</Box>
+    </TabsContextProvider>
+  );
+};
+
+/**
+ * TabsList
+ */
+type TabsListProps = React.PropsWithChildren<any>;
+export const TabsList = (props: TabsListProps) => {
+  const { children } = props;
+  const { setSelectedIndex, selectedIndex, setFocusedIndex } = useTabsContext();
+
+  const validChildren = getValidChildren(children);
+  const childrenWithProps = validChildren.map((child, index) =>
+    React.cloneElement(child as React.ReactElement<React.PropsWithChildren<any>>, {
+      tabIndex: index,
+    }),
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const tabCount = Object.keys(childrenWithProps).length;
+
+    if (e.key === 'ArrowLeft') {
+      const prev = selectedIndex === 0 ? tabCount - 1 : selectedIndex - 1;
+      setFocusedIndex(prev);
+      return setSelectedIndex(prev);
+    }
+    if (e.key === 'ArrowRight') {
+      const next = tabCount - 1 === selectedIndex ? 0 : selectedIndex + 1;
+      setFocusedIndex(next);
+      return setSelectedIndex(next);
+    }
+  };
+
+  return (
+    <Flex
+      onKeyDown={onKeyDown}
+      direction='row'
+      sx={theme => ({ borderBottom: theme.borders.$normal, borderColor: theme.colors.$blackAlpha300 })}
+    >
+      {childrenWithProps}
+    </Flex>
+  );
+};
+
+/**
+ * Tab
+ */
+type TabProps = React.PropsWithChildren<any>;
+type TabPropsWithTabIndex = TabProps & { tabIndex?: number };
+export const Tab = (props: TabProps) => {
+  const { children, tabIndex } = props as TabPropsWithTabIndex;
+
+  if (tabIndex === undefined) {
+    throw new Error('Tab component must be a direct child of TabList.');
+  }
+
+  const { setSelectedIndex, selectedIndex, focusedIndex, setFocusedIndex } = useTabsContext();
+  const ref = React.useRef<HTMLButtonElement | any>(null);
+  const isActive = tabIndex === selectedIndex;
+  const isFocused = tabIndex === focusedIndex;
+
+  const onClick = () => {
+    setSelectedIndex(tabIndex);
+    setFocusedIndex(-1);
+  };
+
+  React.useEffect(() => {
+    if (ref && isFocused) {
+      ref.current.focus();
+    }
+  }, [ref, isFocused]);
+
+  return (
+    <Flex
+      direction='row'
+      sx={{ position: 'relative' }}
+    >
+      <Button
+        onClick={onClick}
+        focusRing={isFocused}
+        variant='ghost'
+        aria-selected={isActive}
+        id={`tab-${tabIndex}`}
+        aria-controls={`tabpanel-${tabIndex}`}
+        role='tab'
+        ref={ref}
+        sx={t => ({
+          background: t.colors.$transparent,
+          color: isActive ? t.colors.$blackAlpha900 : t.colors.$blackAlpha700,
+          gap: t.space.$1x5,
+          fontWeight: t.fontWeights.$medium,
+          borderBottom: t.borders.$normal,
+          borderColor: isActive ? t.colors.$blackAlpha700 : t.colors.$transparent,
+          borderRadius: 0,
+          width: 'fit-content',
+          '&:hover': { backgroundColor: t.colors.$transparent },
+        })}
+      >
+        {children}
+      </Button>
+    </Flex>
+  );
+};
+
+/**
+ * TabPanels
+ */
+type TabPanelsProps = React.PropsWithChildren<any>;
+export const TabPanels = (props: TabPanelsProps) => {
+  const { children } = props;
+
+  const validChildren = getValidChildren(children);
+  const childrenWithProps = validChildren.map((child, index) =>
+    React.cloneElement(child as React.ReactElement<React.PropsWithChildren<any>>, {
+      tabIndex: index,
+    }),
+  );
+
+  return <Flex>{childrenWithProps}</Flex>;
+};
+
+/**
+ * TabPanel
+ */
+type TabPanelProps = React.PropsWithChildren<any>;
+type TabPanelPropsWithTabIndex = TabPanelProps & { tabIndex?: number };
+export const TabPanel = (props: TabPanelProps) => {
+  const { tabIndex, children } = props as TabPanelPropsWithTabIndex;
+
+  if (tabIndex === undefined) {
+    throw new Error('TabPanel component must be a direct child of TabPanels.');
+  }
+
+  const { selectedIndex } = useTabsContext();
+  const isOpen = tabIndex === selectedIndex;
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Flex
+      id={`tabpanel-${tabIndex}`}
+      role='tabpanel'
+      tabIndex={0}
+      aria-labelledby={`tab-${tabIndex}`}
+    >
+      {children}
+    </Flex>
+  );
+};

--- a/packages/clerk-js/src/ui/elements/Tabs.tsx
+++ b/packages/clerk-js/src/ui/elements/Tabs.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
-import * as Primitives from '../../ui/primitives';
-import { Button, Flex } from '../customizables';
+import { Button, Col, Flex } from '../customizables';
 import { createContextAndHook, getValidChildren } from '../utils';
-
-const { Box } = Primitives;
 
 type TabsContextValue = {
   selectedIndex: number;
@@ -26,17 +23,17 @@ export const TabsContextProvider = (props: React.PropsWithChildren<{ value: Tabs
  */
 type TabsProps = {
   children: React.ReactNode;
-  defaultIndex?: number | null;
+  defaultIndex?: number;
 };
 
 export const Tabs = ({ children, ...props }: TabsProps) => {
-  const { defaultIndex = null } = props;
-  const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex ?? 0);
-  const [focusedIndex, setFocusedIndex] = React.useState(defaultIndex ?? 0);
+  const { defaultIndex = 0 } = props;
+  const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex);
+  const [focusedIndex, setFocusedIndex] = React.useState(defaultIndex);
 
   return (
     <TabsContextProvider value={{ selectedIndex, setSelectedIndex, focusedIndex, setFocusedIndex }}>
-      <Box>{children}</Box>
+      <Col>{children}</Col>
     </TabsContextProvider>
   );
 };
@@ -49,9 +46,8 @@ export const TabsList = (props: TabsListProps) => {
   const { children } = props;
   const { setSelectedIndex, selectedIndex, setFocusedIndex } = useTabsContext();
 
-  const validChildren = getValidChildren(children);
-  const childrenWithProps = validChildren.map((child, index) =>
-    React.cloneElement(child as React.ReactElement<React.PropsWithChildren<any>>, {
+  const childrenWithProps = getValidChildren(children).map((child, index) =>
+    React.cloneElement(child, {
       tabIndex: index,
     }),
   );
@@ -76,7 +72,6 @@ export const TabsList = (props: TabsListProps) => {
   return (
     <Flex
       onKeyDown={onKeyDown}
-      direction='row'
       sx={theme => ({ borderBottom: theme.borders.$normal, borderColor: theme.colors.$blackAlpha300 })}
     >
       {childrenWithProps}
@@ -97,7 +92,7 @@ export const Tab = (props: TabProps) => {
   }
 
   const { setSelectedIndex, selectedIndex, focusedIndex, setFocusedIndex } = useTabsContext();
-  const ref = React.useRef<HTMLButtonElement | any>(null);
+  const buttonRef = React.useRef<HTMLButtonElement | any>(null);
   const isActive = tabIndex === selectedIndex;
   const isFocused = tabIndex === focusedIndex;
 
@@ -113,26 +108,23 @@ export const Tab = (props: TabProps) => {
   }, []);
 
   React.useEffect(() => {
-    if (ref && isFocused) {
-      ref.current.focus();
+    if (buttonRef.current && isFocused) {
+      buttonRef.current.focus();
     }
-  }, [ref, isFocused]);
+  }, [isFocused]);
 
   return (
-    <Flex
-      direction='row'
-      sx={{ position: 'relative' }}
-    >
+    <Flex sx={{ position: 'relative' }}>
       <Button
         onClick={onClick}
         focusRing={isFocused}
         isDisabled={isDisabled}
         variant='ghost'
         aria-selected={isActive}
-        id={`tab-${tabIndex}`}
-        aria-controls={`tabpanel-${tabIndex}`}
+        id={`cl-tab-${tabIndex}`}
+        aria-controls={`cl-tabpanel-${tabIndex}`}
         role='tab'
-        ref={ref}
+        ref={buttonRef}
         sx={t => ({
           background: t.colors.$transparent,
           color: isActive ? t.colors.$blackAlpha900 : t.colors.$blackAlpha700,
@@ -158,9 +150,8 @@ type TabPanelsProps = React.PropsWithChildren<any>;
 export const TabPanels = (props: TabPanelsProps) => {
   const { children } = props;
 
-  const validChildren = getValidChildren(children);
-  const childrenWithProps = validChildren.map((child, index) =>
-    React.cloneElement(child as React.ReactElement<React.PropsWithChildren<any>>, {
+  const childrenWithProps = getValidChildren(children).map((child, index) =>
+    React.cloneElement(child, {
       tabIndex: index,
     }),
   );
@@ -189,10 +180,10 @@ export const TabPanel = (props: TabPanelProps) => {
 
   return (
     <Flex
-      id={`tabpanel-${tabIndex}`}
+      id={`cl-tabpanel-${tabIndex}`}
       role='tabpanel'
       tabIndex={0}
-      aria-labelledby={`tab-${tabIndex}`}
+      aria-labelledby={`cl-tab-${tabIndex}`}
     >
       {children}
     </Flex>

--- a/packages/clerk-js/src/ui/elements/Tabs.tsx
+++ b/packages/clerk-js/src/ui/elements/Tabs.tsx
@@ -57,15 +57,17 @@ export const TabsList = (props: TabsListProps) => {
   );
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    const tabCount = Object.keys(childrenWithProps).length;
+    const tabs = childrenWithProps.filter(child => !child.props?.isDisabled).map(child => child.props.tabIndex);
+    const tabsLenth = tabs.length;
+    const current = tabs.indexOf(selectedIndex);
 
     if (e.key === 'ArrowLeft') {
-      const prev = selectedIndex === 0 ? tabCount - 1 : selectedIndex - 1;
+      const prev = current === 0 ? tabs[tabsLenth - 1] : tabs[current - 1];
       setFocusedIndex(prev);
       return setSelectedIndex(prev);
     }
     if (e.key === 'ArrowRight') {
-      const next = tabCount - 1 === selectedIndex ? 0 : selectedIndex + 1;
+      const next = tabsLenth - 1 === current ? tabs[0] : tabs[current + 1];
       setFocusedIndex(next);
       return setSelectedIndex(next);
     }
@@ -88,7 +90,7 @@ export const TabsList = (props: TabsListProps) => {
 type TabProps = React.PropsWithChildren<any>;
 type TabPropsWithTabIndex = TabProps & { tabIndex?: number };
 export const Tab = (props: TabProps) => {
-  const { children, tabIndex } = props as TabPropsWithTabIndex;
+  const { children, tabIndex, isDisabled } = props as TabPropsWithTabIndex;
 
   if (tabIndex === undefined) {
     throw new Error('Tab component must be a direct child of TabList.');
@@ -105,6 +107,12 @@ export const Tab = (props: TabProps) => {
   };
 
   React.useEffect(() => {
+    if (isDisabled && tabIndex === 0) {
+      setSelectedIndex((tabIndex as number) + 1);
+    }
+  }, []);
+
+  React.useEffect(() => {
     if (ref && isFocused) {
       ref.current.focus();
     }
@@ -118,6 +126,7 @@ export const Tab = (props: TabProps) => {
       <Button
         onClick={onClick}
         focusRing={isFocused}
+        isDisabled={isDisabled}
         variant='ghost'
         aria-selected={isActive}
         id={`tab-${tabIndex}`}

--- a/packages/clerk-js/src/ui/elements/index.ts
+++ b/packages/clerk-js/src/ui/elements/index.ts
@@ -28,3 +28,4 @@ export * from './InvisibleRootBox';
 export * from './ClipboardInput';
 export * from './TileButton';
 export * from './FullHeightLoader';
+export * from './Tabs';

--- a/packages/clerk-js/src/ui/utils/getValidReactChildren.ts
+++ b/packages/clerk-js/src/ui/utils/getValidReactChildren.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function getValidChildren(children: React.ReactNode) {
+  return React.Children.toArray(children).filter(child => React.isValidElement(child)) as React.ReactElement[];
+}

--- a/packages/clerk-js/src/ui/utils/index.ts
+++ b/packages/clerk-js/src/ui/utils/index.ts
@@ -16,3 +16,4 @@ export * from './getIdentifier';
 export * from './readObjectPath';
 export * from './useFormControl';
 export * from './errorHandler';
+export * from './getValidReactChildren';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Implement tabs components. 
Note: Tabs are also accessible and can be navigated with arrow keys.
 
### Usage
```jsx
    <Tabs>
      <TabsList>
        <Tab>Active</Tab>
        <Tab>Invited</Tab>
        <Tab>Danger</Tab>
      </TabsList>
       
      <TabPanels>
        <TabPanel>section 1</TabPanel>
        <TabPanel>section 2</TabPanel>
        <TabPanel>section 3</TabPanel>
      </TabPanels>
    </Tabs>
```

### Demo

https://user-images.githubusercontent.com/23478420/194306448-a748c9cf-e629-4d97-a66f-ecbec67cd92b.mov

With disabled tabs

https://user-images.githubusercontent.com/23478420/194340255-5616d336-c798-4bc4-b2b9-acb0e56b4edd.mov



<!-- Fixes # (issue number) -->
