### PR TITLE
fix(clerk-js): Add button element descriptors in UserProfile email code & magic link screens

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/VerifyWithCode.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/VerifyWithCode.tsx
@@ -1,7 +1,7 @@
 import { EmailAddressResource, PhoneNumberResource } from '@clerk/types';
 import React from 'react';
 
-import { localizationKeys } from '../../customizables';
+import { descriptors, localizationKeys } from '../../customizables';
 import { FormButtonContainer, NavigateToFlowStartButton, useCardState, useCodeControl } from '../../elements';
 import { CodeForm } from '../../elements/CodeForm';
 import { useLoadingStatus } from '../../hooks';
@@ -64,7 +64,10 @@ export const VerifyWithCode = (props: VerifyWithCodeProps) => {
         onResendCodeClicked={prepare}
       />
       <FormButtonContainer>
-        <NavigateToFlowStartButton localizationKey={localizationKeys('userProfile.formButtonReset')} />
+        <NavigateToFlowStartButton
+          localizationKey={localizationKeys('userProfile.formButtonReset')}
+          elementDescriptor={descriptors.formButtonReset}
+        />
       </FormButtonContainer>
     </>
   );

--- a/packages/clerk-js/src/ui/components/UserProfile/VerifyWithLink.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/VerifyWithLink.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { EmailLinkStatusCard } from '../../common';
 import { buildMagicLinkRedirectUrl } from '../../common/redirects';
 import { useEnvironment, useUserProfileContext } from '../../contexts';
-import { localizationKeys } from '../../customizables';
+import { descriptors, localizationKeys } from '../../customizables';
 import { FormButtonContainer, NavigateToFlowStartButton, useCardState, VerificationLink } from '../../elements';
 import { useMagicLink } from '../../hooks';
 import { handleError } from '../../utils';
@@ -53,7 +53,10 @@ export const VerifyWithLink = (props: VerifyWithLinkProps) => {
         onResendCodeClicked={startVerification}
       />
       <FormButtonContainer>
-        <NavigateToFlowStartButton localizationKey={localizationKeys('userProfile.formButtonReset')} />
+        <NavigateToFlowStartButton
+          localizationKey={localizationKeys('userProfile.formButtonReset')}
+          elementDescriptor={descriptors.formButtonReset}
+        />
       </FormButtonContainer>
     </>
   );


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add the missing button element descriptors in the UserProfile email code & magic link related screens, so users can target them as well to apply their appearance

<!-- Fixes # (issue number) -->