### PR TITLE
feat(backend): Support new issuer format for dev instances

### DIFF
--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -152,7 +152,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
   }
 
   function verifyRequestState(token: string) {
-    const issuer = (iss: string) => iss.startsWith('https://clerk.');
+    const issuer = (iss: string) => iss.startsWith('https://clerk.') || iss.includes('.clerk.accounts');
 
     return verifyToken(token, {
       ...options,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This commit adds support for the new issuer format we are going to introduce for our dev instances. The new format is `https://foo-bar-13.clerk.accounts.dev` when the old one would be `https://clerk.foo.bar-13.lcl.dev`

<!-- Fixes # (issue number) -->
