### PR TITLE
fix(clerk-js): Account for user clock skew in TokenCache

### DIFF
--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -54,10 +54,6 @@ export function clerkMissingFapiClientInResources(): never {
   throw new Error(`${errorPrefix} Missing FAPI client in resources.`);
 }
 
-export function clerkCoreErrorExpiredToken(expiresAt: number): never {
-  throw new Error(`${errorPrefix} Token has expired (exp='${expiresAt}').`);
-}
-
 export function clerkCoreErrorTokenRefreshFailed(message: string): never {
   throw new Error(`${errorPrefix} Token refresh failed (error='${message}')`);
 }

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -66,8 +66,8 @@ export class Session extends BaseResource implements SessionResource {
       return null;
     }
 
-    const { leewayInSeconds = 10, template, skipCache = false } = options || {};
-    if (!template && leewayInSeconds >= 60) {
+    const { leewayInSeconds, template, skipCache = false } = options || {};
+    if (!template && Number(leewayInSeconds) >= 60) {
       throw new Error('Leeway can not exceed the token lifespan (60 seconds)');
     }
 

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -71,12 +71,8 @@ export class Session extends BaseResource implements SessionResource {
       throw new Error('Leeway can not exceed the token lifespan (60 seconds)');
     }
 
-    if (!!template && this.#isLegacyIntegrationRequest(template)) {
-      return this.#handleLegacyIntegrationToken({
-        template,
-        leewayInSeconds,
-        skipCache,
-      });
+    if (this.#isLegacyIntegrationRequest(template)) {
+      return this.#handleLegacyIntegrationToken({ template, leewayInSeconds, skipCache });
     }
 
     const tokenId = this.#getCacheId(template);
@@ -91,7 +87,7 @@ export class Session extends BaseResource implements SessionResource {
     return tokenResolver.then(res => res.getRawString());
   };
 
-  #hydrateCache = (token: Token | null) => {
+  #hydrateCache = (token: TokenResource | null) => {
     if (token) {
       SessionTokenCache.set({
         tokenId: this.#getCacheId(),
@@ -109,7 +105,7 @@ export class Session extends BaseResource implements SessionResource {
   }
 
   #isLegacyIntegrationRequest = (template: string | undefined): boolean => {
-    return (template || '').startsWith('integration_');
+    return !!template && template.startsWith('integration_');
   };
 
   #removeLegacyIntegrationPrefix = (template: string | undefined): string => {

--- a/packages/clerk-js/src/core/tokenCache.ts
+++ b/packages/clerk-js/src/core/tokenCache.ts
@@ -79,7 +79,7 @@ const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
       .then(newToken => {
         const expiresAt = newToken.jwt.claims.exp;
         const issuedAt = newToken.jwt.claims.iat;
-        const expiresIn = expiresAt - issuedAt;
+        const expiresIn: Seconds = expiresAt - issuedAt;
 
         // Mutate cached value and set expirations
         value.expiresIn = expiresIn;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

getToken() makes the decision about returning from cache by comparing the exp claim on the JWT against the user's computer time. exp is generated on our server (GCP's clock), not the computer's time.

We're accounting for slow/fast clocks by measuring the elapsed time since the token was cached, instead of comparing GCP's clock with the user's clock.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
