### PR TITLE
fix(clerk-js): Set organization to null when in personal workspace

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -493,9 +493,10 @@ export default class Clerk implements ClerkInterface {
     }
 
     this.session = session;
-    this.organization = (this.session?.user.organizationMemberships || [])
-      .map(om => om.organization)
-      .find(org => org.id === this.session?.lastActiveOrganizationId);
+    this.organization =
+      (this.session?.user.organizationMemberships || [])
+        .map(om => om.organization)
+        .find(org => org.id === this.session?.lastActiveOrganizationId) || null;
     this.user = this.session ? this.session.user : null;
 
     this.#emit();
@@ -903,9 +904,10 @@ export default class Clerk implements ClerkInterface {
         (this.#options.selectInitialSession
           ? this.#options.selectInitialSession(newClient)
           : this.#defaultSession(newClient)) || null;
-      this.organization = (this.session?.user.organizationMemberships || [])
-        .map(om => om.organization)
-        .find(org => org.id === this.session?.lastActiveOrganizationId);
+      this.organization =
+        (this.session?.user.organizationMemberships || [])
+          .map(om => om.organization)
+          .find(org => org.id === this.session?.lastActiveOrganizationId) || null;
       this.user = this.session ? this.session.user : null;
     }
     this.client = newClient;
@@ -913,9 +915,10 @@ export default class Clerk implements ClerkInterface {
     if (this.session) {
       const lastId = this.session.id;
       this.session = newClient.activeSessions.find(x => x.id === lastId);
-      this.organization = (this.session?.user.organizationMemberships || [])
-        .map(om => om.organization)
-        .find(org => org.id === this.session?.lastActiveOrganizationId);
+      this.organization =
+        (this.session?.user.organizationMemberships || [])
+          .map(om => om.organization)
+          .find(org => org.id === this.session?.lastActiveOrganizationId) || null;
       this.user = this.session ? this.session.user : null;
     }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
