### PR TITLE
Add org switcher functionality

### DIFF
--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -6,7 +6,7 @@ import ReactDOM from 'react-dom';
 
 import { PRESERVED_QUERYSTRING_PARAMS } from '../core/constants';
 import { clerkUIErrorDOMElementNotFound } from '../core/errors';
-import { OrganizationProfile } from './components/OrganizationProfile';
+import { OrganizationProfile, OrganizationProfileModal } from './components/OrganizationProfile';
 import { OrganizationSwitcher } from './components/OrganizationSwitcher';
 import { SignIn, SignInModal } from './components/SignIn';
 import { SignUp, SignUpModal } from './components/SignUp';
@@ -239,15 +239,8 @@ const Components = (props: ComponentsProps) => {
         <InternalThemeProvider>
           <Modal
             handleClose={() => componentsControls.closeModal('userProfile')}
-            containerSx={{
-              alignItems: 'center',
-            }}
-            contentSx={t => ({
-              height: `min(${t.sizes.$176}, calc(100% - ${t.sizes.$12}))`,
-              margin: 0,
-              // height: t.sizes.$176,
-              // maxHeight: `min(${t.sizes.$176}, calc(100vh - ${t.sizes.$20}))`,
-            })}
+            containerSx={{ alignItems: 'center' }}
+            contentSx={t => ({ height: `min(${t.sizes.$176}, calc(100% - ${t.sizes.$12}))`, margin: 0 })}
           >
             <VirtualRouter
               preservedParams={PRESERVED_QUERYSTRING_PARAMS}
@@ -273,17 +266,14 @@ const Components = (props: ComponentsProps) => {
           <Modal
             handleClose={() => componentsControls.closeModal('organizationProfile')}
             containerSx={{ alignItems: 'center' }}
-            contentSx={t => ({
-              height: `min(${t.sizes.$176}, calc(100% - ${t.sizes.$12}))`,
-              margin: 0,
-            })}
+            contentSx={t => ({ height: `min(${t.sizes.$176}, calc(100% - ${t.sizes.$12}))`, margin: 0 })}
           >
             <VirtualRouter
               preservedParams={PRESERVED_QUERYSTRING_PARAMS}
               onExternalNavigate={() => componentsControls.closeModal('organizationProfile')}
-              startPath='/user'
+              startPath='/organizationProfile'
             >
-              hello from org profil
+              <OrganizationProfileModal />
             </VirtualRouter>
           </Modal>
         </InternalThemeProvider>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -49,7 +49,7 @@ export const MembersListTable = (props: MembersListProps) => {
     comparator: (term, _, itemTerm) => (itemTerm || '').includes(term.toLowerCase()),
     searchTermForItem: searchTermForUser,
   });
-  const pageCount = Math.ceil(filteredItems.length / MAX_ROWS_PER_PAGE);
+  const pageCount = Math.ceil(filteredItems.length / MAX_ROWS_PER_PAGE) || 1;
   const startRowIndex = (page - 1) * MAX_ROWS_PER_PAGE;
   const endRowIndex = Math.min(page * MAX_ROWS_PER_PAGE, filteredItems.length);
 
@@ -116,12 +116,7 @@ export const MembersListTable = (props: MembersListProps) => {
 const EmptyRow = () => {
   return (
     <Tr>
-      <Td
-        sx={{ width: '25%' }}
-        colSpan={4}
-      >
-        No members to display
-      </Td>
+      <Td colSpan={3}>No members to display</Td>
     </Tr>
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfile.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfile.tsx
@@ -39,7 +39,7 @@ export const OrganizationProfile = withCardStateProvider(_OrganizationProfile);
 
 export const OrganizationProfileModal = (props: OrganizationProfileProps): JSX.Element => {
   type OrganizationProfileCtx = any;
-  const userProfileProps: OrganizationProfileCtx = {
+  const organizationProfileProps: OrganizationProfileCtx = {
     ...props,
     routing: 'virtual',
     componentName: 'OrganizationProfile',
@@ -48,10 +48,10 @@ export const OrganizationProfileModal = (props: OrganizationProfileProps): JSX.E
 
   return (
     <Route path='organizationProfile'>
-      {/*<ComponentContext.Provider value={userProfileProps}>*/}
+      {/*<ComponentContext.Provider value={organizationProfileProps}>*/}
       {/*TODO: Used by InvisibleRootBox, can we simplify? */}
       <div>
-        <OrganizationProfile {...userProfileProps} />
+        <OrganizationProfile {...organizationProfileProps} />
       </div>
       {/*</ComponentContext.Provider>*/}
     </Route>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfile.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfile.tsx
@@ -37,22 +37,21 @@ const AuthenticatedRoutes = withCoreUserGuard(() => {
 
 export const OrganizationProfile = withCardStateProvider(_OrganizationProfile);
 
-// @ts-ignore
 export const OrganizationProfileModal = (props: OrganizationProfileProps): JSX.Element => {
-  // const userProfileProps: OrganizationProfileCtx = {
-  //   ...props,
-  //   routing: 'virtual',
-  //   componentName: 'OrganizationProfile',
-  //   mode: 'modal',
-  // };
+  type OrganizationProfileCtx = any;
+  const userProfileProps: OrganizationProfileCtx = {
+    ...props,
+    routing: 'virtual',
+    componentName: 'OrganizationProfile',
+    mode: 'modal',
+  };
 
   return (
-    <Route path='user'>
+    <Route path='organizationProfile'>
       {/*<ComponentContext.Provider value={userProfileProps}>*/}
       {/*TODO: Used by InvisibleRootBox, can we simplify? */}
       <div>
-        {/*<OrganizationProfile {...userProfileProps} />*/}
-        <OrganizationProfile />
+        <OrganizationProfile {...userProfileProps} />
       </div>
       {/*</ComponentContext.Provider>*/}
     </Route>

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -1,7 +1,6 @@
-import { OrganizationResource } from '@clerk/types';
 import React from 'react';
 
-import { useCoreUser } from '../../contexts';
+import { useCoreOrganization, useCoreUser } from '../../contexts';
 import { Button, Flex, Icon, localizationKeys, Text } from '../../customizables';
 import { OrganizationPreview, PersonalWorkspacePreview } from '../../elements';
 import { Selector } from '../../icons';
@@ -11,25 +10,18 @@ type OrganizationSwitcherTriggerProps = PropsOfComponent<typeof Button> & { isOp
 
 export const OrganizationSwitcherTrigger = React.forwardRef<HTMLButtonElement, OrganizationSwitcherTriggerProps>(
   (props, ref) => {
-    // const organization = useCoreOrganization();
     const user = useCoreUser();
+    const { organization, isLoaded } = useCoreOrganization();
 
-    //Mocks
-    const hidePersonal = false;
-    const organization = { name: 'Test Org', logoUrl: user.profileImageUrl } as OrganizationResource;
+    // TODO: if org is undfined, isloaded returns false always
+    // if (!isLoaded) {
+    //   return null;
+    // }
 
-    const personalWorkspace = hidePersonal ? (
-      <Text localizationKey={localizationKeys('organizationSwitcher.notSelected')} />
-    ) : (
-      <PersonalWorkspacePreview
-        user={user}
-        rounded={false}
-      />
-    );
+    const showPersonalAccount = true;
 
     return (
       <Button
-        // elementDescriptor={descriptors.organizationSwitcherTrigger}
         variant='ghost'
         colorScheme='neutral'
         sx={theme => ({
@@ -39,16 +31,27 @@ export const OrganizationSwitcherTrigger = React.forwardRef<HTMLButtonElement, O
         ref={ref}
       >
         <Flex
-          // elementDescriptor={descriptors.organizationSwitcherTriggerBox}
           gap={4}
           center
         >
-          {organization ? <OrganizationPreview organization={organization} /> : personalWorkspace}
-
-          <Icon
-            // do we need a descriptor here?
-            icon={Selector}
-          />
+          {organization && (
+            <OrganizationPreview
+              size={'sm'}
+              organization={organization}
+              user={user}
+            />
+          )}
+          {!organization && !showPersonalAccount && (
+            <Text localizationKey={localizationKeys('organizationSwitcher.notSelected')} />
+          )}
+          {!organization && showPersonalAccount && (
+            <PersonalWorkspacePreview
+              user={user}
+              rounded={false}
+              size={'sm'}
+            />
+          )}
+          <Icon icon={Selector} />
         </Flex>
       </Button>
     );

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
@@ -1,51 +1,112 @@
+import { OrganizationResource } from '@clerk/types';
 import React from 'react';
 
-import { SwitchArrows } from '../../../ui/icons';
-import { Button, Flex, Icon } from '../../customizables';
+import { Plus, SwitchArrows } from '../../../ui/icons';
+import { useCoreOrganization, useCoreOrganizationList, useCoreUser } from '../../contexts';
+import { Box, Button, Icon, localizationKeys, Text } from '../../customizables';
 import {
+  Action,
   Actions,
   OrganizationPreview,
   OrganizationPreviewProps,
   PersonalWorkspacePreview,
-  PersonalWorkspacePreviewProps,
 } from '../../elements';
 import { useCardState } from '../../elements/contexts';
-import { PropsOfComponent } from '../../styledSystem';
+import { common, PropsOfComponent } from '../../styledSystem';
 
-export const OrganizationActions = (props: PropsOfComponent<typeof Flex>) => {
+type OrganizationActionListProps = {
+  onCreateOrganizationClick: React.MouseEventHandler;
+  onPersonalWorkspaceClick: React.MouseEventHandler;
+  onOrganizationClick: (org: OrganizationResource) => unknown;
+};
+
+export const OrganizationActionList = (props: OrganizationActionListProps) => {
+  const { onCreateOrganizationClick, onPersonalWorkspaceClick, onOrganizationClick } = props;
+  const { organizationList } = useCoreOrganizationList();
+  const { organization: currentOrg } = useCoreOrganization();
+  const user = useCoreUser();
+  const showPersonalAccount = true;
+
+  const otherOrgs = (organizationList || []).map(e => e.organization).filter(o => o.id !== currentOrg?.id);
+  console.log({ currentOrg, otherOrgs });
+
+  const createOrganizationButton = (
+    <Action
+      icon={Plus}
+      label={localizationKeys('organizationSwitcher.action__createOrganization')}
+      onClick={onCreateOrganizationClick}
+    />
+  );
+
   return (
     <Actions
-      sx={theme => ({
-        backgroundColor: theme.colors.$blackAlpha20,
-        border: `${theme.borders.$normal} ${theme.colors.$blackAlpha200}`,
+      sx={t => ({
+        backgroundColor: t.colors.$blackAlpha20,
+        border: `${t.borders.$normal} ${t.colors.$blackAlpha200}`,
         borderRight: 0,
         borderLeft: 0,
-        paddingTop: theme.space.$3,
-        paddingBottom: theme.space.$3,
+        paddingTop: t.space.$3,
+        paddingBottom: t.space.$3,
       })}
-      {...props}
-    />
+    >
+      {currentOrg && showPersonalAccount && (
+        <PersonalWorkspacePreviewButton
+          user={user}
+          sx={t => ({ marginBottom: t.space.$4 })}
+          onClick={onPersonalWorkspaceClick}
+        />
+      )}
+      {!!otherOrgs.length && (
+        <Text
+          size='xss'
+          colorScheme='neutral'
+          sx={t => ({
+            paddingLeft: t.space.$6,
+            marginBottom: t.space.$1,
+            textTransform: 'uppercase',
+          })}
+          localizationKey={localizationKeys('organizationSwitcher.listTitle')}
+        />
+      )}
+      <Box
+        sx={t => ({
+          maxHeight: `calc(3 * ${t.sizes.$14})`,
+          overflowY: 'scroll',
+          ...common.unstyledScrollbar(t),
+        })}
+      >
+        {otherOrgs.map(organization => (
+          <OrganizationPreviewButton
+            key={organization.id}
+            organization={organization}
+            user={user}
+            onClick={() => onOrganizationClick(organization)}
+          />
+        ))}
+      </Box>
+      {createOrganizationButton}
+    </Actions>
   );
 };
 
-type OrganizationPreviewButtonProps = PropsOfComponent<typeof Button> & OrganizationPreviewProps;
-
-export const OrganizationPreviewButton = (props: OrganizationPreviewButtonProps) => {
+export const OrganizationPreviewButton = (props: PropsOfComponent<typeof Button> & OrganizationPreviewProps) => {
   const card = useCardState();
-  const { organization, ...rest } = props;
+  const { organization, user, ...rest } = props;
+
   return (
     <Button
       variant='ghost'
       colorScheme='neutral'
       focusRing={false}
       isDisabled={card.isLoading}
+      block
       {...rest}
       sx={[
-        theme => ({
-          height: theme.sizes.$14,
+        t => ({
+          height: t.sizes.$14,
           borderRadius: 0,
           justifyContent: 'space-between',
-          padding: `${theme.space.$3} ${theme.space.$6}`,
+          padding: `${t.space.$3} ${t.space.$6}`,
           ':hover > svg': {
             visibility: 'initial',
           },
@@ -55,9 +116,9 @@ export const OrganizationPreviewButton = (props: OrganizationPreviewButtonProps)
     >
       <OrganizationPreview
         organization={organization}
+        user={user}
         size='sm'
       />
-
       <Icon
         icon={SwitchArrows}
         sx={t => ({ color: t.colors.$blackAlpha500, marginLeft: t.space.$2, visibility: 'hidden' })}
@@ -66,9 +127,9 @@ export const OrganizationPreviewButton = (props: OrganizationPreviewButtonProps)
   );
 };
 
-type PersonalWorkspacePreviewButtonProps = PropsOfComponent<typeof Button> & PersonalWorkspacePreviewProps;
-
-export const PersonalWorkspacePreviewButton = (props: PersonalWorkspacePreviewButtonProps) => {
+export const PersonalWorkspacePreviewButton = (
+  props: PropsOfComponent<typeof Button> & PropsOfComponent<typeof PersonalWorkspacePreview>,
+) => {
   const card = useCardState();
   const { user, ...rest } = props;
   return (
@@ -79,11 +140,11 @@ export const PersonalWorkspacePreviewButton = (props: PersonalWorkspacePreviewBu
       isDisabled={card.isLoading}
       {...rest}
       sx={[
-        theme => ({
-          height: theme.sizes.$14,
+        t => ({
+          height: t.sizes.$14,
           borderRadius: 0,
           justifyContent: 'space-between',
-          padding: `${theme.space.$3} ${theme.space.$6}`,
+          padding: `${t.space.$3} ${t.space.$6}`,
           ':hover > svg': {
             visibility: 'initial',
           },
@@ -95,7 +156,6 @@ export const PersonalWorkspacePreviewButton = (props: PersonalWorkspacePreviewBu
         user={user}
         size='sm'
       />
-
       <Icon
         icon={SwitchArrows}
         sx={t => ({ color: t.colors.$blackAlpha500, marginLeft: t.space.$2, visibility: 'hidden' })}

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -1,7 +1,7 @@
 import { OrganizationResource, UserResource } from '@clerk/types';
 import React from 'react';
 
-import { Flex, Text } from '../customizables';
+import { Flex, localizationKeys, Text } from '../customizables';
 import { PropsOfComponent } from '../styledSystem';
 import { OrganizationAvatar } from './OrganizationAvatar';
 
@@ -17,25 +17,20 @@ export type OrganizationPreviewProps = PropsOfComponent<typeof Flex> & {
 
 export const OrganizationPreview = (props: OrganizationPreviewProps) => {
   const { organization, size = 'md', icon, rounded = false, badge, sx, user, ...rest } = props;
+  const role = user?.organizationMemberships.find(membership => membership.organization.id === organization.id)?.role;
 
   return (
     <Flex
-      // elementDescriptor={descriptors.organizationPreview}
-      // elementId={descriptors.organizationPreview.setId(elementId)}
       gap={3}
       align='center'
       sx={[{ minWidth: '0px', width: '100%' }, sx]}
       {...rest}
     >
       <Flex
-        // elementDescriptor={descriptors.organizationPreviewAvatarContainer}
-        // elementId={descriptors.userPreviewAvatarContainer.setId(elementId)}
         justify='center'
         sx={{ position: 'relative' }}
       >
         <OrganizationAvatar
-          // boxElementDescriptor={descriptors.organizationPreviewAvatarBox}
-          // imageElementDescriptor={descriptors.organizationPreviewAvatarImage}
           {...organization}
           size={t => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size])}
           optimize
@@ -44,15 +39,11 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
         {icon && <Flex sx={{ position: 'absolute', left: 0, bottom: 0 }}>{icon}</Flex>}
       </Flex>
       <Flex
-        // elementDescriptor={descriptors.organizationPreviewTextContainer}
-        // elementId={descriptors.organizationPreviewTextContainer.setId(elementId)}
         direction='col'
         justify='center'
         sx={{ minWidth: '0px', textAlign: 'left' }}
       >
         <Text
-          // elementDescriptor={descriptors.organizationPreviewMainIdentifier}
-          // elementId={descriptors.organizationPreviewMainIdentifier.setId(elementId)}
           variant={size === 'md' ? 'regularMedium' : 'smallMedium'}
           truncate
         >
@@ -60,15 +51,18 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
         </Text>
         {organization.name && (
           <Text
-            // elementDescriptor={descriptors.organizationPreviewSecondaryIdentifier}
-            //   elementId={descriptors.organizationPreviewSecondaryIdentifier.setId(elementId)}
+            localizationKey={
+              role &&
+              {
+                admin: localizationKeys('membershipRole__admin'),
+                basic_member: localizationKeys('membershipRole__basicMember'),
+                guest_member: localizationKeys('membershipRole__guestMember'),
+              }[role]
+            }
             variant='smallRegular'
             colorScheme='neutral'
             truncate
-          >
-            {/*{role}*/}
-            {user && 'Member'}
-          </Text>
+          />
         )}
       </Flex>
     </Flex>

--- a/packages/clerk-js/src/ui/elements/PersonalWorkspacePreview.tsx
+++ b/packages/clerk-js/src/ui/elements/PersonalWorkspacePreview.tsx
@@ -1,82 +1,12 @@
-import { UserResource } from '@clerk/types';
-import React from 'react';
+import { localizationKeys } from '../localization';
+import { UserPreview, UserPreviewProps } from './UserPreview';
 
-import { Flex, localizationKeys, Text } from '../customizables';
-import { PropsOfComponent } from '../styledSystem';
-import { getFullName, getIdentifier } from '../utils';
-import { UserAvatar } from './UserAvatar';
-
-export type PersonalWorkspacePreviewProps = PropsOfComponent<typeof Flex> & {
-  user: Partial<UserResource>;
-  size?: 'lg' | 'md' | 'sm';
-  icon?: React.ReactNode;
-  badge?: React.ReactNode;
-  imageUrl?: string | null;
-  rounded?: boolean;
-  elementId?: any;
-};
-
-export const PersonalWorkspacePreview = (props: PersonalWorkspacePreviewProps) => {
-  const { user, size = 'md', icon, rounded = false, imageUrl, badge, elementId, sx, ...rest } = props;
-  const name = getFullName(user);
-  const identifier = getIdentifier(user);
-
+export const PersonalWorkspacePreview = (props: Omit<UserPreviewProps, 'subtitle'>) => {
   return (
-    <Flex
-      // elementDescriptor={descriptors.personalWorkspacePreview}
-      // elementId={descriptors.personalWorkspace.setId(elementId)}
-      gap={4}
-      align='center'
-      sx={[
-        {
-          minWidth: '0px',
-          width: '100%',
-        },
-        sx,
-      ]}
-      {...rest}
-    >
-      <Flex
-        // elementDescriptor={descriptors.personalWorkspaceAvatarContainer}
-        // elementId={descriptors.personalWorkspacePreviewAvatarContainer.setId(elementId)}
-        justify='center'
-        sx={theme => ({ position: 'relative', flex: `0 0 ${theme.sizes.$11}` })}
-      >
-        <UserAvatar
-          // boxElementDescriptor={descriptors.personalWorkspacePreviewAvatarBox}
-          // imageElementDescriptor={descriptors.personalWorkspacePreviewAvatarImage}
-          {...user}
-          imageUrl={imageUrl || user.profileImageUrl}
-          size={theme => ({ sm: theme.sizes.$8, md: theme.sizes.$11, lg: theme.sizes.$12x5 }[size])}
-          optimize
-          rounded={rounded}
-        />
-        {icon && <Flex sx={{ position: 'absolute', left: 0, bottom: 0 }}>{icon}</Flex>}
-      </Flex>
-      <Flex
-        // elementDescriptor={descriptors.personalWorkspacePreviewTextContainer}
-        // elementId={descriptors.personalWorkspacePreviewTextContainer.setId(elementId)}
-        direction='col'
-        justify='center'
-        sx={{ minWidth: '0px', textAlign: 'left' }}
-      >
-        <Text
-          // elementDescriptor={descriptors.personalWorkspacePreviewMainIdentifier}
-          // elementId={descriptors.personalWorkspacePreviewMainIdentifier.setId(elementId)}
-          variant={size === 'md' ? 'regularMedium' : 'smallMedium'}
-          truncate
-        >
-          {name || identifier} {badge}
-        </Text>
-        <Text
-          // elementDescriptor={descriptors.personalWorkspacePreviewSecondaryIdentifier}
-          // elementId={descriptors.personalWorkspacePreviewSecondaryIdentifier.setId(elementId)}
-          variant='smallRegular'
-          colorScheme='neutral'
-          truncate
-          localizationKey={localizationKeys('organizationSwitcher.personalWorkspace')}
-        />
-      </Flex>
-    </Flex>
+    <UserPreview
+      rounded={false}
+      subtitle={localizationKeys('organizationSwitcher.personalWorkspace')}
+      {...props}
+    />
   );
 };

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -1,7 +1,7 @@
 import { UserResource } from '@clerk/types';
 import React from 'react';
 
-import { descriptors, Flex, Text } from '../customizables';
+import { descriptors, Flex, LocalizationKey, Text } from '../customizables';
 import { PropsOfComponent } from '../styledSystem';
 import { getFullName, getIdentifier } from '../utils';
 import { UserAvatar } from './UserAvatar';
@@ -14,10 +14,11 @@ export type UserPreviewProps = PropsOfComponent<typeof Flex> & {
   imageUrl?: string | null;
   rounded?: boolean;
   elementId?: any;
+  subtitle?: LocalizationKey;
 };
 
 export const UserPreview = (props: UserPreviewProps) => {
-  const { user, size = 'md', icon, rounded = true, imageUrl, badge, elementId, sx, ...rest } = props;
+  const { user, size = 'md', icon, rounded = true, imageUrl, badge, elementId, sx, subtitle, ...rest } = props;
   const name = getFullName(user);
   const identifier = getIdentifier(user);
 
@@ -27,13 +28,7 @@ export const UserPreview = (props: UserPreviewProps) => {
       elementId={descriptors.userPreview.setId(elementId)}
       gap={4}
       align='center'
-      sx={[
-        {
-          minWidth: '0px',
-          width: '100%',
-        },
-        sx,
-      ]}
+      sx={[{ minWidth: '0px', width: '100%' }, sx]}
       {...rest}
     >
       <Flex
@@ -68,16 +63,15 @@ export const UserPreview = (props: UserPreviewProps) => {
         >
           {name || identifier} {badge}
         </Text>
-        {name && identifier && (
+        {(subtitle || (name && identifier)) && (
           <Text
             elementDescriptor={descriptors.userPreviewSecondaryIdentifier}
             elementId={descriptors.userPreviewSecondaryIdentifier.setId(elementId)}
             variant='smallRegular'
             colorScheme='neutral'
             truncate
-          >
-            {identifier}
-          </Text>
+            localizationKey={subtitle || identifier}
+          />
         )}
       </Flex>
     </Flex>

--- a/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
@@ -30,13 +30,22 @@ const useCardState = () => {
   const { state, setState } = _useCardState();
   const { translateError } = useLocalizations();
 
+  const setIdle = (metadata?: Metadata) => setState(s => ({ ...s, status: 'idle', metadata }));
+  const setError = (metadata: ClerkAPIError | Metadata) => setState(s => ({ ...s, error: translateError(metadata) }));
+  const setLoading = (metadata?: Metadata) => setState(s => ({ ...s, status: 'loading', metadata }));
+  const runAsync = async (cb: () => Promise<unknown>) => {
+    setLoading();
+    return cb().then(res => {
+      setIdle();
+      return res;
+    });
+  };
+
   return {
-    setIdle: (metadata?: Metadata) => setState(s => ({ ...s, status: 'idle', metadata })),
-    setError: (metadata: ClerkAPIError | Metadata) =>
-      setState(s => {
-        return { ...s, error: translateError(metadata) };
-      }),
-    setLoading: (metadata?: Metadata) => setState(s => ({ ...s, status: 'loading', metadata })),
+    setIdle,
+    setError,
+    setLoading,
+    runAsync,
     loadingMetadata: state.status === 'loading' ? state.metadata : undefined,
     error: state.error ? state.error : undefined,
     isLoading: state.status === 'loading',

--- a/packages/clerk-js/src/ui/localization/defaultEnglishResource.ts
+++ b/packages/clerk-js/src/ui/localization/defaultEnglishResource.ts
@@ -59,6 +59,9 @@ export const defaultResource: DeepRequired<LocalizationResource> = {
   paginationButton__next: 'Next',
   paginationRowText__displaying: 'Displaying',
   paginationRowText__of: 'of',
+  membershipRole__admin: 'Admin',
+  membershipRole__basicMember: 'Member',
+  membershipRole__guestMember: 'Guest',
   signUp: {
     start: {
       title: 'Create your account',
@@ -402,7 +405,7 @@ export const defaultResource: DeepRequired<LocalizationResource> = {
     action__addAccount: 'Add account',
   },
   organizationSwitcher: {
-    title: 'Organizations',
+    listTitle: 'Organizations',
     personalWorkspace: 'Personal Workspace',
     notSelected: 'No organization selected',
     action__createOrganization: 'Create Organization',

--- a/packages/clerk-js/src/ui/styledSystem/common.ts
+++ b/packages/clerk-js/src/ui/styledSystem/common.ts
@@ -181,21 +181,25 @@ const centeredFlex = (display: 'flex' | 'inline-flex' = 'flex') => ({
   alignItems: 'center',
 });
 
+const unstyledScrollbar = (t: InternalTheme) => ({
+  '::-webkit-scrollbar': {
+    background: 'transparent',
+    width: '8px',
+    height: '8px',
+  },
+  '::-webkit-scrollbar-thumb': {
+    background: t.colors.$blackAlpha500,
+  },
+  '::-webkit-scrollbar-track': {
+    background: 'transparent',
+  },
+});
+
 const maxHeightScroller = (t: InternalTheme) =>
   ({
     height: '100%',
     overflowY: 'scroll',
-    '::-webkit-scrollbar': {
-      background: 'transparent',
-      width: '8px',
-      height: '8px',
-    },
-    '::-webkit-scrollbar-thumb': {
-      background: t.colors.$blackAlpha500,
-    },
-    '::-webkit-scrollbar-track': {
-      background: 'transparent',
-    },
+    ...unstyledScrollbar(t),
   } as const);
 
 export const common = {
@@ -208,4 +212,5 @@ export const common = {
   borderColor,
   centeredFlex,
   maxHeightScroller,
+  unstyledScrollbar,
 };

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -59,6 +59,9 @@ type _LocalizationResource = {
   paginationButton__next: LocalizationValue;
   paginationRowText__displaying: LocalizationValue;
   paginationRowText__of: LocalizationValue;
+  membershipRole__admin: LocalizationValue;
+  membershipRole__basicMember: LocalizationValue;
+  membershipRole__guestMember: LocalizationValue;
   signUp: {
     start: {
       title: LocalizationValue;
@@ -400,7 +403,7 @@ type _LocalizationResource = {
     action__addAccount: LocalizationValue;
   };
   organizationSwitcher: {
-    title: LocalizationValue;
+    listTitle: LocalizationValue;
     personalWorkspace: LocalizationValue;
     notSelected: LocalizationValue;
     action__createOrganization: LocalizationValue;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Adds org-switching functionality to OrganizationSwitcher
- Some small refactors here and there, nothing too big

WIP: 
- Create organization button is a noop for now
- showPersonalAccount is still hardcoded
<!-- Fixes # (issue number) -->
https://www.notion.so/clerkdev/ClerkJS-Orgs-Introduce-OrganizationSwitcher-55803f6a78374fa181cdb6a9234803f2