### PR TITLE
fix(clerk-js): Assert the Select type since it uses HOC with generic

### DIFF
--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -127,6 +127,7 @@ export const PhoneInput = (props: PhoneInputProps) => {
         maxLength={25}
         type='tel'
         sx={theme => ({
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
           paddingLeft: `calc(${theme.space.$20} + ${selectedCountryOption.country.code.length + 1}ch)`,
         })}
         ref={phoneInputRef}

--- a/packages/clerk-js/src/ui/elements/Select.tsx
+++ b/packages/clerk-js/src/ui/elements/Select.tsx
@@ -1,5 +1,5 @@
 import { createContextAndHook } from '@clerk/shared';
-import React, { PropsWithChildren, useState } from 'react';
+import React, { PropsWithChildren, ReactElement, useState } from 'react';
 
 import { usePopover, useSearchInput } from '../../ui/hooks';
 import { Button, descriptors, Flex, Icon, Text } from '../customizables';
@@ -126,7 +126,7 @@ export const Select = withFloatingTree(<O extends Option>(props: PropsWithChildr
       {React.Children.count(children) ? children : defaultChildren}
     </SelectStateCtx.Provider>
   );
-});
+}) as <O extends Option>(props: PropsWithChildren<SelectProps<O>>) => ReactElement;
 
 type SelectOptionBuilderProps<O extends Option> = {
   option: Option;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Since the `Select` component now uses the `withFloatingTree` HOC, its type defaults to the `Option`, which is the type the passed option is supposed to extend. To combat this, we now assert the type of the component.
<!-- Fixes # (issue number) -->
