### PR TITLE
fix(backend-core,edge): Mark @clerk/backend-core and @clerk/edge as deprecated

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,9 +24,8 @@ labels: 'Status: Triage'
 - [ ] `@clerk/themes`
 - [ ] `@clerk/localizations`
 - [ ] `@clerk/clerk-expo`
-- [ ] `@clerk/backend-core`
 - [ ] `@clerk/clerk-sdk-node`
-- [ ] `@clerk/edge`
+- [ ] `@clerk/backend`
 - [ ] other:
 
 ### Version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,6 @@ labels: 'Status: Feature Request'
 - [ ] `@clerk/nextjs`
 - [ ] `@clerk/remix`
 - [ ] `@clerk/clerk-expo`
-- [ ] `@clerk/backend-core`
 - [ ] `@clerk/clerk-sdk-node`
 - [ ] `@clerk/edge`
 - [ ] `@clerk/localizations`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,7 @@
 - [ ] `@clerk/localizations`
 - [ ] `@clerk/clerk-expo`
 - [ ] `@clerk/backend`
-- [ ] `@clerk/backend-core`
 - [ ] `@clerk/clerk-sdk-node`
-- [ ] `@clerk/edge`
 - [ ] `@clerk/shared`
 - [ ] `build/tooling/chore`
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ yarn add @clerk/clerk-sdk-node
 
 For package specific details on installation, architecture and usage usage, you can refer to the package's README file.
 
-- [`@clerk/backend-core`](./packages/backend-core): Functionalities regarded as "core" for Clerk to operate with. _Authentication resolution, API Resources etc._
-- [`@clerk/edge`](./packages/edge): Top level SDK for edge environments containing all required helpers and middleware.
+- [`@clerk/backend`](./packages/backend): Functionalities regarded as "core" for Clerk to operate with. _Authentication resolution, API Resources etc._
 - [`@clerk/clerk-sdk-node`](./packages/sdk-node): SDK for native Node.js environment and frameworks.
 - [`@clerk/nextjs`](./packages/nextjs): Clerk package for Next.js.
 - [`@clerk/clerk-js`](./packages/clerk-js): Core JavaScript implementation used by Clerk in the browser.

--- a/packages/backend-core/README.md
+++ b/packages/backend-core/README.md
@@ -27,6 +27,10 @@
 
 ---
 
+# Deprecation warning
+
+This package has been deprecated in favor of the isomorphic [`@clerk/backend`](https://github.com/clerkinc/javascript) which is now used across all server-enabled Clerk packages. This package will not receive any future updates. It should not be used directly - please use as a reference only.
+
 ## Overview
 
 This package provides Clerk Backend API core resources and low-level authentication utilities for JavaScript environments. It is mostly used as the base for other Clerk SDKs.

--- a/packages/edge/README.md
+++ b/packages/edge/README.md
@@ -25,6 +25,10 @@
 
 ---
 
+# Deprecation warning
+
+This package has been deprecated in favor of the isomorphic [`@clerk/backend`](https://github.com/clerkinc/javascript) which is now used across all server-enabled Clerk packages. This package will not receive any future updates. It should not be used directly - please use as a reference only.
+
 ## Overview
 
 This package is a wrapper around Clerk core capabilities with added functionality and helpers aimed towards different edge and serverless platforms.


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/backend-core`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/edge`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This is a prerequisite in order to deprecate @clerk/backend-core and @clerk/edge. We need to publish one last version in order to update the relevant README files at https://www.npmjs.com/package/@clerk/backend-core and https://www.npmjs.com/package/@clerk/edge

Deleting the actual files follows with a separate PR
<!-- Fixes # (issue number) -->

