### PR TITLE
feat(clerk-js): Show text for organization roles when not an admin

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -2,7 +2,7 @@ import { MembershipRole, OrganizationMembershipResource } from '@clerk/types';
 import React, { useState } from 'react';
 
 import { useCoreOrganization, useCoreUser } from '../../contexts';
-import { Badge, localizationKeys, Td } from '../../customizables';
+import { Badge, localizationKeys, Td, Text } from '../../customizables';
 import { ThreeDotsMenu, useCardState, usePagination, UserPreview } from '../../elements';
 import { handleError } from '../../utils';
 import { MembersListTable, RoleSelect, RowContainer } from './MemberListTable';
@@ -72,11 +72,15 @@ const MemberRow = (props: { membership: OrganizationMembershipResource }) => {
       </Td>
       <Td>{membership.createdAt.toLocaleDateString()}</Td>
       <Td>
-        <RoleSelect
-          isDisabled={!isAdmin || card.isLoading}
-          value={role}
-          onChange={handleRoleChange}
-        />
+        {isAdmin ? (
+          <RoleSelect
+            isDisabled={card.isLoading}
+            value={role}
+            onChange={handleRoleChange}
+          />
+        ) : (
+          <Text>{role}</Text>
+        )}
       </Td>
       <Td>
         {isAdmin && (


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
When not an Organization admin, show text instead of the role `<Select/>`.
<!-- Fixes # (issue number) -->
