### PR TITLE
chore(nextjs): Reuse ClerkProviderProps

### DIFF
--- a/packages/nextjs/src/app-beta/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-beta/ClerkProvider.tsx
@@ -1,9 +1,19 @@
+// import type { ClerkProviderProps } from '@clerk/clerk-react';
 import React from 'react';
 
 import { initialState } from './auth';
+import type { NextAppBetaClerkProviderProps } from './client/ClerkProvider';
 import { ClerkProvider as ClerkProviderClient } from './client/ClerkProvider';
 
-export function ClerkProvider({ children }: { children: React.ReactNode }) {
+export function ClerkProvider({ children, ...restProps }: NextAppBetaClerkProviderProps) {
   const state = initialState()?.__clerk_ssr_state || { sessionId: null, orgId: null, userId: null };
-  return <ClerkProviderClient initialState={state}>{children}</ClerkProviderClient>;
+
+  return (
+    <ClerkProviderClient
+      {...restProps}
+      initialState={state as any}
+    >
+      {children}
+    </ClerkProviderClient>
+  );
 }

--- a/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 // !!! Note the import from react
+import type { ClerkProviderProps } from '@clerk/clerk-react';
 import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
 import { usePathname, useRouter } from 'next/navigation';
 import React, { useCallback, useEffect } from 'react';
@@ -41,11 +42,14 @@ export const useAwaitableNavigate = () => {
   }, []);
 };
 
-export function ClerkProvider(props: React.PropsWithChildren<{ initialState: any }>) {
-  const { children, initialState } = props;
+export type NextAppBetaClerkProviderProps = Pick<ClerkProviderProps, 'children' | 'initialState' | 'localization'>;
+
+export function ClerkProvider(props: NextAppBetaClerkProviderProps) {
+  const { children, initialState, ...restProps } = props;
   const navigate = useAwaitableNavigate();
   return (
     <ReactClerkProvider
+      {...restProps}
       frontendApi={process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || ''}
       publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || ''}
       // @ts-expect-error


### PR DESCRIPTION

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature (nextjs/app-beta)
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/nextjs/app-beta`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

~This PR try to re-use `ClerkProviderProps` from `@clerk/clerk-react` instead of narrower (specific) type to allow feature parity, for example the ability to specify localizations.~

This PR enable localization opt-in in nextjs app folder by re-using `ClerkProviderProps` from `@clerk/clerk-react` instead of narrower (specific) type. Only tested props are added to a `NextAppBetaClerkProviderProps` to ensure DX.