### PR TITLE
fix(clerk-js): Set the next available active session when signing out

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -172,7 +172,7 @@ export default class Clerk implements ClerkInterface {
     await session?.remove();
     if (shouldSignOutCurrent) {
       return this.setActive({
-        session: null,
+        session: this.client.activeSessions.length > 0 ? this.client.activeSessions[0] : null,
         beforeEmit: ignoreEventValue(cb),
       });
     }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Set the next available active session when signing out to avoid it being null, and the Sign out of all accounts button not working in the "Choose" page.
<!-- Fixes # (issue number) -->
