### PR TITLE
fix(nextjs): Propagate correctly the new secretKey prop in nextjs server package

### DIFF
--- a/packages/nextjs/src/server/clerk.ts
+++ b/packages/nextjs/src/server/clerk.ts
@@ -9,6 +9,7 @@ export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || 
 
 const clerkClient = Clerk({
   apiKey: API_KEY,
+  secretKey: SECRET_KEY,
   apiUrl: API_URL,
   apiVersion: API_VERSION,
   // TODO: Fetch version from package.json

--- a/packages/nextjs/src/server/getAuth.ts
+++ b/packages/nextjs/src/server/getAuth.ts
@@ -10,7 +10,7 @@ import {
   signedOutAuthObject,
 } from '@clerk/backend';
 
-import { API_KEY, API_URL, API_VERSION } from './clerk';
+import { API_KEY, API_URL, API_VERSION, SECRET_KEY } from './clerk';
 import type { RequestLike } from './types';
 import { getAuthStatusFromRequest, getCookie, getHeader, injectSSRStateIntoObject } from './utils';
 
@@ -34,6 +34,7 @@ export const getAuth = (req: RequestLike): SignedInAuthObject | SignedOutAuthObj
 
   return signedInAuthObject(jwt.payload, {
     apiKey: API_KEY,
+    secretKey: SECRET_KEY,
     apiUrl: API_URL,
     apiVersion: API_VERSION,
     token: jwt.raw.text,
@@ -71,6 +72,7 @@ export const buildClerkProps: BuildClerkProps = (req, initState = {}) => {
 
   const authObject = signedInAuthObject(payload, {
     apiKey: API_KEY,
+    secretKey: SECRET_KEY,
     apiUrl: API_URL,
     apiVersion: API_VERSION,
     token: raw.text,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<In the next.js server package we were ignoring the new secretKey prop (CLERK_SECRET_KEY). This was causing any Backend request failing as there were no key

<!-- Fixes # (issue number) -->
