### PR TITLE
fix(clerk-js): Proceed with token flow if email is the only required field

### DIFF
--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -128,10 +128,6 @@ function _SignUpStart(): JSX.Element {
   };
 
   React.useLayoutEffect(() => {
-    // Don't proceed with token flow if there are still optional fields to fill in
-    if (Object.values(fields).some(f => f && !f.required)) {
-      return;
-    }
     void handleTokenFlow();
   }, []);
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The reason for this is that SignUp.create needs to be called to know the email of the invitee. If it is called with an email as the only required field, the sign up is completed and the user is created, so we cannon successfully let the user fill optional fields in this screen.
<!-- Fixes # (issue number) -->
