### PR TITLE
chore(backend,clerk-react,clerk-sdk-node,types): Mark frontendApi & apiKey props as deprecated

### DIFF
--- a/packages/backend/src/tokens/keys.ts
+++ b/packages/backend/src/tokens/keys.ts
@@ -89,6 +89,9 @@ export type LoadClerkJWKFromRemoteOptions = {
   jwksCacheTtlInMs?: number;
   skipJwksCache?: boolean;
   secretKey?: string;
+  /**
+   * @deprecated Use `secretKey` instead.
+   */
   apiKey?: string;
   apiUrl?: string;
   apiVersion?: string;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -23,11 +23,11 @@ export type IsomorphicClerkOptions = ClerkOptions & {
 } & PublishableKeyOrFrontendApi;
 
 export interface BrowserClerkConstructor {
-  new (frontendApi: string): BrowserClerk;
+  new (publishableKey: string): BrowserClerk;
 }
 
 export interface HeadlessBrowserClerkConstrutor {
-  new (frontendApi: string): HeadlessBrowserClerk;
+  new (publishableKey: string): HeadlessBrowserClerk;
 }
 
 export type WithClerkProp<T = unknown> = T & { clerk: LoadedClerk };

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -63,6 +63,9 @@ function getScriptSrc({ publishableKey, frontendApi, scriptUrl, scriptVariant = 
 export type ScriptVariant = '' | 'headless';
 
 export interface LoadScriptParams {
+  /**
+   * @deprecated Use `publishableKey` instead.
+   */
   frontendApi?: string;
   publishableKey?: string;
   scriptUrl?: string;

--- a/packages/sdk-node/src/clerkExpressRequireAuth.ts
+++ b/packages/sdk-node/src/clerkExpressRequireAuth.ts
@@ -15,6 +15,9 @@ export type CreateClerkExpressMiddlewareOptions = {
   apiKey?: string;
   /* Secret Key */
   secretKey?: string;
+  /**
+   * @deprecated Use `publishableKey` instead.
+   */
   frontendApi?: string;
   publishableKey?: string;
   apiUrl?: string;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -55,7 +55,10 @@ export interface Clerk {
 
   loaded: boolean;
 
-  /** Clerk Frontend API string. */
+  /**
+   * Clerk Frontend API string
+   * @deprecated Use `publishableKey` instead.
+   */
   frontendApi: string;
 
   /** Clerk Publishable Key string. */


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Mark `frontendApi` & `apiKey` props as deprecated

<!-- Fixes # (issue number) -->
