### PR TITLE
fix(clerk-js): In case of emailOrPhone take into account missing fields for Sign up continue screen

### DIFF
--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -112,12 +112,22 @@ function _SignUpContinue() {
       [] as Array<FormControlState>,
     );
 
-    // In case of emailOrPhone (both email & phone are optional) and neither of them is provided,
-    // add both to the submitted fields to trigger and render an error for both respective inputs
+    // Add both email & phone to the submitted fields to trigger and render an error for both respective inputs in
+    // case all the below requirements are met:
+    // 1. Sign up contains both in the missing fields
+    // 2. The instance settings has both email & phone as optional (emailOrPhone)
+    // 3. Neither of them is provided
     const emailAddressProvided = !!(fieldsToSubmit.find(f => f.id === 'emailAddress')?.value || '');
     const phoneNumberProvided = !!(fieldsToSubmit.find(f => f.id === 'phoneNumber')?.value || '');
+    const emailOrPhoneMissing =
+      signUp.missingFields.includes('email_address') && signUp.missingFields.includes('phone_number');
 
-    if (!emailAddressProvided && !phoneNumberProvided && emailOrPhone(attributes, isProgressiveSignUp)) {
+    if (
+      emailOrPhoneMissing &&
+      !emailAddressProvided &&
+      !phoneNumberProvided &&
+      emailOrPhone(attributes, isProgressiveSignUp)
+    ) {
       fieldsToSubmit.push(formState['emailAddress']);
       fieldsToSubmit.push(formState['phoneNumber']);
     }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

In the edge case an instance has both email & phone as optional and the user ends up in the sign up continue component after an OAuth flow, we should take into account the sign up missing fields to determine if we need to add extra fields in the payload

### Before

https://user-images.githubusercontent.com/22435234/199991227-1f2e8e87-2e8e-4795-a6b4-f3d38f54c37f.mov

### After

https://user-images.githubusercontent.com/22435234/199991237-6878d4d1-1da2-4953-8013-3e9ac266c87c.mov

<!-- Fixes # (issue number) -->
