### PR TITLE
Support setting runtime api keys in @clerk/remix

### DIFF
--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -21,10 +21,16 @@ export type IsomorphicClerkOptions = ClerkOptions & {
   clerkJSVariant?: 'headless' | '';
 } & (
     | {
+        /**
+         * @deprecated Use `publishableKey` instead
+         */
         frontendApi?: never;
         publishableKey: string;
       }
     | {
+        /**
+         * @deprecated Use `publishableKey` instead
+         */
         frontendApi: string;
         publishableKey?: never;
       }

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -19,7 +19,8 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 
   assertValidClerkState(clerkState);
-  const { __clerk_ssr_state, __clerk_debug } = clerkState?.__internal_clerk_state || {};
+  const { __clerk_ssr_state, __frontendApi, __publishableKey, __clerk_debug } =
+    clerkState?.__internal_clerk_state || {};
 
   React.useEffect(() => {
     warnForSsr(clerkState);
@@ -33,6 +34,8 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
     <ReactClerkProvider
       navigate={awaitableNavigate}
       initialState={__clerk_ssr_state}
+      frontendApi={__frontendApi as any}
+      publishableKey={__publishableKey as any}
       {...restProps}
     >
       {children}

--- a/packages/remix/src/client/types.ts
+++ b/packages/remix/src/client/types.ts
@@ -5,7 +5,8 @@ export type ClerkState = {
   __internal_clerk_state: {
     __clerk_ssr_interstitial: string;
     __clerk_ssr_state: InitialState;
-    __frontendApi: string;
+    __frontendApi: string | undefined;
+    __publishableKey: string | undefined;
     __clerk_debug: any;
   };
 };

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -67,5 +67,7 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
 `);
 
 export const noApiKeyError = createErrorMessage(`
-  The CLERK_API_KEY environment variable must be set to use SSR and @clerk/remix/api.');
+A secretKey must be provided in order to use SSR and the exports from @clerk/remix/api.');
+If your runtime supports environment variables, you can add a CLERK_SECRET_KEY variable to your config.
+Otherwise, you can pass a secretKey parameter to rootAuthLoader or getAuth.
 `);

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -2,14 +2,16 @@ import { sanitizeAuthObject } from '@clerk/backend';
 
 import { noLoaderArgsPassedInGetAuth } from '../errors';
 import { authenticateRequest } from './authenticateRequest';
-import { GetAuthReturn, LoaderFunctionArgs } from './types';
+import { GetAuthReturn, LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
 import { interstitialJsonResponse } from './utils';
 
-export async function getAuth(args: LoaderFunctionArgs): GetAuthReturn {
+type GetAuthOptions = Pick<RootAuthLoaderOptions, 'apiKey' | 'secretKey'>;
+
+export async function getAuth(args: LoaderFunctionArgs, opts?: GetAuthOptions): GetAuthReturn {
   if (!args || (args && (!args.request || !args.context))) {
     throw new Error(noLoaderArgsPassedInGetAuth);
   }
-  const requestState = await authenticateRequest(args);
+  const requestState = await authenticateRequest(args, opts);
 
   if (requestState.isInterstitial || !requestState) {
     throw interstitialJsonResponse(requestState, { loader: 'nested' });

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -86,6 +86,7 @@ export const returnLoaderResultJsonResponse = (opts: { requestState: RequestStat
     ...wrapWithClerkState({
       __clerk_ssr_state: rest,
       __frontendApi: opts.requestState.frontendApi,
+      __publishableKey: opts.requestState.publishableKey,
       __clerk_debug: debugRequestState(opts.requestState),
     }),
   });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Correctly propagate `frontendApi` and `publishableKey` from rootAuthLoader to ClerkProvider
- Environment variables are no longer required, so `rootAuthLoader` now accepts all different keys (`apiKey, frontendApi, jwtKey, secretKey, publishableKey`). In order to fully support configurable keys during runtime, this PR makes `getAuth` accept a `frontendApi` or a `secretKey` so it's fully aligned with `rootAuthLoader`


<!-- Fixes # (issue number) -->
