### PR TITLE
fix(clerk-js,types): Invite org member public metadata

### DIFF
--- a/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
@@ -20,7 +20,7 @@ export class OrganizationInvitation extends BaseResource implements Organization
 
   static async create(
     organizationId: string,
-    { emailAddress, role, redirectUrl, publicMetadata }: CreateOrganizationInvitationParams,
+    { emailAddress, role, redirectUrl }: CreateOrganizationInvitationParams,
   ): Promise<OrganizationInvitationResource> {
     const json = (
       await BaseResource._fetch<OrganizationInvitationJSON>({
@@ -30,7 +30,6 @@ export class OrganizationInvitation extends BaseResource implements Organization
           email_address: emailAddress,
           role,
           redirect_url: redirectUrl,
-          public_metadata: JSON.stringify(publicMetadata),
         } as any,
       })
     )?.response as unknown as OrganizationInvitationJSON;
@@ -70,5 +69,4 @@ export type CreateOrganizationInvitationParams = {
   emailAddress: string;
   role: MembershipRole;
   redirectUrl?: string;
-  publicMetadata?: Record<string, unknown>;
 };

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -45,7 +45,6 @@ export interface AddMemberParams {
 export interface InviteMemberParams {
   emailAddress: string;
   role: MembershipRole;
-  publicMetadata?: Record<string, unknown>;
   redirectUrl?: string;
 }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Back in #486 we introduced the ability to set organization invitation metadata when inviting a new member to an organization. It was a mistake.

The public metadata for an organization invitation shouldn't be written through ClerkJS, but they can be read.

Removed the publicMetadata argument from the Organization#inviteMember method.

<!-- Fixes # (issue number) -->
