### PR TITLE
feat(types,clerk-js): List only authenticatable OAuth providers in Sign in/up components

### DIFF
--- a/packages/clerk-js/src/core/resources/UserSettings.test.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.test.ts
@@ -199,7 +199,7 @@ describe('UserSettings', () => {
         oauth_google: {
           enabled: true,
           required: false,
-          authenticatable: true,
+          authenticatable: false,
           strategy: 'oauth_google',
         },
         oauth_gitlab: {
@@ -227,8 +227,8 @@ describe('UserSettings', () => {
       },
     } as any as UserSettingsJSON);
 
-    const res = sut.socialProviderStrategies;
-    expect(res).toEqual(['oauth_facebook', 'oauth_google']);
+    expect(sut.socialProviderStrategies).toEqual(['oauth_facebook', 'oauth_google']);
+    expect(sut.authenticatableSocialStrategies).toEqual(['oauth_facebook']);
   });
 
   it('returns enabled standard form attributes', function () {

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -22,6 +22,7 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
   signUp!: SignUpData;
 
   socialProviderStrategies: OAuthStrategy[] = [];
+  authenticatableSocialStrategies: OAuthStrategy[] = [];
   web3FirstFactors: Web3Strategy[] = [];
   enabledFirstFactorIdentifiers: Array<keyof UserSettingsResource['attributes']> = [];
 
@@ -48,6 +49,7 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     this.signIn = data.sign_in;
     this.signUp = data.sign_up;
     this.socialProviderStrategies = this.getSocialProviderStrategies(data.social);
+    this.authenticatableSocialStrategies = this.getAuthenticatableSocialStrategies(data.social);
     this.web3FirstFactors = this.getWeb3FirstFactors(data.attributes);
     this.enabledFirstFactorIdentifiers = this.getEnabledFirstFactorIdentifiers(data.attributes);
     return this;
@@ -81,6 +83,17 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
 
     return Object.entries(social)
       .filter(([, desc]) => desc.enabled)
+      .map(([, desc]) => desc.strategy)
+      .sort();
+  }
+
+  private getAuthenticatableSocialStrategies(social: OAuthProviders): OAuthStrategy[] {
+    if (!social) {
+      return [];
+    }
+
+    return Object.entries(social)
+      .filter(([, desc]) => desc.enabled && desc.authenticatable)
       .map(([, desc]) => desc.strategy)
       .sort();
   }

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -18,8 +18,7 @@ import {
   withCardStateProvider,
 } from '../../elements';
 import { useCardState } from '../../elements/contexts';
-import { useNavigate } from '../../hooks';
-import { useLoadingStatus } from '../../hooks';
+import { useLoadingStatus, useNavigate } from '../../hooks';
 import { useSupportEmail } from '../../hooks/useSupportEmail';
 import { buildRequest, FormControlState, handleError, isMobileDevice, useFormControl } from '../../utils';
 import { SignInSocialButtons } from './SignInSocialButtons';
@@ -38,7 +37,7 @@ export function _SignInStart(): JSX.Element {
 
   const standardFormAttributes = userSettings.enabledFirstFactorIdentifiers;
   const web3FirstFactors = userSettings.web3FirstFactors;
-  const socialProviderStrategies = userSettings.socialProviderStrategies;
+  const authenticatableSocialStrategies = userSettings.authenticatableSocialStrategies;
   const passwordBasedInstance = userSettings.instanceIsPasswordBased;
   const identifierInputDisplayValues = getIdentifierControlDisplayValues(standardFormAttributes);
 
@@ -178,7 +177,7 @@ export function _SignInStart(): JSX.Element {
     return <LoadingCard />;
   }
 
-  const hasSocialOrWeb3Buttons = !!socialProviderStrategies.length || !!web3FirstFactors.length;
+  const hasSocialOrWeb3Buttons = !!authenticatableSocialStrategies.length || !!web3FirstFactors.length;
   const shouldAutofocus = !isMobileDevice() && hasSocialOrWeb3Buttons;
 
   return (

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -93,7 +93,7 @@ function _SignUpContinue() {
   });
   minimizeFieldsForExistingSignup(fields, signUp);
 
-  const oauthOptions = userSettings.socialProviderStrategies;
+  const oauthOptions = userSettings.authenticatableSocialStrategies;
   const web3Options = userSettings.web3FirstFactors;
 
   const handleChangeActive = (type: ActiveIdentifier) => {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -15,8 +15,7 @@ import {
   withCardStateProvider,
 } from '../../elements';
 import { useCardState } from '../../elements/contexts';
-import { useNavigate } from '../../hooks';
-import { useLoadingStatus } from '../../hooks';
+import { useLoadingStatus, useNavigate } from '../../hooks';
 import { buildRequest, FormControlState, handleError, useFormControl } from '../../utils';
 import { SignUpForm } from './SignUpForm';
 import {
@@ -222,7 +221,7 @@ function _SignUpStart(): JSX.Element {
   const shouldShowForm = showFormFields(userSettings) && visibleFields.length > 0;
 
   const showOauthProviders =
-    (!hasTicket || missingRequirementsWithTicket) && userSettings.socialProviderStrategies.length > 0;
+    (!hasTicket || missingRequirementsWithTicket) && userSettings.authenticatableSocialStrategies.length > 0;
   const showWeb3Providers = !hasTicket && userSettings.web3FirstFactors.length > 0;
 
   return (

--- a/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
+++ b/packages/clerk-js/src/ui/components/SignUp/signUpFormHelpers.ts
@@ -109,9 +109,9 @@ export const getInitialActiveIdentifier = (attributes: Attributes, isProgressive
 };
 
 export function showFormFields(userSettings: UserSettingsResource): boolean {
-  const { socialProviderStrategies, web3FirstFactors } = userSettings;
+  const { authenticatableSocialStrategies, web3FirstFactors } = userSettings;
 
-  return userSettings.hasValidAuthFactor || (!socialProviderStrategies.length && !web3FirstFactors.length);
+  return userSettings.hasValidAuthFactor || (!authenticatableSocialStrategies.length && !web3FirstFactors.length);
 }
 
 export function emailOrPhone(attributes: Attributes, isProgressiveSignUp: boolean) {

--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -26,11 +26,14 @@ const isWeb3Strategy = (val: string): val is Web3Strategy => {
 
 export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
   const { oauthCallback, web3Callback, enableOAuthProviders = true, enableWeb3Providers = true } = props;
-  const { web3Strategies, oauthStrategies, strategyToDisplayData } = useEnabledThirdPartyProviders();
+  const { web3Strategies, authenticatableOauthStrategies, strategyToDisplayData } = useEnabledThirdPartyProviders();
   const card = useCardState();
   const { socialButtonsVariant } = useAppearance().parsedLayout;
 
-  const strategies = [...(enableOAuthProviders ? oauthStrategies : []), ...(enableWeb3Providers ? web3Strategies : [])];
+  const strategies = [
+    ...(enableOAuthProviders ? authenticatableOauthStrategies : []),
+    ...(enableWeb3Providers ? web3Strategies : []),
+  ];
 
   if (!strategies.length) {
     return null;

--- a/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
@@ -27,11 +27,11 @@ const strategyToDisplayData: ThirdPartyStrategyToDataMap = fromEntries(
 ) as ThirdPartyStrategyToDataMap;
 
 export const useEnabledThirdPartyProviders = () => {
-  const { socialProviderStrategies, web3FirstFactors } = useEnvironment().userSettings;
+  const { socialProviderStrategies, web3FirstFactors, authenticatableSocialStrategies } = useEnvironment().userSettings;
   return {
     strategies: [...socialProviderStrategies, ...web3FirstFactors],
     web3Strategies: [...web3FirstFactors],
-    oauthStrategies: [...socialProviderStrategies],
+    authenticatableOauthStrategies: [...authenticatableSocialStrategies],
     strategyToDisplayData,
     providerToDisplayData,
   };

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -70,6 +70,7 @@ export interface UserSettingsResource extends ClerkResource {
   signIn: SignInData;
   signUp: SignUpData;
   socialProviderStrategies: OAuthStrategy[];
+  authenticatableSocialStrategies: OAuthStrategy[];
   web3FirstFactors: Web3Strategy[];
   enabledFirstFactorIdentifiers: Attribute[];
   instanceIsPasswordBased: boolean;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Take into account the authenticatable flag for each OAuth provider and list only those that the value equals true in Sign in/up account. The available OAuth provides in Connect flow are not affected by this change

https://user-images.githubusercontent.com/22435234/195404163-340cabe5-bd39-43ed-b064-cbed6c3e0671.mov

<!-- Fixes # (issue number) -->

Part of https://www.notion.so/clerkdev/Support-authenticatable-OAuth-ee443a7b777d4e47818844b8495a5633
