### PR TITLE
fix(clerk-js): Remove ability to select guest role from the UI

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -34,7 +34,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
   const roles: Array<{ label: string; value: MembershipRole }> = [
     { label: t(roleLocalizationKey('admin')), value: 'admin' },
     { label: t(roleLocalizationKey('basic_member')), value: 'basic_member' },
-    { label: t(roleLocalizationKey('guest_member')), value: 'guest_member' },
+    // { label: t(roleLocalizationKey('guest_member')), value: 'guest_member' },
   ];
 
   const emailAddressField = useFormControl('emailAddress', '', {

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -92,8 +92,13 @@ export const RoleSelect = (props: { value: MembershipRole; onChange: any; isDisa
   const roles: Array<{ label: string; value: MembershipRole }> = [
     { label: t(roleLocalizationKey('admin')), value: 'admin' },
     { label: t(roleLocalizationKey('basic_member')), value: 'basic_member' },
+  ];
+
+  const excludedRoles: Array<{ label: string; value: MembershipRole }> = [
     { label: t(roleLocalizationKey('guest_member')), value: 'guest_member' },
   ];
+
+  const selectedRole = [...roles, ...excludedRoles].find(r => r.value === value);
 
   return (
     <Select
@@ -108,7 +113,9 @@ export const RoleSelect = (props: { value: MembershipRole; onChange: any; isDisa
           backgroundColor: 'transparent',
         })}
         isDisabled={isDisabled}
-      />
+      >
+        {selectedRole?.label}
+      </SelectButton>
       <SelectOptionList />
     </Select>
   );


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Display the guest role only in the Active/Invited members tabled. Admins can set a guest to Admin/Member via the UI. Admin/Members can't be set to Guest. Guest role will not appear in the Invite screen.

<!-- Fixes # (issue number) -->
