### PR TITLE
Bucket of pre-release fixes vol 2

### DIFF
--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -8,12 +8,17 @@ export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
 export const API_KEY = process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '';
 export const PUBLISHABLE_KEY = process.env.CLERK_PUBLISHABLE_KEY || '';
 
-export const Clerk = (options: ClerkOptions) => {
+/**
+ * This needs to be a *named* function in order to support the older
+ * new Clerk() syntax for v4 compatibility.
+ * Arrow functions can never be called with the new keyword because they do not have the [[Construct]] method
+ */
+export function Clerk(options: ClerkOptions) {
   const clerkClient = _Clerk(options);
   const expressWithAuth = createClerkExpressWithAuth({ ...options, clerkClient });
   const expressRequireAuth = createClerkExpressRequireAuth({ ...options, clerkClient });
   return { ...clerkClient, expressWithAuth, expressRequireAuth };
-};
+}
 
 export const createClerkClient = Clerk;
 

--- a/packages/sdk-node/src/instance.ts
+++ b/packages/sdk-node/src/instance.ts
@@ -1,4 +1,4 @@
-import { Clerk } from '@clerk/backend';
+import { Clerk } from './clerkClient';
 
 export default Clerk;
 


### PR DESCRIPTION
Clerk needs to be a *named* function in order to support the older new Clerk() syntax for v4 compatibility. Arrow functions can never be called with the new keyword because they do not have the [[Construct]] method.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
