### PR TITLE
feat(backend): Use Frontend API to fetch JWKs for token verification when issuer provided

### DIFF
--- a/packages/backend/src/tokens/keys.ts
+++ b/packages/backend/src/tokens/keys.ts
@@ -114,8 +114,8 @@ export type LoadClerkJWKFromRemoteOptions = {
 export async function loadClerkJWKFromRemote({
   apiKey,
   secretKey,
-  apiUrl,
-  apiVersion,
+  apiUrl = API_URL,
+  apiVersion = API_VERSION,
   issuer,
   kid,
   jwksCacheTtlInMs = 1000 * 60 * 60, // 1 hour,
@@ -124,9 +124,9 @@ export async function loadClerkJWKFromRemote({
   const shouldRefreshCache = !getFromCache(kid) && reachedMaxCacheUpdatedAt();
   if (skipJwksCache || shouldRefreshCache) {
     let fetcher;
-    const key = secretKey || apiKey || '';
+    const key = secretKey || apiKey;
 
-    if (apiUrl) {
+    if (key) {
       fetcher = () => fetchJWKSFromBAPI(apiUrl, key, apiVersion);
     } else if (issuer) {
       fetcher = () => fetchJWKSFromFAPI(issuer);
@@ -181,7 +181,7 @@ async function fetchJWKSFromFAPI(issuer: string) {
   return response.json();
 }
 
-async function fetchJWKSFromBAPI(apiUrl: string = API_URL, key: string, apiVersion: string = API_VERSION) {
+async function fetchJWKSFromBAPI(apiUrl: string, key: string, apiVersion: string) {
   if (!key) {
     throw new TokenVerificationError({
       action: TokenVerificationErrorAction.SetClerkSecretKeyOrAPIKey,

--- a/packages/backend/src/tokens/verify.test.ts
+++ b/packages/backend/src/tokens/verify.test.ts
@@ -38,12 +38,47 @@ export default (QUnit: QUnit) => {
       assert.ok(fakeFetch.calledOnce);
     });
 
+    test('verifies the token by fetching the JWKs from Backend API when secretKey is provided ', async assert => {
+      const payload = await verifyToken(mockJwt, {
+        secretKey: 'a-valid-key',
+        authorizedParties: ['https://accounts.inspired.puma-74.lcl.dev'],
+        issuer: 'https://clerk.inspired.puma-74.lcl.dev',
+        skipJwksCache: true,
+      });
+
+      fakeFetch.calledOnceWith('https://clerk.inspired.puma-74.lcl.dev/v1/jwks', {
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer a-valid-key',
+          'Content-Type': 'application/json',
+          'Clerk-Backend-SDK': '@clerk/backend',
+        },
+      });
+      assert.propEqual(payload, mockJwtPayload);
+    });
+
+    test('verifies the token by fetching the JWKs from Frontend API when issuer (string) is provided ', async assert => {
+      const payload = await verifyToken(mockJwt, {
+        authorizedParties: ['https://accounts.inspired.puma-74.lcl.dev'],
+        issuer: 'https://clerk.inspired.puma-74.lcl.dev',
+        skipJwksCache: true,
+      });
+
+      fakeFetch.calledOnceWith('https://clerk.inspired.puma-74.lcl.dev/.well-known/jwks.json', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Clerk-Backend-SDK': '@clerk/backend',
+        },
+      });
+      assert.propEqual(payload, mockJwtPayload);
+    });
+
     test('throws an error when the verification fails', async assert => {
       try {
         await verifyToken(mockJwt, {
-          apiUrl: 'https://api.clerk.test',
           apiKey: 'a-valid-key',
-          issuer: 'whatever',
+          issuer: 'https://clerk.whatever.lcl.dev',
           skipJwksCache: true,
         });
         // This should never be reached. If it does, the suite should fail
@@ -52,7 +87,7 @@ export default (QUnit: QUnit) => {
         if (err instanceof Error) {
           assert.equal(
             err.message,
-            'Invalid JWT issuer claim (iss) "https://clerk.inspired.puma-74.lcl.dev". Expected "whatever".',
+            'Invalid JWT issuer claim (iss) "https://clerk.inspired.puma-74.lcl.dev". Expected "https://clerk.whatever.lcl.dev".',
           );
         } else {
           // This should never be reached. If it does, the suite should fail


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Slightly modified the tokens.verifyToken() function into the below behavior:
- If a JWK KEY provided, use it to verify the provided token
- If a apiKey or secretKey provided, use the Backend API to fetch the JWKs and verify the provided token
- If an issuer of type string provided, use the Frontend API and well known endpoint to fetch the JWKs and verify the provided token

<!-- Fixes # (issue number) -->
