### PR TITLE
Use web workers to fire timeouts and intervals

### DIFF
--- a/packages/clerk-js/src/core/services/authentication/AuthenticationPoller.ts
+++ b/packages/clerk-js/src/core/services/authentication/AuthenticationPoller.ts
@@ -7,7 +7,7 @@ const INTERVAL_IN_MS = 5 * 1000;
 
 export class AuthenticationPoller {
   private lock = SafeLock(REFRESH_SESSION_TOKEN_LOCK_KEY);
-  private workerTimers = createWorkerTimers().workerTimers;
+  private workerTimers = createWorkerTimers();
   private timerId: ReturnType<typeof this.workerTimers.setInterval> | null = null;
 
   public startPollingForSessionToken(cb: () => unknown): void {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -14,3 +14,4 @@ export * from './poller';
 export * from './ssr';
 export * from './string';
 export * from './url';
+export * from './workerTimers';

--- a/packages/shared/src/utils/poller.ts
+++ b/packages/shared/src/utils/poller.ts
@@ -14,7 +14,7 @@ export type Poller = {
 };
 
 export function Poller({ delayInMs }: PollerOptions = { delayInMs: 1000 }): Poller {
-  const { workerTimers } = createWorkerTimers();
+  const workerTimers = createWorkerTimers();
 
   let timerId: number | undefined;
   let stopped = false;

--- a/packages/shared/src/utils/poller.ts
+++ b/packages/shared/src/utils/poller.ts
@@ -22,6 +22,7 @@ export function Poller({ delayInMs }: PollerOptions = { delayInMs: 1000 }): Poll
   const stop: PollerStop = () => {
     if (timerId) {
       workerTimers.clearTimeout(timerId);
+      workerTimers.cleanup();
     }
     stopped = true;
   };

--- a/packages/shared/src/utils/workerTimers/createWorkerTimers.ts
+++ b/packages/shared/src/utils/workerTimers/createWorkerTimers.ts
@@ -1,0 +1,63 @@
+import {
+  WorkerClearTimeout,
+  WorkerSetTimeout,
+  WorkerTimeoutCallback,
+  WorkerTimerEvent,
+  WorkerTimerId,
+  WorkerTimerResponseEvent,
+} from './workerTimers.types';
+// @ts-ignore
+import pollerWorkerSource from './workerTimers.worker';
+
+const createWebWorker = (source: string, opts: ConstructorParameters<typeof Worker>[1] = {}) => {
+  const workerFile = new Blob([source]);
+  const workerScript = globalThis.URL.createObjectURL(workerFile);
+  return new Worker(workerScript, opts);
+};
+
+export const createWorkerTimers = () => {
+  if (typeof Worker === 'undefined') {
+    const setTimeout = globalThis.setTimeout as WorkerSetTimeout;
+    const setInterval = globalThis.setInterval as WorkerSetTimeout;
+    const clearTimeout = globalThis.clearTimeout as WorkerClearTimeout;
+    const clearInterval = globalThis.clearInterval as WorkerClearTimeout;
+    return { workerTimers: { setTimeout, setInterval, clearTimeout, clearInterval } };
+  }
+
+  let id = 0;
+  const callbacks = new Map<WorkerTimerId, WorkerTimeoutCallback>();
+  const generateId = () => id++;
+  const worker = createWebWorker(pollerWorkerSource, { name: 'clerk-timers' });
+  const post = (p: WorkerTimerEvent) => worker.postMessage(p);
+
+  worker.addEventListener('message', e => {
+    const data = e.data as WorkerTimerResponseEvent;
+    callbacks.get(data.id)?.();
+  });
+
+  const setTimeout: WorkerSetTimeout = (cb, ms) => {
+    const id = generateId();
+    callbacks.set(id, cb);
+    post({ type: 'setTimeout', id, ms });
+    return id;
+  };
+
+  const setInterval: WorkerSetTimeout = (cb, ms) => {
+    const id = generateId();
+    callbacks.set(id, cb);
+    post({ type: 'setInterval', id, ms });
+    return id;
+  };
+
+  const clearTimeout: WorkerClearTimeout = id => {
+    callbacks.delete(id);
+    post({ type: 'clearTimeout', id });
+  };
+
+  const clearInterval: WorkerClearTimeout = id => {
+    callbacks.delete(id);
+    post({ type: 'clearInterval', id });
+  };
+
+  return { workerTimers: { setTimeout, setInterval, clearTimeout, clearInterval } };
+};

--- a/packages/shared/src/utils/workerTimers/createWorkerTimers.ts
+++ b/packages/shared/src/utils/workerTimers/createWorkerTimers.ts
@@ -21,7 +21,7 @@ export const createWorkerTimers = () => {
     const setInterval = globalThis.setInterval as WorkerSetTimeout;
     const clearTimeout = globalThis.clearTimeout as WorkerClearTimeout;
     const clearInterval = globalThis.clearInterval as WorkerClearTimeout;
-    return { workerTimers: { setTimeout, setInterval, clearTimeout, clearInterval } };
+    return { setTimeout, setInterval, clearTimeout, clearInterval };
   }
 
   let id = 0;
@@ -59,5 +59,5 @@ export const createWorkerTimers = () => {
     post({ type: 'clearInterval', id });
   };
 
-  return { workerTimers: { setTimeout, setInterval, clearTimeout, clearInterval } };
+  return { setTimeout, setInterval, clearTimeout, clearInterval };
 };

--- a/packages/shared/src/utils/workerTimers/index.ts
+++ b/packages/shared/src/utils/workerTimers/index.ts
@@ -1,0 +1,1 @@
+export { createWorkerTimers } from './createWorkerTimers';

--- a/packages/shared/src/utils/workerTimers/workerTimers.types.ts
+++ b/packages/shared/src/utils/workerTimers/workerTimers.types.ts
@@ -1,0 +1,13 @@
+export type WorkerTimerId = number;
+
+export type WorkerTimerEvent = {
+  type: 'setTimeout' | 'clearTimeout' | 'setInterval' | 'clearInterval';
+  id: WorkerTimerId;
+  ms?: number;
+};
+
+export type WorkerTimerResponseEvent = Pick<WorkerTimerEvent, 'id'>;
+
+export type WorkerTimeoutCallback = () => void;
+export type WorkerSetTimeout = (cb: WorkerTimeoutCallback, ms: number) => WorkerTimerId;
+export type WorkerClearTimeout = (id: WorkerTimerId) => void;

--- a/packages/shared/src/utils/workerTimers/workerTimers.worker.ts
+++ b/packages/shared/src/utils/workerTimers/workerTimers.worker.ts
@@ -1,0 +1,39 @@
+import type { WorkerTimerEvent, WorkerTimerId, WorkerTimerResponseEvent } from './workerTimers.types';
+// This file is loaded as TEXT by esbuild during build
+// and fed into a blob so we can easily instantiate the web worker
+// look at the tsup.config.ts file for more details on the loader
+
+const respond = (p: WorkerTimerResponseEvent) => {
+  self.postMessage(p);
+};
+
+const workerToTabIds: Record<WorkerTimerId, WorkerTimerId> = {};
+
+self.addEventListener('message', e => {
+  const data = e.data as WorkerTimerEvent;
+
+  switch (data.type) {
+    case 'setTimeout':
+      workerToTabIds[data.id] = setTimeout(() => {
+        respond({ id: data.id });
+      }, data.ms) as unknown as WorkerTimerId;
+      break;
+    case 'clearTimeout':
+      if (workerToTabIds[data.id]) {
+        clearTimeout(workerToTabIds[data.id]);
+        delete workerToTabIds[data.id];
+      }
+      break;
+    case 'setInterval':
+      workerToTabIds[data.id] = setInterval(() => {
+        respond({ id: data.id });
+      }, data.ms) as unknown as WorkerTimerId;
+      break;
+    case 'clearInterval':
+      if (workerToTabIds[data.id]) {
+        clearInterval(workerToTabIds[data.id]);
+        delete workerToTabIds[data.id];
+      }
+      break;
+  }
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -13,7 +13,8 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "declarationDir": "dist/types",
-    "jsx": "react"
+    "jsx": "react",
+    "lib": ["ES6", "DOM", "WebWorker"]
   },
   "exclude": ["node_modules"],
   "include": ["src/index.ts", "src/testUtils/index.ts", "global.d.ts"]

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -31,7 +31,6 @@ export const WebWorkerMinifyPlugin: Plugin = {
     build.onLoad({ filter: /\.worker\.ts/ }, async args => {
       const f = await readFile(args.path);
       const js = await transform(f, { loader: 'ts', minify: true });
-      console.log(js.code);
       return { loader: 'text', contents: js.code };
     });
   },

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -1,3 +1,5 @@
+import { Plugin, transform } from 'esbuild';
+import { readFile } from 'fs/promises';
 import { defineConfig } from 'tsup';
 
 // @ts-expect-error
@@ -16,5 +18,21 @@ export default defineConfig(overrideOptions => {
     define: { PACKAGE_VERSION: `"${version}"`, __DEV__: `${!isProd}` },
     external: ['@testing-library', 'react', 'react-test-renderer', 'jest', 'jest-environment-jsdom', 'react-dom'],
     legacyOutput: true,
+    esbuildPlugins: [WebWorkerMinifyPlugin],
   };
 });
+
+// Read transform and minify any files ending in .worker.ts
+// These files can be imported as modules and used as string when instantiating
+// a new web worker, without loading an external file during runtime
+export const WebWorkerMinifyPlugin: Plugin = {
+  name: 'WebWorkerMinifyPlugin',
+  setup(build) {
+    build.onLoad({ filter: /\.worker\.ts/ }, async args => {
+      const f = await readFile(args.path);
+      const js = await transform(f, { loader: 'ts', minify: true });
+      console.log(js.code);
+      return { loader: 'text', contents: js.code };
+    });
+  },
+};


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
For more context, you can read this [introductory article](https://developer.chrome.com/blog/timer-throttling-in-chrome-88/) briefly explaining what timer throttling is.

Our authentication poller uses a usual `setInterval` timer to check if the JWT needs to be refreshed and update the `__session` cookie accordingly. Even though most browsers claim to fire the timers at least once per minute, even when throttled, our tests have shown that background tabs under certain conditions will throttle the timers more, and the once-per-minute claim is not guaranteed. 

If the authentication poller does not fire at the correct interval and given that by default, we're using a very short-lived token for security reasons (~1min TTL), the token can expire, and any background requests using that token will eventually fail.

To prevent this issue, we're introducing an abstraction over the web worker API. Web workers run on a different thread and are not subject to the same throttling restrictions. 

## What to test
- JWT refresh
- `__session` cookie update
- email link flow

## Other considerations
The [page lifecycle API](https://wicg.github.io/page-lifecycle/#worklets-workers) states that if a tab transitions to the `frozen` state, worker execution will also halt - no other background requests can be running at that time, though. The frozen state is not yet supported by most browsers, and although Chrome claims it supports it, it's not clear how and if it's actually used yet. If we end up facing issues in the future, we can use the `freeze` and `resume` events to handle the stale token accordingly.

<!-- Fixes # (issue number) -->
