### PR TITLE
fix(clerk-react): Fix erroneously throwing an error when using the new Publishable Key

### DIFF
--- a/packages/react/src/contexts/ClerkProvider.tsx
+++ b/packages/react/src/contexts/ClerkProvider.tsx
@@ -26,7 +26,7 @@ function ClerkProviderBase(props: ClerkProviderProps): JSX.Element {
       errorThrower.throwMissingFrontendApiOrPublishableKeyError();
     } else if (publishableKey && !isPublishableKey(publishableKey)) {
       errorThrower.throwInvalidPublishableKeyError({ key: publishableKey });
-    } else if (frontendApi && !isLegacyFrontendApiKey(frontendApi)) {
+    } else if (!publishableKey && frontendApi && !isLegacyFrontendApiKey(frontendApi)) {
       errorThrower.throwInvalidFrontendApiError({ key: frontendApi });
     }
   }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR fixes the issue: 
When parsing the new Publishable Key, its Frontend API gets extracted and populated in the legacy `frontendApi` variable. This erroneously throws an error. Added an extra check to prevent this when PK is used.
<!-- Fixes # (issue number) -->
