### PR TITLE
fix(nextjs): Correctly set 401 status code for the interstitial in withClerkMiddleware

### DIFF
--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -57,6 +57,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
           frontendApi: FRONTEND_API,
           publishableKey: PUBLISHABLE_KEY,
         }),
+        { status: 401 },
       );
       response.headers.set(constants.Headers.AuthReason, requestState.reason);
       response.headers.set(constants.Headers.AuthMessage, requestState.message);


### PR DESCRIPTION
…
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The interstitial page was returned with a 200 code. This PR correctly sets the code to 401


<!-- Fixes # (issue number) -->
