### PR TITLE
fix(backend,remix): Replace default with a named Clerk export

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -52,7 +52,7 @@ npm install @clerk/backend
 ```
 
 ```
-import Clerk from '@clerk/backend';
+import { Clerk } from '@clerk/backend';
 
 const clerk = Clerk({ apiKey: '...' });
 
@@ -66,7 +66,7 @@ await clerk.users.getUser("user_...");
 Create Clerk SDK that includes an HTTP Rest client for the Backend API and session verification helpers. The clerk object contains the following APIs and methods:
 
 ```js
-import Clerk from '@clerk/backend';
+import { Clerk } from '@clerk/backend';
 
 const clerk = Clerk({ apiKey: '...' });
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,12 +8,9 @@ export * from './tokens/verify';
 
 export type ClerkOptions = CreateBackendApiOptions & Pick<CreateAuthenticateRequestOptions, 'jwtKey'>;
 
-export default function Clerk(options: ClerkOptions) {
+export function Clerk(options: ClerkOptions) {
   const apiClient = createBackendApiClient(options);
   const requestState = createAuthenticateRequest({ ...options, apiClient });
 
-  return {
-    ...apiClient,
-    ...requestState,
-  };
+  return { ...apiClient, ...requestState };
 }

--- a/packages/remix/src/experimental/api/index.ts
+++ b/packages/remix/src/experimental/api/index.ts
@@ -1,4 +1,4 @@
-import Clerk from '@clerk/backend';
+import { Clerk } from '@clerk/backend';
 
 const createClerkClient = Clerk;
 

--- a/packages/remix/src/experimental/ssr/authenticateRequest.ts
+++ b/packages/remix/src/experimental/ssr/authenticateRequest.ts
@@ -1,4 +1,4 @@
-import { type RequestState, default as Clerk } from '@clerk/backend';
+import { type RequestState, Clerk } from '@clerk/backend';
 
 import { noApiKeyError, noFrontendApiError } from '../errors';
 import { assertEnvVar, getEnvVariable } from '../utils';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Replaces the default Clerk export from clerk/backend with a named export to allow for easier CJS/ESM interoperability support
<!-- Fixes # (issue number) -->
