### PR TITLE
fix(clerk-react): Added useAuth test and made getToken, and signOut stable

### DIFF
--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -146,9 +146,9 @@ function deriveState(
       lastOrganizationMember: null,
     };
   }
-  const userId: string | null | undefined = state.user ? state.user.id : state.user;
+  const userId: string | null | undefined = state.user ? state.user.id : (state.user as null | undefined);
   const user = state.user;
-  const sessionId: string | null | undefined = state.session ? state.session.id : state.session;
+  const sessionId: string | null | undefined = state.session ? state.session.id : (state.session as null | undefined);
   const session = state.session;
   const organization = state.organization;
   const lastOrganizationInvitation = state.lastOrganizationInvitation;

--- a/packages/react/src/hooks/useAuth.test.tsx
+++ b/packages/react/src/hooks/useAuth.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, userEvent } from '@clerk/shared/testUtils';
+import React, { useEffect, useState } from 'react';
+
+import { useAuth } from './useAuth';
+import { ClerkProvider } from '../contexts/ClerkProvider';
+
+const withFakeClerk = Component => {
+  return props => (
+    <ClerkProvider frontendApi='https://example.com'>
+      <Component {...props} />
+    </ClerkProvider>
+  );
+};
+
+describe('useAuth()', () => {
+  it('auth is stable between re-renders', async () => {
+    let renderCount = 0;
+    const MyDemo = () => {
+      const [count, setCount] = useState(0);
+      const auth = useAuth();
+      useEffect(() => {
+        renderCount++;
+      }, [auth]);
+      return <button onClick={() => setCount(i => i + 1)}>Hi</button>;
+    };
+    const App = withFakeClerk(MyDemo);
+    render(<App />);
+    const btn = screen.getByText('Hi');
+    userEvent.click(btn);
+    expect(renderCount).toBe(1);
+  });
+
+  it('getToken is stable between re-renders', async () => {
+    let renderCount = 0;
+    const MyDemo = () => {
+      const [count, setCount] = useState(0);
+      const { getToken } = useAuth();
+      useEffect(() => {
+        renderCount++;
+      }, [getToken]);
+      return <button onClick={() => setCount(i => i + 1)}>Hi</button>;
+    };
+    const App = withFakeClerk(MyDemo);
+    render(<App />);
+    const btn = screen.getByText('Hi');
+    userEvent.click(btn);
+    expect(renderCount).toBe(1);
+  });
+});

--- a/packages/react/src/hooks/useAuth.test.tsx
+++ b/packages/react/src/hooks/useAuth.test.tsx
@@ -1,49 +1,62 @@
-import { render, screen, userEvent } from '@clerk/shared/testUtils';
-import React, { useEffect, useState } from 'react';
+import { render } from '@clerk/shared/testUtils';
+import React, { useEffect } from 'react';
 
 import { useAuth } from './useAuth';
 import { ClerkProvider } from '../contexts/ClerkProvider';
 
-const withFakeClerk = Component => {
-  return props => (
-    <ClerkProvider frontendApi='https://example.com'>
-      <Component {...props} />
-    </ClerkProvider>
-  );
-};
+import { withClerk } from '../components/withClerk';
+
+jest.mock('../components/withClerk', () => ({
+  withClerk: (Component: any) => (props: any) => {
+    return (
+      <Component
+        {...props}
+        clerk={{}}
+      />
+    );
+  },
+}));
 
 describe('useAuth()', () => {
-  it('auth is stable between re-renders', async () => {
-    let renderCount = 0;
-    const MyDemo = () => {
-      const [count, setCount] = useState(0);
-      const auth = useAuth();
-      useEffect(() => {
-        renderCount++;
-      }, [auth]);
-      return <button onClick={() => setCount(i => i + 1)}>Hi</button>;
-    };
-    const App = withFakeClerk(MyDemo);
-    render(<App />);
-    const btn = screen.getByText('Hi');
-    userEvent.click(btn);
-    expect(renderCount).toBe(1);
-  });
-
   it('getToken is stable between re-renders', async () => {
     let renderCount = 0;
-    const MyDemo = () => {
-      const [count, setCount] = useState(0);
+    const MyDemo = ({ id }: { id: number }) => {
       const { getToken } = useAuth();
       useEffect(() => {
         renderCount++;
       }, [getToken]);
-      return <button onClick={() => setCount(i => i + 1)}>Hi</button>;
+      return <button>Hi {id}</button>;
     };
-    const App = withFakeClerk(MyDemo);
-    render(<App />);
-    const btn = screen.getByText('Hi');
-    userEvent.click(btn);
+    const App = withClerk(({ id }: { id: number; clerk }) => (
+      <ClerkProvider frontendApi='https://example.com'>
+        <MyDemo id={id} />
+      </ClerkProvider>
+    ));
+    expect(renderCount).toBe(0);
+    const { rerender } = render(<App id={0} />);
+    expect(renderCount).toBe(1);
+    rerender(<App id={1} />);
+    expect(renderCount).toBe(1);
+  });
+
+  it('signOut is stable between re-renders', async () => {
+    let renderCount = 0;
+    const MyDemo = ({ id }: { id: number }) => {
+      const { signOut } = useAuth();
+      useEffect(() => {
+        renderCount++;
+      }, [signOut]);
+      return <button>Hi {id}</button>;
+    };
+    const App = withClerk(({ id }: { id: number; clerk }) => (
+      <ClerkProvider frontendApi='https://example.com'>
+        <MyDemo id={id} />
+      </ClerkProvider>
+    ));
+    expect(renderCount).toBe(0);
+    const { rerender } = render(<App id={0} />);
+    expect(renderCount).toBe(1);
+    rerender(<App id={1} />);
     expect(renderCount).toBe(1);
   });
 });

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -80,7 +80,7 @@ type UseAuth = () => InitReturn | LoadedReturn | UserReturn;
  */
 export const useAuth: UseAuth = () => {
   const { sessionId, userId, actor } = useAuthContext();
-  const isomorphicClerk = useIsomorphicClerkContext() as unknown as IsomorphicClerk;
+  const isomorphicClerk = useIsomorphicClerkContext();
 
   const getToken: GetToken = useCallback(createGetToken(isomorphicClerk), [isomorphicClerk]);
   const signOut: SignOut = useCallback(createSignOut(isomorphicClerk), [isomorphicClerk]);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Following on this issue https://github.com/clerkinc/javascript/issues/201, made the functions returned by `useAuth()` stable (as per [the usual React terminology](https://shopify.engineering/master-reacts-stable-values)); meaning they will not change between unrelated re-renders. This allows you to properly depend on them without worries about re-renders, and when the underlying value _does change_ (isomorphicClerk), then they will update properly.

The logic inside `useAuth()` should be identical as before, just reorganized it a bit to be able to use a `useMemo` to make `auth` also stable.

PS, modified the types a bit, unfortunately I'm not _that_ familiar with TS but the default installation was giving me types issues (before any code change, just by importing the files into the test file). So some of the changes were fixes, and the one modifying `UseAuthReturn` was because I had trouble with getting the highly-dynamic variable to work otherwise.

<!-- Fixes # (issue number) -->

#201 