### PR TITLE
fix(clerk-js): Fix the fullName property returning null when First name or Last name is empty

### DIFF
--- a/packages/clerk-js/src/core/resources/User.test.ts
+++ b/packages/clerk-js/src/core/resources/User.test.ts
@@ -241,4 +241,13 @@ describe('User', () => {
       path: '/me/backup_codes/',
     });
   });
+
+  it('sets the right fullname', () => {
+    expect(new User({ first_name: 'Firstname' } as unknown as UserJSON).fullName).toBe('Firstname');
+    expect(new User({ last_name: 'Lastname' } as unknown as UserJSON).fullName).toBe('Lastname');
+    expect(new User({ first_name: 'Firstname', last_name: 'Lastname' } as unknown as UserJSON).fullName).toBe(
+      'Firstname Lastname',
+    );
+    expect(new User({} as unknown as UserJSON).fullName).toBe(null);
+  });
 });

--- a/packages/clerk-js/src/core/resources/User.test.ts
+++ b/packages/clerk-js/src/core/resources/User.test.ts
@@ -242,12 +242,24 @@ describe('User', () => {
     });
   });
 
-  it('sets the right fullname', () => {
-    expect(new User({ first_name: 'Firstname' } as unknown as UserJSON).fullName).toBe('Firstname');
-    expect(new User({ last_name: 'Lastname' } as unknown as UserJSON).fullName).toBe('Lastname');
-    expect(new User({ first_name: 'Firstname', last_name: 'Lastname' } as unknown as UserJSON).fullName).toBe(
-      'Firstname Lastname',
-    );
-    expect(new User({} as unknown as UserJSON).fullName).toBe(null);
+  describe('Set the right fullName', () => {
+    const cases: Array<[string | null | undefined, string | null | undefined, string | null | undefined]> = [
+      // firstName, lastName, fullName
+      ['A', 'B', 'A B'],
+      ['', 'B', 'B'],
+      ['A', '', 'A'],
+      ['', '', null],
+      [null, '', null],
+      [null, null, null],
+      [undefined, undefined, null],
+    ];
+
+    it.each(cases)("firstName: '%s', lastName: '%s'  =>  fullName: '%s'", (first_name, last_name, fullName) => {
+      const user = new User({
+        first_name,
+        last_name,
+      } as unknown as UserJSON);
+      expect(user.fullName).toBe(fullName);
+    });
   });
 });

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -23,6 +23,7 @@ import type {
   Web3WalletResource,
 } from '@clerk/types';
 
+import { getFullName } from '../../ui/utils';
 import { unixEpochToDate } from '../../utils/date';
 import { normalizeUnsafeMetadata } from '../../utils/resourceParams';
 import { BackupCode } from './BackupCode';
@@ -245,8 +246,8 @@ export class User extends BaseResource implements UserResource {
     this.externalId = data.external_id;
     this.firstName = data.first_name;
     this.lastName = data.last_name;
-    if (this.firstName && this.lastName) {
-      this.fullName = this.firstName + ' ' + this.lastName;
+    if (this.firstName || this.lastName) {
+      this.fullName = getFullName({ firstName: this.firstName, lastName: this.lastName });
     }
 
     this.profileImageUrl = data.profile_image_url;

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -253,22 +253,24 @@ export class User extends BaseResource implements UserResource {
     this.profileImageUrl = data.profile_image_url;
     this.username = data.username;
     this.passwordEnabled = data.password_enabled;
-    this.emailAddresses = data.email_addresses.map(ea => new EmailAddress(ea, this.path() + '/email_addresses'));
+    this.emailAddresses = (data.email_addresses || []).map(
+      ea => new EmailAddress(ea, this.path() + '/email_addresses'),
+    );
 
     this.primaryEmailAddressId = data.primary_email_address_id;
     this.primaryEmailAddress = this.emailAddresses.find(({ id }) => id === this.primaryEmailAddressId) || null;
 
-    this.phoneNumbers = data.phone_numbers.map(ph => new PhoneNumber(ph, this.path() + '/phone_numbers'));
+    this.phoneNumbers = (data.phone_numbers || []).map(ph => new PhoneNumber(ph, this.path() + '/phone_numbers'));
 
     this.primaryPhoneNumberId = data.primary_phone_number_id;
     this.primaryPhoneNumber = this.phoneNumbers.find(({ id }) => id === this.primaryPhoneNumberId) || null;
 
-    this.web3Wallets = data.web3_wallets.map(ph => new Web3Wallet(ph, this.path() + '/web3_wallets'));
+    this.web3Wallets = (data.web3_wallets || []).map(ph => new Web3Wallet(ph, this.path() + '/web3_wallets'));
 
     this.primaryWeb3WalletId = data.primary_web3_wallet_id;
     this.primaryWeb3Wallet = this.web3Wallets.find(({ id }) => id === this.primaryWeb3WalletId) || null;
 
-    this.externalAccounts = data.external_accounts.map(
+    this.externalAccounts = (data.external_accounts || []).map(
       ea => new ExternalAccount(ea, this.path() + '/external_accounts'),
     );
 


### PR DESCRIPTION
It now returns just the first name or the last name.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR fixes the `fullName` value on the `User` resource. It now returns a value even if only First name or only Last name is set.

### Example:

Until now:
- `firstName: 'A', lastName: 'B' => fullName: 'A B'`
- `firstName: 'A', lastName: '' => fullName: null`
- `firstName: '', lastName: 'B' => fullName: null`
- `firstName: '', lastName: '' => fullName: null`

After this PR:
- `firstName: 'A', lastName: 'B' => fullName: 'A B'`
- `firstName: 'A', lastName: '' => fullName: 'A'`
- `firstName: '', lastName: 'B' => fullName: 'B'`
- `firstName: '', lastName: '' => fullName: null`

<!-- Fixes # (issue number) -->

Fixes [JS-73](https://linear.app/clerk/issue/JS-73/fix-the-fullname-property-returning-null-when-first-name-or-last-name)