### PR TITLE
fix(clerk-js): Set objectFit on the image in Avatar

### DIFF
--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -57,6 +57,7 @@ export const Avatar = (props: AvatarProps) => {
         src={src || ''}
         width='100%'
         height='100%'
+        sx={{ objectFit: 'cover' }}
         onError={() => setError(true)}
       />
     );
@@ -76,7 +77,6 @@ export const Avatar = (props: AvatarProps) => {
           borderColor: theme.colors.$avatarBorder,
           backgroundColor: theme.colors.$avatarBackground,
           color: theme.colors.$colorText,
-          objectFit: 'cover',
           backgroundClip: 'padding-box',
         }),
         sx,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Seems like we have the `object-fit: cover`  on the wrong element.
Before: 
<img width="575" alt="Screenshot 2022-12-02 at 22 01 39" src="https://user-images.githubusercontent.com/73396808/205376139-bf0d957c-52b8-44a4-8464-6c002724fc67.png">
After:
<img width="798" alt="Screenshot 2022-12-02 at 22 01 56" src="https://user-images.githubusercontent.com/73396808/205376192-6bb0e230-c8c1-427f-847e-660c0e934d2d.png">

<!-- Fixes # (issue number) -->
