### PR TITLE
fix(backend): Extract interstitial rules from tokens/request

### DIFF
--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -1,0 +1,93 @@
+import { isDevelopmentFromApiKey, isProductionFromApiKey } from '../util/instance';
+import { checkCrossOrigin } from '../util/request';
+import { type RequestState, AuthErrorReason, interstitial, signedOut } from './authStatus';
+
+export type InterstitialRule = <T>(opts: T) => RequestState | undefined;
+
+// In development or staging environments only, based on the request's
+// User Agent, detect non-browser requests (e.g. scripts). Since there
+// is no Authorization header, consider the user as signed out and
+// prevent interstitial rendering
+// In production, script requests will be missing both uat and session cookies, which will be
+// automatically treated as signed out. This exception is needed for development, because the any // missing uat throws an interstitial in development.
+export const nonBrowserRequestInDevRule: InterstitialRule = options => {
+  const { apiKey, secretKey, userAgent } = options as any;
+  const key = secretKey || apiKey;
+  if (isDevelopmentFromApiKey(key) && !userAgent?.startsWith('Mozilla/')) {
+    return signedOut(options, AuthErrorReason.HeaderMissingNonBrowser);
+  }
+  return undefined;
+};
+
+export const crossOriginRequestWithoutHeader: InterstitialRule = options => {
+  const { origin, host, forwardedHost, forwardedPort, forwardedProto } = options as any;
+  const isCrossOrigin =
+    origin &&
+    checkCrossOrigin({
+      originURL: new URL(origin),
+      host,
+      forwardedHost,
+      forwardedPort,
+      forwardedProto,
+    });
+
+  if (isCrossOrigin) {
+    return signedOut(options, AuthErrorReason.HeaderMissingCORS);
+  }
+  return undefined;
+};
+
+export const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = options => {
+  const { apiKey, secretKey, clientUat } = options as any;
+  const key = secretKey || apiKey;
+  const res = isDevelopmentFromApiKey(key);
+  if (res && !clientUat) {
+    return interstitial(options, AuthErrorReason.CookieUATMissing);
+  }
+  return undefined;
+};
+
+export const potentialRequestAfterSignInOrOurFromClerkHostedUiInDev: InterstitialRule = options => {
+  const { apiKey, secretKey, referrer, host, forwardedHost, forwardedPort, forwardedProto } = options as any;
+  const crossOriginReferrer =
+    referrer && checkCrossOrigin({ originURL: new URL(referrer), host, forwardedHost, forwardedPort, forwardedProto });
+  const key = secretKey || apiKey;
+
+  if (isDevelopmentFromApiKey(key) && crossOriginReferrer) {
+    return interstitial(options, AuthErrorReason.CrossOriginReferrer);
+  }
+  return undefined;
+};
+
+export const potentialFirstRequestOnProductionEnvironment: InterstitialRule = options => {
+  const { apiKey, secretKey, clientUat, cookieToken } = options as any;
+  const key = secretKey || apiKey;
+
+  if (isProductionFromApiKey(key) && !clientUat && !cookieToken) {
+    return signedOut(options, AuthErrorReason.CookieAndUATMissing);
+  }
+  return undefined;
+};
+
+// TBD: Can enable if we do not want the __session cookie to be inspected.
+// const signedOutOnDifferentSubdomainButCookieNotRemovedYet: AuthStateRule = (options, key) => {
+//   if (isProduction(key) && !options.clientUat && !options.cookieToken) {
+//     return { status: AuthStatus.Interstitial, errorReason: '' as any };
+//   }
+// };
+export const isNormalSignedOutState: InterstitialRule = options => {
+  const { clientUat } = options as any;
+  if (clientUat === '0') {
+    return signedOut(options, AuthErrorReason.StandardSignedOut);
+  }
+  return undefined;
+};
+
+// This happens when a signed in user visits a new subdomain for the first time. The uat will be available because it's set on naked domain, but session will be missing. It can also happen if the cookieToken is manually removed during development.
+export const hasClientUatButCookieIsMissingInProd: InterstitialRule = options => {
+  const { clientUat, cookieToken } = options as any;
+  if (clientUat && !cookieToken) {
+    return interstitial(options, AuthErrorReason.CookieMissing);
+  }
+  return undefined;
+};

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -78,7 +78,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
 
   async function authenticateRequestWithTokenInCookie() {
     try {
-      const signedOutOrInterstitial = runInterstitialRules(options, [
+      const signedOutOrInterstitial = await runInterstitialRules(options, [
         nonBrowserRequestInDevRule,
         crossOriginRequestWithoutHeader,
         potentialFirstLoadInDevWhenUATMissing,
@@ -136,11 +136,11 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
     return jwt.iat < Number.parseInt(clientUat);
   }
 
-  type RunRules = (opts: AuthenticateRequestOptions, rules: InterstitialRule[]) => RequestState | undefined;
+  type RunRules = (opts: AuthenticateRequestOptions, rules: InterstitialRule[]) => Promise<RequestState | undefined>;
 
-  const runInterstitialRules: RunRules = (opts, rules) => {
+  const runInterstitialRules: RunRules = async (opts, rules) => {
     for (const rule of rules) {
-      const res = rule(opts);
+      const res = await rule(opts);
       if (res) {
         return res;
       }

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -2,11 +2,20 @@ import { parsePublishableKey } from '@clerk/shared';
 import type { JwtPayload } from '@clerk/types';
 
 import { API_URL, API_VERSION } from '../constants';
-import { isDevelopmentFromApiKey, isProductionFromApiKey } from '../util/instance';
-import { checkCrossOrigin } from '../util/request';
 import { type RequestState, AuthErrorReason, signedIn, signedOut, interstitial } from './authStatus';
 import { type TokenCarrier, TokenVerificationError, TokenVerificationErrorReason } from './errors';
 import { type VerifyTokenOptions, verifyToken } from './verify';
+
+import {
+  type InterstitialRule,
+  nonBrowserRequestInDevRule,
+  crossOriginRequestWithoutHeader,
+  potentialFirstLoadInDevWhenUATMissing,
+  potentialRequestAfterSignInOrOurFromClerkHostedUiInDev,
+  potentialFirstRequestOnProductionEnvironment,
+  isNormalSignedOutState,
+  hasClientUatButCookieIsMissingInProd,
+} from './interstitialRule';
 
 export type LoadResourcesOptions = {
   loadSession?: boolean;
@@ -127,7 +136,6 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
     return jwt.iat < Number.parseInt(clientUat);
   }
 
-  type InterstitialRule = (opts: AuthenticateRequestOptions) => RequestState | undefined;
   type RunRules = (opts: AuthenticateRequestOptions, rules: InterstitialRule[]) => RequestState | undefined;
 
   const runInterstitialRules: RunRules = (opts, rules) => {
@@ -136,108 +144,6 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
       if (res) {
         return res;
       }
-    }
-    return undefined;
-  };
-
-  // In development or staging environments only, based on the request's
-  // User Agent, detect non-browser requests (e.g. scripts). Since there
-  // is no Authorization header, consider the user as signed out and
-  // prevent interstitial rendering
-  // In production, script requests will be missing both uat and session cookies, which will be
-  // automatically treated as signed out. This exception is needed for development, because the any // missing uat throws an interstitial in development.
-  const nonBrowserRequestInDevRule: InterstitialRule = ({ apiKey, secretKey, userAgent }) => {
-    const key = secretKey || apiKey;
-    if (isDevelopmentFromApiKey(key) && !userAgent?.startsWith('Mozilla/')) {
-      return signedOut<AuthenticateRequestOptions>(options, AuthErrorReason.HeaderMissingNonBrowser);
-    }
-    return undefined;
-  };
-
-  const crossOriginRequestWithoutHeader: InterstitialRule = ({
-    origin,
-    host,
-    forwardedHost,
-    forwardedPort,
-    forwardedProto,
-  }) => {
-    const isCrossOrigin =
-      origin &&
-      checkCrossOrigin({
-        originURL: new URL(origin),
-        host,
-        forwardedHost,
-        forwardedPort,
-        forwardedProto,
-      });
-
-    if (isCrossOrigin) {
-      return signedOut<AuthenticateRequestOptions>(options, AuthErrorReason.HeaderMissingCORS);
-    }
-    return undefined;
-  };
-
-  const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = ({ apiKey, secretKey, clientUat }) => {
-    const key = secretKey || apiKey;
-
-    const res = isDevelopmentFromApiKey(key);
-    if (res && !clientUat) {
-      return interstitial<AuthenticateRequestOptions>(options, AuthErrorReason.CookieUATMissing);
-    }
-    return undefined;
-  };
-
-  const potentialRequestAfterSignInOrOurFromClerkHostedUiInDev: InterstitialRule = ({
-    apiKey,
-    secretKey,
-    referrer,
-    host,
-    forwardedHost,
-    forwardedPort,
-    forwardedProto,
-  }) => {
-    const crossOriginReferrer =
-      referrer &&
-      checkCrossOrigin({ originURL: new URL(referrer), host, forwardedHost, forwardedPort, forwardedProto });
-    const key = secretKey || apiKey;
-
-    if (isDevelopmentFromApiKey(key) && crossOriginReferrer) {
-      return interstitial<AuthenticateRequestOptions>(options, AuthErrorReason.CrossOriginReferrer);
-    }
-    return undefined;
-  };
-
-  const potentialFirstRequestOnProductionEnvironment: InterstitialRule = ({
-    apiKey,
-    secretKey,
-    clientUat,
-    cookieToken,
-  }) => {
-    const key = secretKey || apiKey;
-
-    if (isProductionFromApiKey(key) && !clientUat && !cookieToken) {
-      return signedOut<AuthenticateRequestOptions>(options, AuthErrorReason.CookieAndUATMissing);
-    }
-    return undefined;
-  };
-
-  // TBD: Can enable if we do not want the __session cookie to be inspected.
-  // const signedOutOnDifferentSubdomainButCookieNotRemovedYet: AuthStateRule = (options, key) => {
-  //   if (isProduction(key) && !options.clientUat && !options.cookieToken) {
-  //     return { status: AuthStatus.Interstitial, errorReason: '' as any };
-  //   }
-  // };
-  const isNormalSignedOutState: InterstitialRule = ({ clientUat }) => {
-    if (clientUat === '0') {
-      return signedOut<AuthenticateRequestOptions>(options, AuthErrorReason.StandardSignedOut);
-    }
-    return undefined;
-  };
-
-  // This happens when a signed in user visits a new subdomain for the first time. The uat will be available because it's set on naked domain, but session will be missing. It can also happen if the cookieToken is manually removed during development.
-  const hasClientUatButCookieIsMissingInProd: InterstitialRule = ({ clientUat, cookieToken }) => {
-    if (clientUat && !cookieToken) {
-      return interstitial<AuthenticateRequestOptions>(options, AuthErrorReason.CookieMissing);
     }
     return undefined;
   };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Purpose of this PR is to extract the interstitial rules to separate module and allow those roles to be unit tested and covered extensively!

Related to: https://github.com/clerkinc/javascript/pull/669