### PR TITLE
Fix: Header token case of unknown 401

### DIFF
--- a/packages/backend/src/tokens/request.test.ts
+++ b/packages/backend/src/tokens/request.test.ts
@@ -3,25 +3,26 @@ import sinon from 'sinon';
 
 import runtime from '../runtime';
 import { jsonOk } from '../util/mockFetch';
-import { mockJwt, mockInvalidSignatureJwt, mockMalformedJwt, mockJwks, mockJwtPayload } from './fixtures';
-import { type AuthenticateRequestOptions, authenticateRequest } from './request';
+import { type AuthReason, type RequestState, AuthErrorReason, AuthStatus } from './authStatus';
 import { TokenVerificationErrorReason } from './errors';
-import { AuthErrorReason, AuthStatus } from './authStatus';
+import { mockInvalidSignatureJwt, mockJwks, mockJwt, mockJwtPayload, mockMalformedJwt } from './fixtures';
+import { type AuthenticateRequestOptions, authenticateRequest } from './request';
 
-function assertSignedOut(assert, requestState, reason, message = '') {
+function assertSignedOut(assert, requestState: RequestState, reason: AuthReason, message = '') {
   assert.propEqual(requestState, {
     frontendApi: 'cafe.babe.clerk.ts',
     publishableKey: '',
     status: AuthStatus.SignedOut,
     isSignedIn: false,
     isInterstitial: false,
+    isUnknown: false,
     message,
     reason,
     toAuth: {},
   });
 }
 
-function assertSignedOutToAuth(assert, requestState) {
+function assertSignedOutToAuth(assert, requestState: RequestState) {
   assert.propContains(requestState.toAuth(), {
     sessionClaims: null,
     sessionId: null,
@@ -36,19 +37,20 @@ function assertSignedOutToAuth(assert, requestState) {
   });
 }
 
-function assertInterstitial(assert, requestState, reason) {
+function assertInterstitial(assert, requestState: RequestState, reason: AuthReason) {
   assert.propContains(requestState, {
     frontendApi: 'cafe.babe.clerk.ts',
     publishableKey: '',
     status: AuthStatus.Interstitial,
     isSignedIn: false,
     isInterstitial: true,
+    isUnknown: false,
     reason,
     toAuth: {},
   });
 }
 
-function assertSignedInToAuth(assert, requestState) {
+function assertSignedInToAuth(assert, requestState: RequestState) {
   assert.propContains(requestState.toAuth(), {
     sessionClaims: mockJwtPayload,
     sessionId: mockJwtPayload.sid,
@@ -63,13 +65,14 @@ function assertSignedInToAuth(assert, requestState) {
   });
 }
 
-function assertSignedIn(assert, requestState) {
+function assertSignedIn(assert, requestState: RequestState) {
   assert.propContains(requestState, {
     frontendApi: 'cafe.babe.clerk.ts',
     publishableKey: '',
     status: AuthStatus.SignedIn,
     isSignedIn: true,
     isInterstitial: false,
+    isUnknown: false,
   });
 }
 

--- a/packages/backend/src/tokens/request.test.ts
+++ b/packages/backend/src/tokens/request.test.ts
@@ -50,6 +50,19 @@ function assertInterstitial(assert, requestState: RequestState, reason: AuthReas
   });
 }
 
+function assertUnknown(assert, requestState: RequestState, reason: AuthReason) {
+  assert.propContains(requestState, {
+    frontendApi: 'cafe.babe.clerk.ts',
+    publishableKey: '',
+    status: AuthStatus.Unknown,
+    isSignedIn: false,
+    isInterstitial: false,
+    isUnknown: true,
+    reason,
+    toAuth: {},
+  });
+}
+
 function assertSignedInToAuth(assert, requestState: RequestState) {
   assert.propContains(requestState.toAuth(), {
     sessionClaims: mockJwtPayload,
@@ -165,7 +178,7 @@ export default (QUnit: QUnit) => {
         headerToken: mockJwt,
       });
 
-      assertInterstitial(assert, requestState, TokenVerificationErrorReason.TokenExpired);
+      assertUnknown(assert, requestState, TokenVerificationErrorReason.TokenExpired);
       assert.strictEqual(requestState.toAuth(), null);
     });
 

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -1,6 +1,6 @@
 import { API_URL, API_VERSION } from '../constants';
 import { parsePublishableKey } from '../util/parsePublishableKey';
-import { type RequestState, AuthErrorReason, interstitial, signedOut, unknownState } from './authStatus';
+import { type RequestState, AuthErrorReason, interstitial, signedOut } from './authStatus';
 import { type TokenCarrier, TokenVerificationError, TokenVerificationErrorReason } from './errors';
 import {
   crossOriginRequestWithoutHeader,
@@ -102,9 +102,6 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
       ].includes(err.reason);
 
       if (reasonToReturnInterstitial) {
-        if (tokenCarrier === 'header') {
-          return unknownState<AuthenticateRequestOptions>(options, err.reason, err.getFullMessage());
-        }
         return interstitial<AuthenticateRequestOptions>(options, err.reason, err.getFullMessage());
       }
       return signedOut<AuthenticateRequestOptions>(options, err.reason, err.getFullMessage());

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -1,6 +1,6 @@
 import { API_URL, API_VERSION } from '../constants';
 import { parsePublishableKey } from '../util/parsePublishableKey';
-import { type RequestState, AuthErrorReason, interstitial, signedOut } from './authStatus';
+import { type RequestState, AuthErrorReason, interstitial, signedOut, unknownState } from './authStatus';
 import { type TokenCarrier, TokenVerificationError, TokenVerificationErrorReason } from './errors';
 import {
   crossOriginRequestWithoutHeader,
@@ -102,6 +102,9 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
       ].includes(err.reason);
 
       if (reasonToReturnInterstitial) {
+        if (tokenCarrier === 'header') {
+          return unknownState<AuthenticateRequestOptions>(options, err.reason, err.getFullMessage());
+        }
         return interstitial<AuthenticateRequestOptions>(options, err.reason, err.getFullMessage());
       }
       return signedOut<AuthenticateRequestOptions>(options, err.reason, err.getFullMessage());

--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -29,7 +29,7 @@ export const withServerSideAuth: WithServerSideAuth = (cbOrOptions: any, options
   return async (ctx: GetServerSidePropsContext) => {
     const requestState = await authenticateRequest(ctx, opts);
 
-    if (requestState.isInterstitial) {
+    if (requestState.isInterstitial || requestState.isUnknown) {
       ctx.res.setHeader(constants.Headers.AuthMessage, requestState.message);
       ctx.res.setHeader(constants.Headers.AuthReason, requestState.reason);
       ctx.res.writeHead(401, { 'Content-Type': 'text/html' });

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -50,7 +50,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     // Interstitial case
     // Note: there is currently no way to rewrite to a protected endpoint
     // Therefore we have to resort to a public interstitial endpoint
-    if (requestState.isInterstitial || !requestState) {
+    if (requestState.isInterstitial) {
       const response = NextResponse.rewrite(
         clerkClient.remotePublicInterstitialUrl({
           apiUrl: API_URL,

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -50,7 +50,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     // Interstitial case
     // Note: there is currently no way to rewrite to a protected endpoint
     // Therefore we have to resort to a public interstitial endpoint
-    if (requestState.isInterstitial) {
+    if (requestState.isInterstitial || requestState.isUnknown) {
       const response = NextResponse.rewrite(
         clerkClient.remotePublicInterstitialUrl({
           apiUrl: API_URL,

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -13,7 +13,7 @@ export async function getAuth(args: LoaderFunctionArgs, opts?: GetAuthOptions): 
   }
   const requestState = await authenticateRequest(args, opts);
 
-  if (requestState.isInterstitial) {
+  if (requestState.isInterstitial || requestState.isUnknown) {
     throw interstitialJsonResponse(requestState, { loader: 'nested' });
   }
 

--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -13,7 +13,7 @@ export async function getAuth(args: LoaderFunctionArgs, opts?: GetAuthOptions): 
   }
   const requestState = await authenticateRequest(args, opts);
 
-  if (requestState.isInterstitial || !requestState) {
+  if (requestState.isInterstitial) {
     throw interstitialJsonResponse(requestState, { loader: 'nested' });
   }
 

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -35,7 +35,7 @@ export const rootAuthLoader: RootAuthLoader = async (
 
   const requestState = await authenticateRequest(args, opts);
 
-  if (requestState.isInterstitial) {
+  if (requestState.isInterstitial || requestState.isUnknown) {
     throw interstitialJsonResponse(requestState, { loader: 'root' });
   }
 

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -38,7 +38,7 @@ export const authenticateRequest = (
 };
 
 export const handleInterstitialCase = (res: ExpressResponse, requestState: RequestState, interstitial: string) => {
-  if (requestState.isInterstitial) {
+  if (requestState.isInterstitial || requestState.isUnknown) {
     res.writeHead(401, { 'Content-Type': 'text/html' });
     res.end(interstitial);
   }

--- a/packages/sdk-node/src/clerkExpressRequireAuth.ts
+++ b/packages/sdk-node/src/clerkExpressRequireAuth.ts
@@ -35,7 +35,7 @@ export const createClerkExpressRequireAuth = (createOpts: CreateClerkExpressMidd
         options,
       );
       decorateResponseWithObservabilityHeaders(res, requestState);
-      if (requestState.isInterstitial) {
+      if (requestState.isInterstitial || requestState.isUnknown) {
         const interstitial = await clerkClient.remotePrivateInterstitial();
         return handleInterstitialCase(res, requestState, interstitial);
       }

--- a/packages/sdk-node/src/clerkExpressWithAuth.ts
+++ b/packages/sdk-node/src/clerkExpressWithAuth.ts
@@ -20,7 +20,7 @@ export const createClerkExpressWithAuth = (createOpts: CreateClerkExpressMiddlew
         options,
       );
       decorateResponseWithObservabilityHeaders(res, requestState);
-      if (requestState.isInterstitial) {
+      if (requestState.isInterstitial || requestState.isUnknown) {
         const interstitial = await clerkClient.remotePrivateInterstitial();
         return handleInterstitialCase(res, requestState, interstitial);
       }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
We have introduced the new `Unknown` state in `RequestState` and the `isUnknown` helper method to support the case of header expired token that should result in returning an http 401 without body before running any other middleware.

The reason we introduced another state instead of reusing the `Interstitial` as i initially suggested in the original discussion is to separate this case and avoid any more confusion about interstitial. With introducing the new state we are closer to the flow diagram and it is more clear to implement and understand. This is also easier to rollout since it's a new state and it will not affect the current implementation.
