### PR TITLE
Improve authenticateRequest observability

### DIFF
--- a/packages/backend/src/api/factory.test.ts
+++ b/packages/backend/src/api/factory.test.ts
@@ -117,7 +117,7 @@ export default (QUnit: QUnit) => {
     test('executes a failed backend API request and parses the error response', async assert => {
       const mockErrorPayload = { code: 'whatever_error', message: 'whatever error', meta: {} };
       fakeFetch = sinon.stub(runtime, 'fetch');
-      fakeFetch.onCall(0).returns(jsonNotOk([mockErrorPayload]));
+      fakeFetch.onCall(0).returns(jsonNotOk({ errors: [mockErrorPayload] }));
 
       try {
         await apiClient.users.getUser('user_deadbeef');

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -138,7 +138,7 @@ export function buildRequest(options: CreateBackendApiOptions) {
 
       return {
         data: null,
-        errors: parseErrors(err as ClerkAPIErrorJSON[]),
+        errors: parseErrors(err),
         // TODO: To be removed with withLegacyReturn
         // @ts-expect-error
         status: res?.status,
@@ -150,8 +150,12 @@ export function buildRequest(options: CreateBackendApiOptions) {
   return withLegacyReturn(request);
 }
 
-function parseErrors(data: ClerkAPIErrorJSON[] = []): ClerkAPIError[] {
-  return data.length > 0 ? data.map(parseError) : [];
+function parseErrors(data: unknown): ClerkAPIError[] {
+  if (!!data && typeof data === 'object' && 'errors' in data) {
+    const errors = data.errors as ClerkAPIErrorJSON[];
+    return errors.length > 0 ? errors.map(parseError) : [];
+  }
+  return [];
 }
 
 function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -15,13 +15,15 @@ const Cookies = {
 
 const Headers = {
   AuthStatus: 'x-clerk-auth-status',
-  AuthReason: 'x-clerk-auth-reasons',
+  AuthReason: 'x-clerk-auth-reason',
   AuthMessage: 'x-clerk-auth-message',
   Authorization: 'authorization',
   ForwardedPort: 'x-forwarded-port',
   ForwardedHost: 'x-forwarded-host',
   Referrer: 'referer',
   UserAgent: 'user-agent',
+  Origin: 'origin',
+  Host: 'host',
 } as const;
 
 const SearchParams = {

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -1,6 +1,6 @@
 import { Clerk, constants, RequestState } from '@clerk/backend';
 import cookie from 'cookie';
-import { Request as ExpressRequest } from 'express';
+import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 
 import { ClerkMiddlewareOptions } from './types';
 
@@ -35,11 +35,15 @@ export const authenticateRequest = (
   });
 };
 
-export const handleInterstitialCase = (res: any, requestState: RequestState, interstitial: string) => {
+export const handleInterstitialCase = (res: ExpressResponse, requestState: RequestState, interstitial: string) => {
   if (requestState.isInterstitial) {
-    res.setHeader(constants.Headers.AuthMessage, requestState.message);
-    res.setHeader(constants.Headers.AuthReason, requestState.reason);
     res.writeHead(401, { 'Content-Type': 'text/html' });
     res.end(interstitial);
   }
+};
+
+export const decorateResponseWithObservabilityHeaders = (res: ExpressResponse, requestState: RequestState) => {
+  requestState.message && res.setHeader(constants.Headers.AuthMessage, requestState.message);
+  requestState.reason && res.setHeader(constants.Headers.AuthReason, requestState.reason);
+  requestState.status && res.setHeader(constants.Headers.AuthStatus, requestState.status);
 };

--- a/packages/sdk-node/src/clerkExpressRequireAuth.ts
+++ b/packages/sdk-node/src/clerkExpressRequireAuth.ts
@@ -1,6 +1,10 @@
 import { Clerk } from '@clerk/backend';
 
-import { authenticateRequest, handleInterstitialCase } from './authenticateRequest';
+import {
+  authenticateRequest,
+  decorateResponseWithObservabilityHeaders,
+  handleInterstitialCase,
+} from './authenticateRequest';
 import type { ClerkMiddlewareOptions, MiddlewareRequireAuthProp, RequireAuthProp } from './types';
 
 export type CreateClerkExpressMiddlewareOptions = {
@@ -17,6 +21,8 @@ export const createClerkExpressRequireAuth = (createOpts: CreateClerkExpressMidd
   return (options: ClerkMiddlewareOptions = {}): MiddlewareRequireAuthProp => {
     return async (req, res, next) => {
       const requestState = await authenticateRequest(clerkClient, apiKey, frontendApi, publishableKey, req, options);
+      decorateResponseWithObservabilityHeaders(res, requestState);
+
       if (requestState.isInterstitial) {
         const interstitial = await clerkClient.remotePrivateInterstitial();
         return handleInterstitialCase(res, requestState, interstitial);

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -1,7 +1,7 @@
 import { AuthObject, SignedInAuthObject } from '@clerk/backend';
 import { NextFunction, Request, Response } from 'express';
 
-type LegacyAuthObject<T extends AuthObject> = Pick<T, 'sessionId' | 'userId' | 'actor' | 'getToken'> & {
+type LegacyAuthObject<T extends AuthObject> = Pick<T, 'sessionId' | 'userId' | 'actor' | 'getToken' | 'debug'> & {
   claims: AuthObject['sessionClaims'];
 };
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Fix an error parsing issue
- Introduces the auth.debug function in the `backend` package

Example usage: 

```tsx
app.use(clerk.expressWithAuth())
app.get('/', async (req: WithAuthProp<Request>, res: Response) => {
  const { userId, debug } = req.auth;
  console.log(debug());
  res.json({ auth: req.auth });
});
```

- Decorate the response in clerk-sdk-node with the requestState observability headers when applicable:
![image](https://user-images.githubusercontent.com/1811063/212596399-3f08e138-1a32-4c26-8598-dcc27592b2aa.png)
These headers are: 
```
  AuthStatus: 'x-clerk-auth-status',
  AuthReason: 'x-clerk-auth-reason',
  AuthMessage: 'x-clerk-auth-message',
```
<!-- Fixes # (issue number) -->
