### PR TITLE
fix(clerk-js): Use inherited color in Previews

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -47,7 +47,7 @@ export const OrganizationSwitcherTrigger = React.forwardRef<HTMLButtonElement, O
         <Icon
           elementDescriptor={descriptors.organizationSwitcherTriggerIcon}
           icon={Selector}
-          sx={t => ({ color: t.colors.$blackAlpha400, marginLeft: `${t.space.$2}` })}
+          sx={t => ({ opacity: t.opacity.$sm, marginLeft: `${t.space.$2}` })}
         />
       </Button>
     );

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
@@ -95,6 +95,7 @@ export const OrganizationActionList = (props: OrganizationActionListProps) => {
             onClick={() => onOrganizationClick(organization)}
           >
             <OrganizationPreview
+              elementId={'organizationSwitcher'}
               avatarSx={t => ({ margin: `0 calc(${t.space.$3}/2)` })}
               organization={organization}
               size='sm'

--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -76,7 +76,6 @@ export const Avatar = (props: AvatarProps) => {
           border: theme.borders.$normal,
           borderColor: theme.colors.$avatarBorder,
           backgroundColor: theme.colors.$avatarBackground,
-          color: theme.colors.$colorText,
           backgroundClip: 'padding-box',
         }),
         sx,
@@ -93,6 +92,7 @@ const InitialsAvatarFallback = (props: { initials: string }) => {
   return (
     <Text
       as='span'
+      colorScheme='inherit'
       sx={{ ...common.centeredFlex('inline-flex'), width: '100%' }}
     >
       {initials}

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -58,6 +58,7 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
           elementDescriptor={descriptors.organizationPreviewMainIdentifier}
           elementId={descriptors.organizationPreviewMainIdentifier.setId(elementId)}
           variant={size === 'md' ? 'regularMedium' : 'smallMedium'}
+          colorScheme='inherit'
           truncate
         >
           {organization.name} {badge}

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -81,6 +81,7 @@ export const UserPreview = (props: UserPreviewProps) => {
           elementDescriptor={descriptors.userPreviewMainIdentifier}
           elementId={descriptors.userPreviewMainIdentifier.setId(elementId)}
           variant={size === 'md' ? 'regularMedium' : 'smallMedium'}
+          colorScheme='inherit'
           truncate
         >
           {localizedTitle || name || identifier} {badge}

--- a/packages/clerk-js/src/ui/foundations/opacity.ts
+++ b/packages/clerk-js/src/ui/foundations/opacity.ts
@@ -1,4 +1,5 @@
 export const opacity = Object.freeze({
+  sm: '24%',
   disabled: '50%',
   inactive: '62%',
 } as const);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Allow customization of the OrganizationSwitcher text color without having to target specific `p` elements.
Example: 
<img width="260" alt="Screenshot 2022-12-29 at 12 41 57" src="https://user-images.githubusercontent.com/73396808/209939999-af13f887-802a-4188-9f68-ce57c422fde6.png">

by doing: 
```
<OrganizationSwitcher
        organizationProfileMode={'navigation'}
        appearance={{
          elements: {
            organizationSwitcherTrigger: {
              '&:hover': {
                background: 'blue',
              },
              color: 'white',
              background: 'blue',
            },
          },
        }}
/>
```
<!-- Fixes # (issue number) -->
