### PR TITLE
fix(nextjs,types): Make frontendApi or publishableKey mutually exclusive but optional

### DIFF
--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -1,5 +1,6 @@
 import { __internal__setErrorThrowerOptions, ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
 import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
+import { PublishableKeyOrFrontendApi } from '@clerk/types';
 import { useRouter } from 'next/router';
 import React from 'react';
 
@@ -11,7 +12,8 @@ export * from '@clerk/clerk-react';
 
 type NextClerkProviderProps = {
   children: React.ReactNode;
-} & IsomorphicClerkOptions;
+} & Omit<IsomorphicClerkOptions, keyof PublishableKeyOrFrontendApi> &
+  Partial<PublishableKeyOrFrontendApi>;
 
 export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JSX.Element {
   // @ts-expect-error

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -3,6 +3,7 @@ import type {
   ClerkOptions,
   ClientResource,
   LoadedClerk,
+  PublishableKeyOrFrontendApi,
   RedirectOptions,
   SessionResource,
   UserResource,
@@ -19,16 +20,7 @@ export type IsomorphicClerkOptions = ClerkOptions & {
   Clerk?: ClerkProp;
   clerkJSUrl?: string;
   clerkJSVariant?: 'headless' | '';
-} & (
-    | {
-        frontendApi?: never;
-        publishableKey: string;
-      }
-    | {
-        frontendApi: string;
-        publishableKey?: never;
-      }
-  );
+} & PublishableKeyOrFrontendApi;
 
 export interface BrowserClerkConstructor {
   new (frontendApi: string): BrowserClerk;

--- a/packages/types/src/key.ts
+++ b/packages/types/src/key.ts
@@ -4,3 +4,13 @@ export type PublishableKey = {
   frontendApi: string;
   instanceType: InstanceType;
 };
+
+export type PublishableKeyOrFrontendApi =
+  | {
+      frontendApi?: never;
+      publishableKey: string;
+    }
+  | {
+      frontendApi: string;
+      publishableKey?: never;
+    };


### PR DESCRIPTION
…

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
The usual _app.tsx provider (nextjs) should not throw an error if none of the keys were passed as props, because the keys can be configured via env variables.

Passing `{...pageProps}` mutes the error because `pageProps` is of type `any`

```
export default function App({ Component, pageProps }: AppProps) {
  return <ClerkProvider>
    <UserButton/>
    <SignInButton/>
    <Component {...pageProps} />
  </ClerkProvider>
}

```

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
