### PR TITLE
feat(clerk-js): Align avatars in organization switcher popover

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
@@ -62,6 +62,7 @@ export const OrganizationActionList = (props: OrganizationActionListProps) => {
               gap={3}
               user={{ profileImageUrl: user.profileImageUrl }}
               size='sm'
+              avatarSx={t => ({ marginLeft: `calc(${t.space.$3}/2)` })}
               title={localizationKeys('organizationSwitcher.personalWorkspace')}
             />
           </PreviewButton>
@@ -86,6 +87,7 @@ export const OrganizationActionList = (props: OrganizationActionListProps) => {
           >
             <OrganizationPreview
               gap={3}
+              avatarSx={t => ({ marginLeft: `calc(${t.space.$3}/2)` })}
               organization={organization}
               size='sm'
             />

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -2,7 +2,7 @@ import { OrganizationResource, UserResource } from '@clerk/types';
 import React from 'react';
 
 import { Flex, Text } from '../customizables';
-import { PropsOfComponent } from '../styledSystem';
+import { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { roleLocalizationKey } from '../utils';
 import { OrganizationAvatar } from './OrganizationAvatar';
 
@@ -10,6 +10,7 @@ export type OrganizationPreviewProps = PropsOfComponent<typeof Flex> & {
   organization: OrganizationResource;
   user?: UserResource;
   size?: 'lg' | 'md' | 'sm';
+  avatarSx?: ThemableCssProp;
   icon?: React.ReactNode;
   badge?: React.ReactNode;
   rounded?: boolean;
@@ -17,7 +18,7 @@ export type OrganizationPreviewProps = PropsOfComponent<typeof Flex> & {
 };
 
 export const OrganizationPreview = (props: OrganizationPreviewProps) => {
-  const { organization, size = 'md', icon, rounded = false, badge, sx, user, ...rest } = props;
+  const { organization, size = 'md', icon, rounded = false, badge, sx, user, avatarSx, ...rest } = props;
   const role = user?.organizationMemberships.find(membership => membership.organization.id === organization.id)?.role;
 
   return (
@@ -35,6 +36,7 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
           {...organization}
           size={t => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size])}
           optimize
+          sx={avatarSx}
           rounded={rounded}
         />
         {icon && <Flex sx={{ position: 'absolute', left: 0, bottom: 0 }}>{icon}</Flex>}

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -2,7 +2,7 @@ import { UserResource } from '@clerk/types';
 import React from 'react';
 
 import { descriptors, Flex, LocalizationKey, Text, useLocalizations } from '../customizables';
-import { PropsOfComponent } from '../styledSystem';
+import { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { getFullName, getIdentifier } from '../utils';
 import { UserAvatar } from './UserAvatar';
 
@@ -14,6 +14,7 @@ export type UserPreviewProps = Omit<PropsOfComponent<typeof Flex>, 'title'> & {
   imageUrl?: string | null;
   rounded?: boolean;
   elementId?: any;
+  avatarSx?: ThemableCssProp;
   title?: LocalizationKey | string;
   subtitle?: LocalizationKey | string;
   showAvatar?: boolean;
@@ -32,6 +33,7 @@ export const UserPreview = (props: UserPreviewProps) => {
     sx,
     title,
     subtitle,
+    avatarSx,
     ...rest
   } = props;
   const { t } = useLocalizations();
@@ -62,6 +64,7 @@ export const UserPreview = (props: UserPreviewProps) => {
             imageUrl={imageUrl || user?.profileImageUrl}
             size={t => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size])}
             optimize
+            sx={avatarSx}
             rounded={rounded}
           />
           {icon && <Flex sx={{ position: 'absolute', left: 0, bottom: 0 }}>{icon}</Flex>}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
<img width="363" alt="Screenshot 2022-11-30 at 09 34 50" src="https://user-images.githubusercontent.com/73396808/204734910-fa75d946-f51d-4fbd-920d-a1073e4ab00c.png">

<!-- Fixes # (issue number) -->
