### PR TITLE
feat(clerk-js,types): Terse paths parameters

### DIFF
--- a/packages/clerk-js/src/ui/common/__tests__/authPropHelpers.test.ts
+++ b/packages/clerk-js/src/ui/common/__tests__/authPropHelpers.test.ts
@@ -1,0 +1,15 @@
+import { normalizeRoutingOptions } from '../authPropHelpers';
+
+describe('auth prop helpers', () => {
+  describe('normalizeRoutingOptions', () => {
+    it("returns routing: 'path' if path was provided and no routing was provided", () => {
+      expect(normalizeRoutingOptions({ path: 'test' })).toEqual({ routing: 'path', path: 'test' });
+    });
+
+    it('returns the same options if routing was provided (any routing) and path was provided', () => {
+      expect(normalizeRoutingOptions({ routing: 'path', path: 'test' })).toEqual({ routing: 'path', path: 'test' });
+      expect(normalizeRoutingOptions({ routing: 'hash', path: 'test' })).toEqual({ routing: 'hash', path: 'test' });
+      expect(normalizeRoutingOptions({ routing: 'virtual' })).toEqual({ routing: 'virtual' });
+    });
+  });
+});

--- a/packages/clerk-js/src/ui/common/__tests__/authPropHelpers.test.ts
+++ b/packages/clerk-js/src/ui/common/__tests__/authPropHelpers.test.ts
@@ -6,7 +6,12 @@ describe('auth prop helpers', () => {
       expect(normalizeRoutingOptions({ path: 'test' })).toEqual({ routing: 'path', path: 'test' });
     });
 
-    it('returns the same options if routing was provided (any routing) and path was provided', () => {
+    it('returns routing: null if path was provided and routing was null (avoid breaking integrations)', () => {
+      //@ts-expect-error
+      expect(normalizeRoutingOptions({ path: 'test', routing: null })).toEqual({ routing: null, path: 'test' });
+    });
+
+    it('returns the same options if routing was provided (any routing) and path was provided (avoid breaking integrations)', () => {
       expect(normalizeRoutingOptions({ routing: 'path', path: 'test' })).toEqual({ routing: 'path', path: 'test' });
       expect(normalizeRoutingOptions({ routing: 'hash', path: 'test' })).toEqual({ routing: 'hash', path: 'test' });
       expect(normalizeRoutingOptions({ routing: 'virtual' })).toEqual({ routing: 'virtual' });

--- a/packages/clerk-js/src/ui/common/authPropHelpers.ts
+++ b/packages/clerk-js/src/ui/common/authPropHelpers.ts
@@ -86,5 +86,5 @@ export const normalizeRoutingOptions = ({
   routing?: RoutingStrategy;
   path?: string;
 }): RoutingOptions => {
-  return { routing: !!path && !routing ? 'path' : routing, path } as RoutingOptions;
+  return { routing: !!path && routing === undefined ? 'path' : routing, path } as RoutingOptions;
 };

--- a/packages/clerk-js/src/ui/common/authPropHelpers.ts
+++ b/packages/clerk-js/src/ui/common/authPropHelpers.ts
@@ -86,5 +86,5 @@ export const normalizeRoutingOptions = ({
   routing?: RoutingStrategy;
   path?: string;
 }): RoutingOptions => {
-  return { routing: !routing && path !== undefined ? 'path' : routing, path } as RoutingOptions;
+  return { routing: !!path && !routing ? 'path' : routing, path } as RoutingOptions;
 };

--- a/packages/clerk-js/src/ui/common/authPropHelpers.ts
+++ b/packages/clerk-js/src/ui/common/authPropHelpers.ts
@@ -1,5 +1,5 @@
 import { camelToSnake } from '@clerk/shared';
-import type { DisplayConfigResource } from '@clerk/types';
+import type { DisplayConfigResource, RoutingOptions, RoutingStrategy } from '@clerk/types';
 import type { ParsedQs } from 'qs';
 import qs from 'qs';
 
@@ -77,4 +77,14 @@ export const buildAuthQueryString = (data: BuildAuthQueryStringArgs): string | n
     }
   }
   return Object.keys(query).length === 0 ? null : qs.stringify(query);
+};
+
+export const normalizeRoutingOptions = ({
+  routing,
+  path,
+}: {
+  routing?: RoutingStrategy;
+  path?: string;
+}): RoutingOptions => {
+  return { routing: !routing && path !== undefined ? 'path' : routing, path } as RoutingOptions;
 };

--- a/packages/react/src/components/withClerk.tsx
+++ b/packages/react/src/components/withClerk.tsx
@@ -1,4 +1,5 @@
 import { LoadedClerk } from '@clerk/types';
+import { Without } from '@clerk/types/src';
 import React from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
@@ -11,7 +12,7 @@ export const withClerk = <P extends { clerk: LoadedClerk }>(
 ) => {
   displayName = displayName || Component.displayName || Component.name || 'Component';
   Component.displayName = displayName;
-  const HOC = (props: Omit<P, 'clerk'>) => {
+  const HOC = (props: Without<P, 'clerk'>) => {
     const clerk = useIsomorphicClerkContext();
 
     if (!clerk.loaded) {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -472,6 +472,26 @@ export interface Resources {
 
 export type RoutingStrategy = 'path' | 'hash' | 'virtual';
 
+export type RoutingOptions =
+  | {
+      /**
+       * Page routing strategy
+       */
+      routing?: Exclude<RoutingStrategy, 'path'>;
+      /**
+       * Root URL where the component is mounted on, eg: '/sign-in'
+       */
+      path?: never;
+    }
+  | {
+      routing: 'path';
+      path: string;
+    }
+  | {
+      routing?: never;
+      path: string;
+    };
+
 export type RedirectOptions = {
   /**
    * Full URL or path to navigate after successful sign in.
@@ -516,15 +536,7 @@ export type SetActiveParams = {
 
 export type SetActive = (params: SetActiveParams) => Promise<void>;
 
-export type SignInProps = {
-  /*
-   * Page routing strategy
-   */
-  routing?: RoutingStrategy;
-  /*
-   * Root URL where the component is mounted on, eg: '/sign in'
-   */
-  path?: string;
+export type SignInProps = RoutingOptions & {
   /**
    * Full URL or path to for the sign up process.
    * Used to fill the "Sign up" link in the SignUp component.
@@ -538,15 +550,7 @@ export type SignInProps = {
   appearance?: SignInTheme;
 } & RedirectOptions;
 
-export type SignUpProps = {
-  /*
-   * Page routing strategy
-   */
-  routing?: RoutingStrategy;
-  /*
-   * Root URL where the component is mounted on, eg: '/sign up'
-   */
-  path?: string;
+export type SignUpProps = RoutingOptions & {
   /**
    * Full URL or path to for the sign in process.
    * Used to fill the "Sign in" link in the SignUp component.
@@ -560,15 +564,7 @@ export type SignUpProps = {
   appearance?: SignUpTheme;
 } & RedirectOptions;
 
-export type UserProfileProps = {
-  /*
-   * Page routing strategy
-   */
-  routing?: RoutingStrategy;
-  /*
-   * Root URL where the component is mounted on, eg: '/user'
-   */
-  path?: string;
+export type UserProfileProps = RoutingOptions & {
   /*
    * Renders only a specific view of the component eg: 'security'
    */
@@ -581,15 +577,7 @@ export type UserProfileProps = {
   appearance?: UserProfileTheme;
 };
 
-export type OrganizationProfileProps = {
-  /*
-   * Page routing strategy
-   */
-  routing?: RoutingStrategy;
-  /*
-   * Root URL where the component is mounted on, eg: '/user'
-   */
-  path?: string;
+export type OrganizationProfileProps = RoutingOptions & {
   /**
    * Full URL or path to navigate to after the user leaves the currently active organization.
    * @default undefined
@@ -603,15 +591,7 @@ export type OrganizationProfileProps = {
   appearance?: OrganizationProfileTheme;
 };
 
-export type CreateOrganizationProps = {
-  /*
-   * Page routing strategy
-   */
-  routing?: RoutingStrategy;
-  /*
-   * Root URL where the component is mounted on, eg: '/user'
-   */
-  path?: string;
+export type CreateOrganizationProps = RoutingOptions & {
   /**
    * Full URL or path to navigate after creating a new organization.
    * @default undefined

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -473,24 +473,8 @@ export interface Resources {
 export type RoutingStrategy = 'path' | 'hash' | 'virtual';
 
 export type RoutingOptions =
-  | {
-      /**
-       * Page routing strategy
-       */
-      routing?: Exclude<RoutingStrategy, 'path'>;
-      /**
-       * Root URL where the component is mounted on, eg: '/sign-in'
-       */
-      path?: never;
-    }
-  | {
-      routing: 'path';
-      path: string;
-    }
-  | {
-      routing?: never;
-      path: string;
-    };
+  | { path: string; routing?: Extract<RoutingStrategy, 'path'> }
+  | { path?: never; routing?: Extract<RoutingStrategy, 'hash' | 'virtual'> };
 
 export type RedirectOptions = {
   /**

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -35,6 +35,13 @@ export type DeepRequired<T> = Required<{
 }>;
 
 /**
+ * Omit without union flattening
+ * */
+export type Without<T, W> = {
+  [P in keyof T as Exclude<P, W>]: T[P];
+};
+
+/**
  * Internal type used by RecordToPath
  */
 type PathImpl<T, Key extends keyof T> = Key extends string


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
After this PR, when the `routing` prop is not passed, and the `path` prop is passed, `routing` will default to `'path'`.

The types for this are also stricter so the path prop will throw a typescript error if passed without `routing='path'`
<!-- Fixes # (issue number) -->
