### PR TITLE
fix(clerk-js): Use ch to calculate phone input padding

### DIFF
--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -39,7 +39,6 @@ export const PhoneInput = (props: PhoneInputProps) => {
   const selectedCountryOption = React.useMemo(() => {
     return countryOptions.find(o => o.country.iso === selectedIso) || countryOptions[0];
   }, [selectedIso]);
-  const dynamicPadding = selectedCountryOption.country.code.length * 5; // this is to calculate the padding of the input field depending the length of country code
 
   React.useEffect(callOnChangeProp, [cleanPhoneNumber]);
 
@@ -122,7 +121,9 @@ export const PhoneInput = (props: PhoneInputProps) => {
         onChange={handlePhoneNumberChange}
         maxLength={25}
         type='tel'
-        sx={theme => ({ paddingLeft: `calc(${theme.space.$20} + ${dynamicPadding}px)` })}
+        sx={theme => ({
+          paddingLeft: `calc(${theme.space.$20} + ${selectedCountryOption.country.code.length + 1}ch)`,
+        })}
         ref={phoneInputRef}
         {...rest}
       />


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
before
![image](https://user-images.githubusercontent.com/1811063/203295827-98fbc3c5-e78b-4f23-a703-e826a2cd0b99.png)

after
![image](https://user-images.githubusercontent.com/1811063/203295982-71446396-ff98-443f-abf5-b1f358959725.png)

<!-- Fixes # (issue number) -->
