### PR TITLE
fix(backend,clerk-react): Staging detection for new hosts

### DIFF
--- a/packages/backend/src/util/instance.ts
+++ b/packages/backend/src/util/instance.ts
@@ -10,6 +10,7 @@ export function isStaging(frontendApi: string): boolean {
   return (
     frontendApi.endsWith('.lclstage.dev') ||
     frontendApi.endsWith('.stgstage.dev') ||
-    frontendApi.endsWith('.clerkstage.dev')
+    frontendApi.endsWith('.clerkstage.dev') ||
+    frontendApi.endsWith('.accountsstage.dev')
   );
 }

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -28,7 +28,8 @@ const forceStagingReleaseForClerkFapi = (frontendApi: string): boolean => {
   return (
     frontendApi.endsWith('.lclstage.dev') ||
     frontendApi.endsWith('.stgstage.dev') ||
-    frontendApi.endsWith('.clerkstage.dev')
+    frontendApi.endsWith('.clerkstage.dev') ||
+    frontendApi.endsWith('.accountsstage.dev')
   );
 };
 


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

The new FAPI/Accounts hosts when publishable key is used, end in accountsstage.dev. Therefore we fix the interstitial to properly detect that we're on staging and load the appropriate version, instead of using `latest`.

Resolves AUTH-127

