### PR TITLE
feat(clerk-js): Add hoverAsFocus prop to Button primitive

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
@@ -106,6 +106,7 @@ const PreviewButton = (props: PropsOfComponent<typeof Button>) => {
       variant='ghost'
       colorScheme='neutral'
       focusRing={false}
+      hoverAsFocus
       isDisabled={card.isLoading}
       sx={[
         t => ({

--- a/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInAccountSwitcher.tsx
@@ -91,6 +91,7 @@ const UserPreviewButton = (props: UserPreviewButtonProps) => {
       variant='ghost'
       colorScheme='neutral'
       focusRing={false}
+      hoverAsFocus
       isDisabled={card.isLoading}
       sx={theme => ({ height: theme.sizes.$14, justifyContent: 'flex-start' })}
       {...rest}

--- a/packages/clerk-js/src/ui/components/UserButton/OtherSessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/OtherSessionActions.tsx
@@ -30,6 +30,7 @@ export const UserPreviewButton = (props: UserPreviewButtonProps) => {
       variant='ghost'
       colorScheme='neutral'
       focusRing={false}
+      hoverAsFocus
       isDisabled={card.isLoading}
       {...rest}
       sx={[

--- a/packages/clerk-js/src/ui/elements/Actions.tsx
+++ b/packages/clerk-js/src/ui/elements/Actions.tsx
@@ -55,6 +55,7 @@ export const Action = (props: ActionProps) => {
       colorScheme='neutral'
       textVariant='buttonSmallRegular'
       focusRing={false}
+      hoverAsFocus
       // TODO: colors should be colorTextSecondary
       sx={[
         theme => ({

--- a/packages/clerk-js/src/ui/elements/Menu.tsx
+++ b/packages/clerk-js/src/ui/elements/Menu.tsx
@@ -159,6 +159,7 @@ export const MenuItem = (props: MenuItemProps) => {
     <Button
       ref={buttonRef}
       focusRing={false}
+      hoverAsFocus
       variant='ghost'
       colorScheme={destructive ? 'danger' : 'neutral'}
       role='menuitem'
@@ -173,9 +174,6 @@ export const MenuItem = (props: MenuItemProps) => {
           borderRadius: theme.radii.$none,
           paddingLeft: theme.space.$4,
           paddingRight: theme.space.$4,
-          ':focus': {
-            backgroundColor: theme.colors.$blackAlpha200,
-          },
         }),
         sx,
       ]}

--- a/packages/clerk-js/src/ui/primitives/Button.tsx
+++ b/packages/clerk-js/src/ui/primitives/Button.tsx
@@ -8,7 +8,7 @@ import { Spinner } from './Spinner';
 
 const vars = createCssVariables('accent', 'accentDark', 'accentDarker', 'accentLighter', 'accentLightest', 'border');
 
-const { applyVariants, filterProps } = createVariants((theme, opts: { hoverAsFocus: boolean }) => {
+const { applyVariants, filterProps } = createVariants((theme, props: OwnProps) => {
   return {
     base: {
       margin: 0,
@@ -61,7 +61,7 @@ const { applyVariants, filterProps } = createVariants((theme, opts: { hoverAsFoc
           backgroundColor: vars.accent,
           color: theme.colors.$colorTextOnPrimaryBackground,
           '&:hover': { backgroundColor: vars.accentDark },
-          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentDark } : undefined,
+          '&:focus': props.hoverAsFocus ? { backgroundColor: vars.accentDark } : undefined,
           '&:active': { backgroundColor: vars.accentDarker },
         },
         outline: {
@@ -69,13 +69,13 @@ const { applyVariants, filterProps } = createVariants((theme, opts: { hoverAsFoc
           borderColor: vars.accentLighter,
           color: vars.accent,
           '&:hover': { backgroundColor: vars.accentLightest },
-          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
+          '&:focus': props.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
           '&:active': { backgroundColor: vars.accentLighter },
         },
         ghost: {
           color: vars.accent,
           '&:hover': { backgroundColor: vars.accentLightest },
-          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
+          '&:focus': props.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
           '&:active': { backgroundColor: vars.accentLighter },
         },
         icon: {
@@ -84,7 +84,7 @@ const { applyVariants, filterProps } = createVariants((theme, opts: { hoverAsFoc
           borderRadius: theme.radii.$lg,
           borderColor: vars.border,
           '&:hover': { backgroundColor: vars.accentLightest },
-          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
+          '&:focus': props.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
           '&:active': { backgroundColor: vars.accentLighter },
         },
         ghostIcon: {
@@ -93,7 +93,7 @@ const { applyVariants, filterProps } = createVariants((theme, opts: { hoverAsFoc
           width: theme.sizes.$6,
           padding: `${theme.space.$1} ${theme.space.$1}`,
           '&:hover': { color: vars.accentDark },
-          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentDark } : undefined,
+          '&:focus': props.hoverAsFocus ? { backgroundColor: vars.accentDark } : undefined,
           '&:active': { color: vars.accentDarker },
         },
         link: {
@@ -105,7 +105,7 @@ const { applyVariants, filterProps } = createVariants((theme, opts: { hoverAsFoc
           padding: 0,
           color: vars.accent,
           '&:hover': { textDecoration: 'underline' },
-          '&:focus': opts.hoverAsFocus ? { textDecoration: 'underline' } : undefined,
+          '&:focus': props.hoverAsFocus ? { textDecoration: 'underline' } : undefined,
           '&:active': { color: vars.accentDark },
         },
         roundWrapper: { padding: 0, margin: 0, height: 'unset', width: 'unset', minHeight: 'unset' },
@@ -138,7 +138,16 @@ type ButtonProps = OwnProps & StyleVariants<typeof applyVariants>;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
   const parsedProps: ButtonProps = { ...props, isDisabled: props.isDisabled || props.isLoading };
-  const { isLoading, isDisabled, loadingText, children, onClick: onClickProp, ...rest } = filterProps(parsedProps);
+  const {
+    isLoading,
+    isDisabled,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    hoverAsFocus,
+    loadingText,
+    children,
+    onClick: onClickProp,
+    ...rest
+  } = filterProps(parsedProps);
 
   const onClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     if (rest.type !== 'submit') {
@@ -179,7 +188,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => 
 
 const SimpleButton = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
   const parsedProps: ButtonProps = { ...props, isDisabled: props.isDisabled || props.isLoading };
-  const { loadingText, isDisabled, children, onClick: onClickProp, ...rest } = filterProps(parsedProps);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { loadingText, isDisabled, hoverAsFocus, children, onClick: onClickProp, ...rest } = filterProps(parsedProps);
 
   const onClick: React.MouseEventHandler<HTMLButtonElement> = e => {
     if (rest.type !== 'submit') {

--- a/packages/clerk-js/src/ui/primitives/Button.tsx
+++ b/packages/clerk-js/src/ui/primitives/Button.tsx
@@ -8,7 +8,7 @@ import { Spinner } from './Spinner';
 
 const vars = createCssVariables('accent', 'accentDark', 'accentDarker', 'accentLighter', 'accentLightest', 'border');
 
-const { applyVariants, filterProps } = createVariants(theme => {
+const { applyVariants, filterProps } = createVariants((theme, opts: { hoverAsFocus: boolean }) => {
   return {
     base: {
       margin: 0,
@@ -60,19 +60,22 @@ const { applyVariants, filterProps } = createVariants(theme => {
         solid: {
           backgroundColor: vars.accent,
           color: theme.colors.$colorTextOnPrimaryBackground,
-          '&:hover, :focus': { backgroundColor: vars.accentDark },
+          '&:hover': { backgroundColor: vars.accentDark },
+          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentDark } : undefined,
           '&:active': { backgroundColor: vars.accentDarker },
         },
         outline: {
           border: theme.borders.$normal,
           borderColor: vars.accentLighter,
           color: vars.accent,
-          '&:hover, :focus': { backgroundColor: vars.accentLightest },
+          '&:hover': { backgroundColor: vars.accentLightest },
+          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
           '&:active': { backgroundColor: vars.accentLighter },
         },
         ghost: {
           color: vars.accent,
-          '&:hover, :focus': { backgroundColor: vars.accentLightest },
+          '&:hover': { backgroundColor: vars.accentLightest },
+          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
           '&:active': { backgroundColor: vars.accentLighter },
         },
         icon: {
@@ -80,7 +83,8 @@ const { applyVariants, filterProps } = createVariants(theme => {
           border: theme.borders.$normal,
           borderRadius: theme.radii.$lg,
           borderColor: vars.border,
-          '&:hover, :focus': { backgroundColor: vars.accentLightest },
+          '&:hover': { backgroundColor: vars.accentLightest },
+          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentLightest } : undefined,
           '&:active': { backgroundColor: vars.accentLighter },
         },
         ghostIcon: {
@@ -88,7 +92,8 @@ const { applyVariants, filterProps } = createVariants(theme => {
           minHeight: theme.sizes.$6,
           width: theme.sizes.$6,
           padding: `${theme.space.$1} ${theme.space.$1}`,
-          '&:hover, :focus': { color: vars.accentDark },
+          '&:hover': { color: vars.accentDark },
+          '&:focus': opts.hoverAsFocus ? { backgroundColor: vars.accentDark } : undefined,
           '&:active': { color: vars.accentDarker },
         },
         link: {
@@ -99,7 +104,8 @@ const { applyVariants, filterProps } = createVariants(theme => {
           textTransform: 'none',
           padding: 0,
           color: vars.accent,
-          '&:hover, :focus': { textDecoration: 'underline' },
+          '&:hover': { textDecoration: 'underline' },
+          '&:focus': opts.hoverAsFocus ? { textDecoration: 'underline' } : undefined,
           '&:active': { color: vars.accentDark },
         },
         roundWrapper: { padding: 0, margin: 0, height: 'unset', width: 'unset', minHeight: 'unset' },
@@ -126,6 +132,7 @@ type OwnProps = PrimitiveProps<'button'> & {
   loadingText?: string;
   isDisabled?: boolean;
   isActive?: boolean;
+  hoverAsFocus?: boolean;
 };
 type ButtonProps = OwnProps & StyleVariants<typeof applyVariants>;
 


### PR DESCRIPTION
The hoverAsFocus prop will enable the hover style on focus of the button. Useful for accessibility when we set the focusRing to false.

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
