### PR TITLE
Add support for Reverse proxy

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -91,6 +91,7 @@ declare global {
     Clerk?: Clerk;
     __clerk_frontend_api?: string;
     __clerk_publishable_key?: string;
+    __clerk_proxy_url?: Pick<ClerkInterface, 'proxyUrl'>['proxyUrl'];
   }
 }
 
@@ -99,6 +100,8 @@ const defaultOptions: ClerkOptions = {
   standardBrowser: true,
   touchSession: true,
 };
+
+type ClerkConstructorOptions = Pick<ClerkInterface, 'proxyUrl'>;
 
 export default class Clerk implements ClerkInterface {
   public static mountComponentRenderer?: MountComponentRenderer;
@@ -109,6 +112,7 @@ export default class Clerk implements ClerkInterface {
   public user?: UserResource | null;
   public frontendApi: string;
   public publishableKey?: string;
+  public proxyUrl?: ClerkConstructorOptions['proxyUrl'];
 
   #authService: AuthenticationService | null = null;
   #broadcastChannel: LocalStorageBroadcastChannel<ClerkCoreBroadcastChannelEvent> | null = null;
@@ -132,8 +136,10 @@ export default class Clerk implements ClerkInterface {
     return this.#isReady;
   }
 
-  public constructor(key: string) {
+  public constructor(key: string, options?: unknown) {
     key = (key || '').trim();
+
+    this.proxyUrl = (options as ClerkConstructorOptions | undefined)?.proxyUrl;
 
     if (isLegacyFrontendApiKey(key)) {
       if (!validateFrontendApi(key)) {

--- a/packages/clerk-js/src/index.browser.ts
+++ b/packages/clerk-js/src/index.browser.ts
@@ -15,7 +15,14 @@ const frontendApi =
   window.__clerk_frontend_api ||
   '';
 
-window.Clerk = new Clerk(publishableKey || frontendApi);
+const proxyUrl =
+  document.querySelector('script[data-clerk-proxy-url]')?.getAttribute('data-clerk-proxy-url') ||
+  window.__clerk_proxy_url ||
+  '';
+
+window.Clerk = new Clerk(publishableKey || frontendApi, {
+  proxyUrl,
+});
 
 if (module.hot) {
   module.hot.accept();

--- a/packages/clerk-js/src/index.headless.browser.ts
+++ b/packages/clerk-js/src/index.headless.browser.ts
@@ -12,7 +12,14 @@ const frontendApi =
   window.__clerk_frontend_api ||
   '';
 
-window.Clerk = new Clerk(publishableKey || frontendApi);
+const proxyUrl =
+  document.querySelector('script[data-clerk-proxy-url]')?.getAttribute('data-clerk-proxy-url') ||
+  window.__clerk_proxy_url ||
+  '';
+
+window.Clerk = new Clerk(publishableKey || frontendApi, {
+  proxyUrl,
+});
 
 if (module.hot) {
   module.hot.accept();

--- a/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
@@ -45,10 +45,11 @@ export function ClerkProvider(props: React.PropsWithChildren<{ initialState: any
   const { children, initialState } = props;
   const navigate = useAwaitableNavigate();
   return (
-    // @ts-expect-error
     <ReactClerkProvider
       frontendApi={process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || ''}
       publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || ''}
+      // @ts-expect-error
+      proxyUrl={process.env.NEXT_PUBLIC_CLERK_PROXY_URL}
       navigate={navigate}
       initialState={initialState}
     >

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -18,17 +18,19 @@ type NextClerkProviderProps = {
 export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JSX.Element {
   // @ts-expect-error
   // Allow for overrides without making the type public
-  const { authServerSideProps, frontendApi, publishableKey, __clerk_ssr_state, clerkJSUrl, ...restProps } = rest;
+  const { authServerSideProps, frontendApi, publishableKey, proxyUrl, __clerk_ssr_state, clerkJSUrl, ...restProps } =
+    rest;
   const { push } = useRouter();
 
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 
   return (
-    // @ts-expect-error
     <ReactClerkProvider
       frontendApi={frontendApi || process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || ''}
       publishableKey={publishableKey || process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || ''}
       clerkJSUrl={clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS}
+      // @ts-expect-error
+      proxyUrl={proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL}
       navigate={to => push(to)}
       // withServerSideAuth automatically injects __clerk_ssr_state
       // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -25,6 +25,7 @@ import { OrganizationProfileProps, OrganizationSwitcherProps } from '@clerk/type
 import type {
   BrowserClerk,
   BrowserClerkConstructor,
+  ClerkConstructorOptions,
   ClerkProp,
   HeadlessBrowserClerk,
   HeadlessBrowserClerkConstrutor,
@@ -47,6 +48,7 @@ export default class IsomorphicClerk {
   private mode: 'browser' | 'server';
   private frontendApi?: string;
   private publishableKey?: string;
+  private proxyUrl?: ClerkConstructorOptions['proxyUrl'];
   private options: IsomorphicClerkOptions;
   private Clerk: ClerkProp;
   private clerkjs: BrowserClerk | HeadlessBrowserClerk | null = null;
@@ -83,9 +85,10 @@ export default class IsomorphicClerk {
   }
 
   constructor(options: IsomorphicClerkOptions) {
-    const { Clerk = null, frontendApi, publishableKey, ...rest } = options || {};
+    const { Clerk = null, frontendApi, publishableKey } = options || {};
     this.frontendApi = frontendApi;
     this.publishableKey = publishableKey;
+    this.proxyUrl = (options as ClerkConstructorOptions | undefined)?.proxyUrl;
     this.options = options;
     this.Clerk = Clerk;
     this.mode = inClientSide() ? 'browser' : 'server';
@@ -109,6 +112,7 @@ export default class IsomorphicClerk {
     // - https://github.com/facebook/react/issues/24430
     window.__clerk_frontend_api = this.frontendApi;
     window.__clerk_publishable_key = this.publishableKey;
+    window.__clerk_proxy_url = this.proxyUrl;
 
     try {
       if (this.Clerk) {
@@ -117,7 +121,9 @@ export default class IsomorphicClerk {
 
         if (isConstructor<BrowserClerkConstructor | HeadlessBrowserClerkConstrutor>(this.Clerk)) {
           // Construct a new Clerk object if a constructor is passed
-          c = new this.Clerk(this.publishableKey || this.frontendApi || '');
+          c = new this.Clerk(this.publishableKey || this.frontendApi || '', {
+            proxyUrl: this.proxyUrl,
+          });
           await c.load(this.options);
         } else {
           // Otherwise use the instantiated Clerk object
@@ -134,6 +140,7 @@ export default class IsomorphicClerk {
         await loadScript({
           frontendApi: this.frontendApi,
           publishableKey: this.publishableKey,
+          proxyUrl: this.proxyUrl,
           scriptUrl: this.options.clerkJSUrl,
           scriptVariant: this.options.clerkJSVariant,
         });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -13,8 +13,11 @@ declare global {
   interface Window {
     __clerk_frontend_api?: string;
     __clerk_publishable_key?: string;
+    __clerk_proxy_url?: ClerkConstructorOptions['proxyUrl'];
   }
 }
+
+export type ClerkConstructorOptions = Pick<Clerk, 'proxyUrl'>;
 
 export type IsomorphicClerkOptions = ClerkOptions & {
   Clerk?: ClerkProp;
@@ -23,11 +26,11 @@ export type IsomorphicClerkOptions = ClerkOptions & {
 } & PublishableKeyOrFrontendApi;
 
 export interface BrowserClerkConstructor {
-  new (publishableKey: string): BrowserClerk;
+  new (publishableKey: string, options?: ClerkConstructorOptions): BrowserClerk;
 }
 
 export interface HeadlessBrowserClerkConstrutor {
-  new (publishableKey: string): HeadlessBrowserClerk;
+  new (publishableKey: string, options?: ClerkConstructorOptions): HeadlessBrowserClerk;
 }
 
 export type WithClerkProp<T = unknown> = T & { clerk: LoadedClerk };

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -68,13 +68,14 @@ export interface LoadScriptParams {
    */
   frontendApi?: string;
   publishableKey?: string;
+  proxyUrl?: string;
   scriptUrl?: string;
   scriptVariant?: ScriptVariant;
 }
 
 export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptElement | null> {
   return new Promise((resolve, reject) => {
-    const { frontendApi, publishableKey } = params;
+    const { frontendApi, publishableKey, proxyUrl } = params;
 
     if (global.Clerk) {
       resolve(null);
@@ -91,7 +92,9 @@ export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptEl
     } else if (frontendApi) {
       script.setAttribute('data-clerk-frontend-api', frontendApi);
     }
-
+    if (proxyUrl) {
+      script.setAttribute('data-clerk-proxy-url', proxyUrl);
+    }
     script.setAttribute('crossorigin', 'anonymous');
     script.async = true;
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -64,6 +64,9 @@ export interface Clerk {
   /** Clerk Publishable Key string. */
   publishableKey?: string;
 
+  /** Clerk Proxy url string. */
+  proxyUrl?: string;
+
   instanceType?: InstanceType;
 
   /** Client handling most Clerk operations. */


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
Silenty introducing a new prop to handle FAPI requests through a proxy
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
