### PR TITLE
fix(nextjs): Pass auth-result from middleware to auth()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29498,7 +29498,7 @@
     },
     "packages/nextjs": {
       "name": "@clerk/nextjs",
-      "version": "4.6.0-staging.2",
+      "version": "4.6.0-staging.3",
       "license": "MIT",
       "dependencies": {
         "@clerk/clerk-react": "^4.4.2-staging.2",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clerk/nextjs",
-  "version": "4.6.0-staging.2",
+  "version": "4.6.0-staging.3",
   "license": "MIT",
   "description": "Clerk.dev SDK for NextJS",
   "keywords": [

--- a/packages/nextjs/src/app-beta/auth.tsx
+++ b/packages/nextjs/src/app-beta/auth.tsx
@@ -1,42 +1,17 @@
-import { cookies } from 'next/headers';
+import { headers } from 'next/headers';
 import { NextRequest } from 'next/server';
 
 import { getAuthEdge } from '../server/getAuthEdge';
 import { buildClerkProps } from '../server/utils/getAuth';
 
-// Warning: This is insecure unless withClerkMiddleware has run
+const buildRequestLike = () => {
+  return new NextRequest('https://placeholder.com', { headers: headers() });
+};
 
-// We cannot currently detect if withClerkMiddleware has run for
-// the appDir, so we can't throw an error if they misconfigure
-// middleware, which would make this strategy quite insecure.
+export const auth = () => {
+  return getAuthEdge(buildRequestLike());
+};
 
-// Track resolution here - looks like it will be in 13.0.1:
-// https://github.com/vercel/next.js/pull/41380
-
-function buildReqLike() {
-  const session = cookies().get('__session');
-  const sessionString = typeof session === 'string' ? session : session?.value;
-
-  if (session) {
-    return new NextRequest('https://example.com', {
-      headers: new Headers({
-        'auth-result': 'standard-signed-in',
-        authorization: `Bearer ${sessionString}`,
-      }),
-    });
-  }
-
-  return new NextRequest('https://example.com', {
-    headers: new Headers({
-      'auth-result': 'standard-signed-out',
-    }),
-  });
-}
-
-export function auth() {
-  return getAuthEdge(buildReqLike());
-}
-
-export function initialState() {
-  return buildClerkProps(buildReqLike());
-}
+export const initialState = () => {
+  return buildClerkProps(buildRequestLike());
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
