### PR TITLE
feat(nextjs): Support publishable key in public interstitial

### DIFF
--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -27,7 +27,8 @@
 
 ## Overview
 
-Clerk is the easiest way to add authentication and user management to your Next.js application. Add sign up, sign in, and profile management to your application in minutes.
+Clerk is the easiest way to add authentication and user management to your Next.js application. Add sign up, sign in,
+and profile management to your application in minutes.
 
 ## Getting Started
 
@@ -60,13 +61,18 @@ npm run dev
 
 Clerk requires your application to be wrapped in the `<ClerkProvider/>` context.
 
-Set `NEXT_PUBLIC_CLERK_FRONTEND_API` to your Frontend API in your `.env.local` file to make the environment variable accessible to the Provider.
+Set `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` to your Publishable Key in your `.env.local` file to make the environment
+variable accessible to the Provider.
+
+If you are using the previous version of Clerk keys, set `NEXT_PUBLIC_CLERK_FRONTEND_API` to your Frontend API in
+your `.env.local` file.
 
 ```sh
 NEXT_PUBLIC_CLERK_FRONTEND_API=clerk.[your-domain].[tld]
 ```
 
-An implementation of `<ClerkProvider />` with our flexible Control Components to build an authentication flow in `pages/_app.js`:
+An implementation of `<ClerkProvider />` with our flexible Control Components to build an authentication flow
+in `pages/_app.js`:
 
 ```jsx
 import { ClerkProvider, RedirectToSignIn, SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
@@ -94,19 +100,24 @@ function MyApp({ Component, pageProps }) {
 export default MyApp;
 ```
 
-_For further details and examples, please refer to our [Documentation](https://clerk.dev/docs?utm_source=github&utm_medium=clerk_nextjs)._
+_For further details and examples, please refer to
+our [Documentation](https://clerk.dev/docs?utm_source=github&utm_medium=clerk_nextjs)._
 
 ## Support
 
 You can get in touch with us in any of the following ways:
 
-- Join our official community [Discord server](https://discord.com/invite/b5rXHjAg7A)?utm_source=github&utm_medium=clerk_react
-- Open a [GitHub support issue](https://github.com/clerkinc/javascript/issues/new?assignees=&labels=question&template=ask_a_question.md&title=Support%3A+)
+- Join our official community [Discord server](https://discord.com/invite/b5rXHjAg7A)
+  ?utm_source=github&utm_medium=clerk_react
+- Open
+  a [GitHub support issue](https://github.com/clerkinc/javascript/issues/new?assignees=&labels=question&template=ask_a_question.md&title=Support%3A+)
 - Contact options listed on [our Support page](https://clerk.dev/support?utm_source=github&utm_medium=clerk_nextjs)
 
 ## Contributing
 
-We're open to all community contributions! If you'd like to contribute in any way, please read [our contribution guidelines](https://github.com/clerkinc/javascript/blob/main/packages/nextjs/docs/CONTRIBUTING.md).
+We're open to all community contributions! If you'd like to contribute in any way, please
+read [our contribution guidelines](https://github.com/clerkinc/javascript/blob/main/packages/nextjs/docs/CONTRIBUTING.md)
+.
 
 ## Security
 
@@ -114,7 +125,8 @@ We're open to all community contributions! If you'd like to contribute in any wa
 
 `@clerk/nextjs` is provided **"as is"** without any **warranty**. Use at your own risk.
 
-_For more information and to report security issues, please refer to our [security documentation](https://github.com/clerkinc/javascript/blob/main/packages/nextjs/docs/SECURITY.md)._
+_For more information and to report security issues, please refer to
+our [security documentation](https://github.com/clerkinc/javascript/blob/main/packages/nextjs/docs/SECURITY.md)._
 
 ## License
 

--- a/packages/nextjs/src/server/utils/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/utils/withClerkMiddleware.ts
@@ -20,9 +20,7 @@ import {
 
 const DEFAULT_API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
 const DEFAULT_API_VERSION = process.env.CLERK_API_VERSION || 'v1';
-
-// Using public interstitial endpoint for time being
-const INTERSTITIAL_URL = `${DEFAULT_API_URL}/${DEFAULT_API_VERSION}/public/interstitial?frontendApi=${process.env.NEXT_PUBLIC_CLERK_FRONTEND_API}`;
+const PUBLIC_INTERSTITIAL_URL = buildPublicInsterstitialUrl(); // Using public interstitial endpoint for time being
 
 type WithAuthOptions = {
   jwtKey?: string;
@@ -68,7 +66,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     // Therefore we have to resort to a public interstitial endpoint
 
     if (status === AuthStatus.Interstitial) {
-      const response = NextResponse.rewrite(INTERSTITIAL_URL);
+      const response = NextResponse.rewrite(PUBLIC_INTERSTITIAL_URL);
       response.headers.set(AUTH_RESULT, errorReason as string);
       return response;
     }
@@ -144,4 +142,16 @@ export function handleMiddlewareResult({ req, res, authResult }: HandleMiddlewar
   }
 
   return res;
+}
+
+function buildPublicInsterstitialUrl(): string {
+  const url = new URL(`${DEFAULT_API_URL}/${DEFAULT_API_VERSION}/public/interstitial`);
+
+  if (process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
+    url.searchParams.append('publishable_key', process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+  } else if (process.env.NEXT_PUBLIC_CLERK_FRONTEND_API) {
+    url.searchParams.append('frontendApi', process.env.NEXT_PUBLIC_CLERK_FRONTEND_API);
+  }
+
+  return url.href;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [X] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.

When accessing the public interstitial endpoint the `frontentApi` passed in the query params so that BAPI can interpolate it in the interstitial HTML.

It's value it set to `process.env.NEXT_PUBLIC_CLERK_FRONTEND_API`.

For the new publishable keys, the `publishable_key` query param will be set instead if `process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is populated.

Note: current commit addresses only the existing public intestitial mechanism, not the upcoming clerk-backend version.
