### PR TITLE
feat(clerk-js,types): Organization invitation metadata

### DIFF
--- a/packages/clerk-js/src/core/resources/OrganizationInvitation.test.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationInvitation.test.ts
@@ -7,6 +7,9 @@ describe('OrganizationInvitation', () => {
       email_address: 'test_email',
       id: 'test_id',
       organization_id: 'test_organization_id',
+      public_metadata: {
+        public: 'metadata',
+      },
       role: 'basic_member',
       created_at: 12345,
       updated_at: 5678,

--- a/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
@@ -12,6 +12,7 @@ export class OrganizationInvitation extends BaseResource implements Organization
   id!: string;
   emailAddress!: string;
   organizationId!: string;
+  publicMetadata: Record<string, unknown> = {};
   status!: OrganizationInvitationStatus;
   role!: MembershipRole;
   createdAt!: Date;
@@ -19,7 +20,7 @@ export class OrganizationInvitation extends BaseResource implements Organization
 
   static async create(
     organizationId: string,
-    { emailAddress, role, redirectUrl }: CreateOrganizationInvitationParams,
+    { emailAddress, role, redirectUrl, publicMetadata }: CreateOrganizationInvitationParams,
   ): Promise<OrganizationInvitationResource> {
     const json = (
       await BaseResource._fetch<OrganizationInvitationJSON>({
@@ -29,6 +30,7 @@ export class OrganizationInvitation extends BaseResource implements Organization
           email_address: emailAddress,
           role,
           redirect_url: redirectUrl,
+          public_metadata: JSON.stringify(publicMetadata),
         } as any,
       })
     )?.response as unknown as OrganizationInvitationJSON;
@@ -55,6 +57,7 @@ export class OrganizationInvitation extends BaseResource implements Organization
     this.id = data.id;
     this.emailAddress = data.email_address;
     this.organizationId = data.organization_id;
+    this.publicMetadata = data.public_metadata;
     this.role = data.role;
     this.status = data.status;
     this.createdAt = unixEpochToDate(data.created_at);
@@ -67,4 +70,5 @@ export type CreateOrganizationInvitationParams = {
   emailAddress: string;
   role: MembershipRole;
   redirectUrl?: string;
+  publicMetadata?: Record<string, unknown>;
 };

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationInvitation.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationInvitation.test.ts.snap
@@ -7,6 +7,9 @@ OrganizationInvitation {
   "id": "test_id",
   "organizationId": "test_organization_id",
   "pathRoot": "",
+  "publicMetadata": Object {
+    "public": "metadata",
+  },
   "revoke": [Function],
   "role": "basic_member",
   "status": "pending",

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -275,8 +275,9 @@ export interface OrganizationMembershipJSON extends ClerkResourceJSON {
 export interface OrganizationInvitationJSON extends ClerkResourceJSON {
   object: 'organization_invitation';
   id: string;
-  organization_id: string;
   email_address: string;
+  organization_id: string;
+  public_metadata: Record<string, unknown>;
   status: OrganizationInvitationStatus;
   role: MembershipRole;
   created_at: number;

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -45,6 +45,7 @@ export interface AddMemberParams {
 export interface InviteMemberParams {
   emailAddress: string;
   role: MembershipRole;
+  publicMetadata?: Record<string, unknown>;
   redirectUrl?: string;
 }
 

--- a/packages/types/src/organizationInvitation.ts
+++ b/packages/types/src/organizationInvitation.ts
@@ -1,9 +1,21 @@
 import { MembershipRole } from './organizationMembership';
 
+declare global {
+  /**
+   * If you want to provide custom types for the organizationInvitation.publicMetadata
+   * object, simply redeclare this rule in the global namespace.
+   * Every organizationInvitation object will use the provided type.
+   */
+  interface OrganizationInvitationPublicMetadata {
+    [k: string]: unknown;
+  }
+}
+
 export interface OrganizationInvitationResource {
   id: string;
   emailAddress: string;
   organizationId: string;
+  publicMetadata: OrganizationInvitationPublicMetadata;
   role: MembershipRole;
   status: OrganizationInvitationStatus;
   createdAt: Date;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Added support for OrganizationInvitation publicMetadata. 

They can be set when calling the Organization#inviteMember() method.

<!-- Fixes # (issue number) -->
