### PR TITLE
fix(clerk-js): Display unsupported country emojis as Text

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -118,7 +118,7 @@
     "files": [
       {
         "path": "./dist/clerk.browser.js",
-        "maxSize": "178kB"
+        "maxSize": "179kB"
       },
       {
         "path": "./dist/clerk.headless.js",

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 
 import { getLongestValidCountryCode } from '../../../ui/utils/phoneUtils';
 import { Flex, Input, Text } from '../../customizables';
@@ -174,18 +174,18 @@ const CountryCodeListItem = React.memo((props: CountryCodeListItemProps) => {
 });
 
 const Flag = (props: { iso: CountryIso }) => {
-  const [isWindows, setIsWindows] = useState(false);
+  const [supportsCountryEmoji, setSupportsCountryEmoji] = useState(false);
 
   useLayoutEffect(() => {
-    setIsWindows(window.navigator.userAgent.indexOf('Windows') > -1);
+    setSupportsCountryEmoji(!window.navigator.userAgent.includes('Windows'));
   }, []);
 
   return (
     <>
-      {isWindows ? (
-        <Text variant='smallBold'>{props.iso.toUpperCase()}</Text>
-      ) : (
+      {supportsCountryEmoji ? (
         <Flex sx={theme => ({ fontSize: theme.fontSizes.$md })}>{getFlagEmojiFromCountryIso(props.iso)}</Flex>
+      ) : (
+        <Text variant='smallBold'>{props.iso.toUpperCase()}</Text>
       )}
     </>
   );

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 
 import { getLongestValidCountryCode } from '../../../ui/utils/phoneUtils';
 import { Flex, Input, Text } from '../../customizables';
@@ -137,11 +137,10 @@ export const PhoneInput = (props: PhoneInputProps) => {
   );
 };
 
-type CountryCodeListItem = PropsOfComponent<typeof Flex> & {
+type CountryCodeListItemProps = PropsOfComponent<typeof Flex> & {
   country: CountryEntry;
 };
-
-const CountryCodeListItem = React.memo((props: CountryCodeListItem) => {
+const CountryCodeListItem = React.memo((props: CountryCodeListItemProps) => {
   const { country, sx, ...rest } = props;
   return (
     <Flex
@@ -175,5 +174,19 @@ const CountryCodeListItem = React.memo((props: CountryCodeListItem) => {
 });
 
 const Flag = (props: { iso: CountryIso }) => {
-  return <Flex sx={theme => ({ fontSize: theme.fontSizes.$md })}>{getFlagEmojiFromCountryIso(props.iso)}</Flex>;
+  const [isWindows, setIsWindows] = useState(false);
+
+  useLayoutEffect(() => {
+    setIsWindows(window.navigator.userAgent.indexOf('Windows') > -1);
+  }, []);
+
+  return (
+    <>
+      {isWindows ? (
+        <Text variant='smallBold'>{props.iso.toUpperCase()}</Text>
+      ) : (
+        <Flex sx={theme => ({ fontSize: theme.fontSizes.$md })}>{getFlagEmojiFromCountryIso(props.iso)}</Flex>
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Added the logic to replace the emojis on Windows. A text for now, but we can add a sprite whenever it's ready!

Before:
![image](https://user-images.githubusercontent.com/73396808/210768705-f9e98f20-8d41-4510-b5b3-d767bdb034ce.png)

After:
![image](https://user-images.githubusercontent.com/73396808/210769915-32879edb-8f71-4f9e-91f1-b4081b2321f1.png)


<!-- Fixes # (issue number) -->
