### PR TITLE
fix(backend,types): Remove inline type imports

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,5 +1,5 @@
-import { type CreateBackendApiOptions, createBackendApiClient } from './api';
-import { type CreateAuthenticateRequestOptions, createAuthenticateRequest } from './tokens';
+import { createBackendApiClient, CreateBackendApiOptions } from './api';
+import { createAuthenticateRequest, CreateAuthenticateRequestOptions } from './tokens';
 
 export * from './api/resources';
 export * from './tokens';

--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -1,8 +1,8 @@
 import type { ActClaim, JwtPayload, ServerGetToken, ServerGetTokenOptions } from '@clerk/types';
 
-import { type Organization, type Session, type User, createBackendApiClient } from '../api';
-import { AuthenticateRequestOptions } from './request';
+import { createBackendApiClient, Organization, Session, User } from '../api';
 import { RequestState } from './authStatus';
+import { AuthenticateRequestOptions } from './request';
 
 type AuthObjectDebugData = Partial<AuthenticateRequestOptions & RequestState>;
 type CreateAuthObjectDebug = (data?: AuthObjectDebugData) => AuthObjectDebug;

--- a/packages/backend/src/tokens/factory.ts
+++ b/packages/backend/src/tokens/factory.ts
@@ -1,14 +1,14 @@
-import { type ApiClient } from '../api';
+import { ApiClient } from '../api';
 import { API_URL, API_VERSION } from '../constants';
 import {
-  type LoadInterstitialOptions,
   buildPublicInterstitialUrl,
   loadInterstitialFromBAPI,
   loadInterstitialFromLocal,
+  LoadInterstitialOptions,
 } from './interstitial';
 import {
-  type AuthenticateRequestOptions,
   authenticateRequest as authenticateRequestOriginal,
+  AuthenticateRequestOptions,
   debugRequestState,
 } from './request';
 

--- a/packages/backend/src/tokens/index.ts
+++ b/packages/backend/src/tokens/index.ts
@@ -1,10 +1,10 @@
 export * from './authObjects';
 export * from './factory';
-export { type RequestState, AuthStatus } from './authStatus';
+export { RequestState, AuthStatus } from './authStatus';
 export { loadInterstitialFromLocal } from './interstitial';
 export {
   debugRequestState,
-  type AuthenticateRequestOptions,
-  type OptionalVerifyTokenOptions,
-  type RequiredVerifyTokenOptions,
+  AuthenticateRequestOptions,
+  OptionalVerifyTokenOptions,
+  RequiredVerifyTokenOptions,
 } from './request';

--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -1,6 +1,6 @@
 import { isDevelopmentFromApiKey, isProductionFromApiKey } from '../util/instance';
 import { checkCrossOrigin } from '../util/request';
-import { type RequestState, AuthErrorReason, interstitial, signedOut, signedIn } from './authStatus';
+import { AuthErrorReason, interstitial, RequestState, signedIn, signedOut } from './authStatus';
 import { verifyToken } from './verify';
 
 export type InterstitialRule = <T>(opts: T) => Promise<RequestState | undefined>;
@@ -95,13 +95,13 @@ export const hasClientUatButCookieIsMissingInProd: InterstitialRule = async opti
 
 export const hasValidHeaderToken: InterstitialRule = async options => {
   const { headerToken } = options as any;
-  const sessionClaims = await verifyRequestState(options, headerToken!);
+  const sessionClaims = await verifyRequestState(options, headerToken);
   return await signedIn(options, sessionClaims);
 };
 
 export const hasValidCookieToken: InterstitialRule = async options => {
   const { cookieToken, clientUat } = options as any;
-  const sessionClaims = await verifyRequestState(options, cookieToken!);
+  const sessionClaims = await verifyRequestState(options, cookieToken);
   const state = await signedIn(options, sessionClaims);
 
   const jwt = state.toAuth().sessionClaims;

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -1,7 +1,7 @@
 import { API_URL, API_VERSION } from '../constants';
 import { parsePublishableKey } from '../util/parsePublishableKey';
-import { type RequestState, AuthErrorReason, interstitial, signedOut, unknownState } from './authStatus';
-import { type TokenCarrier, TokenVerificationError, TokenVerificationErrorReason } from './errors';
+import { AuthErrorReason, interstitial, RequestState, signedOut, unknownState } from './authStatus';
+import { TokenCarrier, TokenVerificationError, TokenVerificationErrorReason } from './errors';
 import {
   crossOriginRequestWithoutHeader,
   hasClientUatButCookieIsMissingInProd,
@@ -14,7 +14,7 @@ import {
   potentialRequestAfterSignInOrOurFromClerkHostedUiInDev,
   runInterstitialRules,
 } from './interstitialRule';
-import { type VerifyTokenOptions } from './verify';
+import { VerifyTokenOptions } from './verify';
 
 export type LoadResourcesOptions = {
   loadSession?: boolean;

--- a/packages/backend/src/tokens/verify.ts
+++ b/packages/backend/src/tokens/verify.ts
@@ -1,7 +1,7 @@
 import type { JwtPayload } from '@clerk/types';
 
 import { TokenVerificationError, TokenVerificationErrorAction, TokenVerificationErrorReason } from './errors';
-import { type VerifyJwtOptions, decodeJwt, verifyJwt } from './jwt';
+import { decodeJwt, verifyJwt, VerifyJwtOptions } from './jwt';
 import { loadClerkJWKFromLocal, loadClerkJWKFromRemote, LoadClerkJWKFromRemoteOptions } from './keys';
 
 /**

--- a/packages/nextjs/src/server/getAuth.ts
+++ b/packages/nextjs/src/server/getAuth.ts
@@ -1,12 +1,12 @@
 import type { Organization, Session, User } from '@clerk/backend';
 import {
-  type SignedInAuthObject,
-  type SignedOutAuthObject,
   AuthStatus,
   constants,
   decodeJwt,
   sanitizeAuthObject,
+  SignedInAuthObject,
   signedInAuthObject,
+  SignedOutAuthObject,
   signedOutAuthObject,
 } from '@clerk/backend';
 

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -1,4 +1,4 @@
-import { type OptionalVerifyTokenOptions, AuthStatus, constants } from '@clerk/backend';
+import { AuthStatus, constants, OptionalVerifyTokenOptions } from '@clerk/backend';
 import { NextMiddleware, NextMiddlewareResult } from 'next/dist/server/web/types';
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 

--- a/packages/react/src/utils/errorThrower.ts
+++ b/packages/react/src/utils/errorThrower.ts
@@ -1,4 +1,4 @@
-import { type ErrorThrowerOptions, buildErrorThrower } from '@clerk/shared';
+import { buildErrorThrower, ErrorThrowerOptions } from '@clerk/shared';
 
 const errorThrower = buildErrorThrower({ packageName: '@clerk/react' });
 

--- a/packages/remix/src/errorThrower.ts
+++ b/packages/remix/src/errorThrower.ts
@@ -1,4 +1,4 @@
-import { type ErrorThrowerOptions, buildErrorThrower } from '@clerk/shared';
+import { buildErrorThrower, ErrorThrowerOptions } from '@clerk/shared';
 
 const errorThrower = buildErrorThrower({ packageName: '@clerk/remix' });
 

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -1,4 +1,4 @@
-import { type RequestState, Clerk } from '@clerk/backend';
+import { Clerk, RequestState } from '@clerk/backend';
 
 import { noSecretKeyOrApiKeyError } from '../errors';
 import { getEnvVariable } from '../utils';

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -1,4 +1,4 @@
-import { type AuthObject, type RequestState, debugRequestState, loadInterstitialFromLocal } from '@clerk/backend';
+import { AuthObject, debugRequestState, loadInterstitialFromLocal, RequestState } from '@clerk/backend';
 import { LIB_VERSION } from '@clerk/clerk-react/dist/info';
 import { json } from '@remix-run/server-runtime';
 import cookie from 'cookie';

--- a/packages/types/src/key.ts
+++ b/packages/types/src/key.ts
@@ -1,4 +1,4 @@
-import { type InstanceType } from './clerk';
+import { InstanceType } from './clerk';
 
 export type PublishableKey = {
   frontendApi: string;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Inline type imports were introduced in TS 4.5, which, at the moment of writing, can be considered a recent release. Customers using older TS/babel versions reported build errors when trying to compile the new clerk/backend package. We decided to replace inline type imports with the older syntax as we have no apparent need for it right now.

<!-- Fixes # (issue number) -->
