### PR TITLE
chore(nextjs): Invalidate next sdc/sbc router cache before setActive

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -395,6 +395,17 @@ export default class Clerk implements ClerkInterface {
       );
     }
 
+    type SetActiveHook = () => void;
+    const onBeforeSetActive: SetActiveHook =
+      typeof window !== 'undefined' && typeof window.__unstable__onBeforeSetActive === 'function'
+        ? window.__unstable__onBeforeSetActive
+        : noop;
+
+    const onAfterSetActive: SetActiveHook =
+      typeof window !== 'undefined' && typeof window.__unstable__onAfterSetActive === 'function'
+        ? window.__unstable__onAfterSetActive
+        : noop;
+
     if (typeof session === 'string') {
       session = (this.client.sessions.find(x => x.id === session) as ActiveSessionResource) || null;
     }
@@ -418,6 +429,8 @@ export default class Clerk implements ClerkInterface {
     if (shouldSignoutSession) {
       this.#broadcastSignOutEvent();
     }
+
+    onBeforeSetActive();
 
     //1. setLastActiveSession to passed user session (add a param).
     //   Note that this will also update the session's active organization
@@ -449,7 +462,7 @@ export default class Clerk implements ClerkInterface {
 
     this.#setAccessors(newSession);
     this.#emit();
-
+    onAfterSetActive();
     this.#resetComponentsState();
   };
 

--- a/packages/clerk-js/src/globals.d.ts
+++ b/packages/clerk-js/src/globals.d.ts
@@ -1,6 +1,11 @@
 declare global {
   const __DEV__: boolean;
   const __CLERKJS_VERSION__: string;
+
+  interface Window {
+    __unstable__onBeforeSetActive: () => void;
+    __unstable__onAfterSetActive: () => void;
+  }
 }
 
 declare module '*.svg' {

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -1,8 +1,10 @@
 import { __internal__setErrorThrowerOptions, ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
-import { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
-import { PublishableKeyOrFrontendApi } from '@clerk/types';
+import type { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
+import type { PublishableKeyOrFrontendApi } from '@clerk/types';
 import { useRouter } from 'next/router';
 import React from 'react';
+
+import { invalidateNextRouterCache } from './invalidateNextRouterCache';
 
 __internal__setErrorThrowerOptions({
   packageName: '@clerk/nextjs',
@@ -23,6 +25,10 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
   const { push } = useRouter();
 
   ReactClerkProvider.displayName = 'ReactClerkProvider';
+
+  React.useLayoutEffect(() => {
+    window.__unstable__onBeforeSetActive = invalidateNextRouterCache;
+  }, []);
 
   return (
     <ReactClerkProvider

--- a/packages/nextjs/src/client/invalidateNextRouterCache.ts
+++ b/packages/nextjs/src/client/invalidateNextRouterCache.ts
@@ -1,0 +1,55 @@
+// interface FetchDataOutput {
+//   dataHref: string;
+//   json: Record<string, any> | null;
+//   response: Response;
+//   text: string;
+//   cacheKey: string;
+// }
+//
+// interface NextDataCache {
+//   [asPath: string]: Promise<FetchDataOutput>;
+// }
+
+/**
+ * A placeholder for the actual next types.
+ * The types above are not exported from the next package currently,
+ * we only include them here for documentation purposes.
+ * see: https://github.com/vercel/next.js/blob/018208fb15c9b969e173684668cea89588f4c536/packages/next/src/shared/lib/router/router.ts#L655
+ */
+type NextDataCache = any;
+
+/**
+ * Next currently prefetches the page of every visible Link on the page.
+ * For every prefetch request, the middleware runs and the response is cached in
+ * window.next.router.sdc or window.next.router.sdc
+ *
+ * Imagine a scenario with a /protected page requiring the user to be signed in using middleware.
+ * If we don't invalidate the cache, we end up in the following redirect flow:
+ * home -> /protected -> middleware redirects to /sign-in -> perform sign-in
+ *            -> try to navigate to /protected but the cached 307 response is used
+ *                   -> redirect to /sign-in instead -> withRedirectToHome -> home
+ * When the auth state changes and the middleware runs again, the client-side router
+ * does not automatically invalidate the cache so the browser follows the cached response
+ *
+ * This helper invalidates both known caches help prevent the scenario described above.
+ */
+export const invalidateNextRouterCache = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const invalidate = (cache: NextDataCache) => {
+    // deleting the keys without nuking the cache by reassigning the variable to an empty object,
+    // in case next holds a reference to it
+    Object.keys(cache).forEach(key => {
+      delete cache[key];
+    });
+  };
+
+  try {
+    invalidate((window as any).next.router.sdc);
+    invalidate((window as any).next.router.sbc);
+  } catch (e) {
+    return;
+  }
+};

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -1,1 +1,8 @@
+declare global {
+  interface Window {
+    __unstable__onBeforeSetActive: () => void;
+    __unstable__onAfterSetActive: () => void;
+  }
+}
+
 export * from './client';


### PR DESCRIPTION


## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
See comment within the changes files

<!-- Fixes # (issue number) -->
