### PR TITLE
feat(backend,nextjs,remix,clerk-sdk-node): Support new secretKey prop

### DIFF
--- a/packages/backend/src/api/factory.ts
+++ b/packages/backend/src/api/factory.ts
@@ -16,8 +16,13 @@ import {
 import { buildRequest } from './request';
 
 export type CreateBackendApiOptions = {
-  /* Backend API key */
-  apiKey: string;
+  /**
+   * Backend API key
+   * @deprecated Use `secretKey` instead.
+   */
+  apiKey?: string;
+  /* Secret Key */
+  secretKey?: string;
   /* Backend API URL */
   apiUrl?: string;
   /* Backend API version */

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -62,12 +62,21 @@ const withLegacyReturn =
 
 export function buildRequest(options: CreateBackendApiOptions) {
   const request = async <T>(requestOptions: ClerkBackendApiRequestOptions): Promise<ClerkBackendApiResponse<T>> => {
-    const { apiKey, apiUrl = API_URL, apiVersion = API_VERSION, userAgent = USER_AGENT, httpOptions = {} } = options;
+    const {
+      apiKey,
+      secretKey,
+      apiUrl = API_URL,
+      apiVersion = API_VERSION,
+      userAgent = USER_AGENT,
+      httpOptions = {},
+    } = options;
     const { path, method, queryParams, headerParams, bodyParams } = requestOptions;
 
-    if (!apiKey) {
+    const key = secretKey || apiKey;
+
+    if (!key) {
       throw Error(
-        'Missing Clerk API Key. Go to https://dashboard.clerk.dev and get your Clerk API Key for your instance.',
+        'Missing Clerk Secret Key or API Key. Go to https://dashboard.clerk.dev and get your key for your instance.',
       );
     }
 
@@ -90,7 +99,7 @@ export function buildRequest(options: CreateBackendApiOptions) {
 
     // Build headers
     const headers = {
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${key}`,
       'Content-Type': 'application/json',
       'Clerk-Backend-SDK': userAgent,
       ...headerParams,

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -8,7 +8,11 @@ type CreateAuthObjectDebug = (data?: AuthObjectDebugData) => AuthObjectDebug;
 type AuthObjectDebug = () => unknown;
 
 export type SignedInAuthObjectOptions = {
-  apiKey: string;
+  /**
+   * @deprecated Use `secretKey` instead.
+   */
+  apiKey?: string;
+  secretKey?: string;
   apiUrl: string;
   apiVersion: string;
   token: string;
@@ -71,10 +75,11 @@ export function signedInAuthObject(
     org_slug: orgSlug,
     sub: userId,
   } = sessionClaims;
-  const { apiKey, apiUrl, apiVersion, token, session, user, organization } = options;
+  const { apiKey, secretKey, apiUrl, apiVersion, token, session, user, organization } = options;
 
   const { sessions } = createBackendApiClient({
     apiKey,
+    secretKey,
     apiUrl,
     apiVersion,
   });

--- a/packages/backend/src/tokens/errors.ts
+++ b/packages/backend/src/tokens/errors.ts
@@ -25,7 +25,7 @@ export enum TokenVerificationErrorAction {
   ContactSupport = 'Contact support@clerk.dev',
   EnsureClerkJWT = 'Make sure that this is a valid Clerk generate JWT.',
   SetClerkJWTKey = 'Set the CLERK_JWT_KEY environment variable.',
-  SetClerkAPIKey = 'Set the CLERK_API_KEY environment variable.',
+  SetClerkSecretKeyOrAPIKey = 'Set the CLERK_SECRET_KEY or CLERK_API_KEY environment variable.',
 }
 
 export class TokenVerificationError extends Error {

--- a/packages/backend/src/tokens/factory.ts
+++ b/packages/backend/src/tokens/factory.ts
@@ -14,7 +14,10 @@ import {
 
 export type CreateAuthenticateRequestOptions = {
   options: Partial<
-    Pick<AuthenticateRequestOptions, 'apiKey' | 'apiUrl' | 'apiVersion' | 'frontendApi' | 'publishableKey' | 'jwtKey'>
+    Pick<
+      AuthenticateRequestOptions,
+      'apiKey' | 'secretKey' | 'apiUrl' | 'apiVersion' | 'frontendApi' | 'publishableKey' | 'jwtKey'
+    >
   >;
   apiClient: ApiClient;
 };
@@ -23,6 +26,7 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
   const { apiClient } = params;
   const {
     apiKey: buildtimeApiKey = '',
+    secretKey: buildtimeSecretKey = '',
     jwtKey: buildtimeJwtKey = '',
     apiUrl = API_URL,
     apiVersion = API_VERSION,
@@ -32,6 +36,7 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
 
   const authenticateRequest = ({
     apiKey: runtimeApiKey,
+    secretKey: runtimeSecretKey,
     frontendApi: runtimeFrontendApi,
     publishableKey: runtimePublishableKey,
     jwtKey: runtimeJwtKey,
@@ -40,6 +45,7 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
     return authenticateRequestOriginal({
       ...rest,
       apiKey: runtimeApiKey || buildtimeApiKey,
+      secretKey: runtimeSecretKey || buildtimeSecretKey,
       apiUrl,
       apiVersion,
       frontendApi: runtimeFrontendApi || buildtimeFrontendApi,

--- a/packages/backend/src/tokens/keys.ts
+++ b/packages/backend/src/tokens/keys.ts
@@ -86,29 +86,12 @@ export type LoadClerkJWKFromRemoteOptions = {
   kid: string;
   jwksCacheTtlInMs?: number;
   skipJwksCache?: boolean;
-} & (
-  | {
-      apiKey: string;
-      secretKey?: never;
-      apiUrl?: string;
-      apiVersion?: string;
-      issuer?: never;
-    }
-  | {
-      apiKey?: never;
-      secretKey: string;
-      apiUrl?: string;
-      apiVersion?: string;
-      issuer?: never;
-    }
-  | {
-      apiKey?: never;
-      secretKey?: never;
-      apiUrl?: never;
-      apiVersion?: never;
-      issuer: string;
-    }
-);
+  secretKey?: string;
+  apiKey?: string;
+  apiUrl?: string;
+  apiVersion?: string;
+  issuer?: string;
+};
 
 /**
  *

--- a/packages/backend/src/tokens/request.test.ts
+++ b/packages/backend/src/tokens/request.test.ts
@@ -12,6 +12,7 @@ export default (QUnit: QUnit) => {
   /* An otherwise bare state on a request. */
   const defaultMockAuthenticateRequestOptions: AuthenticateRequestOptions = {
     apiKey: 'deadbeef',
+    secretKey: '',
     apiUrl: 'https://api.clerk.test',
     apiVersion: 'v1',
     frontendApi: 'cafe.babe.clerk.ts',

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -20,7 +20,9 @@ export type LoadResourcesOptions = {
   loadOrganization?: boolean;
 };
 
-export type RequiredVerifyTokenOptions = Required<Pick<VerifyTokenOptions, 'apiKey' | 'apiUrl' | 'apiVersion'>>;
+export type RequiredVerifyTokenOptions = Required<
+  Pick<VerifyTokenOptions, 'apiKey' | 'secretKey' | 'apiUrl' | 'apiVersion'>
+>;
 
 export type OptionalVerifyTokenOptions = Partial<
   Pick<VerifyTokenOptions, 'authorizedParties' | 'clockSkewInSeconds' | 'jwksCacheTtlInMs' | 'skipJwksCache' | 'jwtKey'>
@@ -192,6 +194,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
 
     const {
       apiKey,
+      secretKey,
       apiUrl,
       apiVersion,
       cookieToken,
@@ -203,7 +206,12 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
       loadOrganization,
     } = options;
 
-    const { sessions, users, organizations } = createBackendApiClient({ apiKey, apiUrl, apiVersion });
+    const { sessions, users, organizations } = createBackendApiClient({
+      apiKey,
+      secretKey,
+      apiUrl,
+      apiVersion,
+    });
 
     const [sessionResp, userResp, organizationResp] = await Promise.all([
       loadSession ? sessions.getSession(sessionId) : Promise.resolve(undefined),
@@ -222,6 +230,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
       sessionClaims,
       {
         apiKey,
+        secretKey,
         apiUrl,
         apiVersion,
         token: cookieToken || headerToken || '',
@@ -289,8 +298,9 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
   // prevent interstitial rendering
   // In production, script requests will be missing both uat and session cookies, which will be
   // automatically treated as signed out. This exception is needed for development, because the any // missing uat throws an interstitial in development.
-  const nonBrowserRequestInDevRule: InterstitialRule = ({ apiKey, userAgent }) => {
-    if (isDevelopmentFromApiKey(apiKey) && !userAgent?.startsWith('Mozilla/')) {
+  const nonBrowserRequestInDevRule: InterstitialRule = ({ apiKey, secretKey, userAgent }) => {
+    const key = secretKey || apiKey;
+    if (isDevelopmentFromApiKey(key) && !userAgent?.startsWith('Mozilla/')) {
       return signedOut(RequestErrorReason.HeaderMissingNonBrowser);
     }
     return undefined;
@@ -319,8 +329,10 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
     return undefined;
   };
 
-  const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = ({ apiKey, clientUat }) => {
-    const res = isDevelopmentFromApiKey(apiKey);
+  const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = ({ apiKey, secretKey, clientUat }) => {
+    const key = secretKey || apiKey;
+
+    const res = isDevelopmentFromApiKey(key);
     if (res && !clientUat) {
       return interstitial(RequestErrorReason.CookieUATMissing);
     }
@@ -329,6 +341,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
 
   const potentialRequestAfterSignInOrOurFromClerkHostedUiInDev: InterstitialRule = ({
     apiKey,
+    secretKey,
     referrer,
     host,
     forwardedHost,
@@ -338,15 +351,23 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
     const crossOriginReferrer =
       referrer &&
       checkCrossOrigin({ originURL: new URL(referrer), host, forwardedHost, forwardedPort, forwardedProto });
+    const key = secretKey || apiKey;
 
-    if (isDevelopmentFromApiKey(apiKey) && crossOriginReferrer) {
+    if (isDevelopmentFromApiKey(key) && crossOriginReferrer) {
       return interstitial(RequestErrorReason.CrossOriginReferrer);
     }
     return undefined;
   };
 
-  const potentialFirstRequestOnProductionEnvironment: InterstitialRule = ({ apiKey, clientUat, cookieToken }) => {
-    if (isProductionFromApiKey(apiKey) && !clientUat && !cookieToken) {
+  const potentialFirstRequestOnProductionEnvironment: InterstitialRule = ({
+    apiKey,
+    secretKey,
+    clientUat,
+    cookieToken,
+  }) => {
+    const key = secretKey || apiKey;
+
+    if (isProductionFromApiKey(key) && !clientUat && !cookieToken) {
       return signedOut(RequestErrorReason.CookieAndUATMissing);
     }
     return undefined;

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -1,3 +1,4 @@
+import { parsePublishableKey } from '@clerk/shared';
 import type { JwtPayload } from '@clerk/types';
 
 import { createBackendApiClient } from '../api';
@@ -6,13 +7,12 @@ import { isDevelopmentFromApiKey, isProductionFromApiKey } from '../util/instanc
 import { checkCrossOrigin } from '../util/request';
 import {
   type SignedInAuthObject,
-  signedInAuthObject,
   type SignedOutAuthObject,
+  signedInAuthObject,
   signedOutAuthObject,
 } from './authObjects';
 import { TokenVerificationError, TokenVerificationErrorReason } from './errors';
-import { verifyToken, type VerifyTokenOptions } from './verify';
-import { parsePublishableKey } from '@clerk/shared';
+import { type VerifyTokenOptions, verifyToken } from './verify';
 
 export type LoadResourcesOptions = {
   loadSession?: boolean;

--- a/packages/nextjs/src/middleware/utils/authenticateRequest.ts
+++ b/packages/nextjs/src/middleware/utils/authenticateRequest.ts
@@ -1,6 +1,6 @@
 import { GetServerSidePropsContext } from 'next';
 
-import { API_KEY, clerkClient, FRONTEND_API, PUBLISHABLE_KEY } from '../../server';
+import { API_KEY, clerkClient, FRONTEND_API, PUBLISHABLE_KEY, SECRET_KEY } from '../../server';
 import { WithServerSideAuthOptions } from '../types';
 
 /**
@@ -15,6 +15,7 @@ export async function authenticateRequest(ctx: GetServerSidePropsContext, opts: 
   return clerkClient.authenticateRequest({
     ...opts,
     apiKey: API_KEY,
+    secretKey: SECRET_KEY,
     frontendApi: FRONTEND_API,
     publishableKey: PUBLISHABLE_KEY,
     cookieToken,

--- a/packages/nextjs/src/server/clerk.ts
+++ b/packages/nextjs/src/server/clerk.ts
@@ -2,7 +2,8 @@ import { Clerk } from '@clerk/backend';
 
 export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
-export const API_KEY = process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '';
+export const API_KEY = process.env.CLERK_API_KEY || '';
+export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
 export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
 

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -3,7 +3,7 @@ import { NextMiddleware, NextMiddlewareResult } from 'next/dist/server/web/types
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 
 import { constants as nextConstants } from '../constants';
-import { API_KEY, API_URL, clerkClient, FRONTEND_API, PUBLISHABLE_KEY } from './clerk';
+import { API_KEY, API_URL, clerkClient, FRONTEND_API, PUBLISHABLE_KEY, SECRET_KEY } from './clerk';
 import {
   getCookie,
   nextJsVersionCanOverrideRequestHeaders,
@@ -32,8 +32,8 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
 
     const requestState = await clerkClient.authenticateRequest({
       ...opts,
-      // TODO: Make apiKey optional
       apiKey: API_KEY,
+      secretKey: SECRET_KEY,
       frontendApi: FRONTEND_API,
       publishableKey: PUBLISHABLE_KEY,
       cookieToken,

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -66,8 +66,8 @@ export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) =>
 })
 `);
 
-export const noApiKeyError = createErrorMessage(`
-A secretKey must be provided in order to use SSR and the exports from @clerk/remix/api.');
-If your runtime supports environment variables, you can add a CLERK_SECRET_KEY variable to your config.
+export const noSecretKeyOrApiKeyError = createErrorMessage(`
+A secretKey or apiKey must be provided in order to use SSR and the exports from @clerk/remix/api.');
+If your runtime supports environment variables, you can add a CLERK_SECRET_KEY or CLERK_API_KEY variable to your config.
 Otherwise, you can pass a secretKey parameter to rootAuthLoader or getAuth.
 `);

--- a/packages/sdk-node/src/authenticateRequest.test.ts
+++ b/packages/sdk-node/src/authenticateRequest.test.ts
@@ -34,9 +34,10 @@ describe('authenticateRequest', () => {
 
     const clerkClient = mockClerkClient();
     const apiKey = 'apiKey';
+    const secretKey = '';
     const frontendApi = 'frontendApi';
     const publishableKey = 'publishableKey';
-    await authenticateRequest(clerkClient as any, apiKey, frontendApi, publishableKey, req, options);
+    await authenticateRequest(clerkClient as any, apiKey, secretKey, frontendApi, publishableKey, req, options);
     expect(clerkClient.authenticateRequest).toHaveBeenCalledWith({
       authorizedParties: ['party1'],
       clientUat: 'token',
@@ -44,6 +45,7 @@ describe('authenticateRequest', () => {
       forwardedHost: 'host',
       forwardedPort: 'port',
       apiKey: apiKey,
+      secretKey: secretKey,
       frontendApi: frontendApi,
       publishableKey: publishableKey,
       headerToken: 'token',

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -11,6 +11,7 @@ const parseCookies = (req: ExpressRequest) => {
 export const authenticateRequest = (
   clerkClient: ReturnType<typeof Clerk>,
   apiKey: string,
+  secretKey: string,
   frontendApi: string,
   publishableKey: string,
   req: ExpressRequest,
@@ -20,6 +21,7 @@ export const authenticateRequest = (
   const { jwtKey, authorizedParties } = options || {};
   return clerkClient.authenticateRequest({
     apiKey,
+    secretKey,
     frontendApi,
     publishableKey,
     jwtKey,

--- a/packages/sdk-node/src/clerkExpressRequireAuth.ts
+++ b/packages/sdk-node/src/clerkExpressRequireAuth.ts
@@ -9,20 +9,32 @@ import type { ClerkMiddlewareOptions, MiddlewareRequireAuthProp, RequireAuthProp
 
 export type CreateClerkExpressMiddlewareOptions = {
   clerkClient: ReturnType<typeof Clerk>;
+  /**
+   * @deprecated Use `secretKey` instead.
+   */
   apiKey?: string;
+  /* Secret Key */
+  secretKey?: string;
   frontendApi?: string;
   publishableKey?: string;
   apiUrl?: string;
 };
 
 export const createClerkExpressRequireAuth = (createOpts: CreateClerkExpressMiddlewareOptions) => {
-  const { clerkClient, frontendApi = '', apiKey = '', publishableKey = '' } = createOpts;
+  const { clerkClient, frontendApi = '', apiKey = '', secretKey = '', publishableKey = '' } = createOpts;
 
   return (options: ClerkMiddlewareOptions = {}): MiddlewareRequireAuthProp => {
     return async (req, res, next) => {
-      const requestState = await authenticateRequest(clerkClient, apiKey, frontendApi, publishableKey, req, options);
+      const requestState = await authenticateRequest(
+        clerkClient,
+        apiKey,
+        secretKey,
+        frontendApi,
+        publishableKey,
+        req,
+        options,
+      );
       decorateResponseWithObservabilityHeaders(res, requestState);
-
       if (requestState.isInterstitial) {
         const interstitial = await clerkClient.remotePrivateInterstitial();
         return handleInterstitialCase(res, requestState, interstitial);

--- a/packages/sdk-node/src/clerkExpressWithAuth.ts
+++ b/packages/sdk-node/src/clerkExpressWithAuth.ts
@@ -7,12 +7,19 @@ import { CreateClerkExpressMiddlewareOptions } from './clerkExpressRequireAuth';
 import type { ClerkMiddlewareOptions, MiddlewareWithAuthProp, WithAuthProp } from './types';
 
 export const createClerkExpressWithAuth = (createOpts: CreateClerkExpressMiddlewareOptions) => {
-  const { clerkClient, frontendApi = '', apiKey = '', publishableKey = '' } = createOpts;
+  const { clerkClient, frontendApi = '', apiKey = '', secretKey = '', publishableKey = '' } = createOpts;
   return (options: ClerkMiddlewareOptions = {}): MiddlewareWithAuthProp => {
     return async (req, res, next) => {
-      const requestState = await authenticateRequest(clerkClient, apiKey, frontendApi, publishableKey, req, options);
+      const requestState = await authenticateRequest(
+        clerkClient,
+        apiKey,
+        secretKey,
+        frontendApi,
+        publishableKey,
+        req,
+        options,
+      );
       decorateResponseWithObservabilityHeaders(res, requestState);
-
       if (requestState.isInterstitial) {
         const interstitial = await clerkClient.remotePrivateInterstitial();
         return handleInterstitialCase(res, requestState, interstitial);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Add support for the new `secretKey` prop & `CLERK_SECRET_KEY` env variable and flag the old apiKey as deprecated

<!-- Fixes # (issue number) -->
