### PR TITLE
feat(backend-core): Organization invitation metadata

### DIFF
--- a/packages/backend-core/API.md
+++ b/packages/backend-core/API.md
@@ -291,6 +291,8 @@ Create an invitation to join an organization and send an email to the email addr
 
 You must pass the ID of the user that invites the new member as `inviterUserId`. The inviter user must be an administrator in the organization.
 
+You can optionally pass metadata for the organization invitation with the `publicMetadata` field. These metadata will be accessible from both the Frontend and the Backend. Once the invitation is accepted, the metadata will be transferred to the newly created organization membership.
+
 Available parameters:
 
 - _organizationId_ The unique ID of the organization the invitation is about.
@@ -298,6 +300,7 @@ Available parameters:
 - _role_ The new member's role in the organization.
 - _inviterUserId_ The ID of the organization administrator that invites the new member.
 - _redirectUrl_ An optional URL to redirect to after the invited member clicks the link from the invitation email.
+- _publicMetadata_ Optionally pass metadata for the organization invitation which will be visible to both your Frontend and Backend.
 
 ```js
 const invitation = await clerkAPI.organizations.createOrganizationInvitation({

--- a/packages/backend-core/src/__tests__/endpoints/OrganizationApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/OrganizationApi.test.ts
@@ -348,11 +348,13 @@ test('createOrganizationInvitation() creates an invitation for an organization',
   const status: OrganizationInvitationStatus = 'pending';
   const emailAddress = 'invitation@example.com';
   const redirectUrl = 'https://example.com';
+  const publicMetadata = { foo: 'bar' };
   const resJSON: OrganizationInvitationJSON = {
     object: ObjectType.OrganizationInvitation,
     id: 'orginv_randomid',
     role,
     status,
+    public_metadata: publicMetadata,
     email_address: emailAddress,
     organization_id: organizationId,
     created_at: 1612378465,
@@ -366,6 +368,7 @@ test('createOrganizationInvitation() creates an invitation for an organization',
     emailAddress,
     role,
     redirectUrl,
+    publicMetadata,
     inviterUserId: 'user_randomid',
   });
   expect(orgInvitation).toEqual(OrganizationInvitation.fromJSON(resJSON));
@@ -381,6 +384,7 @@ test('getPendingOrganizationInvitationList() returns a list of organization memb
       email_address: 'invited@example.org',
       organization_id: organizationId,
       status: 'pending',
+      public_metadata: {},
       created_at: 1612378465,
       updated_at: 1612378465,
     },
@@ -408,6 +412,7 @@ test('revokeOrganizationInvitation() revokes an organization invitation', async 
     email_address: 'invited@example.org',
     organization_id: organizationId,
     status: 'revoked',
+    public_metadata: {},
     created_at: 1612378465,
     updated_at: 1612378465,
   };

--- a/packages/backend-core/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend-core/src/api/endpoints/OrganizationApi.ts
@@ -59,6 +59,7 @@ type CreateOrganizationInvitationParams = {
   inviterUserId: string;
   emailAddress: string;
   role: OrganizationMembershipRole;
+  publicMetadata?: Record<string, unknown>;
   redirectUrl?: string;
 };
 

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -125,6 +125,7 @@ export interface OrganizationJSON extends ClerkResourceJSON {
 export interface OrganizationInvitationJSON extends ClerkResourceJSON {
   email_address: string;
   organization_id: string;
+  public_metadata: Record<string, unknown>;
   role: OrganizationMembershipRole;
   status: OrganizationInvitationStatus;
   created_at: number;

--- a/packages/backend-core/src/api/resources/OrganizationInvitation.ts
+++ b/packages/backend-core/src/api/resources/OrganizationInvitation.ts
@@ -9,6 +9,7 @@ export class OrganizationInvitation {
     readonly organizationId: string,
     readonly createdAt: number,
     readonly updatedAt: number,
+    readonly publicMetadata: Record<string, unknown> = {},
     readonly status?: OrganizationInvitationStatus,
   ) {}
 
@@ -20,6 +21,7 @@ export class OrganizationInvitation {
       data.organization_id,
       data.created_at,
       data.updated_at,
+      data.public_metadata,
       data.status,
     );
   }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Added support for passing public metadata when creating an organization invitation.
<!-- Fixes # (issue number) -->
