### PR TITLE
fix(clerk-js): Fallback to Default Gravatar when not provided an imageUrl

### DIFF
--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -35,7 +35,9 @@ export const Avatar = (props: AvatarProps) => {
   const avatarExists = hasAvatar(imageUrl);
   let src;
 
-  if (avatarExists && !optimize && imageUrl) {
+  if (!avatarExists) {
+    src = GRAVATAR_DEFAULT_AVATAR;
+  } else if (!optimize && imageUrl) {
     const optimizedHeight = Math.max(imageFetchSize) * (isRetinaDisplay() ? 2 : 1);
     const srcUrl = new URL(imageUrl);
     srcUrl.searchParams.append('height', optimizedHeight.toString());
@@ -98,6 +100,7 @@ const InitialsAvatarFallback = (props: { initials: string }) => {
   );
 };
 
+const GRAVATAR_DEFAULT_AVATAR = 'https://www.gravatar.com/avatar?d=mp';
 const CLERK_IMAGE_URL_REGEX = /https:\/\/images\.(lcl)?clerk/i;
 
 // TODO: How do we want to handle this?


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Re-provide a fallback url for the `Avatar` element.

<!-- Fixes # (issue number) -->
