### PR TITLE
fix(backend-core): Add missing OauthAccessToken types

### DIFF
--- a/packages/backend-core/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/backend-core/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -47,6 +47,7 @@ Object {
   "IdentificationLink": [Function],
   "Invitation": [Function],
   "Logger": [Function],
+  "OauthAccessToken": [Function],
   "ObjectType": Object {
     "AllowlistIdentifier": "allowlist_identifier",
     "Client": "client",
@@ -56,6 +57,7 @@ Object {
     "FacebookAccount": "facebook_account",
     "GoogleAccount": "google_account",
     "Invitation": "invitation",
+    "OauthAccessToken": "oauth_access_token",
     "Organization": "organization",
     "OrganizationInvitation": "organization_invitation",
     "OrganizationMembership": "organization_membership",

--- a/packages/backend-core/src/__tests__/endpoints/PhoneNumberApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/PhoneNumberApi.test.ts
@@ -17,8 +17,6 @@ test('getPhoneNumber() returns a single phone number', async () => {
 
   const phoneNumber = await TestClerkAPI.phoneNumbers.getPhoneNumber('idn_avocado');
 
-  console.log(phoneNumber);
-
   expect(phoneNumber).toBeInstanceOf(PhoneNumber);
   expect(phoneNumber.id).toEqual('idn_avocado');
   expect(phoneNumber.phoneNumber).toEqual('+15555555555');

--- a/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
+++ b/packages/backend-core/src/__tests__/endpoints/UserApi.test.ts
@@ -265,3 +265,28 @@ test('getOrganizationMembershipList() returns a list of organization memberships
   expect(organizationMembershipList[0].organization).toBeInstanceOf(Organization);
   expect(organizationMembershipList[0].publicUserData).toBeInstanceOf(OrganizationMembershipPublicUserData);
 });
+
+test('getUserOauthAccessToken() returns a valid access token', async () => {
+  const userId = 'user_randomid';
+  const provider = 'oauth_test';
+  const resJSON = [
+    {
+      object: 'oauth_access_token',
+      provider,
+      token: 'deadbeef',
+      public_metadata: {
+        foo_bar: 42,
+      },
+      label: 'clerk',
+      scopes: ['scope_1'],
+    },
+  ];
+
+  nock(defaultServerAPIUrl)
+    .get(new RegExp(`/v1/users/${userId}/oauth_access_tokens/${provider}`))
+    .reply(200, resJSON);
+
+  const [oauthAccessToken] = await TestClerkAPI.users.getUserOauthAccessToken(userId, provider);
+  expect(oauthAccessToken.provider).toBe(provider);
+  expect(oauthAccessToken.token).toBe('deadbeef');
+});

--- a/packages/backend-core/src/api/endpoints/UserApi.ts
+++ b/packages/backend-core/src/api/endpoints/UserApi.ts
@@ -1,5 +1,5 @@
 import { joinPaths } from '../../util/path';
-import { OrganizationMembership, User } from '../resources';
+import { OauthAccessToken, OrganizationMembership, User } from '../resources';
 import { AbstractAPI } from './AbstractApi';
 
 const basePath = '/users';
@@ -119,7 +119,7 @@ export class UserAPI extends AbstractAPI {
 
   public async getUserOauthAccessToken(userId: string, provider: `oauth_${string}`) {
     this.requireId(userId);
-    return this.APIClient.request<User>({
+    return this.APIClient.request<OauthAccessToken[]>({
       method: 'GET',
       path: joinPaths(basePath, userId, 'oauth_access_tokens', provider),
     });

--- a/packages/backend-core/src/api/resources/Deserializer.ts
+++ b/packages/backend-core/src/api/resources/Deserializer.ts
@@ -3,9 +3,10 @@ import {
   AllowlistIdentifier,
   Client,
   DeletedObject,
-  EmailAddress,
   Email,
+  EmailAddress,
   Invitation,
+  OauthAccessToken,
   Organization,
   OrganizationInvitation,
   OrganizationMembership,
@@ -61,6 +62,8 @@ function jsonToObject(item: any): any {
       return Email.fromJSON(item);
     case ObjectType.Invitation:
       return Invitation.fromJSON(item);
+    case ObjectType.OauthAccessToken:
+      return OauthAccessToken.fromJSON(item);
     case ObjectType.Organization:
       return Organization.fromJSON(item);
     case ObjectType.OrganizationInvitation:

--- a/packages/backend-core/src/api/resources/JSON.ts
+++ b/packages/backend-core/src/api/resources/JSON.ts
@@ -18,6 +18,7 @@ export enum ObjectType {
   FacebookAccount = 'facebook_account',
   GoogleAccount = 'google_account',
   Invitation = 'invitation',
+  OauthAccessToken = 'oauth_access_token',
   Organization = 'organization',
   OrganizationInvitation = 'organization_invitation',
   OrganizationMembership = 'organization_membership',
@@ -109,6 +110,18 @@ export interface InvitationJSON extends ClerkResourceJSON {
   created_at: number;
   updated_at: number;
   revoked?: boolean;
+}
+
+export interface OauthAccessTokenJSON {
+  object: ObjectType.OauthAccessToken;
+  provider: string;
+  token: string;
+  public_metadata: Record<string, unknown>;
+  label: string;
+  // Only set in OAuth 2.0 tokens
+  scopes?: string[];
+  // Only set in OAuth 1.0 tokens
+  token_secret?: string;
 }
 
 export interface OrganizationJSON extends ClerkResourceJSON {

--- a/packages/backend-core/src/api/resources/OauthAccessToken.ts
+++ b/packages/backend-core/src/api/resources/OauthAccessToken.ts
@@ -1,0 +1,23 @@
+import type { OauthAccessTokenJSON } from './JSON';
+
+export class OauthAccessToken {
+  constructor(
+    readonly provider: string,
+    readonly token: string,
+    readonly publicMetadata: Record<string, unknown> = {},
+    readonly label: string,
+    readonly scopes?: string[],
+    readonly tokenSecret?: string,
+  ) {}
+
+  static fromJSON(data: OauthAccessTokenJSON) {
+    return new OauthAccessToken(
+      data.provider,
+      data.token,
+      data.public_metadata,
+      data.label,
+      data.scopes,
+      data.token_secret,
+    );
+  }
+}

--- a/packages/backend-core/src/api/resources/index.ts
+++ b/packages/backend-core/src/api/resources/index.ts
@@ -9,6 +9,7 @@ export * from './ExternalAccount';
 export * from './IdentificationLink';
 export * from './Invitation';
 export * from './JSON';
+export * from './OauthAccessToken';
 export * from './Organization';
 export * from './OrganizationInvitation';
 export * from './OrganizationMembership';


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->

Fixes https://github.com/clerkinc/javascript/issues/447
