### PR TITLE
fix(remix): Remix 1.8 hotfix

### DIFF
--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -66,10 +66,6 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
 })
 `);
 
-export const getAuthInterstitialErrorRendered = createErrorMessage(
-  `This state shouldn't be possible. Please reach out to support@clerk.dev so we can help, or use the links below:`,
-);
-
 export const noFrontendApiError = createErrorMessage(`
 The CLERK_FRONTEND_API environment variable must be set before using Clerk.
 During development, grab the Frontend Api value from the Clerk Dashboard, create an .env file and set the CLERK_FRONTEND_API key.

--- a/packages/remix/src/experimental/errors.ts
+++ b/packages/remix/src/experimental/errors.ts
@@ -66,10 +66,6 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
 })
 `);
 
-export const getAuthInterstitialErrorRendered = createErrorMessage(
-  `This state shouldn't be possible. Please reach out to support@clerk.dev so we can help, or use the links below:`,
-);
-
 export const noFrontendApiError = createErrorMessage(`
 The CLERK_FRONTEND_API environment variable must be set before using Clerk.
 During development, grab the Frontend Api value from the Clerk Dashboard, create an .env file and set the CLERK_FRONTEND_API key.

--- a/packages/remix/src/experimental/ssr/getAuth.ts
+++ b/packages/remix/src/experimental/ssr/getAuth.ts
@@ -1,11 +1,7 @@
-import { json } from '@remix-run/server-runtime';
-
-import { getAuthInterstitialErrorRendered, noLoaderArgsPassedInGetAuth } from '../errors';
+import { noLoaderArgsPassedInGetAuth } from '../errors';
 import { getAuthState } from './getAuthState';
 import { GetAuthReturn, LoaderFunctionArgs } from './types';
-import { sanitizeAuthData } from './utils';
-
-const EMPTY_INTERSTITIAL_RESPONSE = { message: getAuthInterstitialErrorRendered };
+import { interstitialJsonResponse, sanitizeAuthData } from './utils';
 
 export async function getAuth(args: LoaderFunctionArgs): GetAuthReturn {
   if (!args || (args && (!args.request || !args.context))) {
@@ -14,7 +10,7 @@ export async function getAuth(args: LoaderFunctionArgs): GetAuthReturn {
   const authState = await getAuthState(args);
 
   if (authState.isInterstitial || !authState) {
-    throw json(EMPTY_INTERSTITIAL_RESPONSE, { status: 401 });
+    throw interstitialJsonResponse(authState, { loader: 'nested' });
   }
 
   return sanitizeAuthData(authState);

--- a/packages/remix/src/experimental/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/experimental/ssr/rootAuthLoader.ts
@@ -4,11 +4,11 @@ import { LoaderFunctionArgs, LoaderFunctionReturn, RootAuthLoaderCallback, RootA
 import {
   assertObject,
   injectAuthIntoRequest,
+  interstitialJsonResponse,
   isRedirect,
   isResponse,
   returnLoaderResultJsonResponse,
   sanitizeAuthData,
-  throwInterstitialJsonResponse,
 } from './utils';
 
 interface RootAuthLoader {
@@ -35,7 +35,7 @@ export const rootAuthLoader: RootAuthLoader = async (
   const authState = await getAuthState(args, opts);
 
   if (authState.isInterstitial) {
-    throw throwInterstitialJsonResponse(authState);
+    throw interstitialJsonResponse(authState, { loader: 'root' });
   }
 
   if (!callback) {

--- a/packages/remix/src/experimental/ssr/utils.ts
+++ b/packages/remix/src/experimental/ssr/utils.ts
@@ -80,9 +80,10 @@ export function assertObject(val: any, error?: string): asserts val is Record<st
 /**
  * @internal
  */
-export const throwInterstitialJsonResponse = (authState: AuthState) => {
-  throw json(
+export const interstitialJsonResponse = (authState: AuthState, opts: { loader: 'root' | 'nested' }) => {
+  return json(
     wrapWithClerkState({
+      __loader: opts.loader,
       __clerk_ssr_interstitial_html: clerk.localInterstitial({
         debugData: clerk.debugAuthState(authState),
         frontendApi: authState.frontendApi,

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -5,11 +5,11 @@ import { LoaderFunctionArgs, LoaderFunctionReturn, RootAuthLoaderCallback, RootA
 import {
   assertObject,
   injectAuthIntoRequest,
+  interstitialJsonResponse,
   isRedirect,
   isResponse,
   returnLoaderResultJsonResponse,
   sanitizeAuthData,
-  throwInterstitialJsonResponse,
 } from './utils';
 
 interface RootAuthLoader {
@@ -39,7 +39,7 @@ export const rootAuthLoader: RootAuthLoader = async (
   const { authData, showInterstitial, errorReason } = await getAuthData(args.request, opts);
 
   if (showInterstitial) {
-    throw throwInterstitialJsonResponse({ frontendApi, errorReason });
+    throw interstitialJsonResponse({ frontendApi, errorReason, loader: 'root' });
   }
 
   if (!callback) {

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -75,12 +75,17 @@ export function assertObject(val: any, error?: string): asserts val is Record<st
 /**
  * @internal
  */
-export const throwInterstitialJsonResponse = (opts: { frontendApi: string; errorReason: string | undefined }) => {
-  throw json(
+export const interstitialJsonResponse = (opts: {
+  frontendApi: string;
+  errorReason: string | undefined;
+  loader: 'root' | 'nested';
+}) => {
+  return json(
     wrapWithClerkState({
       __clerk_ssr_interstitial: true,
       __frontendApi: opts.frontendApi,
       __lastAuthResult: opts.errorReason,
+      __loader: opts.loader,
     }),
     { status: 401 },
   );


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
We temporarily throw the interstitial page from within getAuth in addition to the rootAuthLoader.ts

See https://github.com/remix-run/remix/issues/4791 for details
<!-- Fixes # (issue number) -->
