### PR TITLE
feat(clerk-js): Add white border to QR code svg

### DIFF
--- a/packages/clerk-js/src/ui/common/QRCode.tsx
+++ b/packages/clerk-js/src/ui/common/QRCode.tsx
@@ -1,0 +1,26 @@
+import { QRCodeSVG } from 'qrcode.react';
+
+import { descriptors, Flex } from '../customizables';
+import { PropsOfComponent } from '../styledSystem';
+
+type QRCodeProps = PropsOfComponent<typeof Flex> & { url: string; size?: number };
+
+export const QRCode = (props: QRCodeProps) => {
+  const { size = 200, url, ...rest } = props;
+  return (
+    <Flex
+      elementDescriptor={descriptors.qrCodeRow}
+      {...rest}
+    >
+      <Flex
+        elementDescriptor={descriptors.qrCodeContainer}
+        sx={t => ({ backgroundColor: 'white', padding: t.space.$2x5 })}
+      >
+        <QRCodeSVG
+          value={url || ''}
+          size={size}
+        />
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/clerk-js/src/ui/common/index.ts
+++ b/packages/clerk-js/src/ui/common/index.ts
@@ -10,3 +10,4 @@ export * from './EmailLinkStatusCard';
 export * from './Wizard';
 export * from './PrintableComponent';
 export * from './withOrganizationsEnabledGuard';
+export * from './QRCode';

--- a/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
@@ -59,6 +59,7 @@ export const AddAuthenticatorApp = (props: AddAuthenticatorAppProps) => {
                 />
 
                 <QRCodeSVG
+                  style={{ border: '10px solid white' }}
                   size={200}
                   value={totp.uri || ''}
                 />

--- a/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/AddAuthenticatorApp.tsx
@@ -1,7 +1,7 @@
 import { TOTPResource } from '@clerk/types';
-import { QRCodeSVG } from 'qrcode.react';
 import React from 'react';
 
+import { QRCode } from '../../common';
 import { useCoreUser } from '../../contexts';
 import { Button, Col, descriptors, LocalizationKey, localizationKeys, Text } from '../../customizables';
 import {
@@ -58,11 +58,7 @@ export const AddAuthenticatorApp = (props: AddAuthenticatorAppProps) => {
                   localizationKey={localizationKeys('userProfile.mfaTOTPPage.authenticatorApp.infoText__ableToScan')}
                 />
 
-                <QRCodeSVG
-                  style={{ border: '10px solid white' }}
-                  size={200}
-                  value={totp.uri || ''}
-                />
+                <QRCode url={totp.uri || ''} />
 
                 <Button
                   variant='link'

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -224,6 +224,9 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'accordionTriggerButton',
   'accordionContent',
 
+  'qrCodeRow',
+  'qrCodeContainer',
+
   'badge',
   'button',
   'providerIcon',

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -346,6 +346,9 @@ export type ElementsConfig = {
   accordionTriggerButton: WithOptions<never, never, never>;
   accordionContent: WithOptions<never, never, never>;
 
+  qrCodeRow: WithOptions<never, never, never>;
+  qrCodeContainer: WithOptions<never, never, never>;
+
   // default descriptors
   badge: WithOptions<'primary' | 'actionRequired', never, never>;
   button: WithOptions<never, LoadingState, never>;


### PR DESCRIPTION
Add a white border of 10px to the QR code svg so that it is scannable when the background is dark

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Example with dark background: 
<img width="375" alt="Screenshot 2022-12-01 at 19 35 02" src="https://user-images.githubusercontent.com/73396808/205121592-b597d971-a68a-4499-b9fc-be303d72e1d5.png">

<!-- Fixes # (issue number) -->
