### PR TITLE
fix(clerk-js): Add missing localization keys on backup codes finish screen

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodeList.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaBackupCodeList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { PrintableComponent, usePrintable } from '../../common';
 import { useCoreUser, useEnvironment } from '../../contexts';
-import { Button, Col, Flex, Grid, Heading, LocalizationKey, Text } from '../../customizables';
+import { Button, Col, Flex, Grid, Heading, LocalizationKey, localizationKeys, Text } from '../../customizables';
 import { useClipboard } from '../../hooks';
 import { mqu } from '../../styledSystem';
 import { getIdentifier } from '../../utils';
@@ -40,7 +40,7 @@ export const MfaBackupCodeList = (props: MfaBackupCodeListProps) => {
     <>
       <Col gap={1}>
         <Text
-          localizationKey={'Backup codes'}
+          localizationKey={localizationKeys('userProfile.backupCodePage.title__codelist')}
           variant='regularMedium'
         />
         <Text
@@ -71,25 +71,26 @@ export const MfaBackupCodeList = (props: MfaBackupCodeListProps) => {
           variant='link'
           colorScheme='primary'
           onClick={onCopy}
-        >
-          {!hasCopied ? 'Copy all' : 'Copied!'}
-        </Button>
+          localizationKey={
+            !hasCopied
+              ? localizationKeys('userProfile.backupCodePage.actionLabel__copy')
+              : localizationKeys('userProfile.backupCodePage.actionLabel__copied')
+          }
+        />
 
         <Button
           variant='link'
           colorScheme='primary'
           onClick={onDownloadTxtFile}
-        >
-          Download .txt
-        </Button>
+          localizationKey={localizationKeys('userProfile.backupCodePage.actionLabel__download')}
+        />
 
         <Button
           variant='link'
           colorScheme='primary'
           onClick={print}
-        >
-          Print
-        </Button>
+          localizationKey={localizationKeys('userProfile.backupCodePage.actionLabel__print')}
+        />
       </Flex>
 
       <PrintableComponent {...printableProps}>

--- a/packages/clerk-js/src/ui/localization/defaultEnglishResource.ts
+++ b/packages/clerk-js/src/ui/localization/defaultEnglishResource.ts
@@ -425,6 +425,7 @@ export const defaultResource: DeepRequired<LocalizationResource> = {
     },
     backupCodePage: {
       title: 'Add backup code verification',
+      title__codelist: 'Backup codes',
       subtitle__codelist: 'Store them securely and keep them secret.',
       infoText1: 'Backup codes will be enabled for this account.',
       infoText2:
@@ -433,6 +434,10 @@ export const defaultResource: DeepRequired<LocalizationResource> = {
         'You can use one of these to sign in to your account, if you lose access to your authentication device.',
       successMessage:
         'Backup codes are now enabled. You can use one of these to sign in to your account, if you lose access to your authentication device. Each code can only be used once.',
+      actionLabel__copy: 'Copy all',
+      actionLabel__copied: 'Copied!',
+      actionLabel__download: 'Download .txt',
+      actionLabel__print: 'Print',
     },
   },
   userButton: {

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -425,11 +425,16 @@ type _LocalizationResource = {
     };
     backupCodePage: {
       title: LocalizationValue;
+      title__codelist: LocalizationValue;
       subtitle__codelist: LocalizationValue;
       infoText1: LocalizationValue;
       infoText2: LocalizationValue;
       successSubtitle: LocalizationValue;
       successMessage: LocalizationValue;
+      actionLabel__copy: LocalizationValue;
+      actionLabel__copied: LocalizationValue;
+      actionLabel__download: LocalizationValue;
+      actionLabel__print: LocalizationValue;
     };
   };
   userButton: {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add some missing localization keys for users to be able to translate all the text in the backup codes finish screen. This PR also adds some new localization resources which are the below:
- `userProfile.backupCodePage.title__codelist`
- `userProfile.backupCodePage. actionLabel__copy`
- `userProfile.backupCodePage. actionLabel__copied`
- `userProfile.backupCodePage. actionLabel__download`
- `userProfile.backupCodePage. actionLabel__print`

<!-- Fixes # (issue number) -->
