### PR TITLE
fix(clerk-js): Fix globalObject for UMD packaging

### DIFF
--- a/packages/clerk-js/webpack.dev.js
+++ b/packages/clerk-js/webpack.dev.js
@@ -37,6 +37,7 @@ const getProductionConfig = (mode = 'production') => {
       path: path.resolve(__dirname, 'dist'),
       filename: '[name].js',
       libraryTarget: 'umd',
+      globalObject: 'globalThis',
     },
   };
 };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Current our webpack-powered UMD packaging was setting `seld` as the output global object.

Historically, accessing the global object has required different syntax in different JavaScript environments. On the web you can use window, self, or frames - but in Web Workers only self will work. In Node.js none of these work, and you must instead use global. The this keyword could be used inside functions running in non–strict mode, but this will be undefined in Modules and inside functions running in strict mode. You can also use Function('return this')(), but environments that disable eval(), like CSP in browsers, prevent use of Function in this way.

This issue came up in Remix when ClerkJS is not hotloaded and should be bundled in the application. To fix it we use the `globalThis`.

<img width="500" alt="Screenshot 2022-11-01 at 3 38 24 PM" src="https://user-images.githubusercontent.com/1352422/199275771-251c2707-2f45-44d3-94ae-c66e1104f41d.png">

<img width="498" alt="Screenshot 2022-11-01 at 3 36 29 PM" src="https://user-images.githubusercontent.com/1352422/199275783-bd022a17-af2b-472b-bebd-45d5dfff2566.png">



The globalThis property provides a standard way of accessing the global this value (and hence the global object itself) across environments. Unlike similar properties such as window and self, it's guaranteed to work in window and non-window contexts. In this way, you can access the global object in a consistent manner without having to know which environment the code is being run in.

More information at:
- https://webpack.js.org/configuration/output/#outputglobalobject
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
