### PR TITLE
feat(clerk-js): Improve Popover behaviour

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -1,14 +1,13 @@
 import { withOrganizationsEnabledGuard } from '../../common';
 import { withCoreUserGuard } from '../../contexts';
 import { Flow } from '../../customizables';
-import { withCardStateProvider } from '../../elements';
-import { Portal } from '../../elements/Portal';
+import { Popover, withCardStateProvider, withFloatingTree } from '../../elements';
 import { usePopover } from '../../hooks';
 import { OrganizationSwitcherPopover } from './OrganizationSwitcherPopover';
 import { OrganizationSwitcherTrigger } from './OrganizationSwitcherTrigger';
 
-const _OrganizationSwitcher = () => {
-  const { floating, reference, styles, toggle, isOpen } = usePopover({
+const _OrganizationSwitcher = withFloatingTree(() => {
+  const { floating, reference, styles, toggle, isOpen, nodeId, context } = usePopover({
     placement: 'bottom-start',
     offset: 8,
   });
@@ -20,17 +19,20 @@ const _OrganizationSwitcher = () => {
         onClick={toggle}
         isOpen={isOpen}
       />
-      <Portal>
+      <Popover
+        nodeId={nodeId}
+        context={context}
+        isOpen={isOpen}
+      >
         <OrganizationSwitcherPopover
-          isOpen={isOpen}
           close={toggle}
           ref={floating}
           style={{ ...styles }}
         />
-      </Portal>
+      </Popover>
     </Flow.Root>
   );
-};
+});
 
 export const OrganizationSwitcher = withOrganizationsEnabledGuard(
   withCoreUserGuard(withCardStateProvider(_OrganizationSwitcher)),

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -15,13 +15,11 @@ import { CogFilled } from '../../icons';
 import { PropsOfComponent } from '../../styledSystem';
 import { OrganizationActionList } from './OtherOrganizationActions';
 
-type OrganizationSwitcherPopoverProps = { isOpen: boolean; close: () => void } & PropsOfComponent<
-  typeof PopoverCard.Root
->;
+type OrganizationSwitcherPopoverProps = { close: () => void } & PropsOfComponent<typeof PopoverCard.Root>;
 
 export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, OrganizationSwitcherPopoverProps>(
   (props, ref) => {
-    const { isOpen, close, ...rest } = props;
+    const { close, ...rest } = props;
     const card = useCardState();
     const { openOrganizationProfile, openCreateOrganization } = useCoreClerk();
     const { organization: currentOrg } = useCoreOrganization();
@@ -68,10 +66,6 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
       }
       openOrganizationProfile({ afterLeaveOrganizationUrl });
     };
-
-    if (!isOpen) {
-      return null;
-    }
 
     const manageOrganizationButton = (
       <Action

--- a/packages/clerk-js/src/ui/components/UserButton/UserButton.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/UserButton.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 
 import { useCoreUser, useUserButtonContext, withCoreUserGuard } from '../../contexts';
 import { descriptors, Flex, Flow, Text } from '../../customizables';
-import { withCardStateProvider } from '../../elements';
-import { Portal } from '../../elements/Portal';
+import { Popover, withCardStateProvider, withFloatingTree } from '../../elements';
 import { usePopover } from '../../hooks';
 import { getFullName, getIdentifier } from '../../utils';
 import { UserButtonPopover } from './UserButtonPopover';
 import { UserButtonTrigger } from './UserButtonTrigger';
 
-const _UserButton = () => {
+const _UserButton = withFloatingTree(() => {
   const { defaultOpen } = useUserButtonContext();
-  const { floating, reference, styles, toggle, isOpen } = usePopover({
+  const { floating, reference, styles, toggle, isOpen, nodeId, context } = usePopover({
     defaultOpen,
     placement: 'bottom-end',
     offset: 8,
@@ -31,18 +30,21 @@ const _UserButton = () => {
           onClick={toggle}
           isOpen={isOpen}
         />
-        <Portal>
+        <Popover
+          nodeId={nodeId}
+          context={context}
+          isOpen={isOpen}
+        >
           <UserButtonPopover
-            isOpen={isOpen}
             close={toggle}
             ref={floating}
             style={{ ...styles }}
           />
-        </Portal>
+        </Popover>
       </Flex>
     </Flow.Root>
   );
-};
+});
 
 const UserButtonTopLevelIdentifier = () => {
   const user = useCoreUser();

--- a/packages/clerk-js/src/ui/components/UserButton/UserButtonPopover.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/UserButtonPopover.tsx
@@ -10,10 +10,10 @@ import { PropsOfComponent } from '../../styledSystem';
 import { SessionActions, UserPreviewButton } from './OtherSessionActions';
 import { useMultisessionActions } from './useMultisessionActions';
 
-type UserButtonPopoverProps = { isOpen: boolean; close: () => void } & PropsOfComponent<typeof PopoverCard.Root>;
+type UserButtonPopoverProps = { close: () => void } & PropsOfComponent<typeof PopoverCard.Root>;
 
 export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopoverProps>((props, ref) => {
-  const { isOpen, close, ...rest } = props;
+  const { close, ...rest } = props;
   const session = useCoreSession() as ActiveSessionResource;
   const { authConfig } = useEnvironment();
   const user = useCoreUser();
@@ -25,10 +25,6 @@ export const UserButtonPopover = React.forwardRef<HTMLDivElement, UserButtonPopo
     handleSignOutSessionClicked,
     otherSessions,
   } = useMultisessionActions({ ...useUserButtonContext(), actionCompleteCallback: close, user });
-
-  if (!isOpen) {
-    return null;
-  }
 
   const addAccountButton = (
     <Action

--- a/packages/clerk-js/src/ui/elements/Menu.tsx
+++ b/packages/clerk-js/src/ui/elements/Menu.tsx
@@ -1,11 +1,12 @@
 import { createContextAndHook } from '@clerk/shared';
-import React, { cloneElement, isValidElement, PropsWithChildren, useEffect, useRef } from 'react';
+import React, { cloneElement, isValidElement, PropsWithChildren, useLayoutEffect, useRef } from 'react';
 
 import { Button, Col } from '../customizables';
 import { usePopover, UsePopoverReturn } from '../hooks';
 import { animations, PropsOfComponent } from '../styledSystem';
 import { colors } from '../utils/colors';
-import { Portal } from './Portal';
+import { withFloatingTree } from './contexts';
+import { Popover } from './Popover';
 
 type MenuState = {
   popoverCtx: UsePopoverReturn;
@@ -15,7 +16,7 @@ const [MenuStateCtx, useMenuState] = createContextAndHook<MenuState>('MenuState'
 
 type MenuProps = PropsWithChildren<Record<never, never>>;
 
-export const Menu = (props: MenuProps) => {
+export const Menu = withFloatingTree((props: MenuProps) => {
   const popoverCtx = usePopover({
     placement: 'right-start',
     offset: 8,
@@ -29,7 +30,7 @@ export const Menu = (props: MenuProps) => {
       {...props}
     />
   );
-};
+});
 
 type MenuTriggerProps = React.PropsWithChildren<Record<never, never>>;
 
@@ -67,13 +68,12 @@ type MenuListProps = PropsOfComponent<typeof Col>;
 export const MenuList = (props: MenuListProps) => {
   const { sx, ...rest } = props;
   const { popoverCtx } = useMenuState();
-  const { floating, styles, isOpen } = popoverCtx;
-  const containerRef = useRef<HTMLDivElement>(null);
+  const { floating, styles, isOpen, context, nodeId } = popoverCtx;
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const current = containerRef.current;
     floating(current);
-    current?.focus();
   }, [isOpen]);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -92,12 +92,13 @@ export const MenuList = (props: MenuListProps) => {
     }
   };
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <Portal>
+    <Popover
+      context={context}
+      nodeId={nodeId}
+      isOpen={isOpen}
+      order={['floating', 'content']}
+    >
       <Col
         ref={containerRef}
         role='menu'
@@ -124,7 +125,7 @@ export const MenuList = (props: MenuListProps) => {
         style={styles}
         {...rest}
       />
-    </Portal>
+    </Popover>
   );
 };
 

--- a/packages/clerk-js/src/ui/elements/Modal.tsx
+++ b/packages/clerk-js/src/ui/elements/Modal.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { descriptors, Flex } from '../customizables';
 import { usePopover, useSafeLayoutEffect, useScrollLock } from '../hooks';
 import { animations, mqu, ThemableCssProp } from '../styledSystem';
-import { Portal } from './Portal';
+import { withFloatingTree } from './contexts';
+import { Popover } from './Popover';
 
 type ModalProps = React.PropsWithChildren<{
   handleOpen?: () => void;
@@ -12,16 +13,14 @@ type ModalProps = React.PropsWithChildren<{
   containerSx?: ThemableCssProp;
 }>;
 
-export const Modal = (props: ModalProps) => {
+export const Modal = withFloatingTree((props: ModalProps) => {
   const { handleClose, handleOpen, contentSx, containerSx } = props;
-  const { floating, isOpen } = usePopover({ defaultOpen: true, autoUpdate: false, bubbles: false });
+  const { floating, isOpen, context, nodeId } = usePopover({
+    defaultOpen: true,
+    autoUpdate: false,
+    bubbles: false,
+  });
   const { disableScroll, enableScroll } = useScrollLock(document.body);
-  const containerRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    floating(containerRef.current);
-    containerRef.current?.focus();
-  }, []);
 
   React.useEffect(() => {
     if (!isOpen) {
@@ -36,12 +35,13 @@ export const Modal = (props: ModalProps) => {
     return () => enableScroll();
   });
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <Portal>
+    <Popover
+      nodeId={nodeId}
+      context={context}
+      isOpen={isOpen}
+      order={['floating', 'content']}
+    >
       <Flex
         aria-hidden
         elementDescriptor={descriptors.modalBackdrop}
@@ -65,9 +65,9 @@ export const Modal = (props: ModalProps) => {
       >
         <Flex
           elementDescriptor={descriptors.modalContent}
-          ref={containerRef}
-          aria-modal='true'
+          ref={floating}
           tabIndex={0}
+          aria-modal='true'
           role='dialog'
           sx={[
             t => ({
@@ -84,6 +84,6 @@ export const Modal = (props: ModalProps) => {
           {props.children}
         </Flex>
       </Flex>
-    </Portal>
+    </Popover>
   );
-};
+});

--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -17,7 +17,9 @@ import { Menu } from '../icons';
 import { useRouter } from '../router';
 import { animations, mqu, PropsOfComponent } from '../styledSystem';
 import { colors } from '../utils';
+import { withFloatingTree } from './contexts';
 import { useNavigateToFlowStart } from './NavigateToFlowStartButton';
+import { Popover } from './Popover';
 
 type NavbarContextValue = { isOpen: boolean; open: () => void; close: () => void };
 export const [NavbarContext, useNavbarContext, useUnsafeNavbarContext] =
@@ -177,9 +179,9 @@ const NavbarContainer = (props: React.PropsWithChildren<Record<never, never>>) =
   );
 };
 
-const MobileNavbarContainer = (props: React.PropsWithChildren<Record<never, never>>) => {
+const MobileNavbarContainer = withFloatingTree((props: React.PropsWithChildren<Record<never, never>>) => {
   const navbarContext = useNavbarContext();
-  const { floating, isOpen, open, close } = usePopover({ defaultOpen: false, autoUpdate: false });
+  const { floating, isOpen, open, close, nodeId, context } = usePopover({ defaultOpen: false, autoUpdate: false });
 
   React.useEffect(() => {
     if (navbarContext.isOpen) {
@@ -195,44 +197,50 @@ const MobileNavbarContainer = (props: React.PropsWithChildren<Record<never, neve
     }
   }, [isOpen]);
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <Col
-      sx={t => ({
-        position: 'absolute',
-        top: 0,
-        bottom: 0,
-        width: '100%',
-        zIndex: t.zIndices.$navbar,
-        borderRadius: t.radii.$xl,
-        overflow: 'hidden',
-      })}
+    <Popover
+      nodeId={nodeId}
+      context={context}
+      isOpen={isOpen}
+      order={['floating', 'content']}
+      portal={false}
     >
       <Col
-        ref={floating}
-        elementDescriptor={descriptors.navbar}
         sx={t => ({
           position: 'absolute',
           top: 0,
           bottom: 0,
-          width: t.space.$60,
-          backgroundColor: colors.makeSolid(t.colors.$colorBackground),
-          borderTopRightRadius: t.radii.$lg,
-          borderBottomRightRadius: t.radii.$lg,
-          borderRight: `${t.borders.$normal} ${t.colors.$blackAlpha100}`,
-          padding: `${t.space.$9x5} ${t.space.$6}`,
-          animation: `${animations.navbarSlideIn} ${t.transitionDuration.$slower} ${t.transitionTiming.$slowBezier}`,
-          boxShadow: t.shadows.$cardDropShadow,
+          width: '100%',
+          zIndex: t.zIndices.$navbar,
+          borderRadius: t.radii.$xl,
+          overflow: 'hidden',
         })}
       >
-        {props.children}
+        <Col
+          ref={floating}
+          elementDescriptor={descriptors.navbar}
+          tabIndex={0}
+          sx={t => ({
+            outline: 0,
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            width: t.space.$60,
+            backgroundColor: colors.makeSolid(t.colors.$colorBackground),
+            borderTopRightRadius: t.radii.$lg,
+            borderBottomRightRadius: t.radii.$lg,
+            borderRight: `${t.borders.$normal} ${t.colors.$blackAlpha100}`,
+            padding: `${t.space.$9x5} ${t.space.$6}`,
+            animation: `${animations.navbarSlideIn} ${t.transitionDuration.$slower} ${t.transitionTiming.$slowBezier}`,
+            boxShadow: t.shadows.$cardDropShadow,
+          })}
+        >
+          {props.children}
+        </Col>
       </Col>
-    </Col>
+    </Popover>
   );
-};
+});
 
 type NavButtonProps = PropsOfComponent<typeof Button> & {
   icon: React.ComponentType;

--- a/packages/clerk-js/src/ui/elements/Popover.tsx
+++ b/packages/clerk-js/src/ui/elements/Popover.tsx
@@ -1,0 +1,54 @@
+import {
+  FloatingContext,
+  FloatingFocusManager,
+  FloatingNode,
+  FloatingPortal,
+  ReferenceType,
+} from '@floating-ui/react-dom-interactions';
+import React from 'react';
+import { PropsWithChildren } from 'react';
+
+type PopoverProps = PropsWithChildren<{
+  context: FloatingContext<ReferenceType>;
+  nodeId: string;
+  isOpen?: boolean;
+  initialFocus?: number | React.MutableRefObject<HTMLElement | null>;
+  order?: Array<'reference' | 'floating' | 'content'>;
+  portal?: boolean;
+}>;
+
+export const Popover = (props: PopoverProps) => {
+  const { context, initialFocus, order = ['reference', 'content'], nodeId, isOpen, portal = true, children } = props;
+
+  if (portal) {
+    return (
+      <FloatingNode id={nodeId}>
+        <FloatingPortal>
+          {isOpen && (
+            <FloatingFocusManager
+              context={context}
+              initialFocus={initialFocus}
+              order={order}
+            >
+              <>{children}</>
+            </FloatingFocusManager>
+          )}
+        </FloatingPortal>
+      </FloatingNode>
+    );
+  }
+
+  return (
+    <FloatingNode id={nodeId}>
+      {isOpen && (
+        <FloatingFocusManager
+          context={context}
+          initialFocus={initialFocus}
+          order={order}
+        >
+          <>{children}</>
+        </FloatingFocusManager>
+      )}
+    </FloatingNode>
+  );
+};

--- a/packages/clerk-js/src/ui/elements/Tabs.tsx
+++ b/packages/clerk-js/src/ui/elements/Tabs.tsx
@@ -137,7 +137,7 @@ export const Tab = (props: TabProps) => {
           borderColor: isActive ? t.colors.$blackAlpha700 : t.colors.$transparent,
           borderRadius: 0,
           width: 'fit-content',
-          '&:hover': { backgroundColor: t.colors.$transparent },
+          '&:hover, :focus': { backgroundColor: t.colors.$transparent },
         })}
       >
         {children}

--- a/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
@@ -60,7 +60,7 @@ export const withCardStateProvider = <T,>(Component: React.ComponentType<T>) => 
   return (props: T) => {
     return (
       <CardStateProvider>
-        {/* @ts-ignore */}
+        {/* @ts-expect-error */}
         <Component {...props} />
       </CardStateProvider>
     );

--- a/packages/clerk-js/src/ui/elements/contexts/FloatingTreeContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/FloatingTreeContext.tsx
@@ -1,0 +1,19 @@
+import { FloatingTree, useFloatingParentNodeId } from '@floating-ui/react-dom-interactions';
+import React from 'react';
+
+export const withFloatingTree = <T,>(Component: React.ComponentType<T>): React.ComponentType<T> => {
+  return (props: T) => {
+    const parentId = useFloatingParentNodeId();
+    if (parentId == null) {
+      return (
+        <FloatingTree>
+          {/* @ts-expect-error */}
+          <Component {...props} />
+        </FloatingTree>
+      );
+    }
+
+    /* @ts-expect-error */
+    return <Component {...props} />;
+  };
+};

--- a/packages/clerk-js/src/ui/elements/contexts/index.ts
+++ b/packages/clerk-js/src/ui/elements/contexts/index.ts
@@ -1,2 +1,3 @@
 export * from './CardStateContext';
 export * from './FlowMetadataContext';
+export * from './FloatingTreeContext';

--- a/packages/clerk-js/src/ui/elements/index.ts
+++ b/packages/clerk-js/src/ui/elements/index.ts
@@ -51,3 +51,4 @@ export * from './FormButtons';
 export * from './NavigateToFlowStartButton';
 export * from './SuccessPage';
 export * from './IconCircle';
+export * from './Popover';

--- a/packages/clerk-js/src/ui/hooks/usePopover.ts
+++ b/packages/clerk-js/src/ui/hooks/usePopover.ts
@@ -5,6 +5,7 @@ import {
   shift,
   useDismiss,
   useFloating,
+  useFloatingNodeId,
   UseFloatingProps,
 } from '@floating-ui/react-dom-interactions';
 import React, { useEffect } from 'react';
@@ -22,25 +23,21 @@ export type UsePopoverReturn = ReturnType<typeof usePopover>;
 export const usePopover = (props: UsePopoverProps = {}) => {
   const { bubbles = true } = props;
   const [isOpen, setIsOpen] = React.useState(props.defaultOpen || false);
+  const nodeId = useFloatingNodeId();
   const { update, reference, floating, strategy, x, y, context, refs } = useFloating({
     open: isOpen,
     onOpenChange: setIsOpen,
+    nodeId,
     whileElementsMounted: props.autoUpdate === false ? undefined : autoUpdate,
     placement: props.placement || 'bottom-start',
     middleware: [offset(props.offset || 6), flip(), shift()],
   });
 
-  useEffect(() => {
-    if (props.defaultOpen) {
-      update();
-    }
-  }, []);
-
   useDismiss(context, { bubbles });
 
   useEffect(() => {
     const handleFocus = (e: FocusEvent) => {
-      if (e.relatedTarget === null) {
+      if (!e.relatedTarget) {
         (refs.floating.current as HTMLElement | null)?.focus();
       }
     };
@@ -56,6 +53,12 @@ export const usePopover = (props: UsePopoverProps = {}) => {
     };
   }, [bubbles]);
 
+  useEffect(() => {
+    if (props.defaultOpen) {
+      update();
+    }
+  }, []);
+
   const toggle = React.useCallback(() => setIsOpen(o => !o), [setIsOpen]);
   const open = React.useCallback(() => setIsOpen(true), [setIsOpen]);
   const close = React.useCallback(() => setIsOpen(false), [setIsOpen]);
@@ -65,6 +68,7 @@ export const usePopover = (props: UsePopoverProps = {}) => {
     floating,
     toggle,
     open,
+    nodeId,
     close,
     isOpen,
     styles: { position: strategy, top: y ?? 0, left: x ?? 0 },

--- a/packages/clerk-js/src/ui/primitives/Button.tsx
+++ b/packages/clerk-js/src/ui/primitives/Button.tsx
@@ -60,19 +60,19 @@ const { applyVariants, filterProps } = createVariants(theme => {
         solid: {
           backgroundColor: vars.accent,
           color: theme.colors.$colorTextOnPrimaryBackground,
-          '&:hover': { backgroundColor: vars.accentDark },
+          '&:hover, :focus': { backgroundColor: vars.accentDark },
           '&:active': { backgroundColor: vars.accentDarker },
         },
         outline: {
           border: theme.borders.$normal,
           borderColor: vars.accentLighter,
           color: vars.accent,
-          '&:hover': { backgroundColor: vars.accentLightest },
+          '&:hover, :focus': { backgroundColor: vars.accentLightest },
           '&:active': { backgroundColor: vars.accentLighter },
         },
         ghost: {
           color: vars.accent,
-          '&:hover': { backgroundColor: vars.accentLightest },
+          '&:hover, :focus': { backgroundColor: vars.accentLightest },
           '&:active': { backgroundColor: vars.accentLighter },
         },
         icon: {
@@ -80,7 +80,7 @@ const { applyVariants, filterProps } = createVariants(theme => {
           border: theme.borders.$normal,
           borderRadius: theme.radii.$lg,
           borderColor: vars.border,
-          '&:hover': { backgroundColor: vars.accentLightest },
+          '&:hover, :focus': { backgroundColor: vars.accentLightest },
           '&:active': { backgroundColor: vars.accentLighter },
         },
         ghostIcon: {
@@ -88,7 +88,7 @@ const { applyVariants, filterProps } = createVariants(theme => {
           minHeight: theme.sizes.$6,
           width: theme.sizes.$6,
           padding: `${theme.space.$1} ${theme.space.$1}`,
-          '&:hover': { color: vars.accentDark },
+          '&:hover, :focus': { color: vars.accentDark },
           '&:active': { color: vars.accentDarker },
         },
         link: {
@@ -99,7 +99,7 @@ const { applyVariants, filterProps } = createVariants(theme => {
           textTransform: 'none',
           padding: 0,
           color: vars.accent,
-          '&:hover': { textDecoration: 'underline' },
+          '&:hover, :focus': { textDecoration: 'underline' },
           '&:active': { color: vars.accentDark },
         },
         roundWrapper: { padding: 0, margin: 0, height: 'unset', width: 'unset', minHeight: 'unset' },


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
### Issue
When having nested popovers, clicking the second popover will result in all popovers being closed.

### Solution
This PR attempts to fix this issue by utilizing more of the floating-ui library and take advantage of its focus-trap, focus-return mechanisms and its ability to allow or block dismissal bubbling in each popover.

I have introduced a new `<Popover>` component which wraps the `children` with the appropriate components needed by the `floating-ui` library. The new component also receives an `isOpen` props and hides `children` accordingly. It also traps the focus into the Popover and returns the focus once it is closed. 

The `usePopover` hook now receives the `bubbles?: boolean` prop which determined if the Popover dismissal should stop or continue in the popover. This makes more in sense in modals than other Popovers.

The `usePopover` hook now subscribes the Popover to the `FloatingTree` context and returns a `nodeId` which has to be passed to the `Popover` component. This is necessary for the correct nested Popover behaviour.

In this PR, I have integrated these changes to every popover used in our codebase. If the popover does not need to be portalled, we pass `portal={false}` to the `<Popover/>` component.
<!-- Fixes # (issue number) -->
