### PR TITLE
fix(backend): Refresh jwks when kid not found if at least 5 min have passed

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -3,6 +3,7 @@ export const API_VERSION = 'v1';
 
 // TODO: Get information from package.json or define them from ESBuild
 export const USER_AGENT = `@clerk/backend`;
+export const MAX_CACHE_LAST_UPDATED_AT_SECONDS = 5 * 60;
 
 const Attributes = {
   AuthStatus: '__clerkAuthStatus',

--- a/packages/backend/src/tokens/keys.test.ts
+++ b/packages/backend/src/tokens/keys.test.ts
@@ -113,6 +113,8 @@ export default (QUnit: QUnit) => {
     });
 
     test('throws an error when JWKS can not be fetched from Backend or Frontend API', async assert => {
+      // advance clock for 5 minutes and 1 second
+      fakeClock.tick(5 * 60 * 1000 + 1);
       try {
         await loadClerkJWKFromRemote({
           apiKey: 'deadbeef',
@@ -123,6 +125,26 @@ export default (QUnit: QUnit) => {
         if (err instanceof Error) {
           assert.propEqual(err, {
             reason: 'jwk-remote-failed-to-load',
+            action: 'Contact support@clerk.dev',
+          });
+        } else {
+          // This should never be reached. If it does, the suite should fail
+          assert.false(true);
+        }
+      }
+    });
+
+    test('throws an error when JWKS can not be fetched from Backend or Frontend API and cache updated less than 5 minutes ago', async assert => {
+      try {
+        await loadClerkJWKFromRemote({
+          apiKey: 'deadbeef',
+          kid: 'ins_whatever',
+        });
+        assert.false(true);
+      } catch (err) {
+        if (err instanceof Error) {
+          assert.propEqual(err, {
+            reason: 'jwk-remote-missing',
             action: 'Contact support@clerk.dev',
           });
         } else {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Use the same approach as clerk-ruby-sdk and refresh jwks from remote when kid is not found only if more than 5 minutes have passed since the latest cache update!

