### PR TITLE
fix(nextjs): Remove optional auth violation error from withClerkMiddl…

### DIFF
--- a/packages/nextjs/src/server/utils/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/utils/withClerkMiddleware.ts
@@ -12,7 +12,6 @@ import {
   SESSION_COOKIE_NAME,
 } from '../types';
 import {
-  getAuthResultFromRequest,
   getCookie,
   nextJsVersionCanOverrideRequestHeaders,
   setPrivateAuthResultOnRequest,
@@ -43,11 +42,6 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
   return async (req: NextRequest, event: NextFetchEvent) => {
     const { headers } = req;
     const { jwtKey, authorizedParties } = opts;
-
-    // throw an error if the request already includes an auth result, because that means it has been spoofed
-    if (getAuthResultFromRequest(req)) {
-      throw new Error('withClerkMiddleware: Auth violation detected');
-    }
 
     // get auth state, check if we need to return an interstitial
     const cookieToken = getCookie(req, SESSION_COOKIE_NAME);


### PR DESCRIPTION
…eware

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
From slack:
> We needed it in Next 12 because we didn't know which of the two strategies would work. For 13.1+, we know that any attempt to spoof will be overwritten by middleware, so we should be fine just eliminating it.

This also solves a TRPC-related issue 

<!-- Fixes # (issue number) -->
