### PR TITLE
fix(clerk-js): Leave default border in Role Select in MemberListTable

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -128,7 +128,6 @@ export const RoleSelect = (props: { value: MembershipRole; onChange: any; isDisa
     >
       <SelectButton
         sx={t => ({
-          border: 'none',
           color: t.colors.$colorTextSecondary,
           backgroundColor: 'transparent',
         })}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Leave the default border for the Select in order to appear aligned with the table headers.
<img width="600" alt="Screenshot 2022-12-12 at 13 33 27" src="https://user-images.githubusercontent.com/73396808/207035140-b39e75be-2aec-44bf-855a-de6fcd51979c.png">
<!-- Fixes # (issue number) -->
