### PR TITLE
fix(clerk-js): Stop re-triggering a magic link delivery on expiration

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneEmailLinkCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneEmailLinkCard.tsx
@@ -50,8 +50,7 @@ export const SignInFactorOneEmailLinkCard = (props: SignInFactorOneEmailLinkCard
   const handleVerificationResult = async (si: SignInResource) => {
     const ver = si.firstFactorVerification;
     if (ver.status === 'expired') {
-      card.setError('The verification link expired. A replacement link has just been sent to your email address.');
-      void startEmailLinkVerification();
+      card.setError('The verification link expired. Please resend it.');
     } else if (ver.verifiedFromTheSameClient()) {
       setShowVerifyModal(true);
     } else {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpEmailLinkCard.tsx
@@ -44,8 +44,7 @@ export const SignUpEmailLinkCard = () => {
   const handleVerificationResult = async (su: SignUpResource) => {
     const ver = su.verifications.emailAddress;
     if (ver.status === 'expired') {
-      card.setError('The verification link expired. A replacement link has just been sent to your email address.');
-      void startEmailLinkVerification();
+      card.setError('The verification link expired. Please resend it.');
     } else if (ver.verifiedFromTheSameClient()) {
       setShowVerifyModal(true);
     } else {

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailPage.tsx
@@ -7,7 +7,6 @@ import { localizationKeys, Text } from '../../customizables';
 import { ContentPage, Form, FormButtons, SuccessPage, useCardState, withCardStateProvider } from '../../elements';
 import { useRouter } from '../../router';
 import { handleError, useFormControl } from '../../utils';
-import { OrganizationProfileBreadcrumbs } from '../OrganizationProfile/OrganizationProfileNavbar';
 import { UserProfileBreadcrumbs } from './UserProfileNavbar';
 import { magicLinksEnabledForInstance } from './utils';
 import { VerifyWithCode } from './VerifyWithCode';


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

When the user leaves the magic link verification screen of the <SignIn/> or <SignUp/> open in a forgotten tab, the components should not re-trigger another delivery.

Before this fix, components were sending a magic link email every 10 minutes.