### PR TITLE
fix(clerk-js): Make connected account removal copywriting more generic

### DIFF
--- a/packages/clerk-js/src/ui/localization/defaultEnglishResource.ts
+++ b/packages/clerk-js/src/ui/localization/defaultEnglishResource.ts
@@ -319,7 +319,8 @@ export const defaultResource: DeepRequired<LocalizationResource> = {
       removeResource: {
         title: 'Remove connected account',
         messageLine1: '{{identifier}} will be removed from this account.',
-        messageLine2: 'You will no longer be able to sign in using this connected account.',
+        messageLine2:
+          'You will no longer be able to use this connected account and any dependent features will no longer work.',
         successMessage: '{{connectedAccount}} has been removed from your account.',
       },
     },


### PR DESCRIPTION
## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.

Since oauth can be used for more than authentication, we need to make the removal text more generic.

Related issue:

https://www.notion.so/clerkdev/Support-authenticatable-OAuth-ee443a7b777d4e47818844b8495a5633