### PR TITLE
fix(clerk-react): Fix useAuth failing after user update

### DIFF
--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -51,7 +51,7 @@ export function ClerkContextProvider(props: ClerkContextProvider): JSX.Element |
   const { sessionId, session, userId, user, organizationId, organization } = derivedState;
   const actor = session?.actor || null;
   const organizationMembership = organization
-    ? session?.user.organizationMemberships.find(m => m.organization.id === organizationId)
+    ? user?.organizationMemberships.find(m => m.organization.id === organizationId)
     : organization;
   const orgId = organizationId;
   const orgRole = organizationMembership ? organizationMembership.role : organizationMembership;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This is a hotfix as more investigation is required. It looks like a mutation causes state.session.user.organizationMembership to be [] under certain conditions, while state.user.organizationMembership contains the expected memberships.


<!-- Fixes # (issue number) -->
