### PR TITLE
fix(clerk-js): Remove object-fit:contain from Avatar

### DIFF
--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -58,7 +58,6 @@ export const Avatar = (props: AvatarProps) => {
         width='100%'
         height='100%'
         onError={() => setError(true)}
-        sx={{ objectFit: 'contain' }}
       />
     );
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
`objectFit: 'contain'` causes this behaviour and overrides the `objectFit:'cover'` set on the container.

<img width="501" alt="Screenshot 2022-11-07 at 15 17 49" src="https://user-images.githubusercontent.com/73396808/200320140-5259dbee-9587-4792-a4db-a07ba1dc25e3.png">

<!-- Fixes # (issue number) -->
