### PR TITLE
feat(clerk-js): Separate url builders from Clerk redirection functions

### DIFF
--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -37,6 +37,9 @@ describe('Clerk singleton', () => {
     signInUrl: 'http://test.host/sign-in',
     signUpUrl: 'http://test.host/sign-up',
     userProfileUrl: 'http://test.host/user-profile',
+    homeUrl: 'http://test.host/home',
+    createOrganizationUrl: 'http://test.host/create-organization',
+    organizationProfileUrl: 'http://test.host/organization-profile',
   } as DisplayConfig;
 
   let mockWindowLocation;
@@ -102,7 +105,7 @@ describe('Clerk singleton', () => {
     mockNavigate = jest.fn((to: string) => Promise.resolve(to));
   });
 
-  describe('.redirectTo(SignUp|SignIn|UserProfile)', () => {
+  describe('.redirectTo(SignUp|SignIn|UserProfile|Home|CreateOrganization|OrganizationProfile)', () => {
     let sut: Clerk;
 
     beforeEach(async () => {
@@ -112,19 +115,34 @@ describe('Clerk singleton', () => {
       });
     });
 
-    it('redirects to signInUrl', () => {
-      sut.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
+    it('redirects to signInUrl', async () => {
+      await sut.redirectToSignIn({ redirectUrl: 'https://www.example.com/' });
       expect(mockNavigate).toHaveBeenCalledWith('/sign-in#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
     });
 
-    it('redirects to signUpUrl', () => {
-      sut.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
+    it('redirects to signUpUrl', async () => {
+      await sut.redirectToSignUp({ redirectUrl: 'https://www.example.com/' });
       expect(mockNavigate).toHaveBeenCalledWith('/sign-up#/?redirect_url=https%3A%2F%2Fwww.example.com%2F');
     });
 
-    it('redirects to userProfileUrl', () => {
-      sut.redirectToUserProfile();
+    it('redirects to userProfileUrl', async () => {
+      await sut.redirectToUserProfile();
       expect(mockNavigate).toHaveBeenCalledWith('/user-profile');
+    });
+
+    it('redirects to home', async () => {
+      await sut.redirectToHome();
+      expect(mockNavigate).toHaveBeenCalledWith('/home');
+    });
+
+    it('redirects to create organization', async () => {
+      await sut.redirectToCreateOrganization();
+      expect(mockNavigate).toHaveBeenCalledWith('/create-organization');
+    });
+
+    it('redirects to organization profile', async () => {
+      await sut.redirectToOrganizationProfile();
+      expect(mockNavigate).toHaveBeenCalledWith('/organization-profile');
     });
   });
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -277,38 +277,90 @@ export interface Clerk {
   navigate: CustomNavigation;
 
   /**
-   * Redirects to the configured sign in URL. Retrieved from {@link environment}.
+   *
+   * Decorates the provided url with the auth token for development instances.
+   *
+   * @param {string} to
+   */
+  buildUrlWithAuth(to: string): string;
+
+  /**
+   * Returns the configured url where <SignIn/> is mounted or a custom sign-in page is rendered.
+   *
+   * @param opts A {@link RedirectOptions} object
+   *
+   */
+  buildSignInUrl(opts?: RedirectOptions): string;
+
+  /**
+   * Returns the configured url where <SignUp/> is mounted or a custom sign-up page is rendered.
+   *
+   * @param opts A {@link RedirectOptions} object
+   *
+   */
+  buildSignUpUrl(opts?: RedirectOptions): string;
+
+  /**
+   * Returns the url where <UserProfile /> is mounted or a custom user-profile page is rendered.
+   */
+  buildUserProfileUrl(): string;
+
+  /**
+   * Returns the configured url where <CreateOrganization /> is mounted or a custom create-organization page is rendered.
+   */
+  buildCreateOrganizationUrl(): string;
+
+  /**
+   * Returns the configured url where <OrganizationProfile /> is mounted or a custom organization-profile page is rendered.
+   */
+  buildOrganizationProfileUrl(): string;
+
+  /**
+   * Returns the configured home URL of the instance.
+   */
+  buildHomeUrl(): string;
+
+  /**
+   *
+   * Redirects to the provided url after decorating it with the auth token for development instances.
+   *
+   * @param {string} to
+   */
+  redirectWithAuth(to: string): Promise<unknown>;
+
+  /**
+   * Redirects to the configured URL where <SignIn/> is mounted.
    *
    * @param opts A {@link RedirectOptions} object
    */
   redirectToSignIn(opts?: RedirectOptions): Promise<unknown>;
 
   /**
-   * Redirects to the configured sign up URL. Retrieved from {@link environment}.
+   * Redirects to the configured URL where <SignUp/> is mounted.
    *
    * @param opts A {@link RedirectOptions} object
    */
   redirectToSignUp(opts?: RedirectOptions): Promise<unknown>;
 
   /**
-   * Redirects to the configured user profile URL. Retrieved from {@link environment}.
+   * Redirects to the configured URL where <UserProfile/> is mounted.
    */
   redirectToUserProfile: () => void;
 
   /**
-   * Redirects to the configured home URL. Retrieved from {@link environment}.
-   */
-  redirectToHome: () => void;
-
-  /**
-   * Redirects to the configured URL where <OrganizationProfile /> is mounted. Retrieved from {@link environment}.
+   * Redirects to the configured URL where <OrganizationProfile /> is mounted.
    */
   redirectToOrganizationProfile: () => void;
 
   /**
-   * Redirects to the configured URL where <CreateOrganization /> is mounted. Retrieved from {@link environment}.
+   * Redirects to the configured URL where <CreateOrganization /> is mounted.
    */
   redirectToCreateOrganization: () => void;
+
+  /**
+   * Redirects to the configured home URL of the instance.
+   */
+  redirectToHome: () => void;
 
   /**
    * Completes an OAuth flow started by {@link Clerk.client.signIn.authenticateWithRedirect} or {@link Clerk.client.signUp.authenticateWithRedirect}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The introduction of cookieless-auth for development instances makes Clerk redirection function crucial for application development as developers should use them to handle all redirection logic in their applications.

Url builders are meant to be used by non-browser environments such as Expo where as redirection functions use the url builders and operate in a browser context.