### PR TITLE
fix(clerk-react): Export HOC-related types to support older React pat…

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,14 @@
 export * from './contexts';
 export * from './components';
 export * from './hooks';
-export type { BrowserClerk, ClerkProp, HeadlessBrowserClerk } from './types';
+export type {
+  BrowserClerk,
+  ClerkProp,
+  HeadlessBrowserClerk,
+  WithUserProp,
+  WithClerkProp,
+  WithSessionProp,
+} from './types';
 export { isMagicLinkError, MagicLinkErrorCode } from './errors';
 export { useMagicLink } from './hooks/useMagicLink';
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,12 @@
-import type { Clerk, ClerkOptions, ClientResource, LoadedClerk, RedirectOptions, UserResource } from '@clerk/types';
+import type {
+  Clerk,
+  ClerkOptions,
+  ClientResource,
+  LoadedClerk,
+  RedirectOptions,
+  SessionResource,
+  UserResource,
+} from '@clerk/types';
 
 declare global {
   interface Window {
@@ -30,9 +38,11 @@ export interface HeadlessBrowserClerkConstrutor {
   new (frontendApi: string): HeadlessBrowserClerk;
 }
 
-export type WithClerkProp<T> = T & { clerk: LoadedClerk };
+export type WithClerkProp<T = unknown> = T & { clerk: LoadedClerk };
 
-export type WithUserProp<T> = T & { user: UserResource };
+export type WithUserProp<T = unknown> = T & { user: UserResource };
+
+export type WithSessionProp<T = unknown> = T & { session: SessionResource };
 
 // Clerk object
 export interface MountProps {


### PR DESCRIPTION
…terns

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Our docs: https://clerk.dev/docs/reference/clerk-react/useuser state that withUser can be used with the WithUserProp type, which we currently do not export.

This PR correctly exports the `WithUserProp` and other HOC-related helper types from all related packages (react, nextjs etc)

[COR-58](https://linear.app/clerk/issue/COR-58/export-withuserprop-and-other-relevant-hoc-related-types)