### PR TITLE
fix(clerk-js): Await mountComponentRenderer to mount the components before firing loaded event

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1,10 +1,5 @@
-import {
-  inClientSide,
-  isLegacyFrontendApiKey,
-  LocalStorageBroadcastChannel,
-  noop,
-  parsePublishableKey,
-} from '@clerk/shared';
+import type { LocalStorageBroadcastChannel } from '@clerk/shared';
+import { inClientSide, isLegacyFrontendApiKey, noop, parsePublishableKey } from '@clerk/shared';
 import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
@@ -65,13 +60,15 @@ import {
 } from '../utils';
 import { memoizeListenerCallback } from '../utils/memoizeStateListenerCallback';
 import { DEV_BROWSER_SSO_JWT_PARAMETER, ERROR_CODES } from './constants';
-import createDevBrowserHandler, { DevBrowserHandler } from './devBrowserHandler';
+import type { DevBrowserHandler } from './devBrowserHandler';
+import createDevBrowserHandler from './devBrowserHandler';
 import {
   clerkErrorInitFailed,
   clerkMissingDevBrowserJwt,
   clerkOAuthCallbackDidNotCompleteSignInSIgnUp,
 } from './errors';
-import createFapiClient, { FapiClient, FapiRequestCallback } from './fapiClient';
+import type { FapiClient, FapiRequestCallback } from './fapiClient';
+import createFapiClient from './fapiClient';
 import {
   BaseResource,
   Client,
@@ -914,11 +911,11 @@ export default class Clerk implements ClerkInterface {
     return this.#environment;
   }
 
-  __unstable__setEnvironment = (env: EnvironmentJSON): void => {
+  __unstable__setEnvironment = async (env: EnvironmentJSON) => {
     this.#environment = new Environment(env);
 
     if (Clerk.mountComponentRenderer) {
-      this.#componentControls = Clerk.mountComponentRenderer(this, this.#environment, this.#options);
+      this.#componentControls = await Clerk.mountComponentRenderer(this, this.#environment, this.#options);
     }
   };
 
@@ -978,7 +975,7 @@ export default class Clerk implements ClerkInterface {
         });
 
         if (Clerk.mountComponentRenderer) {
-          this.#componentControls = Clerk.mountComponentRenderer(this, this.#environment, this.#options);
+          this.#componentControls = await Clerk.mountComponentRenderer(this, this.#environment, this.#options);
         }
 
         break;
@@ -1010,7 +1007,7 @@ export default class Clerk implements ClerkInterface {
     // TODO: Add an auth service also for non standard browsers that will poll for the __session JWT but won't use cookies
 
     if (Clerk.mountComponentRenderer) {
-      this.#componentControls = Clerk.mountComponentRenderer(this, this.#environment, this.#options);
+      this.#componentControls = await Clerk.mountComponentRenderer(this, this.#environment, this.#options);
     }
   };
 

--- a/packages/shared/src/utils/createDeferredPromise.ts
+++ b/packages/shared/src/utils/createDeferredPromise.ts
@@ -1,0 +1,17 @@
+import { noop } from './noop';
+
+type Callback = (val?: any) => void;
+
+/**
+ * Create a promise that can be resolved or rejected from
+ * outside the Promise constructor callback
+ */
+export const createDeferredPromise = () => {
+  let resolve: Callback = noop;
+  let reject: Callback = noop;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -18,3 +18,4 @@ export * from './url';
 export * from './workerTimers';
 export * from './runWithExponentialBackOff';
 export * from './isomorphicAtob';
+export * from './createDeferredPromise';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
When we replaced ReactDom.render with the new, React18, createRoot we noticed that the async (concurrent) nature of the new react version caused a race condition during the initial bootstrap phase.
```
ReactDom.render (pre r18)
- Components layout effect runs, componentControls is populated
- clerk isready
- mountUserButton
- Components mount
```
```
ReactDom.createRoot (r18)
- clerk isready
- mountUserButton // FAILS
- Components layout effect runs, componentControls is populated
- Components mount
```
The example above shows that when createRoot is used, the useLayoutEffect that populates the component rendered methods is fired asyncronously, possibly after clerk has loaded. If a mountComponent method is called before then (eg mountSignIn), clerk-js will throw. By awaiting the useLayoutEffect, we simulate the pre-r18 flow:

```
(POST-FIX) ReactDom.createRoot (r18)
- Components layout effect runs, componentControls is populated
- Components resolves deferredPromise
- clerk isready
- mountUserButton
- Components mount
```
<!-- Fixes # (issue number) -->
