### PR TITLE
test(clerk-js): Add jest timers abstraction

### DIFF
--- a/packages/clerk-js/src/testUtils.ts
+++ b/packages/clerk-js/src/testUtils.ts
@@ -7,6 +7,7 @@ const render = (ui: React.ReactElement, options?: RenderOptions) => {
   return { ..._render(ui, { ...options }), userEvent };
 };
 
+export * from './ui/utils/test/runFakeTimers';
 export * from './ui/utils/test/createFixtures';
 export * from '@testing-library/react';
 export { render };

--- a/packages/clerk-js/src/ui/utils/test/runFakeTimers.ts
+++ b/packages/clerk-js/src/ui/utils/test/runFakeTimers.ts
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+import { act } from '@testing-library/react';
+
+type WithAct = <T>(fn: T) => T;
+const withAct = ((fn: any) =>
+  (...args: any) => {
+    act(() => {
+      fn(...args);
+    });
+  }) as WithAct;
+
+const advanceTimersByTime = withAct(jest.advanceTimersByTime.bind(jest));
+const runAllTimers = withAct(jest.runAllTimers.bind(jest));
+const runOnlyPendingTimers = withAct(jest.runOnlyPendingTimers.bind(jest));
+
+const createFakeTimersHelpers = () => {
+  return { advanceTimersByTime, runAllTimers, runOnlyPendingTimers };
+};
+
+type FakeTimersHelpers = ReturnType<typeof createFakeTimersHelpers>;
+type RunFakeTimersCallback = (timers: FakeTimersHelpers) => void | Promise<void>;
+
+export const runFakeTimers = <T extends RunFakeTimersCallback, R extends ReturnType<T>>(
+  cb: T,
+): R extends Promise<any> ? Promise<void> : void => {
+  jest.useFakeTimers();
+  const res = cb(createFakeTimersHelpers());
+  if (res && 'then' in res) {
+    // @ts-expect-error
+    return res.finally(() => jest.useRealTimers());
+  }
+  jest.useFakeTimers();
+  // @ts-ignore
+  return;
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Abstract `act` and jest timers behind a `runFakeTimers` HOF
<!-- Fixes # (issue number) -->
