### PR TITLE
fix(clerk-js): Prioritize focus of tabs when keyboard navigating

### DIFF
--- a/packages/clerk-js/src/ui/elements/Tabs.tsx
+++ b/packages/clerk-js/src/ui/elements/Tabs.tsx
@@ -27,7 +27,7 @@ type TabsProps = PropsOfComponent<typeof Col> & {
 export const Tabs = (props: TabsProps) => {
   const { defaultIndex = 0, children, sx, ...rest } = props;
   const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex);
-  const [focusedIndex, setFocusedIndex] = React.useState(defaultIndex);
+  const [focusedIndex, setFocusedIndex] = React.useState(-1);
 
   return (
     <TabsContextProvider value={{ selectedIndex, setSelectedIndex, focusedIndex, setFocusedIndex }}>
@@ -90,7 +90,7 @@ export const Tab = (props: TabProps) => {
   }
 
   const { setSelectedIndex, selectedIndex, focusedIndex, setFocusedIndex } = useTabsContext();
-  const buttonRef = React.useRef<HTMLButtonElement | any>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
   const isActive = tabIndex === selectedIndex;
   const isFocused = tabIndex === focusedIndex;
 
@@ -106,9 +106,9 @@ export const Tab = (props: TabProps) => {
   }, []);
 
   React.useEffect(() => {
-    // if (buttonRef.current && isFocused) {
-    //   buttonRef.current.focus();
-    // }
+    if (buttonRef.current && isFocused) {
+      buttonRef.current.focus();
+    }
   }, [isFocused]);
 
   return (
@@ -118,8 +118,9 @@ export const Tab = (props: TabProps) => {
     >
       <Button
         onClick={onClick}
-        focusRing={isFocused}
+        focusRing={isActive}
         isDisabled={isDisabled}
+        tabIndex={isActive ? 0 : -1}
         variant='ghost'
         aria-selected={isActive}
         id={`cl-tab-${tabIndex}`}
@@ -184,7 +185,6 @@ export const TabPanel = (props: TabPanelProps) => {
     <Flex
       id={`cl-tabpanel-${tabIndex}`}
       role='tabpanel'
-      tabIndex={0}
       aria-labelledby={`cl-tab-${tabIndex}`}
       sx={sx}
       {...rest}

--- a/packages/clerk-js/src/ui/elements/Tabs.tsx
+++ b/packages/clerk-js/src/ui/elements/Tabs.tsx
@@ -185,8 +185,14 @@ export const TabPanel = (props: TabPanelProps) => {
     <Flex
       id={`cl-tabpanel-${tabIndex}`}
       role='tabpanel'
+      tabIndex={0}
       aria-labelledby={`cl-tab-${tabIndex}`}
-      sx={sx}
+      sx={[
+        {
+          outline: 0,
+        },
+        sx,
+      ]}
       {...rest}
     >
       {children}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
