### PR TITLE
fix(backend,clerk-sdk-node,shared): Drop support for NodeJS 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31196,7 +31196,6 @@
         "@peculiar/webcrypto": "1.4.1",
         "@types/node": "16.18.6",
         "deepmerge": "4.2.2",
-        "node-fetch": "2.6.8",
         "node-fetch-native": "1.0.1",
         "rfc4648": "1.5.2",
         "snakecase-keys": "5.4.4",
@@ -32434,48 +32433,10 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
       "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
     },
-    "packages/backend/node_modules/node-fetch": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
-      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "packages/backend/node_modules/node-fetch-native": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
       "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg=="
-    },
-    "packages/backend/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "packages/backend/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "packages/backend/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
@@ -40279,7 +40240,6 @@
         "esbuild": "^0.15.12",
         "esbuild-register": "^3.3.3",
         "miniflare": "^2.11.0",
-        "node-fetch": "2.6.8",
         "node-fetch-native": "1.0.1",
         "npm-run-all": "^4.1.5",
         "qunit": "^2.19.3",
@@ -40297,37 +40257,10 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
           "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
         },
-        "node-fetch": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
-          "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
         "node-fetch-native": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
           "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg=="
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
         }
       }
     },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,7 +28,6 @@
     "@peculiar/webcrypto": "1.4.1",
     "@types/node": "16.18.6",
     "deepmerge": "4.2.2",
-    "node-fetch": "2.6.8",
     "node-fetch-native": "1.0.1",
     "rfc4648": "1.5.2",
     "snakecase-keys": "5.4.4",

--- a/packages/backend/src/runtime/node/fetch.js
+++ b/packages/backend/src/runtime/node/fetch.js
@@ -1,14 +1,2 @@
-let fetch;
-try {
-  // Pre-node14 runtimes do not support the node: prefix
-  // this package uses internally, and they throw.
-  // This package is preferred as it does not polyfill the native fetch
-  // if it's supported by the runtime
-  // https://github.com/node-fetch/node-fetch/issues/1367
-  fetch = require('node-fetch-native');
-} catch (e) {
-  // Otherwise, we will fall back to this lib
-  fetch = require('node-fetch');
-}
-
+const fetch = require('node-fetch-native');
 module.exports = fetch;

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -17,7 +17,7 @@
     "skipLibCheck": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2019"
+    "target": "ES2020"
   },
   "include": ["src", "global.d.ts"],
   "exclude": ["node_modules", "dist", "/src/runtime/*", "src/**/*.spec.ts", "src/**/*.test.ts", "src/__tests__"]

--- a/packages/sdk-node/tsconfig.json
+++ b/packages/sdk-node/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2019"
+    "target": "ES2020"
   },
   "exclude": ["node_modules"],
   "include": ["src/index.ts", "src/instance.ts"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES2020",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Drop support for Node 12, as Node 12 reached its end-of-life on 30 Apr 2022 and it no longer receives security updates.
The minimum required Node version is now 14.
<!-- Fixes # (issue number) -->
