### PR TITLE
Fix(clerk-js): setActive issue with cookie and session syncing

### DIFF
--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -367,7 +367,7 @@ describe('Clerk singleton', () => {
       sut.client.signUp.create = mockSignUpCreate;
       sut.setActive = mockSetActive;
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSignUpCreate).toHaveBeenCalledWith({ transfer: true });
@@ -422,7 +422,7 @@ describe('Clerk singleton', () => {
       }
       sut.client.signUp.create = mockSignUpCreate;
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSignUpCreate).toHaveBeenCalledWith({ transfer: true });
@@ -489,7 +489,7 @@ describe('Clerk singleton', () => {
       sut.client.signIn.create = mockSignInCreate;
       sut.setActive = mockSetActive;
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSignInCreate).toHaveBeenCalledWith({ transfer: true });
@@ -540,7 +540,7 @@ describe('Clerk singleton', () => {
       });
       sut.setActive = mockSetActive;
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSetActive).toHaveBeenCalled();
@@ -594,7 +594,7 @@ describe('Clerk singleton', () => {
       sut.client.signUp.create = mockSignUpCreate;
       sut.setActive = mockSetActive;
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockSignUpCreate).toHaveBeenCalledWith({ transfer: true });
@@ -635,7 +635,7 @@ describe('Clerk singleton', () => {
         navigate: mockNavigate,
       });
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/sign-in#/factor-two');
@@ -837,7 +837,7 @@ describe('Clerk singleton', () => {
         navigate: mockNavigate,
       });
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/sign-up');
@@ -885,7 +885,7 @@ describe('Clerk singleton', () => {
         navigate: mockNavigate,
       });
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/sign-up');
@@ -926,7 +926,7 @@ describe('Clerk singleton', () => {
         navigate: mockNavigate,
       });
 
-      sut.handleRedirectCallback();
+      await sut.handleRedirectCallback();
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith('/sign-up#/continue');

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -117,6 +117,18 @@ describe('Clerk singleton', () => {
       mockSession.touch.mockReset();
     });
 
+    it('does not call session touch on signout', async () => {
+      mockSession.touch.mockReturnValueOnce(Promise.resolve());
+      mockClientFetch.mockReturnValue(Promise.resolve({ activeSessions: [mockSession] }));
+
+      const sut = new Clerk(frontendApi);
+      await sut.load();
+      await sut.setActive({ session: null });
+      await waitFor(() => {
+        expect(mockSession.touch).not.toHaveBeenCalled();
+      });
+    });
+
     it('calls session.touch by default', async () => {
       mockSession.touch.mockReturnValueOnce(Promise.resolve());
       mockClientFetch.mockReturnValue(Promise.resolve({ activeSessions: [mockSession] }));

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -82,7 +82,6 @@ import {
   OrganizationMembership,
 } from './resources/internal';
 import { AuthenticationService } from './services';
-import { SessionTokenCache } from './tokenCache';
 
 export type ClerkCoreBroadcastChannelEvent = { type: 'signout' };
 
@@ -419,8 +418,6 @@ export default class Clerk implements ClerkInterface {
       } else {
         session.lastActiveOrganizationId = organization.id;
       }
-
-      SessionTokenCache.clear();
     }
 
     this.#authService?.setAuthCookiesFromSession(session);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This tickets tries to resolve cookie and session syncing issues found in setActive upon user and organization switching.

### Issue

Steps to reproduce:
1. user with multiple organizations signin
2. visit `/organization` page from tab A with organization A
3. open Application tab in Developer tools and find `__session` cookie
4. open a new tab B
5. go back to tab A
6. switch to organization B

Cookie `__session` will include id of organization A instead of organization B.

### Improvements 

Extra improvements in performance achieved with this PR:

1. org switch will not request `/tokens`
3. user switch will not request `/tokens`
5. poller will not request `/tokens` before 60 seconds (minus leeway) of inactivity (session cookie is being updated in every `/touch` request)