### PR TITLE
fix(nextjs): Fallback to lower-cased header name if `Auth-Result` is …

### DIFF
--- a/packages/nextjs/src/server/utils/requestResponseUtils.ts
+++ b/packages/nextjs/src/server/utils/requestResponseUtils.ts
@@ -46,9 +46,10 @@ export function getHeader(req: RequestLike, name: string): string | null | undef
     return req.headers.get(name);
   }
 
-  // @ts-expect-error
   // If no header has been determined for IncomingMessage case, check if available within private `socket` headers
-  return req.headers[name] || req.socket?._httpMessage?.getHeader(name);
+  // When deployed to vercel, req.headers for API routes is a `IncomingHttpHeaders` key-val object which does not follow
+  // the Headers spec so the name is no longer case-insensitive.
+  return req.headers[name] || req.headers[name.toLowerCase()] || (req.socket as any)?._httpMessage?.getHeader(name);
 }
 
 export function getCookie(req: RequestLike, name: string): string | undefined {


### PR DESCRIPTION
…not found

When deployed to vercel, req.headers for API routes is a `IncomingHttpHeaders` key-val object which does not follow the Headers spec so the name is no longer case-insensitive.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Deploying to vercel w/ a nextjs13 app using the latest headers fix breaks if we don't add a query. The reason most likely is that the API route req.header obj is not a `Headers` obj, thus its case sensitive
<!-- Fixes # (issue number) -->
