### PR TITLE
fix(clerk-js): Use createRoot instead of ReactDOM.render

### DIFF
--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -10,7 +10,7 @@ import type {
 import { OrganizationProfileProps } from '@clerk/types';
 import { UserProfileProps } from '@clerk/types/src';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { PRESERVED_QUERYSTRING_PARAMS } from '../core/constants';
 import { clerkUIErrorDOMElementNotFound } from '../core/errors';
@@ -121,13 +121,12 @@ export const mountComponentRenderer = (
     document.body.appendChild(clerkRoot);
   }
 
-  ReactDOM.render<ComponentsProps>(
+  createRoot(clerkRoot).render(
     <Components
       clerk={clerk}
       environment={environment}
       options={options}
     />,
-    clerkRoot,
   );
 
   return componentsControls;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR may be fixing a race condition that causes components not to render on soft redirections on Next and Remix projects. According to the React 18 upgrade guide, ReactDOM.render should be replaced with createRoot. (https://reactjs.org/link/switch-to-createroot)

Error in console:
```
ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it’s running React 17.
```
<!-- Fixes # (issue number) -->
