### PR TITLE
fix(clerk-js): Fix cookieless logic

### DIFF
--- a/packages/clerk-js/src/core/devBrowserHandler.ts
+++ b/packages/clerk-js/src/core/devBrowserHandler.ts
@@ -32,7 +32,7 @@ export default function createDevBrowserHandler({
   const cookieHandler = createCookieHandler();
   const key = DEV_BROWSER_SSO_JWT_KEY;
 
-  let isCookielessDev = false;
+  let isCookielessDev = true;
 
   function getDevBrowserJWT() {
     return localStorage.getItem(key);
@@ -135,6 +135,8 @@ export default function createDevBrowserHandler({
       isCookielessDev = true;
       const data = await resp.json();
       setDevBrowserJWT(data?.token);
+    } else {
+      isCookielessDev = false;
     }
   }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

ClerkJS assumes it starts in cookieless mode by default. Then it switches to cookie based only if the FAPI POST /dev_browser request fails.

That way, redirecting from localhost to accounts will work correctly.