### PR TITLE
chore(clerk-js): Introduce Organization.inviteMembers for sending bul…

### DIFF
--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -157,7 +157,7 @@ export default function createFapiClient(clerkInstance: Clerk): FapiClient {
     // In case FormData is provided, we don't want to mess with the headers,
     // because for file uploads the header is properly set by the browser.
     if (method !== 'GET' && !(body instanceof FormData)) {
-      requestInit.body = qs.stringify(body, { encoder: camelToSnakeEncoder });
+      requestInit.body = qs.stringify(body, { encoder: camelToSnakeEncoder, indices: false });
       // @ts-ignore
       requestInit.headers.set('Content-Type', 'application/x-www-form-urlencoded');
     }

--- a/packages/clerk-js/src/core/resources/Error.ts
+++ b/packages/clerk-js/src/core/resources/Error.ts
@@ -37,6 +37,7 @@ export function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {
     meta: {
       paramName: error?.meta?.param_name,
       sessionId: error?.meta?.session_id,
+      emailAddresses: error?.meta?.email_addresses,
     },
   };
 }

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -1,13 +1,16 @@
 import type {
+  AddMemberParams,
   CreateOrganizationParams,
   GetMembershipsParams,
   GetPendingInvitationsParams,
-  MembershipRole,
+  InviteMemberParams,
+  InviteMembersParams,
   OrganizationInvitationJSON,
   OrganizationJSON,
   OrganizationMembershipJSON,
   OrganizationResource,
   SetOrganizationLogoParams,
+  UpdateMembershipParams,
   UpdateOrganizationParams,
 } from '@clerk/types';
 
@@ -100,8 +103,12 @@ export class Organization extends BaseResource implements OrganizationResource {
     return newMember;
   };
 
-  inviteMember = async (inviteMemberParams: InviteMemberParams) => {
-    return await OrganizationInvitation.create(this.id, inviteMemberParams);
+  inviteMember = async (params: InviteMemberParams) => {
+    return OrganizationInvitation.create(this.id, params);
+  };
+
+  inviteMembers = async (params: InviteMembersParams) => {
+    return OrganizationInvitation.createMany(this.id, params);
   };
 
   updateMember = async ({ userId, role }: UpdateMembershipParams): Promise<OrganizationMembership> => {
@@ -149,24 +156,3 @@ export class Organization extends BaseResource implements OrganizationResource {
     return this;
   }
 }
-
-export type GetOrganizationParams = {
-  limit?: number;
-  offset?: number;
-};
-
-export type AddMemberParams = {
-  userId: string;
-  role: MembershipRole;
-};
-
-export type InviteMemberParams = {
-  emailAddress: string;
-  role: MembershipRole;
-  redirectUrl?: string;
-};
-
-export type UpdateMembershipParams = {
-  userId: string;
-  role: MembershipRole;
-};

--- a/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
@@ -1,4 +1,6 @@
 import {
+  CreateManyOrganizationInvitationParams,
+  CreateOrganizationInvitationParams,
   MembershipRole,
   OrganizationInvitationJSON,
   OrganizationInvitationResource,
@@ -25,17 +27,30 @@ export class OrganizationInvitation extends BaseResource implements Organization
       await BaseResource._fetch<OrganizationInvitationJSON>({
         path: `/organizations/${organizationId}/invitations`,
         method: 'POST',
-        body: {
-          email_address: emailAddress,
-          role,
-          redirect_url: redirectUrl,
-        } as any,
+        body: { email_address: emailAddress, role, redirect_url: redirectUrl } as any,
       })
     )?.response as unknown as OrganizationInvitationJSON;
-
     const newInvitation = new OrganizationInvitation(json);
     this.clerk.__unstable__invitationUpdate(newInvitation);
     return newInvitation;
+  }
+
+  static async createMany(
+    organizationId: string,
+    params: CreateManyOrganizationInvitationParams,
+  ): Promise<OrganizationInvitationResource[]> {
+    const { emailAddresses, redirectUrl, role } = params;
+    const json = (
+      await BaseResource._fetch<OrganizationInvitationJSON>({
+        path: `/organizations/${organizationId}/invitations/bulk`,
+        method: 'POST',
+        body: { email_address: emailAddresses, role, redirect_url: redirectUrl } as any,
+      })
+    )?.response as unknown as OrganizationInvitationJSON[];
+    // const newInvitation = new OrganizationInvitation(json);
+    // TODO: Figure out what this is...
+    // this.clerk.__unstable__invitationUpdate(newInvitation);
+    return json.map(invitationJson => new OrganizationInvitation(invitationJson));
   }
 
   constructor(data: OrganizationInvitationJSON) {
@@ -62,9 +77,3 @@ export class OrganizationInvitation extends BaseResource implements Organization
     return this;
   }
 }
-
-export type CreateOrganizationInvitationParams = {
-  emailAddress: string;
-  role: MembershipRole;
-  redirectUrl?: string;
-};

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -8,6 +8,7 @@ export interface ClerkAPIError {
   meta?: {
     paramName?: string;
     sessionId?: string;
+    emailAddresses?: string[];
   };
 }
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -597,6 +597,12 @@ export type CreateOrganizationInvitationParams = {
   redirectUrl?: string;
 };
 
+export type CreateManyOrganizationInvitationParams = {
+  emailAddresses: string[];
+  role: MembershipRole;
+  redirectUrl?: string;
+};
+
 export interface CreateOrganizationParams {
   name: string;
   slug?: string;

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -231,6 +231,7 @@ export interface ClerkAPIErrorJSON {
   meta?: {
     param_name?: string;
     session_id?: string;
+    email_addresses?: string[];
   };
 }
 

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -1,7 +1,6 @@
 import { ClerkPaginationParams } from './api';
 import { OrganizationInvitationResource } from './organizationInvitation';
-import { OrganizationMembershipResource } from './organizationMembership';
-import { MembershipRole } from './organizationMembership';
+import { MembershipRole, OrganizationMembershipResource } from './organizationMembership';
 
 declare global {
   /**
@@ -27,6 +26,7 @@ export interface OrganizationResource {
   getPendingInvitations: (params?: GetPendingInvitationsParams) => Promise<OrganizationInvitationResource[]>;
   addMember: (params: AddMemberParams) => Promise<OrganizationMembershipResource>;
   inviteMember: (params: InviteMemberParams) => Promise<OrganizationInvitationResource>;
+  inviteMembers: (params: InviteMembersParams) => Promise<OrganizationInvitationResource[]>;
   updateMember: (params: UpdateMembershipParams) => Promise<OrganizationMembershipResource>;
   removeMember: (userId: string) => Promise<OrganizationMembershipResource>;
   destroy: () => Promise<void>;
@@ -44,6 +44,12 @@ export interface AddMemberParams {
 
 export interface InviteMemberParams {
   emailAddress: string;
+  role: MembershipRole;
+  redirectUrl?: string;
+}
+
+export interface InviteMembersParams {
+  emailAddresses: string[];
   role: MembershipRole;
   redirectUrl?: string;
 }


### PR DESCRIPTION
…k invites

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR introduces the `Organization.inviteMembers` API and the necessary `OrganizationInvitation.createMany` method that uses the newly introduced `/invitations/bulk` FAPI endpoint.

Even though the implementation is straightforward, I'd like your feedback regarding the naming of the methods described above, as this is the first time we're introducing  "bulk" capabilities for an existing method/endpoint.

## Example usage
```ts
  const onSubmit = async (e: React.FormEvent) => {
    e.preventDefault();
    return organization
      .inviteMembers({ emailAddresses: [ 'hey@clerk.dev', 'hello@clerk.dev' ], role: 'basic_member' })
      .then(wizard.nextStep)
      .catch(handleError);
  };
```

## Remaining tasks:
It is currently unclear to me how the `this.clerk.__unstable__invitationUpdate(newInvitation);` line that is commented out behaves. I'll have to investigate more and possibly refactor the flow a bit to make things more readable, but this can be done in a separate PR.

## Extra context
In case it helps, the UI using the above looks like this:
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/1811063/198153446-abfaf381-751f-4269-8e9b-07a9f016a1ca.png">

<!-- Fixes # (issue number) -->
