### PR TITLE
fix(clerk-js): Replace createObjectUrl with a base64 transformation

### DIFF
--- a/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
+++ b/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
@@ -11,6 +11,15 @@ export type AvatarUploaderProps = {
   onAvatarChange: (file: File) => Promise<unknown>;
 };
 
+export const fileToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = error => reject(error);
+  });
+};
+
 export const AvatarUploader = (props: AvatarUploaderProps) => {
   const [showUpload, setShowUpload] = React.useState(false);
   const [objectUrl, setObjectUrl] = React.useState<string>();
@@ -22,7 +31,7 @@ export const AvatarUploader = (props: AvatarUploaderProps) => {
   };
 
   const handleFileDrop = (file: File) => {
-    setObjectUrl(URL.createObjectURL(file));
+    void fileToBase64(file).then(setObjectUrl);
     card.setLoading();
     return onAvatarChange(file)
       .then(() => {
@@ -31,10 +40,6 @@ export const AvatarUploader = (props: AvatarUploaderProps) => {
       })
       .catch(err => handleError(err, [], card.setError));
   };
-
-  React.useEffect(() => () => {
-    objectUrl && URL.revokeObjectURL(objectUrl);
-  });
 
   return (
     <Col gap={4}>


### PR DESCRIPTION


## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
If the components are mounted within an app using CSP, the developer will need to explicitly enable either the `data:` or the `blob:` protocols. The base64 (data:) protocol is more common, so we'll use that by default.

![image](https://user-images.githubusercontent.com/1811063/200019920-e4810e04-16e7-49be-8f2c-85bbf29607b9.png)

<!-- Fixes # (issue number) -->
