### PR TITLE
feat(clerk-js): Update impersonation fab behaviour

### DIFF
--- a/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
+++ b/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
@@ -175,6 +175,7 @@ export const ImpersonationFab = () => {
         onPointerDown={onPointerDown}
         align='center'
         sx={t => ({
+          touchAction: 'none', //for drag to work on mobile consistently
           position: 'fixed',
           overflow: 'hidden',
           top: `var(${topProperty}, ${defaultTop}px)`,

--- a/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
+++ b/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
@@ -1,4 +1,4 @@
-import React, { PointerEventHandler, useEffect, useRef } from 'react';
+import React, { PointerEventHandler, TransitionEventHandler, useEffect, useRef, useState } from 'react';
 
 import { mqu, PropsOfComponent } from '../../ui/styledSystem';
 import { getFullName, getIdentifier } from '../../ui/utils';
@@ -174,6 +174,7 @@ export const ImpersonationFab = () => {
       <Flex
         ref={containerRef}
         elementDescriptor={descriptors.impersonationFab}
+        onPointerDown={onPointerDown}
         align='center'
         sx={t => ({
           position: 'fixed',
@@ -185,6 +186,9 @@ export const ImpersonationFab = () => {
           borderRadius: t.radii.$halfHeight, //to match the circular eye perfectly
           backgroundColor: t.colors.$white,
           fontFamily: t.fonts.$main,
+          ':hover': {
+            cursor: 'grab',
+          },
           ':hover #cl-impersonationText': {
             maxWidth: `min(calc(50vw - ${eyeWidth} - 2 * ${defaultRight}px), ${titleLength}ch)`,
             [mqu.md]: {
@@ -197,12 +201,6 @@ export const ImpersonationFab = () => {
         })}
       >
         <EyeCircle
-          onPointerDown={onPointerDown}
-          sx={{
-            ':hover': {
-              cursor: 'grab',
-            },
-          }}
           width={eyeWidth}
           height={eyeHeight}
         />

--- a/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
+++ b/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
@@ -1,4 +1,4 @@
-import React, { PointerEventHandler, TransitionEventHandler, useEffect, useRef, useState } from 'react';
+import React, { PointerEventHandler, useEffect, useRef } from 'react';
 
 import { mqu, PropsOfComponent } from '../../ui/styledSystem';
 import { getFullName, getIdentifier } from '../../ui/utils';
@@ -190,10 +190,12 @@ export const ImpersonationFab = () => {
             cursor: 'grab',
           },
           ':hover #cl-impersonationText': {
+            transition: `max-width ${t.transitionDuration.$slowest} ease, opacity ${t.transitionDuration.$slower} ease ${t.transitionDuration.$slowest}`,
             maxWidth: `min(calc(50vw - ${eyeWidth} - 2 * ${defaultRight}px), ${titleLength}ch)`,
             [mqu.md]: {
               maxWidth: `min(calc(100vw - ${eyeWidth} - 2 * ${defaultRight}px), ${titleLength}ch)`,
             },
+            opacity: 1,
           },
           ':hover #cl-impersonationEye': {
             transform: 'rotate(-180deg)',
@@ -208,8 +210,9 @@ export const ImpersonationFab = () => {
         <Flex
           id='cl-impersonationText'
           sx={t => ({
+            transition: `max-width ${t.transitionDuration.$slowest} ease, opacity ${t.transitionDuration.$fast} ease`,
             maxWidth: '0px',
-            transition: `max-width ${t.transitionDuration.$slowest} ease`,
+            opacity: 0,
           })}
         >
           <FabContent

--- a/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
+++ b/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
@@ -27,14 +27,12 @@ const EyeCircle = ({ width, height, ...props }: EyeCircleProps) => {
   const { sx, ...rest } = props;
   return (
     <Col
-      id='cl-impersonationEye'
       elementDescriptor={descriptors.impersonationFabIconContainer}
       center
       sx={[
         t => ({
           width,
           height,
-          transition: `transform ${t.transitionDuration.$slowest} ease`,
           backgroundColor: t.colors.$danger500,
           borderRadius: t.radii.$circle,
         }),
@@ -203,8 +201,12 @@ export const ImpersonationFab = () => {
         })}
       >
         <EyeCircle
+          id='cl-impersonationEye'
           width={eyeWidth}
           height={eyeHeight}
+          sx={t => ({
+            transition: `transform ${t.transitionDuration.$slowest} ease`,
+          })}
         />
 
         <Flex


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The ImpersonationFab content now fades in and out when the Fab is hovered. Also, the entire Fab is now draggable.

<!-- Fixes # (issue number) -->
