### PR TITLE
Rework clerk js exports

### DIFF
--- a/packages/clerk-js/headless/index.d.ts
+++ b/packages/clerk-js/headless/index.d.ts
@@ -1,0 +1,4 @@
+import Clerk from '../dist/types/src/index.headless';
+
+export default Clerk;
+export * from '../dist/types/src/index.headless';

--- a/packages/clerk-js/headless/index.js
+++ b/packages/clerk-js/headless/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/clerk.headless');

--- a/packages/clerk-js/src/core/resources/index.ts
+++ b/packages/clerk-js/src/core/resources/index.ts
@@ -1,9 +1,10 @@
 export * from './AuthConfig';
 export * from './Client';
-export * from './DisplayConfig';
 export * from './DeletedObject';
+export * from './DisplayConfig';
 export * from './EmailAddress';
 export * from './Environment';
+export * from './Error';
 export * from './ExternalAccount';
 export * from './IdentificationLink';
 export * from './Image';
@@ -16,5 +17,3 @@ export * from './Token';
 export * from './User';
 export * from './Verification';
 export * from './Web3Wallet';
-
-export { isMagicLinkError, MagicLinkError, MagicLinkErrorCode } from './Error';

--- a/packages/clerk-js/src/index.headless.ts
+++ b/packages/clerk-js/src/index.headless.ts
@@ -2,7 +2,7 @@ import 'regenerator-runtime/runtime';
 
 import Clerk from './core/clerk';
 
-export { MagicLinkError, MagicLinkErrorCode, isMagicLinkError } from './core/resources';
+export * from './core/resources/Error';
 
 export default Clerk;
 

--- a/packages/clerk-js/src/index.ts
+++ b/packages/clerk-js/src/index.ts
@@ -3,7 +3,7 @@ import 'regenerator-runtime/runtime';
 import Clerk from './core/clerk';
 import { mountComponentRenderer } from './ui';
 
-export { MagicLinkError, MagicLinkErrorCode, isMagicLinkError } from './core/resources';
+export * from './core/resources/Error';
 
 Clerk.mountComponentRenderer = mountComponentRenderer;
 export default Clerk;

--- a/packages/expo/src/ClerkProvider.tsx
+++ b/packages/expo/src/ClerkProvider.tsx
@@ -14,25 +14,13 @@ export type ClerkProviderProps = ClerkReactProviderProps & {
 };
 
 export function ClerkProvider(props: ClerkProviderProps): JSX.Element {
-  const { children, tokenCache, hotload, ...rest } = props;
+  const { children, tokenCache, ...rest } = props;
   const frontendApi = props.frontendApi || process.env.CLERK_FRONTEND_API || '';
-
-  const clerkRef = React.useRef<ReturnType<typeof buildClerk> | null>(null);
-
-  function getClerk() {
-    if (clerkRef.current === null && !hotload) {
-      clerkRef.current = buildClerk({
-        frontendApi,
-        tokenCache,
-      });
-    }
-    return clerkRef.current;
-  }
 
   return (
     <ClerkReactProvider
       {...rest}
-      Clerk={getClerk()}
+      Clerk={buildClerk({ frontendApi, tokenCache })}
       standardBrowser={!isReactNative()}
     >
       {children}

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -25,4 +25,6 @@ export {
   MagicLinkErrorCode,
 } from '@clerk/clerk-react';
 
+export { clerk as Clerk } from './singleton';
+
 export * from './ClerkProvider';

--- a/packages/expo/src/singleton.ts
+++ b/packages/expo/src/singleton.ts
@@ -1,13 +1,12 @@
-// @ts-ignore
-import Clerk from '@clerk/clerk-js/dist/clerk.headless';
 import type { FapiRequestInit, FapiResponse } from '@clerk/clerk-js/dist/types/src/core/fapiClient';
-import type { ClerkProp } from '@clerk/clerk-react';
+import Clerk from '@clerk/clerk-js/headless';
+import type { HeadlessBrowserClerk } from '@clerk/clerk-react';
 
 import { getToken as getTokenFromMemory, saveToken as saveTokenInMemory, TokenCache } from './cache';
 
 const KEY = '__clerk_client_jwt';
 
-export let clerk: ClerkProp;
+export let clerk: HeadlessBrowserClerk;
 
 type BuildClerkOptions = {
   frontendApi: string;
@@ -15,10 +14,10 @@ type BuildClerkOptions = {
 };
 
 export function buildClerk({ frontendApi, tokenCache }: BuildClerkOptions): ClerkProp {
-  const getToken = (tokenCache && tokenCache.getToken) ?? getTokenFromMemory;
-  const saveToken = (tokenCache && tokenCache.saveToken) ?? saveTokenInMemory;
-
   if (!clerk) {
+    const getToken = (tokenCache && tokenCache.getToken) ?? getTokenFromMemory;
+    const saveToken = (tokenCache && tokenCache.saveToken) ?? saveTokenInMemory;
+
     clerk = new Clerk(frontendApi);
 
     if (!tokenCache) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
 export * from './contexts';
 export * from './components';
 export * from './hooks';
-export type { ClerkProp } from './types';
+export type { BrowserClerk, ClerkProp, HeadlessBrowserClerk } from './types';
 export { isMagicLinkError, MagicLinkErrorCode } from './errors';
 export { useMagicLink } from './hooks/useMagicLink';
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -28,9 +28,12 @@ export interface MountProps {
   props?: any;
 }
 
-export interface BrowserClerk extends Clerk {
+export interface HeadlessBrowserClerk extends Clerk {
   load: (opts?: ClerkOptions) => Promise<void>;
   updateClient: (client: ClientResource) => void;
+}
+
+export interface BrowserClerk extends HeadlessBrowserClerk {
   onComponentsReady: Promise<void>;
   components: any;
 }

--- a/packages/shared/src/utils/date.test.ts
+++ b/packages/shared/src/utils/date.test.ts
@@ -48,7 +48,7 @@ describe.concurrent('date utils', () => {
     ];
 
     it.each(cases)('.formatRelative(%s, %s) => %s', (a, b, expected) => {
-      expect(formatRelative(a as Date, b as Date, 'us-EN')).toBe(expected);
+      expect(formatRelative(a as Date, b as Date, 'en-US')).toBe(expected);
     });
   });
 

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -58,7 +58,7 @@ export function formatRelative(
   const dayName = DAYS_EN[a.getDay()];
 
   if (differenceInDays < -6) {
-    return a.toLocaleDateString();
+    return a.toLocaleDateString(locale);
   }
   if (differenceInDays < -1) {
     return `last ${dayName} at ${time12Hour}`;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This PR exposes all ClerkJS error utilities so that users who import ClerkJS in their codebases (e.g. in Expo) can reuse the internal error handling logic. This came as a response to a customer request.