### PR TITLE
feat(types,shared): Introduce publishable key helpers

### DIFF
--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './cookies';
 export * from './date';
 export * from './file';
 export * from './index';
+export * from './keys';
 export * from './isRetinaDisplay';
 export * from './localStorageBroadcastChannel';
 export * from './mimeTypeExtensions';

--- a/packages/shared/src/utils/keys.test.ts
+++ b/packages/shared/src/utils/keys.test.ts
@@ -1,0 +1,57 @@
+import { buildPublishableKey, isLegacyFrontendApiKey, isPublishableKey, parsePublishableKey } from './keys';
+
+describe.concurrent('buildPublishableKey(key)', () => {
+  const cases = [
+    ['example.clerk.accounts.dev', 'pk_live_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk'],
+    ['foo-bar-13.clerk.accounts.dev', 'pk_test_Zm9vLWJhci0xMy5jbGVyay5hY2NvdW50cy5kZXYk'],
+  ];
+
+  test.each(cases)(
+    'given %p as a frontend api, returns publishable key %p',
+    (frontendApi, expectedPublishableKeyStr) => {
+      const result = buildPublishableKey(frontendApi);
+      expect(result).toEqual(expectedPublishableKeyStr);
+    },
+  );
+});
+
+describe.concurrent('parsePublishableKey(key)', () => {
+  const cases = [
+    [null, null],
+    [undefined, null],
+    ['', null],
+    ['whatever', null],
+    [
+      'pk_live_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk',
+      { instanceType: 'production', frontendApi: 'example.clerk.accounts.dev' },
+    ],
+    [
+      'pk_test_Zm9vLWJhci0xMy5jbGVyay5hY2NvdW50cy5kZXYk',
+      { instanceType: 'development', frontendApi: 'foo-bar-13.clerk.accounts.dev' },
+    ],
+  ];
+
+  test.each(cases)('given %p as a publishable key string, returns %p', (publishableKeyStr, expectedPublishableKey) => {
+    const result = parsePublishableKey(publishableKeyStr);
+    expect(result).toEqual(expectedPublishableKey);
+  });
+});
+
+describe.concurrent('isPublishableKey(key)', () => {
+  it('returns true if the key is a valid publishable key', () => {
+    expect(isPublishableKey('pk_live_Y2xlcmsuY2xlcmsuZGV2JA==')).toBe(true);
+  });
+
+  it('returns false if the key is not a valid publishable key', () => {
+    expect(isPublishableKey('clerk.clerk.dev')).toBe(false);
+  });
+});
+
+describe.concurrent('isLegacyFrontendApiKey(key)', () => {
+  it('returns true if the key is a valid legacy frontend Api key', () => {
+    expect(isLegacyFrontendApiKey('clerk.clerk.dev')).toBe(true);
+  });
+  it('returns true if the key is not a valid legacy frontend Api key', () => {
+    expect(isLegacyFrontendApiKey('pk_live_Y2xlcmsuY2xlcmsuZGV2JA==')).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/keys.ts
+++ b/packages/shared/src/utils/keys.ts
@@ -1,0 +1,53 @@
+import { type PublishableKey } from '@clerk/types';
+
+const PUBLISHABLE_KEY_LIVE_PREFIX = 'pk_live_';
+const PUBLISHABLE_KEY_TEST_PREFIX = 'pk_test_';
+
+// This regex matches the publishable like frontend API keys (e.g. foo-bar-13.clerk.accounts.dev)
+const PUBLISHABLE_FRONTEND_API_DEV_REGEX = /^(([a-z]+)-){2}([0-9]{1,2})\.clerk\.accounts([a-z.]*)(dev|com)$/i;
+
+export function buildPublishableKey(frontendApi: string): string {
+  const keyPrefix = PUBLISHABLE_FRONTEND_API_DEV_REGEX.test(frontendApi)
+    ? PUBLISHABLE_KEY_TEST_PREFIX
+    : PUBLISHABLE_KEY_LIVE_PREFIX;
+  return `${keyPrefix}${btoa(`${frontendApi}$`)}`;
+}
+
+export function parsePublishableKey(key: string): PublishableKey | null {
+  key = key || '';
+
+  if (!isPublishableKey(key)) {
+    return null;
+  }
+
+  const instanceType = key.startsWith(PUBLISHABLE_KEY_LIVE_PREFIX) ? 'production' : 'development';
+
+  let frontendApi = atob(key.split('_')[2]);
+
+  if (!frontendApi.endsWith('$')) {
+    return null;
+  }
+
+  frontendApi = frontendApi.slice(0, -1);
+
+  return {
+    instanceType,
+    frontendApi,
+  };
+}
+
+export function isPublishableKey(key: string) {
+  key = key || '';
+
+  const hasValidPrefix = key.startsWith(PUBLISHABLE_KEY_LIVE_PREFIX) || key.startsWith(PUBLISHABLE_KEY_TEST_PREFIX);
+
+  const hasValidFrontendApiPostfix = atob(key.split('_')[2] || '').endsWith('$');
+
+  return hasValidPrefix && hasValidFrontendApiPostfix;
+}
+
+export function isLegacyFrontendApiKey(key: string) {
+  key = key || '';
+
+  return key.startsWith('clerk.');
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,6 +16,7 @@ export * from './identifiers';
 export * from './image';
 export * from './json';
 export * from './jwt';
+export * from './key';
 export * from './localization';
 export * from './jwtv2';
 export * from './oauth';

--- a/packages/types/src/key.ts
+++ b/packages/types/src/key.ts
@@ -1,0 +1,6 @@
+import { type InstanceType } from './clerk';
+
+export type PublishableKey = {
+  frontendApi: string;
+  instanceType: InstanceType;
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [x] `@clerk/shared`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Introduce some new shared helpers regarding publishable keys and the relevant PublishableKey type. The list of the new helpers are:
- buildPublishableKey()
- parsePublishableKey()
- isPublishableKey()
- isLegacyFrontendApiKey()

<!-- Fixes # (issue number) -->
