### PR TITLE
refactor(clerk-js): Make Avatar Element generic

### DIFF
--- a/packages/clerk-js/src/ui/components/UserButton/UserButtonTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/UserButtonTrigger.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useCoreUser } from '../../contexts';
 import { Button, descriptors } from '../../customizables';
-import { Avatar } from '../../elements';
+import { UserAvatar } from '../../elements';
 import { PropsOfComponent } from '../../styledSystem';
 
 type UserButtonTriggerProps = PropsOfComponent<typeof Button> & { isOpen: boolean };
@@ -18,7 +18,7 @@ export const UserButtonTrigger = React.forwardRef<HTMLButtonElement, UserButtonT
       {...props}
       ref={ref}
     >
-      <Avatar
+      <UserAvatar
         boxElementDescriptor={descriptors.userButtonAvatarBox}
         imageElementDescriptor={descriptors.userButtonAvatarImage}
         {...user}

--- a/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useWizard, Wizard } from '../../common';
 import { useCoreUser, useEnvironment } from '../../contexts';
 import { Button, Col, Flex, localizationKeys, Text } from '../../customizables';
-import { Avatar, FileDropArea, Form, useCardState, withCardStateProvider } from '../../elements';
+import { FileDropArea, Form, useCardState, UserAvatar, withCardStateProvider } from '../../elements';
 import { handleError, useFormControl } from '../../utils';
 import { FormButtons } from './FormButtons';
 import { ContentPage } from './Page';
@@ -118,7 +118,7 @@ const AvatarUploader = (props: AvatarUploaderProps) => {
         align='center'
         {...rest}
       >
-        <Avatar
+        <UserAvatar
           {...user}
           size={theme => theme.sizes.$11}
           optimize

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileSection.tsx
@@ -19,7 +19,7 @@ export const UserProfileSection = () => {
     >
       <BlockButton onClick={() => navigate('profile')}>
         <UserPreview
-          user={userWithoutIdentifiers as UserResource}
+          user={userWithoutIdentifiers}
           size='lg'
         />
       </BlockButton>

--- a/packages/clerk-js/src/ui/elements/IdentityPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/IdentityPreview.tsx
@@ -5,6 +5,7 @@ import { AuthApp, PencilEdit } from '../icons';
 import { PropsOfComponent } from '../styledSystem';
 import { formatSafeIdentifier, getFlagEmojiFromCountryIso, isMaskedIdentifier, parsePhoneString } from '../utils';
 import { Avatar } from './Avatar';
+import { UserAvatar } from './UserAvatar';
 
 type IdentityPreviewProps = {
   avatarUrl: string | null | undefined;
@@ -75,7 +76,7 @@ const IdentifierContainer = (props: React.PropsWithChildren<{}>) => {
 const UsernameOrEmailIdentifier = (props: any) => {
   return (
     <>
-      <Avatar
+      <UserAvatar
         boxElementDescriptor={descriptors.identityPreviewAvatarBox}
         imageElementDescriptor={descriptors.identityPreviewAvatarImage}
         profileImageUrl={props.avatarUrl}

--- a/packages/clerk-js/src/ui/elements/UserAvatar.tsx
+++ b/packages/clerk-js/src/ui/elements/UserAvatar.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { Avatar } from '../elements';
+import { PropsOfComponent } from '../styledSystem';
+import { getFullName, getInitials } from '../utils';
+
+type UserAvatarProps = PropsOfComponent<typeof Avatar> & {
+  name?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  profileImageUrl?: string;
+};
+
+export const UserAvatar = (props: UserAvatarProps) => {
+  const { name, firstName, lastName, profileImageUrl, ...rest } = props;
+  const generatedName = getFullName({ name, firstName, lastName });
+  const initials = getInitials({ name, firstName, lastName });
+
+  return (
+    <Avatar
+      title={generatedName}
+      initials={initials}
+      imageUrl={profileImageUrl}
+      {...rest}
+    />
+  );
+};

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -45,6 +45,7 @@ export const UserPreview = (props: UserPreviewProps) => {
           boxElementDescriptor={descriptors.userPreviewAvatarBox}
           imageElementDescriptor={descriptors.userPreviewAvatarImage}
           {...user}
+          profileImageUrl={profileImageUrl || user.profileImageUrl}
           size={theme => ({ sm: theme.sizes.$8, md: theme.sizes.$11, lg: theme.sizes.$12x5 }[size])}
           optimize
         />

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import { descriptors, Flex, Text } from '../customizables';
 import { PropsOfComponent } from '../styledSystem';
 import { getFullName, getIdentifier } from '../utils';
-import { Avatar } from './Avatar';
+import { UserAvatar } from './UserAvatar';
 
 export type UserPreviewProps = PropsOfComponent<typeof Flex> & {
-  user: UserResource;
+  user: Partial<UserResource>;
   size?: 'lg' | 'md' | 'sm';
   icon?: React.ReactNode;
   badge?: React.ReactNode;
@@ -41,11 +41,10 @@ export const UserPreview = (props: UserPreviewProps) => {
         justify='center'
         sx={theme => ({ position: 'relative', flex: `0 0 ${theme.sizes.$11}` })}
       >
-        <Avatar
+        <UserAvatar
           boxElementDescriptor={descriptors.userPreviewAvatarBox}
           imageElementDescriptor={descriptors.userPreviewAvatarImage}
           {...user}
-          {...(profileImageUrl !== undefined && { profileImageUrl })}
           size={theme => ({ sm: theme.sizes.$8, md: theme.sizes.$11, lg: theme.sizes.$12x5 }[size])}
           optimize
         />

--- a/packages/clerk-js/src/ui/elements/index.ts
+++ b/packages/clerk-js/src/ui/elements/index.ts
@@ -33,3 +33,4 @@ export * from './Pagination';
 export * from './FullHeightLoader';
 export * from './Tabs';
 export * from './InputWithIcon';
+export * from './UserAvatar';

--- a/packages/clerk-js/src/ui/utils/getIdentifier.ts
+++ b/packages/clerk-js/src/ui/utils/getIdentifier.ts
@@ -1,6 +1,6 @@
 import { UserResource } from '@clerk/types';
 
-export const getIdentifier = (user: UserResource): string => {
+export const getIdentifier = (user: Partial<UserResource>): string => {
   if (user.username) {
     return user.username;
   }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Refactor the `<Avatar/>` element to be generic and add a `<UserAvatar/>` element that makes use of the generic element.
The `<Avatar/>` element also takes a `rounded` prop in order to support rectangular and rounded shape.

<!-- Fixes # (issue number) -->
