### PR TITLE
fix(clerk-js): Wrap ImpersonationFab with withCoreUserGuard

### DIFF
--- a/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
+++ b/packages/clerk-js/src/ui/ImpersonationFab/ImpersonationFab.tsx
@@ -2,7 +2,7 @@ import React, { PointerEventHandler, useEffect, useRef } from 'react';
 
 import { mqu, PropsOfComponent } from '../../ui/styledSystem';
 import { getFullName, getIdentifier } from '../../ui/utils';
-import { useCoreClerk, useCoreSession, withCoreSessionSwitchGuard } from '../contexts';
+import { useCoreClerk, useCoreSession, withCoreUserGuard } from '../contexts';
 import {
   Col,
   descriptors,
@@ -228,4 +228,4 @@ const _ImpersonationFab = () => {
   );
 };
 
-export const ImpersonationFab = withCoreSessionSwitchGuard(_ImpersonationFab);
+export const ImpersonationFab = withCoreUserGuard(_ImpersonationFab);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Correctly guard the ImpersonationFab from throwing during the session switch flow (user -> undefined -> user), or when the user is signed out (null)
<!-- Fixes # (issue number) -->
