### PR TITLE
fix(clerk-sdk-node): Add esm/instance and cjs/instance import paths

### DIFF
--- a/packages/sdk-node/.gitignore
+++ b/packages/sdk-node/.gitignore
@@ -3,7 +3,6 @@
 .idea
 node_modules
 dist
-esm
 coverage
 .env
 .env.local

--- a/packages/sdk-node/cjs/instance.d.ts
+++ b/packages/sdk-node/cjs/instance.d.ts
@@ -1,0 +1,2 @@
+export * from '../dist/cjs/instance';
+export { default } from '../dist/cjs/instance';

--- a/packages/sdk-node/cjs/instance.js
+++ b/packages/sdk-node/cjs/instance.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/cjs/instance');

--- a/packages/sdk-node/esm/instance.d.ts
+++ b/packages/sdk-node/esm/instance.d.ts
@@ -1,0 +1,2 @@
+export * from '../dist/esm/instance';
+export { default } from '../dist/esm/instance';

--- a/packages/sdk-node/esm/instance.js
+++ b/packages/sdk-node/esm/instance.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/esm/instance');

--- a/packages/sdk-node/instance.d.ts
+++ b/packages/sdk-node/instance.d.ts
@@ -1,2 +1,0 @@
-export * from './dist/instance';
-export { default } from './dist/instance';

--- a/packages/sdk-node/instance.js
+++ b/packages/sdk-node/instance.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/instance');

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -6,9 +6,9 @@
   "typings": "dist/cjs/index.d.ts",
   "files": [
     "dist",
-    "instance.js",
-    "instance.d.ts",
-    "package.json"
+    "package.json",
+    "esm",
+    "cjs"
   ],
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Adds support for:
```
import Clerk from '@clerk/clerk-sdk-node/esm/instance';
```

and 

```
const Clerk = require('@clerk/clerk-sdk-node/cjs/instance').default;
```

As shown in the [clerk-sdk-node docs](https://clerk.dev/docs/reference/node/getting-started#esm)
<!-- Fixes # (issue number) -->
