### PR TITLE
fix(clerk-react): Only throw loadClerkJS error in development

### DIFF
--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -184,8 +184,9 @@ export default class IsomorphicClerk {
   throwError(errorMsg: string): void {
     if (process.env.NODE_ENV === 'production') {
       console.error(errorMsg);
+    } else {
+      throw new Error(errorMsg);
     }
-    throw new Error(errorMsg);
   }
 
   private hydrateClerkJS = async (clerkjs: BrowserClerk | HeadlessBrowserClerk | undefined) => {


### PR DESCRIPTION
As per the comment above the function which has been changed, we should only throw the error in development.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
