### PR TITLE
feat(backend-core): Add support for updating user's totp secret and backup codes

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -560,6 +560,7 @@ Available parameters are:
 - _firstName_ User's first name.
 - _lastName_ User's last name.
 - _totpSecret_ User's secret for TOTP. Useful while migrating users with enabled 2FA Authenticator Apps.
+- _backupCodes_ User's backup codes. Useful while migrating users with already existed 2FA backup codes.
 - _publicMetadata_ Metadata saved on the user, that is visible to both your Frontend and Backend APIs.
 - _privateMetadata_ Metadata saved on the user, that is only visible to your Backend API.
 - _unsafeMetadata_ Metadata saved on the user, that can be updated from both the Frontend and Backend APIs. Note: Since this data can be modified from the frontend, it is not guaranteed to be safe.
@@ -587,6 +588,8 @@ Supported user attributes for update are:
 | primaryPhoneNumberID  |         string          |
 |    publicMetadata     | Record<string, unknown> |
 |    privateMetadata    | Record<string, unknown> |
+|      totpSecret       |         string          |
+|      backupCodes      |        string[]         |
 
 #### deleteUser(userId)
 

--- a/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
@@ -148,6 +148,7 @@ test('createUser() creates a user', async () => {
     firstName: 'Boss',
     lastName: 'Clerk',
     totpSecret: 'AICJ3HCXKO4KOY6NDH6RII4E3ZYL5ZBH',
+    backupCodes: ['1234', 'abcd'],
   };
 
   nock(defaultServerAPIUrl)
@@ -169,6 +170,8 @@ test('updateUser() updates a user', async () => {
         nestedKey: 42,
       },
     },
+    totpSecret: 'AICJ3HCXKO4KOY6NDH6RII4E3ZYL5ZBH',
+    backupCodes: ['1234', 'abcd'],
   };
 
   nock(defaultServerAPIUrl)
@@ -181,6 +184,8 @@ test('updateUser() updates a user', async () => {
           nestedKey: 42,
         },
       },
+      totp_secret: 'AICJ3HCXKO4KOY6NDH6RII4E3ZYL5ZBH',
+      backup_codes: ['1234', 'abcd'],
     })
     .replyWithFile(200, __dirname + '/responses/updateUser.json', {
       'Content-Type': '',

--- a/packages/backend-core/src/api/endpoints/UserApi.ts
+++ b/packages/backend-core/src/api/endpoints/UserApi.ts
@@ -36,6 +36,7 @@ type CreateUserParams = {
   skipPasswordChecks?: boolean;
   skipPasswordRequirement?: boolean;
   totpSecret?: string;
+  backupCodes?: string[];
 } & UserMetadataParams;
 
 interface UpdateUserParams extends UserMetadataParams {
@@ -45,6 +46,8 @@ interface UpdateUserParams extends UserMetadataParams {
   password?: string;
   primaryEmailAddressID?: string;
   primaryPhoneNumberID?: string;
+  totpSecret?: string;
+  backupCodes?: string[];
 }
 
 type GetOrganizationMembershipListParams = {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add support for updating user's totp secret and backup codes

https://www.notion.so/clerkdev/Allow-updating-totp_secret-backup_codes-for-a-user-via-BAPI-77ed76eeed3d4681b54f04e2ae566016
