### PR TITLE
fix(clerk-sdk-node): Remove unused jsonwebtoken dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37533,7 +37533,6 @@
         "@types/node-fetch": "2.6.2",
         "camelcase-keys": "6.2.2",
         "cookie": "0.5.0",
-        "jsonwebtoken": "8.5.1",
         "snakecase-keys": "3.2.1",
         "tslib": "2.4.1"
       },
@@ -43455,7 +43454,6 @@
         "camelcase-keys": "6.2.2",
         "cookie": "0.5.0",
         "jest": "*",
-        "jsonwebtoken": "8.5.1",
         "nock": "^13.0.7",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.5.0",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -64,7 +64,6 @@
     "@types/node-fetch": "2.6.2",
     "camelcase-keys": "6.2.2",
     "cookie": "0.5.0",
-    "jsonwebtoken": "8.5.1",
     "snakecase-keys": "3.2.1",
     "tslib": "2.4.1"
   },


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This dependency has been incorrectly listed in our package.json. Removed as we no longer use it.
<!-- Fixes # (issue number) -->
