### PR TITLE
Populate Frontend Api Url when Publishable Key is used

### DIFF
--- a/packages/nextjs/src/api/requireAuth.ts
+++ b/packages/nextjs/src/api/requireAuth.ts
@@ -1,7 +1,7 @@
 import { ClerkMiddlewareOptions, createClerkExpressRequireAuth, RequireAuthProp } from '@clerk/clerk-sdk-node';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 
-import { API_URL, clerkClient, FRONTEND_API } from '../server';
+import { API_URL, clerkClient, FRONTEND_API, PUBLISHABLE_KEY } from '../server';
 import { runMiddleware } from './utils';
 
 type NextApiHandlerRequireAuth<T = any> = (
@@ -19,7 +19,12 @@ export function requireAuth(handler: NextApiHandlerRequireAuth, options?: ClerkM
       await runMiddleware(
         req,
         res,
-        createClerkExpressRequireAuth({ clerkClient, apiUrl: API_URL, frontendApi: FRONTEND_API })(options),
+        createClerkExpressRequireAuth({
+          clerkClient,
+          apiUrl: API_URL,
+          frontendApi: FRONTEND_API,
+          publishableKey: PUBLISHABLE_KEY,
+        })(options),
       );
       return handler(req as RequireAuthProp<NextApiRequest>, res);
     } catch (error) {

--- a/packages/nextjs/src/api/withAuth.ts
+++ b/packages/nextjs/src/api/withAuth.ts
@@ -1,7 +1,7 @@
 import { ClerkMiddlewareOptions, createClerkExpressRequireAuth, WithAuthProp } from '@clerk/clerk-sdk-node';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { API_URL, clerkClient, FRONTEND_API } from '../server';
+import { API_URL, clerkClient, FRONTEND_API, PUBLISHABLE_KEY } from '../server';
 import { runMiddleware } from './utils';
 
 type NextApiHandlerWithAuth<T = any> = (
@@ -18,7 +18,12 @@ export function withAuth(handler: NextApiHandlerWithAuth, options?: ClerkMiddlew
     await runMiddleware(
       req,
       res,
-      createClerkExpressRequireAuth({ clerkClient, frontendApi: FRONTEND_API, apiUrl: API_URL })(options),
+      createClerkExpressRequireAuth({
+        clerkClient,
+        frontendApi: FRONTEND_API,
+        apiUrl: API_URL,
+        publishableKey: PUBLISHABLE_KEY,
+      })(options),
     );
 
     return handler(req, res);

--- a/packages/nextjs/src/server/clerk.ts
+++ b/packages/nextjs/src/server/clerk.ts
@@ -1,10 +1,12 @@
 import { Clerk } from '@clerk/backend';
+import { parsePublishableKey } from '@clerk/shared';
 
 export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
 export const API_KEY = process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '';
-export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
+export const FRONTEND_API =
+  parsePublishableKey(PUBLISHABLE_KEY)?.frontendApi || process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
 
 const clerkClient = Clerk({
   apiKey: API_KEY,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR ensures that the frontendApi key is correctly populated when Publishable Key is used.

<!-- Fixes # (issue number) -->
