### PR TITLE
fix(shared): Use legacy esm output

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "description": "Internal package utils used by the Clerk SDKs",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "files": [
     "dist",
     "testUtils"

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -15,5 +15,6 @@ export default defineConfig(overrideOptions => {
     format: ['cjs', 'esm'],
     define: { PACKAGE_VERSION: `"${version}"`, __DEV__: `${!isProd}` },
     external: ['@testing-library', 'react', 'react-test-renderer', 'jest', 'jest-environment-jsdom', 'react-dom'],
+    legacyOutput: true,
   };
 });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
