### PR TITLE
fix(clerk-js): Return focus to non-bubbling popovers when it is lost

### DIFF
--- a/packages/clerk-js/src/ui/hooks/usePopover.ts
+++ b/packages/clerk-js/src/ui/hooks/usePopover.ts
@@ -7,7 +7,7 @@ import {
   useFloating,
   UseFloatingProps,
 } from '@floating-ui/react-dom-interactions';
-import React, { RefObject, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 type UsePopoverProps = {
   defaultOpen?: boolean;
@@ -22,7 +22,7 @@ export type UsePopoverReturn = ReturnType<typeof usePopover>;
 export const usePopover = (props: UsePopoverProps = {}) => {
   const { bubbles = true } = props;
   const [isOpen, setIsOpen] = React.useState(props.defaultOpen || false);
-  const { update, reference, floating, strategy, x, y, context } = useFloating({
+  const { update, reference, floating, strategy, x, y, context, refs } = useFloating({
     open: isOpen,
     onOpenChange: setIsOpen,
     whileElementsMounted: props.autoUpdate === false ? undefined : autoUpdate,
@@ -37,6 +37,24 @@ export const usePopover = (props: UsePopoverProps = {}) => {
   }, []);
 
   useDismiss(context, { bubbles });
+
+  useEffect(() => {
+    const handleFocus = (e: FocusEvent) => {
+      if (e.relatedTarget === null) {
+        (refs.floating.current as HTMLElement | null)?.focus();
+      }
+    };
+
+    if (!bubbles) {
+      window.addEventListener('focusout', handleFocus);
+    }
+
+    return () => {
+      if (!bubbles) {
+        window.removeEventListener('focusout', handleFocus);
+      }
+    };
+  }, [bubbles]);
 
   const toggle = React.useCallback(() => setIsOpen(o => !o), [setIsOpen]);
   const open = React.useCallback(() => setIsOpen(true), [setIsOpen]);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
### Issue & Solution
As per floating-ui docs, popovers that use the `bubbles:false` prop need to remain in focus for accessibility controls to work as expected. When focus is lost inside our popover, it needs to be reinstated. 

### Concerns for future use
I have not yet tested this for nested non-bubbling popovers(both popovers would have `bubbles:false`) as we do not use or intend to use them in the close future. We should see if the behaviour suits us in that case as well if we decide to use them in such manner.
<!-- Fixes # (issue number) -->
