### PR TITLE
fix(backend): Temporarily drop the `clerk/shared` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31178,7 +31178,6 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^0.9.0",
         "@clerk/types": "^3.24.0",
         "@peculiar/webcrypto": "1.4.1",
         "@types/node": "16.18.6",
@@ -41407,7 +41406,6 @@
     "@clerk/backend": {
       "version": "file:packages/backend",
       "requires": {
-        "@clerk/shared": "^0.9.0",
         "@clerk/types": "^3.24.0",
         "@cloudflare/workers-types": "^3.18.0",
         "@peculiar/webcrypto": "1.4.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,6 @@
     "test:cloudflare-workerd": "tests/cloudflare-workerd/run.sh"
   },
   "dependencies": {
-    "@clerk/shared": "^0.9.0",
     "@clerk/types": "^3.24.0",
     "@peculiar/webcrypto": "1.4.1",
     "@types/node": "16.18.6",

--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -1,11 +1,10 @@
-import { parsePublishableKey } from '@clerk/shared';
-
 import { API_VERSION } from '../constants';
 // DO NOT CHANGE: Runtime needs to be imported as a default export so that we can stub its dependencies with Sinon.js
 // For more information refer to https://sinonjs.org/how-to/stub-dependency/
 import runtime from '../runtime';
 import { callWithRetry } from '../util/callWithRetry';
 import { isStaging } from '../util/instance';
+import { parsePublishableKey } from '../util/parsePublishableKey';
 import { joinPaths } from '../util/path';
 import { TokenVerificationError, TokenVerificationErrorAction, TokenVerificationErrorReason } from './errors';
 

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -1,21 +1,20 @@
-import { parsePublishableKey } from '@clerk/shared';
 import { API_URL, API_VERSION } from '../constants';
+import { parsePublishableKey } from '../util/parsePublishableKey';
 import { type RequestState, AuthErrorReason, interstitial, signedOut } from './authStatus';
-import { type VerifyTokenOptions } from './verify';
 import { type TokenCarrier, TokenVerificationError, TokenVerificationErrorReason } from './errors';
-
 import {
-  nonBrowserRequestInDevRule,
   crossOriginRequestWithoutHeader,
-  potentialFirstLoadInDevWhenUATMissing,
-  potentialRequestAfterSignInOrOurFromClerkHostedUiInDev,
-  potentialFirstRequestOnProductionEnvironment,
-  isNormalSignedOutState,
   hasClientUatButCookieIsMissingInProd,
   hasValidCookieToken,
   hasValidHeaderToken,
+  isNormalSignedOutState,
+  nonBrowserRequestInDevRule,
+  potentialFirstLoadInDevWhenUATMissing,
+  potentialFirstRequestOnProductionEnvironment,
+  potentialRequestAfterSignInOrOurFromClerkHostedUiInDev,
   runInterstitialRules,
 } from './interstitialRule';
+import { type VerifyTokenOptions } from './verify';
 
 export type LoadResourcesOptions = {
   loadSession?: boolean;

--- a/packages/backend/src/util/parsePublishableKey.ts
+++ b/packages/backend/src/util/parsePublishableKey.ts
@@ -1,0 +1,56 @@
+import { PublishableKey } from '@clerk/types';
+
+const PUBLISHABLE_KEY_LIVE_PREFIX = 'pk_live_';
+const PUBLISHABLE_KEY_TEST_PREFIX = 'pk_test_';
+
+// This regex matches the publishable like frontend API keys (e.g. foo-bar-13.clerk.accounts.dev)
+const PUBLISHABLE_FRONTEND_API_DEV_REGEX = /^(([a-z]+)-){2}([0-9]{1,2})\.clerk\.accounts([a-z.]*)(dev|com)$/i;
+
+export function buildPublishableKey(frontendApi: string): string {
+  const keyPrefix = PUBLISHABLE_FRONTEND_API_DEV_REGEX.test(frontendApi)
+    ? PUBLISHABLE_KEY_TEST_PREFIX
+    : PUBLISHABLE_KEY_LIVE_PREFIX;
+  return `${keyPrefix}${btoa(`${frontendApi}$`)}`;
+}
+
+export function parsePublishableKey(key: string): PublishableKey | null {
+  key = key || '';
+
+  if (!isPublishableKey(key)) {
+    return null;
+  }
+
+  const instanceType = key.startsWith(PUBLISHABLE_KEY_LIVE_PREFIX) ? 'production' : 'development';
+
+  let frontendApi = isomorphicAtob(key.split('_')[2]);
+
+  if (!frontendApi.endsWith('$')) {
+    return null;
+  }
+
+  frontendApi = frontendApi.slice(0, -1);
+
+  return {
+    instanceType,
+    frontendApi,
+  };
+}
+
+export function isPublishableKey(key: string) {
+  key = key || '';
+
+  const hasValidPrefix = key.startsWith(PUBLISHABLE_KEY_LIVE_PREFIX) || key.startsWith(PUBLISHABLE_KEY_TEST_PREFIX);
+
+  const hasValidFrontendApiPostfix = isomorphicAtob(key.split('_')[2] || '').endsWith('$');
+
+  return hasValidPrefix && hasValidFrontendApiPostfix;
+}
+
+const isomorphicAtob = (data: string) => {
+  if (typeof atob !== 'undefined' && typeof atob === 'function') {
+    return atob(data);
+  } else if (typeof Buffer !== 'undefined') {
+    return new Buffer(data, 'base64').toString();
+  }
+  return data;
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
NextJS cannot treeshake some of the modules within @clerk/shared. 
We're temporarily replacing the dependency with a copy of the required helpers while we investigate further
<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
