### PR TITLE
fix(clerk-js): Set color for RootBox and Navbar to prevent breaking change

### DIFF
--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -173,6 +173,7 @@ const NavbarContainer = (props: React.PropsWithChildren<Record<never, never>>) =
         [mqu.md]: {
           display: 'none',
         },
+        color: t.colors.$colorText,
       })}
     >
       {props.children}
@@ -215,6 +216,7 @@ const MobileNavbarContainer = withFloatingTree((props: React.PropsWithChildren<R
           zIndex: t.zIndices.$navbar,
           borderRadius: t.radii.$xl,
           overflow: 'hidden',
+          color: t.colors.$colorText,
         })}
       >
         <Col

--- a/packages/clerk-js/src/ui/elements/RootBox.tsx
+++ b/packages/clerk-js/src/ui/elements/RootBox.tsx
@@ -8,7 +8,7 @@ export const RootBox = (props: PropsOfComponent<typeof Col>) => {
       sx={t => ({
         boxSizing: 'border-box',
         width: 'fit-content',
-
+        color: t.colors.$colorText,
         fontFamily: t.fonts.$main,
         fontStyle: t.fontStyles.$normal,
       })}


### PR DESCRIPTION
Set the color in these places to prevent the inheritance of the body color, since this was not the behaviour we currently have in v4.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
