### PR TITLE
chore(backend,nextjs): Correctly propagate PK in backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31177,6 +31177,7 @@
       "version": "0.4.0-staging.5",
       "license": "MIT",
       "dependencies": {
+        "@clerk/shared": "^0.9.0-staging.2",
         "@clerk/types": "^3.24.0-staging.1",
         "@types/node": "16.18.6",
         "deepmerge": "^4.2.2",
@@ -41400,6 +41401,7 @@
     "@clerk/backend": {
       "version": "file:packages/backend",
       "requires": {
+        "@clerk/shared": "^0.9.0-staging.2",
         "@clerk/types": "^3.24.0-staging.1",
         "@cloudflare/workers-types": "^3.18.0",
         "@types/chai": "^4.3.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,7 @@
     "test:cloudflare-workerd": "tests/cloudflare-workerd/run.sh"
   },
   "dependencies": {
+    "@clerk/shared": "^0.9.0-staging.2",
     "@clerk/types": "^3.24.0-staging.1",
     "@types/node": "16.18.6",
     "deepmerge": "^4.2.2",

--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -112,16 +112,16 @@ export function buildPublicInterstitialUrl(options: LoadInterstitialOptions) {
 
 // TODO: Move to @clerk/shared as the same logic is used in @clerk/react
 const getClerkJsMajorVersionOrTag = (frontendApi: string, pkgVersion?: string) => {
+  if (!pkgVersion && isStaging(frontendApi)) {
+    return 'staging';
+  }
+
   if (!pkgVersion) {
     return 'latest';
   }
 
   if (pkgVersion.includes('next')) {
     return 'next';
-  }
-
-  if (isStaging(frontendApi)) {
-    return 'staging';
   }
 
   return pkgVersion.split('.')[0] || 'latest';

--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -1,3 +1,5 @@
+import { parsePublishableKey } from '@clerk/shared';
+
 import { API_VERSION } from '../constants';
 // DO NOT CHANGE: Runtime needs to be imported as a default export so that we can stub its dependencies with Sinon.js
 // For more information refer to https://sinonjs.org/how-to/stub-dependency/
@@ -79,6 +81,7 @@ export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions,
 
 // TODO: Add caching to Interstitial
 export async function loadInterstitialFromBAPI(options: LoadInterstitialOptions) {
+  options.frontendApi = options.frontendApi || parsePublishableKey(options.publishableKey)?.frontendApi || '';
   const url = buildPublicInterstitialUrl(options);
   const response = await callWithRetry(() => runtime.fetch(buildPublicInterstitialUrl(options)));
 
@@ -94,6 +97,7 @@ export async function loadInterstitialFromBAPI(options: LoadInterstitialOptions)
 }
 
 export function buildPublicInterstitialUrl(options: LoadInterstitialOptions) {
+  options.frontendApi = options.frontendApi || parsePublishableKey(options.publishableKey)?.frontendApi || '';
   const { apiUrl, frontendApi, pkgVersion, publishableKey } = options;
   const url = new URL(apiUrl);
   url.pathname = joinPaths(url.pathname, API_VERSION, '/public/interstitial');

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -6,12 +6,13 @@ import { isDevelopmentFromApiKey, isProductionFromApiKey } from '../util/instanc
 import { checkCrossOrigin } from '../util/request';
 import {
   type SignedInAuthObject,
-  type SignedOutAuthObject,
   signedInAuthObject,
+  type SignedOutAuthObject,
   signedOutAuthObject,
 } from './authObjects';
 import { TokenVerificationError, TokenVerificationErrorReason } from './errors';
-import { type VerifyTokenOptions, verifyToken } from './verify';
+import { verifyToken, type VerifyTokenOptions } from './verify';
+import { parsePublishableKey } from '@clerk/shared';
 
 export type LoadResourcesOptions = {
   loadSession?: boolean;
@@ -111,6 +112,7 @@ export type InterstitialState = Omit<SignedOutState, 'isInterstitial' | 'status'
 export type RequestState = SignedInState | SignedOutState | InterstitialState;
 
 export async function authenticateRequest(options: AuthenticateRequestOptions): Promise<RequestState> {
+  options.frontendApi = options.frontendApi || parsePublishableKey(options.publishableKey)?.frontendApi || '';
   options.apiUrl = options.apiUrl || API_URL;
   options.apiVersion = options.apiVersion || API_VERSION;
 

--- a/packages/nextjs/src/api/requireAuth.ts
+++ b/packages/nextjs/src/api/requireAuth.ts
@@ -1,7 +1,7 @@
 import { ClerkMiddlewareOptions, createClerkExpressRequireAuth, RequireAuthProp } from '@clerk/clerk-sdk-node';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 
-import { API_URL, clerkClient, FRONTEND_API } from '../server';
+import { API_URL, clerkClient, FRONTEND_API, PUBLISHABLE_KEY } from '../server';
 import { runMiddleware } from './utils';
 
 type NextApiHandlerRequireAuth<T = any> = (
@@ -19,7 +19,12 @@ export function requireAuth(handler: NextApiHandlerRequireAuth, options?: ClerkM
       await runMiddleware(
         req,
         res,
-        createClerkExpressRequireAuth({ clerkClient, apiUrl: API_URL, frontendApi: FRONTEND_API })(options),
+        createClerkExpressRequireAuth({
+          clerkClient,
+          apiUrl: API_URL,
+          frontendApi: FRONTEND_API,
+          publishableKey: PUBLISHABLE_KEY,
+        })(options),
       );
       return handler(req as RequireAuthProp<NextApiRequest>, res);
     } catch (error) {

--- a/packages/nextjs/src/api/withAuth.ts
+++ b/packages/nextjs/src/api/withAuth.ts
@@ -1,7 +1,7 @@
 import { ClerkMiddlewareOptions, createClerkExpressRequireAuth, WithAuthProp } from '@clerk/clerk-sdk-node';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { API_URL, clerkClient, FRONTEND_API } from '../server';
+import { API_URL, clerkClient, FRONTEND_API, PUBLISHABLE_KEY } from '../server';
 import { runMiddleware } from './utils';
 
 type NextApiHandlerWithAuth<T = any> = (
@@ -18,7 +18,12 @@ export function withAuth(handler: NextApiHandlerWithAuth, options?: ClerkMiddlew
     await runMiddleware(
       req,
       res,
-      createClerkExpressRequireAuth({ clerkClient, frontendApi: FRONTEND_API, apiUrl: API_URL })(options),
+      createClerkExpressRequireAuth({
+        clerkClient,
+        frontendApi: FRONTEND_API,
+        apiUrl: API_URL,
+        publishableKey: PUBLISHABLE_KEY,
+      })(options),
     );
 
     return handler(req, res);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR ensures that the frontendApi key is correctly populated when Publishable Key is used.
<!-- Fixes # (issue number) -->
