### PR TITLE
test(clerk-js): Run fake timers in SignIn tests where necessary

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
@@ -36,7 +36,7 @@ describe('SignInFactorTwo', () => {
       expect(inputs.length).toBe(6);
     });
 
-    it('sets an active session when user submits second factor successfully', async () => {
+    it.only('sets an active session when user submits second factor successfully', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.startSignInFactorTwo();
       });
@@ -44,11 +44,14 @@ describe('SignInFactorTwo', () => {
       fixtures.signIn.attemptSecondFactor.mockReturnValueOnce(
         Promise.resolve({ status: 'complete' } as SignInResource),
       );
-      const { userEvent } = render(<SignInFactorTwo />, { wrapper });
+      await runFakeTimers(async timers => {
+        const { userEvent } = render(<SignInFactorTwo />, { wrapper });
 
-      await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
-      await waitFor(() => {
-        expect(fixtures.clerk.setActive).toBeCalled();
+        await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
+        timers.runOnlyPendingTimers();
+        await waitFor(() => {
+          expect(fixtures.clerk.setActive).toHaveBeenCalled();
+        });
       });
     });
   });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
