### PR TITLE
fix(backend): Prevent illegal invocation error

### DIFF
--- a/packages/backend/src/runtime/index.ts
+++ b/packages/backend/src/runtime/index.ts
@@ -22,7 +22,15 @@ type Runtime = {
   fetch: typeof global.fetch;
 };
 
+// Invoking the global.fetch without binding it first to the globalObject fails in
+// Cloudflare Workers with an "Illegal Invocation" error.
+//
+// The globalThis object is supported for Node >= 12.0.
+//
+// https://github.com/supabase/supabase/issues/4417
+const globalFetch = fetch.bind(globalThis);
+
 // DO NOT CHANGE: Runtime needs to be imported as a default export so that we can stub its dependencies with Sinon.js
 // For more information refer to https://sinonjs.org/how-to/stub-dependency/
-const runtime: Runtime = { crypto, fetch };
+const runtime: Runtime = { crypto, fetch: globalFetch };
 export default runtime;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Invoking the global.fetch without binding it first to the globalObject fails in Cloudflare Workers with an "Illegal Invocation" error. To fix the issue, we have to bind fetch to the globalThis object. A customer reported this issue using @clerk/remix on Cloudflare Pages.

The globalThis object is supported for Node >= 12.0.

For more information, refer to https://github.com/supabase/supabase/issues/4417
