### PR TITLE
fix(types): Allow oauth strategy for sign up prepare verification

### DIFF
--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -94,6 +94,11 @@ export type PrepareVerificationParams =
     }
   | {
       strategy: Web3Strategy;
+    }
+  | {
+      strategy: OAuthStrategy;
+      redirectUrl?: string;
+      actionCompleteRedirectUrl?: string;
     };
 
 export type AttemptVerificationParams =


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The sign up prepare verification method also supports an oauth strategy along with the redirect urls. This commit adds the missing params in the PrepareVerificationParams type

<!-- Fixes # (issue number) -->

https://www.notion.so/clerkdev/Fix-inconsistencies-with-v1-client-sign_ups-signUpID-prepare_verification-endpoint-for-oauth-e63d5e662bf04c818a12162b02f92e40
