### PR TITLE
chore(clerk-react,shared): Eliminate missing frontendApi error message

### DIFF
--- a/packages/react/src/contexts/ClerkProvider.tsx
+++ b/packages/react/src/contexts/ClerkProvider.tsx
@@ -23,7 +23,7 @@ function ClerkProviderBase(props: ClerkProviderProps): JSX.Element {
 
   if (!userInitialisedClerk) {
     if (!publishableKey && !frontendApi) {
-      errorThrower.throwMissingFrontendApiOrPublishableKeyError();
+      errorThrower.throwMissingPublishableKeyError();
     } else if (publishableKey && !isPublishableKey(publishableKey)) {
       errorThrower.throwInvalidPublishableKeyError({ key: publishableKey });
     } else if (!publishableKey && frontendApi && !isLegacyFrontendApiKey(frontendApi)) {

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -40,7 +40,7 @@ function getScriptSrc({ publishableKey, frontendApi, scriptUrl, scriptVariant = 
 
   const scriptHost = publishableKey ? parsePublishableKey(publishableKey)?.frontendApi : frontendApi;
   if (!scriptHost) {
-    errorThrower.throwMissingFrontendApiOrPublishableKeyError();
+    errorThrower.throwMissingPublishableKeyError();
   }
 
   const variant = scriptVariant ? `${scriptVariant.replace(/\.+$/, '')}.` : '';
@@ -80,7 +80,7 @@ export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptEl
     const script = document.createElement('script');
 
     if (!publishableKey && !frontendApi) {
-      errorThrower.throwMissingFrontendApiOrPublishableKeyError();
+      errorThrower.throwMissingPublishableKeyError();
     }
 
     if (publishableKey) {

--- a/packages/shared/src/errors/thrower.test.ts
+++ b/packages/shared/src/errors/thrower.test.ts
@@ -10,8 +10,8 @@ describe.concurrent('ErrorThrower', () => {
   });
 
   it('throws the correct error message and interpolates pkg if no parameters are provided', () => {
-    expect(() => errorThrower.throwMissingFrontendApiOrPublishableKeyError()).toThrow(
-      '@clerk/test-package: Missing frontendApi or publishableKey. You can get your key at https://dashboard.clerk.dev/last-active?path=api-keys.',
+    expect(() => errorThrower.throwMissingPublishableKeyError()).toThrow(
+      '@clerk/test-package: Missing publishableKey. You can get your key at https://dashboard.clerk.dev/last-active?path=api-keys.',
     );
   });
 

--- a/packages/shared/src/errors/thrower.ts
+++ b/packages/shared/src/errors/thrower.ts
@@ -1,7 +1,7 @@
 const DefaultMessages = Object.freeze({
   InvalidFrontendApiErrorMessage: `The frontendApi passed to Clerk is invalid. You can get your Frontend API key at https://dashboard.clerk.dev/last-active?path=api-keys. (key={{key}})`,
   InvalidPublishableKeyErrorMessage: `The publishableKey passed to Clerk is invalid. You can get your Publishable key at https://dashboard.clerk.dev/last-active?path=api-keys. (key={{key}})`,
-  MissingFrontendApiPublishableKeyErrorMessage: `Missing frontendApi or publishableKey. You can get your key at https://dashboard.clerk.dev/last-active?path=api-keys.`,
+  MissingPublishableKeyErrorMessage: `Missing publishableKey. You can get your key at https://dashboard.clerk.dev/last-active?path=api-keys.`,
 });
 
 type MessageKeys = keyof typeof DefaultMessages;
@@ -20,7 +20,7 @@ export interface ErrorThrower {
   setMessages(options: ErrorThrowerOptions): ErrorThrower;
   throwInvalidPublishableKeyError(params: { key?: string }): never;
   throwInvalidFrontendApiError(params: { key?: string }): never;
-  throwMissingFrontendApiOrPublishableKeyError(): never;
+  throwMissingPublishableKeyError(): never;
 }
 
 export function buildErrorThrower({ packageName, customMessages }: ErrorThrowerOptions): ErrorThrower {
@@ -68,8 +68,8 @@ export function buildErrorThrower({ packageName, customMessages }: ErrorThrowerO
       throw new Error(buildMessage(messages.InvalidFrontendApiErrorMessage, params));
     },
 
-    throwMissingFrontendApiOrPublishableKeyError(): never {
-      throw new Error(buildMessage(messages.MissingFrontendApiPublishableKeyErrorMessage));
+    throwMissingPublishableKeyError(): never {
+      throw new Error(buildMessage(messages.MissingPublishableKeyErrorMessage));
     },
   };
 }


### PR DESCRIPTION


## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

Resolves AUTH-160