### PR TITLE
Revert "feat(clerk-js,types): Terse paths parameters (#572)"

### DIFF
--- a/packages/react/src/components/withClerk.tsx
+++ b/packages/react/src/components/withClerk.tsx
@@ -1,5 +1,4 @@
 import { LoadedClerk } from '@clerk/types';
-import { Without } from '@clerk/types/src';
 import React from 'react';
 
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
@@ -12,7 +11,7 @@ export const withClerk = <P extends { clerk: LoadedClerk }>(
 ) => {
   displayName = displayName || Component.displayName || Component.name || 'Component';
   Component.displayName = displayName;
-  const HOC = (props: Without<P, 'clerk'>) => {
+  const HOC = (props: Omit<P, 'clerk'>) => {
     const clerk = useIsomorphicClerkContext();
 
     if (!clerk.loaded) {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -464,10 +464,6 @@ export interface Resources {
 
 export type RoutingStrategy = 'path' | 'hash' | 'virtual';
 
-export type RoutingOptions =
-  | { path: string; routing?: Extract<RoutingStrategy, 'path'> }
-  | { path?: never; routing?: Extract<RoutingStrategy, 'hash' | 'virtual'> };
-
 export type RedirectOptions = {
   /**
    * Full URL or path to navigate after successful sign in.
@@ -512,7 +508,15 @@ export type SetActiveParams = {
 
 export type SetActive = (params: SetActiveParams) => Promise<void>;
 
-export type SignInProps = RoutingOptions & {
+export type SignInProps = {
+  /*
+   * Page routing strategy
+   */
+  routing?: RoutingStrategy;
+  /*
+   * Root URL where the component is mounted on, eg: '/sign in'
+   */
+  path?: string;
   /**
    * Full URL or path to for the sign up process.
    * Used to fill the "Sign up" link in the SignUp component.
@@ -526,7 +530,15 @@ export type SignInProps = RoutingOptions & {
   appearance?: SignInTheme;
 } & RedirectOptions;
 
-export type SignUpProps = RoutingOptions & {
+export type SignUpProps = {
+  /*
+   * Page routing strategy
+   */
+  routing?: RoutingStrategy;
+  /*
+   * Root URL where the component is mounted on, eg: '/sign up'
+   */
+  path?: string;
   /**
    * Full URL or path to for the sign in process.
    * Used to fill the "Sign in" link in the SignUp component.
@@ -540,7 +552,15 @@ export type SignUpProps = RoutingOptions & {
   appearance?: SignUpTheme;
 } & RedirectOptions;
 
-export type UserProfileProps = RoutingOptions & {
+export type UserProfileProps = {
+  /*
+   * Page routing strategy
+   */
+  routing?: RoutingStrategy;
+  /*
+   * Root URL where the component is mounted on, eg: '/user'
+   */
+  path?: string;
   /*
    * Renders only a specific view of the component eg: 'security'
    */
@@ -553,7 +573,15 @@ export type UserProfileProps = RoutingOptions & {
   appearance?: UserProfileTheme;
 };
 
-export type OrganizationProfileProps = RoutingOptions & {
+export type OrganizationProfileProps = {
+  /*
+   * Page routing strategy
+   */
+  routing?: RoutingStrategy;
+  /*
+   * Root URL where the component is mounted on, eg: '/user'
+   */
+  path?: string;
   /**
    * Full URL or path to navigate to after the user leaves the currently active organization.
    * @default undefined
@@ -567,7 +595,15 @@ export type OrganizationProfileProps = RoutingOptions & {
   appearance?: OrganizationProfileTheme;
 };
 
-export type CreateOrganizationProps = RoutingOptions & {
+export type CreateOrganizationProps = {
+  /*
+   * Page routing strategy
+   */
+  routing?: RoutingStrategy;
+  /*
+   * Root URL where the component is mounted on, eg: '/user'
+   */
+  path?: string;
   /**
    * Full URL or path to navigate after creating a new organization.
    * @default undefined

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -35,13 +35,6 @@ export type DeepRequired<T> = Required<{
 }>;
 
 /**
- * Omit without union flattening
- * */
-export type Without<T, W> = {
-  [P in keyof T as Exclude<P, W>]: T[P];
-};
-
-/**
  * Internal type used by RecordToPath
  */
 type PathImpl<T, Key extends keyof T> = Key extends string


### PR DESCRIPTION


## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
For users that incorrectly use the routing and path props on our components, this is a breaking change. To avoid unintentionally breaking production apps, we will delay this for v5
<!-- Fixes # (issue number) -->
