### PR TITLE
setActive house keeping - p1

### DIFF
--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -1,6 +1,13 @@
 import { deepSnakeToCamel } from '@clerk/shared';
-import type { ActJWTClaim, PublicUserData, SessionJSON, SessionResource, SessionStatus } from '@clerk/types';
-import { GetToken, GetTokenOptions, UserResource } from '@clerk/types/src';
+import type {
+  ActJWTClaim,
+  PublicUserData,
+  SessionJSON,
+  SessionResource,
+  SessionStatus,
+  TokenResource,
+} from '@clerk/types';
+import { GetToken, GetTokenOptions, UserResource } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
 import { SessionTokenCache } from '../tokenCache';
@@ -12,7 +19,7 @@ export class Session extends BaseResource implements SessionResource {
   id!: string;
   status!: SessionStatus;
   lastActiveAt!: Date;
-  lastActiveToken!: Token | null;
+  lastActiveToken!: TokenResource | null;
   lastActiveOrganizationId!: string | null;
   actor!: ActJWTClaim | null;
   user!: UserResource | null;

--- a/packages/clerk-js/src/core/tokenCache.test.ts
+++ b/packages/clerk-js/src/core/tokenCache.test.ts
@@ -2,7 +2,7 @@ import { TokenResource } from '@clerk/types';
 import jwtGen from 'jsonwebtoken';
 
 import { Token } from './resources/internal';
-import { MemoryTokenCache } from './tokenCache';
+import { SessionTokenCache } from './tokenCache';
 
 // This is required since abstract TS methods are undefined in Jest
 jest.mock('./resources/Base', () => {
@@ -25,7 +25,7 @@ const jwt = jwtGen.sign(
 
 describe('MemoryTokenCache', () => {
   it('caches tokenResolver while is pending until the JWT expiration', async () => {
-    const cache = MemoryTokenCache();
+    const cache = SessionTokenCache;
     const token = new Token({
       object: 'token',
       id: 'foo',

--- a/packages/clerk-js/tsconfig.dev.json
+++ b/packages/clerk-js/tsconfig.dev.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true,
+    "target": "ESNext",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  }
+}

--- a/packages/clerk-js/tsconfig.json
+++ b/packages/clerk-js/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "sourceMap": false,

--- a/packages/clerk-js/webpack.dev.js
+++ b/packages/clerk-js/webpack.dev.js
@@ -77,6 +77,7 @@ const tsLoaderDev = {
     {
       loader: 'ts-loader',
       options: {
+        configFile: 'tsconfig.dev.json',
         transpileOnly: true,
         getCustomTransformers: () => ({
           before: [ReactRefreshTypeScript()],

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -260,10 +260,8 @@ export interface Clerk {
   setActive: SetActive;
 
   /**
-   * Set the current session explicitly.
-   *
-   * Setting the session to `null` deletes the active session.
-   *
+   * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
+   * Set the current session explicitly. Setting the session to `null` deletes the active session.
    * @param session Passed session resource object, session id (string version) or null
    * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
    */
@@ -271,12 +269,10 @@ export interface Clerk {
 
   /**
    * Function used to commit a navigation after certain steps in the Clerk processes.
-   *
    */
   navigate: CustomNavigation;
 
   /**
-   *
    * Decorates the provided url with the auth token for development instances.
    *
    * @param {string} to
@@ -287,7 +283,6 @@ export interface Clerk {
    * Returns the configured url where <SignIn/> is mounted or a custom sign-in page is rendered.
    *
    * @param opts A {@link RedirectOptions} object
-   *
    */
   buildSignInUrl(opts?: RedirectOptions): string;
 
@@ -295,7 +290,6 @@ export interface Clerk {
    * Returns the configured url where <SignUp/> is mounted or a custom sign-up page is rendered.
    *
    * @param opts A {@link RedirectOptions} object
-   *
    */
   buildSignUpUrl(opts?: RedirectOptions): string;
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
**This is not the actual seActive fix**
- Deprecates setSession
- Adds better sourcemap support for debugging clerkjs locally
<!-- Fixes # (issue number) -->
