### PR TITLE
fix(clerk-react): Proper error on missing API keys

### DIFF
--- a/packages/react/src/contexts/ClerkProvider.tsx
+++ b/packages/react/src/contexts/ClerkProvider.tsx
@@ -22,7 +22,7 @@ function ClerkProviderBase(props: ClerkProviderProps): JSX.Element {
   const { frontendApi = '', publishableKey = '' } = restIsomorphicClerkOptions;
 
   if (!publishableKey && !frontendApi) {
-    errorThrower.throwMissingFrontendApiPublishableKeyError();
+    errorThrower.throwMissingFrontendApiOrPublishableKeyError();
   } else if (publishableKey && !isPublishableKey(publishableKey)) {
     errorThrower.throwInvalidPublishableKeyError({ key: publishableKey });
   } else if (frontendApi && !isLegacyFrontendApiKey(frontendApi)) {

--- a/packages/react/src/contexts/ClerkProvider.tsx
+++ b/packages/react/src/contexts/ClerkProvider.tsx
@@ -21,8 +21,12 @@ function ClerkProviderBase(props: ClerkProviderProps): JSX.Element {
   const { initialState, children, ...restIsomorphicClerkOptions } = props;
   const { frontendApi = '', publishableKey = '' } = restIsomorphicClerkOptions;
 
-  if (!isPublishableKey(publishableKey) && !isLegacyFrontendApiKey(frontendApi)) {
-    errorThrower.throwInvalidPublishableKeyError({ key: publishableKey || frontendApi || '' });
+  if (!publishableKey && !frontendApi) {
+    errorThrower.throwMissingFrontendApiPublishableKeyError();
+  } else if (publishableKey && !isPublishableKey(publishableKey)) {
+    errorThrower.throwInvalidPublishableKeyError({ key: publishableKey });
+  } else if (frontendApi && !isLegacyFrontendApiKey(frontendApi)) {
+    errorThrower.throwInvalidFrontendApiError({ key: frontendApi });
   }
 
   return (

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -98,7 +98,7 @@ export default class IsomorphicClerk {
     }
 
     if (typeof this.publishableKey === 'undefined' && typeof this.frontendApi === 'undefined') {
-      errorThrower.throwMissingFrontendApiPublishableKeyError();
+      errorThrower.throwMissingFrontendApiOrPublishableKeyError();
     }
 
     // Store frontendAPI value on window as a fallback. This value can be used as a

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -44,7 +44,7 @@ function getScriptSrc({ publishableKey, frontendApi, scriptUrl, scriptVariant = 
   } else if (frontendApi) {
     scriptHost = frontendApi;
   } else {
-    errorThrower.throwMissingFrontendApiPublishableKeyError();
+    errorThrower.throwMissingFrontendApiOrPublishableKeyError();
   }
 
   const variant = scriptVariant ? `${scriptVariant.replace(/\.+$/, '')}.` : '';

--- a/packages/shared/src/errors/thrower.test.ts
+++ b/packages/shared/src/errors/thrower.test.ts
@@ -10,7 +10,7 @@ describe.concurrent('ErrorThrower', () => {
   });
 
   it('throws the correct error message and interpolates pkg if no parameters are provided', () => {
-    expect(() => errorThrower.throwMissingFrontendApiPublishableKeyError()).toThrow(
+    expect(() => errorThrower.throwMissingFrontendApiOrPublishableKeyError()).toThrow(
       '@clerk/test-package: Missing frontendApi or publishableKey. You can get your key at https://dashboard.clerk.dev/last-active?path=api-keys.',
     );
   });

--- a/packages/shared/src/errors/thrower.ts
+++ b/packages/shared/src/errors/thrower.ts
@@ -20,7 +20,7 @@ export interface ErrorThrower {
   setMessages(options: ErrorThrowerOptions): ErrorThrower;
   throwInvalidPublishableKeyError(params: { key?: string }): never;
   throwInvalidFrontendApiError(params: { key?: string }): never;
-  throwMissingFrontendApiPublishableKeyError(): never;
+  throwMissingFrontendApiOrPublishableKeyError(): never;
 }
 
 export function buildErrorThrower({ packageName, customMessages }: ErrorThrowerOptions): ErrorThrower {
@@ -68,7 +68,7 @@ export function buildErrorThrower({ packageName, customMessages }: ErrorThrowerO
       throw new Error(buildMessage(messages.InvalidFrontendApiErrorMessage, params));
     },
 
-    throwMissingFrontendApiPublishableKeyError(): never {
+    throwMissingFrontendApiOrPublishableKeyError(): never {
       throw new Error(buildMessage(messages.MissingFrontendApiPublishableKeyErrorMessage));
     },
   };


### PR DESCRIPTION


## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

Before this change, when neither of the keys were set (publishableKey or frontendApi), the following error would be thrown:

    The publishableKey passed to Clerk is invalid. You can get your
    Publishable key at
    https://dashboard.clerk.dev/last-active?path=api-keys. (key=)

This was misleading, since it implies that publishableKey is the only actionable from the user, whereas someone has to set either publishableKey _or_ frontendApi. Therefore, this patch changes the error message to the following when both keys are missing:

    Missing frontendApi or publishableKey. You can get your key at
    https://dashboard.clerk.dev/last-active?path=api-keys.

Similarly it renders more relevant messages when either of the keys were passed but was invalid.

Fixes AUTH-121
