### PR TITLE
fix(clerk-js): Add button element descriptors in TOPT & backup code related UserProfile screens

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
@@ -3,7 +3,7 @@ import { QRCodeSVG } from 'qrcode.react';
 import React from 'react';
 
 import { useCoreUser } from '../../contexts';
-import { Button, Col, LocalizationKey, localizationKeys, Text } from '../../customizables';
+import { Button, Col, descriptors, LocalizationKey, localizationKeys, Text } from '../../customizables';
 import {
   ClipboardInput,
   ContentPage,
@@ -111,9 +111,13 @@ export const AddAuthenticatorApp = (props: AddAuthenticatorAppProps) => {
               textVariant='buttonExtraSmallBold'
               onClick={onContinue}
               localizationKey={localizationKeys('userProfile.formButtonPrimary__continue')}
+              elementDescriptor={descriptors.formButtonPrimary}
             />
 
-            <NavigateToFlowStartButton localizationKey={localizationKeys('userProfile.formButtonReset')} />
+            <NavigateToFlowStartButton
+              localizationKey={localizationKeys('userProfile.formButtonReset')}
+              elementDescriptor={descriptors.formButtonReset}
+            />
           </FormButtonContainer>
         </>
       )}

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodeCreatePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodeCreatePage.tsx
@@ -2,7 +2,7 @@ import { BackupCodeResource } from '@clerk/types';
 import React from 'react';
 
 import { useCoreUser } from '../../contexts';
-import { localizationKeys, Text } from '../../customizables';
+import { descriptors, localizationKeys, Text } from '../../customizables';
 import {
   ContentPage,
   FormButtonContainer,
@@ -63,6 +63,7 @@ export const MfaBackupCodeCreatePage = () => {
               variant='solid'
               autoFocus
               localizationKey={localizationKeys('userProfile.formButtonPrimary__finish')}
+              elementDescriptor={descriptors.formButtonPrimary}
             />
           </FormButtonContainer>
         </>

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodePage.tsx
@@ -1,5 +1,5 @@
 import { useWizard, Wizard } from '../../common';
-import { Button, localizationKeys, Text } from '../../customizables';
+import { Button, descriptors, localizationKeys, Text } from '../../customizables';
 import { ContentPage, FormButtonContainer, NavigateToFlowStartButton, withCardStateProvider } from '../../elements';
 import { MfaBackupCodeCreatePage } from './MfaBackupCodeCreatePage';
 import { UserProfileBreadcrumbs } from './UserProfileNavbar';
@@ -36,9 +36,13 @@ const AddBackupCode = (props: AddBackupCodeProps) => {
           textVariant='buttonExtraSmallBold'
           onClick={onContinue}
           localizationKey={localizationKeys('userProfile.formButtonPrimary__finish')}
+          elementDescriptor={descriptors.formButtonPrimary}
         />
 
-        <NavigateToFlowStartButton localizationKey={localizationKeys('userProfile.formButtonReset')} />
+        <NavigateToFlowStartButton
+          localizationKey={localizationKeys('userProfile.formButtonReset')}
+          elementDescriptor={descriptors.formButtonReset}
+        />
       </FormButtonContainer>
     </ContentPage>
   );

--- a/packages/clerk-js/src/ui/components/UserProfile/VerifyTOTP.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/VerifyTOTP.tsx
@@ -2,7 +2,7 @@ import { TOTPResource } from '@clerk/types';
 import React from 'react';
 
 import { useCoreUser } from '../../contexts';
-import { Col, localizationKeys } from '../../customizables';
+import { Col, descriptors, localizationKeys } from '../../customizables';
 import {
   ContentPage,
   FormButtonContainer,
@@ -68,7 +68,10 @@ export const VerifyTOTP = (props: VerifyTOTPProps) => {
       </Col>
 
       <FormButtonContainer sx={{ marginTop: 0 }}>
-        <NavigateToFlowStartButton localizationKey={localizationKeys('userProfile.formButtonReset')} />
+        <NavigateToFlowStartButton
+          localizationKey={localizationKeys('userProfile.formButtonReset')}
+          elementDescriptor={descriptors.formButtonReset}
+        />
       </FormButtonContainer>
     </ContentPage>
   );

--- a/packages/clerk-js/src/ui/elements/SuccessPage.tsx
+++ b/packages/clerk-js/src/ui/elements/SuccessPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Text } from '../customizables';
+import { descriptors, Text } from '../customizables';
 import { ContentPage, FormButtonContainer, NavigateToFlowStartButton } from '../elements';
 import { LocalizationKey, localizationKeys } from '../localization';
 import { PropsOfComponent } from '../styledSystem';
@@ -34,6 +34,7 @@ export const SuccessPage = (props: SuccessPageProps) => {
           autoFocus
           //Do we need a separate key here?
           localizationKey={finishLabel || localizationKeys('userProfile.formButtonPrimary__finish')}
+          elementDescriptor={descriptors.formButtonPrimary}
           {...(onFinish ? { onClick: onFinish } : {})}
         />
       </FormButtonContainer>


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add some missing button element descriptors in UserProfile TOTP & backup related screens, so a user can target them as well within the appearance prop

<!-- Fixes # (issue number) -->
