### PR TITLE
feat(clerk-js,types): Add footerLink elementIds

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -35,7 +35,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
       <NavbarMenuButtonRow />
       <Col
         elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('organization-members')}
+        elementId={descriptors.profilePage.setId('organizationMembers')}
         gap={8}
       >
         <Flex

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
@@ -14,7 +14,7 @@ export const OrganizationSettings = () => {
       <NavbarMenuButtonRow />
       <Col
         elementDescriptor={descriptors.profilePage}
-        elementId={descriptors.profilePage.setId('organization-settings')}
+        elementId={descriptors.profilePage.setId('organizationSettings')}
         gap={8}
       >
         <Header.Root>
@@ -50,7 +50,7 @@ const OrganizationProfileSection = () => {
   return (
     <ProfileSection
       title={localizationKeys('organizationProfile.profilePage.title')}
-      id='organization-profile'
+      id='organizationProfile'
     >
       {isAdmin ? <BlockButton onClick={() => navigate('profile')}>{profile}</BlockButton> : profile}
     </ProfileSection>
@@ -67,7 +67,7 @@ const OrganizationDangerSection = () => {
 
   return (
     <ProfileSection
-      id='organization-danger'
+      id='organizationDanger'
       title={localizationKeys('organizationProfile.profilePage.dangerSection.title')}
       sx={t => ({ marginBottom: t.space.$4 })}
     >

--- a/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
@@ -78,7 +78,7 @@ const AlternativeMethodsList = (props: AlternativeMethodsProps & { onHavingTroub
           </Flex>
         </Flex>
         <Footer.Root>
-          <Footer.Action elementId='help'>
+          <Footer.Action elementId='havingTrouble'>
             <Footer.ActionLink
               localizationKey={localizationKeys('signIn.alternativeMethods.actionLink')}
               onClick={onHavingTroubleClick}

--- a/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/AlternativeMethods.tsx
@@ -78,7 +78,7 @@ const AlternativeMethodsList = (props: AlternativeMethodsProps & { onHavingTroub
           </Flex>
         </Flex>
         <Footer.Root>
-          <Footer.Action>
+          <Footer.Action elementId='help'>
             <Footer.ActionLink
               localizationKey={localizationKeys('signIn.alternativeMethods.actionLink')}
               onClick={onHavingTroubleClick}

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -78,7 +78,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
           </Form.Root>
         </Flex>
         <Footer.Root>
-          <Footer.Action elementId='alternative'>
+          <Footer.Action elementId='alternativeMethods'>
             <Footer.ActionLink
               localizationKey={localizationKeys('signIn.password.actionLink')}
               onClick={onShowAlternativeMethodsClick}

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -78,7 +78,7 @@ export const SignInFactorOnePasswordCard = (props: SignInFactorOnePasswordProps)
           </Form.Root>
         </Flex>
         <Footer.Root>
-          <Footer.Action>
+          <Footer.Action elementId='alternative'>
             <Footer.ActionLink
               localizationKey={localizationKeys('signIn.password.actionLink')}
               onClick={onShowAlternativeMethodsClick}

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoAlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoAlternativeMethods.tsx
@@ -63,7 +63,7 @@ const AlternativeMethodsList = (props: AlternativeMethodsProps & { onHavingTroub
           </Col>
         </Col>
         <Footer.Root>
-          <Footer.Action elementId='help'>
+          <Footer.Action elementId='havingTrouble'>
             <Footer.ActionLink
               localizationKey={localizationKeys('signIn.alternativeMethods.actionLink')}
               onClick={onHavingTroubleClick}

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoAlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoAlternativeMethods.tsx
@@ -63,7 +63,7 @@ const AlternativeMethodsList = (props: AlternativeMethodsProps & { onHavingTroub
           </Col>
         </Col>
         <Footer.Root>
-          <Footer.Action>
+          <Footer.Action elementId='help'>
             <Footer.ActionLink
               localizationKey={localizationKeys('signIn.alternativeMethods.actionLink')}
               onClick={onHavingTroubleClick}

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
@@ -67,7 +67,7 @@ export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCa
         </Form.Root>
       </Col>
       <Footer.Root>
-        <Footer.Action>
+        <Footer.Action elementId='alternative'>
           {onShowAlternativeMethodsClicked && (
             <Footer.ActionLink
               localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorTwoBackupCodeCard.tsx
@@ -67,7 +67,7 @@ export const SignInFactorTwoBackupCodeCard = (props: SignInFactorTwoBackupCodeCa
         </Form.Root>
       </Col>
       <Footer.Root>
-        <Footer.Action elementId='alternative'>
+        <Footer.Action elementId='alternativeMethods'>
           {onShowAlternativeMethodsClicked && (
             <Footer.ActionLink
               localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -214,7 +214,7 @@ export function _SignInStart(): JSX.Element {
           </SocialButtonsReversibleContainerWithDivider>
         </Col>
         <Footer.Root>
-          <Footer.Action>
+          <Footer.Action elementId='signUp'>
             <Footer.ActionText localizationKey={localizationKeys('signIn.start.actionText')}>
               No account?
             </Footer.ActionText>

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -214,7 +214,7 @@ export function _SignInStart(): JSX.Element {
           </SocialButtonsReversibleContainerWithDivider>
         </Col>
         <Footer.Root>
-          <Footer.Action elementId='signUp'>
+          <Footer.Action elementId='signIn'>
             <Footer.ActionText localizationKey={localizationKeys('signIn.start.actionText')}>
               No account?
             </Footer.ActionText>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -185,7 +185,7 @@ function _SignUpContinue() {
           </SocialButtonsReversibleContainerWithDivider>
         </Flex>
         <Footer.Root>
-          <Footer.Action elementId='signIn'>
+          <Footer.Action elementId='signUp'>
             <Footer.ActionText localizationKey={localizationKeys('signUp.continue.actionText')} />
             <Footer.ActionLink
               localizationKey={localizationKeys('signUp.continue.actionLink')}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -185,7 +185,7 @@ function _SignUpContinue() {
           </SocialButtonsReversibleContainerWithDivider>
         </Flex>
         <Footer.Root>
-          <Footer.Action>
+          <Footer.Action elementId='signIn'>
             <Footer.ActionText localizationKey={localizationKeys('signUp.continue.actionText')} />
             <Footer.ActionLink
               localizationKey={localizationKeys('signUp.continue.actionLink')}

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -254,7 +254,7 @@ function _SignUpStart(): JSX.Element {
           </SocialButtonsReversibleContainerWithDivider>
         </Flex>
         <Footer.Root>
-          <Footer.Action>
+          <Footer.Action elementId='signIn'>
             <Footer.ActionText localizationKey={localizationKeys('signUp.start.actionText')}>
               Have an account?
             </Footer.ActionText>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -254,7 +254,7 @@ function _SignUpStart(): JSX.Element {
           </SocialButtonsReversibleContainerWithDivider>
         </Flex>
         <Footer.Root>
-          <Footer.Action elementId='signIn'>
+          <Footer.Action elementId='signUp'>
             <Footer.ActionText localizationKey={localizationKeys('signUp.start.actionText')}>
               Have an account?
             </Footer.ActionText>

--- a/packages/clerk-js/src/ui/elements/Footer.tsx
+++ b/packages/clerk-js/src/ui/elements/Footer.tsx
@@ -1,3 +1,4 @@
+import { FooterActionId } from '@clerk/types';
 import React from 'react';
 
 import { descriptors, Flex, Link, localizationKeys, Text, useAppearance } from '../customizables';
@@ -15,11 +16,16 @@ const FooterRoot = (props: React.PropsWithChildren<any>): JSX.Element => {
   );
 };
 
-const FooterAction = (props: React.PropsWithChildren<any>): JSX.Element => {
+type FooterActionProps = Omit<PropsOfComponent<typeof Flex>, 'elementId'> & {
+  elementId?: FooterActionId;
+};
+const FooterAction = (props: FooterActionProps): JSX.Element => {
+  const { elementId, ...rest } = props;
   return (
     <Flex
       elementDescriptor={descriptors.footerAction}
-      {...props}
+      elementId={descriptors.footerAction.setId(elementId)}
+      {...rest}
       gap={1}
     />
   );

--- a/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
+++ b/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
@@ -89,7 +89,7 @@ export const VerificationCodeCard = (props: VerificationCodeCardProps) => {
         />
       </Col>
       <Footer.Root>
-        <Footer.Action>
+        <Footer.Action elementId='alternative'>
           {props.onShowAlternativeMethodsClicked && (
             <Footer.ActionLink
               localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}

--- a/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
+++ b/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
@@ -89,7 +89,7 @@ export const VerificationCodeCard = (props: VerificationCodeCardProps) => {
         />
       </Col>
       <Footer.Root>
-        <Footer.Action elementId='alternative'>
+        <Footer.Action elementId='alternativeMethods'>
           {props.onShowAlternativeMethodsClicked && (
             <Footer.ActionLink
               localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}

--- a/packages/clerk-js/src/ui/elements/VerificationLinkCard.tsx
+++ b/packages/clerk-js/src/ui/elements/VerificationLinkCard.tsx
@@ -55,7 +55,7 @@ export const VerificationLinkCard = (props: VerificationLinkCardProps) => {
           />
         </Col>
         <Footer.Root>
-          <Footer.Action>
+          <Footer.Action elementId='alternative'>
             {props.onShowAlternativeMethodsClicked && (
               <Footer.ActionLink
                 localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}

--- a/packages/clerk-js/src/ui/elements/VerificationLinkCard.tsx
+++ b/packages/clerk-js/src/ui/elements/VerificationLinkCard.tsx
@@ -55,7 +55,7 @@ export const VerificationLinkCard = (props: VerificationLinkCardProps) => {
           />
         </Col>
         <Footer.Root>
-          <Footer.Action elementId='alternative'>
+          <Footer.Action elementId='alternativeMethods'>
             {props.onShowAlternativeMethodsClicked && (
               <Footer.ActionLink
                 localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -84,7 +84,7 @@ export type NavbarItemId = 'account' | 'security' | 'members' | 'settings';
 export type UserPreviewId = 'userButton' | 'personalWorkspace';
 export type OrganizationPreviewId = 'organizationSwitcher';
 
-export type FooterActionId = 'help' | 'alternative' | 'signUp' | 'signIn';
+export type FooterActionId = 'havingTrouble' | 'alternativeMethods' | 'signUp' | 'signIn';
 
 /**
  * A type that describes the states and the ids that we will combine

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -84,6 +84,8 @@ export type NavbarItemId = 'account' | 'security';
 export type UserPreviewId = 'userButton' | 'personalWorkspace';
 export type OrganizationPreviewId = 'organizationSwitcher';
 
+export type FooterActionId = 'help' | 'alternative' | 'signUp' | 'signIn';
+
 /**
  * A type that describes the states and the ids that we will combine
  * in order to create all theming combinations
@@ -153,7 +155,7 @@ export type ElementsConfig = {
   main: WithOptions<never, never, never>;
 
   footer: WithOptions<never, never, never>;
-  footerAction: WithOptions<never, never, never>;
+  footerAction: WithOptions<FooterActionId, never, never>;
   footerActionText: WithOptions<never, never, never>;
   footerActionLink: WithOptions<never, never, never>;
   footerPages: WithOptions<never, never, never>;

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -75,11 +75,11 @@ export type ProfileSectionId =
   | 'password'
   | 'mfa'
   | 'activeDevices'
-  | 'organization-profile'
-  | 'organization-danger';
-export type ProfilePageId = 'account' | 'security' | 'organization-settings' | 'organization-members';
+  | 'organizationProfile'
+  | 'organizationDanger';
+export type ProfilePageId = 'account' | 'security' | 'organizationSettings' | 'organizationMembers';
 
-export type NavbarItemId = 'account' | 'security';
+export type NavbarItemId = 'account' | 'security' | 'members' | 'settings';
 
 export type UserPreviewId = 'userButton' | 'personalWorkspace';
 export type OrganizationPreviewId = 'organizationSwitcher';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR adds some extra classes to allow hiding of specific footer actions.
Example (in the sign-in screen):
<img width="419" alt="Screenshot 2022-12-12 at 14 22 00" src="https://user-images.githubusercontent.com/73396808/207043937-7ee668b6-3e2a-4989-9eb2-7b2b3d52c6fb.png">

Also fixing the casing for some elementIds that were recently introduced, and adding the type for a couple more, to get rid of some typescript errors.
<!-- Fixes # (issue number) -->
