### PR TITLE
fix(clerk-js): Correctly truncate social buttons

### DIFF
--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -139,7 +139,7 @@ const SocialButtonIcon = (props: SocialButtonProps): JSX.Element => {
 };
 
 const SocialButtonBlock = (props: SocialButtonProps): JSX.Element => {
-  const { label, id, providerName, ...rest } = props;
+  const { label, id, providerName, sx, ...rest } = props;
 
   return (
     <ArrowBlockButton
@@ -150,6 +150,13 @@ const SocialButtonBlock = (props: SocialButtonProps): JSX.Element => {
       textLocalizationKey={localizationKeys('socialButtonsBlockButton', { provider: providerName })}
       arrowElementDescriptor={descriptors.socialButtonsBlockButtonArrow}
       arrowElementId={descriptors.socialButtonsBlockButtonArrow.setId(id)}
+      sx={[
+        {
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+        },
+        sx,
+      ]}
       {...rest}
     >
       {label}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Before:
<img width="570" alt="Screenshot 2022-10-06 at 15 28 33" src="https://user-images.githubusercontent.com/73396808/194313208-db189780-be73-4c81-954c-59b5b0a3ae14.png">

After:
<img width="623" alt="Screenshot 2022-10-06 at 15 27 01" src="https://user-images.githubusercontent.com/73396808/194313249-85b4aaff-4cad-42b6-8f63-0ec7373bee4c.png">


<!-- Fixes # (issue number) -->
