### PR TITLE
fix(clerk-js): Fix React error on handling providerName attribute on SocialButtonIcon

### DIFF
--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -128,7 +128,7 @@ type SocialButtonProps = PropsOfComponent<typeof Button> & {
 };
 
 const SocialButtonIcon = (props: SocialButtonProps): JSX.Element => {
-  const { icon, label, id, ...rest } = props;
+  const { icon, label, id, providerName, ...rest } = props;
   return (
     <Button
       elementDescriptor={descriptors.socialButtonsIconButton}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR fixes the error occurred by React when `SocialButtonIcon` is rendered and cannot handle the `providerName` attribute.

<!-- Fixes # (issue number) -->
