### PR TITLE
Support multi-domain authentication

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -51,6 +51,7 @@ import {
   appendAsQueryParams,
   buildURL,
   createBeforeUnloadTracker,
+  createClerkQueryParam,
   createPageLifecycle,
   errorThrower,
   getClerkQueryParam,
@@ -63,6 +64,7 @@ import {
   isError,
   noOrganizationExists,
   noUserExists,
+  removeClerkQueryParam,
   sessionExistsAndSingleSessionModeEnabled,
   setSearchParameterInHash,
   stripOrigin,
@@ -955,23 +957,16 @@ export default class Clerk implements ClerkInterface {
 
   #syncWithPrimary = () => {
     const q = new URLSearchParams({
-      redirect_url: `${window.location.href}?synced=true`,
+      redirect_url: createClerkQueryParam('__clerk_synced', 'true').toString(),
     });
     window.location.replace(new URL(`/v1/client/sync?${q.toString()}`, `https://${this.domain}`).toString());
   };
 
   #handleSyncedQueryParam = () => {
-    function stripSyncedQueryParam(q: URLSearchParams) {
-      q.delete('synced');
-      const queryString = q.toString() ? `?${q.toString()}` : '';
-      window.history.replaceState({}, '', `${window.location.pathname}${queryString}`);
-    }
-
-    const q = new URLSearchParams(window.location.search);
-    if (q.get('synced') !== 'true') {
+    if (getClerkQueryParam('__clerk_synced') !== 'true') {
       return true;
     }
-    stripSyncedQueryParam(q);
+    removeClerkQueryParam('__clerk_synced');
     return false;
   };
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -953,34 +953,34 @@ export default class Clerk implements ClerkInterface {
     this.#componentControls?.updateProps(props);
   };
 
-  #redirectToSyncWithPrimary = () => {
+  #syncWithPrimary = () => {
     const q = new URLSearchParams({
       redirect_url: `${window.location.href}?synced=true`,
     });
     window.location.replace(new URL(`/v1/client/sync?${q.toString()}`, `https://${this.domain}`).toString());
   };
 
-  #stripSyncedQueryParam = (q: URLSearchParams) => {
-    q.delete('synced');
-    const queryString = q.toString() ? `?${q.toString()}` : '';
-    window.history.replaceState({}, '', `${window.location.pathname}${queryString}`);
-  };
+  #handleSyncedQueryParam = () => {
+    function stripSyncedQueryParam(q: URLSearchParams) {
+      q.delete('synced');
+      const queryString = q.toString() ? `?${q.toString()}` : '';
+      window.history.replaceState({}, '', `${window.location.pathname}${queryString}`);
+    }
 
-  #shouldSyncWithMain = () => {
     const q = new URLSearchParams(window.location.search);
     if (q.get('synced') !== 'true') {
-      this.#redirectToSyncWithPrimary();
       return true;
     }
-    this.#stripSyncedQueryParam(q);
+    stripSyncedQueryParam(q);
     return false;
   };
 
+  #shouldSyncWithPrimary = () => this.#options.isSatellite && this.#handleSyncedQueryParam();
+
   #loadInStandardBrowser = async (): Promise<boolean> => {
-    if (this.#options.isSatellite) {
-      if (this.#shouldSyncWithMain()) {
-        return false;
-      }
+    if (this.#shouldSyncWithPrimary()) {
+      this.#syncWithPrimary();
+      return false;
     }
 
     this.#authService = new AuthenticationService(this);

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -93,7 +93,7 @@ import { AuthenticationService } from './services';
 
 export type ClerkCoreBroadcastChannelEvent = { type: 'signout' };
 
-type ClerkConstructorOptions = Pick<ClerkInterface, 'proxyUrl' | 'domain' | 'isSatellite'>;
+type ClerkConstructorOptions = Pick<ClerkInterface, 'proxyUrl' | 'domain'>;
 
 declare global {
   interface Window {
@@ -102,7 +102,6 @@ declare global {
     __clerk_publishable_key?: string;
     __clerk_proxy_url?: ClerkConstructorOptions['proxyUrl'];
     __clerk_domain?: ClerkConstructorOptions['domain'];
-    __clerk_is_satellite?: ClerkConstructorOptions['isSatellite'];
   }
 }
 
@@ -110,6 +109,7 @@ const defaultOptions: ClerkOptions = {
   polling: true,
   standardBrowser: true,
   touchSession: true,
+  isSatellite: false,
 };
 
 export default class Clerk implements ClerkInterface {
@@ -123,7 +123,6 @@ export default class Clerk implements ClerkInterface {
   public readonly publishableKey?: string;
   public readonly proxyUrl?: ClerkConstructorOptions['proxyUrl'];
   public readonly domain?: ClerkConstructorOptions['domain'];
-  public readonly isSatellite?: ClerkConstructorOptions['isSatellite'];
 
   #authService: AuthenticationService | null = null;
   #broadcastChannel: LocalStorageBroadcastChannel<ClerkCoreBroadcastChannelEvent> | null = null;
@@ -158,7 +157,6 @@ export default class Clerk implements ClerkInterface {
     this.proxyUrl = proxyUrlToAbsoluteURL(_unfilteredProxy);
 
     this.domain = (options as ClerkConstructorOptions | undefined)?.domain;
-    this.isSatellite = (options as ClerkConstructorOptions | undefined)?.isSatellite;
 
     if (isLegacyFrontendApiKey(key)) {
       if (!validateFrontendApi(key)) {
@@ -964,8 +962,8 @@ export default class Clerk implements ClerkInterface {
   };
 
   #loadInStandardBrowser = async (): Promise<void> => {
-    console.log('----- isSatellite -----', this.isSatellite);
-    if (this.isSatellite) {
+    console.log('----- isSatellite -----', this.#options.isSatellite);
+    if (this.#options.isSatellite) {
       const q = new URLSearchParams(window.location.search);
       if (q.get('synced') !== 'true') {
         this.#syncWithPrimary();

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -185,7 +185,7 @@ export default class Clerk implements ClerkInterface {
 
   public isReady = (): boolean => this.#isReady;
 
-  public load = async (options?: ClerkOptions): Promise<void> => {
+  public load = async (options?: Omit<ClerkOptions, 'isSatellite'>): Promise<void> => {
     if (this.#isReady) {
       return;
     }

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -140,7 +140,7 @@ export default function createFapiClient(clerkInstance: Omit<Clerk, 'proxyUrl'>)
 
     return buildUrlUtil(
       {
-        base: `https://${clerkInstance.frontendApi}`,
+        base: `https://${clerkInstance.domain || clerkInstance.frontendApi}`,
         pathname: `v1${path}`,
         search: buildQueryString(requestInit),
       },

--- a/packages/clerk-js/src/index.browser.ts
+++ b/packages/clerk-js/src/index.browser.ts
@@ -20,8 +20,18 @@ const proxyUrl =
   window.__clerk_proxy_url ||
   '';
 
+const domain =
+  document.querySelector('script[data-clerk-domain]')?.getAttribute('data-clerk-domain') || window.__clerk_domain || '';
+
+const isSatellite =
+  document.querySelector('script[data-clerk-is-satellite]')?.getAttribute('data-clerk-is-satellite') === 'true' ||
+  window.__clerk_is_satellite ||
+  false;
+
 window.Clerk = new Clerk(publishableKey || frontendApi, {
   proxyUrl,
+  domain,
+  isSatellite,
 });
 
 if (module.hot) {

--- a/packages/clerk-js/src/index.browser.ts
+++ b/packages/clerk-js/src/index.browser.ts
@@ -23,15 +23,9 @@ const proxyUrl =
 const domain =
   document.querySelector('script[data-clerk-domain]')?.getAttribute('data-clerk-domain') || window.__clerk_domain || '';
 
-const isSatellite =
-  document.querySelector('script[data-clerk-is-satellite]')?.getAttribute('data-clerk-is-satellite') === 'true' ||
-  window.__clerk_is_satellite ||
-  false;
-
 window.Clerk = new Clerk(publishableKey || frontendApi, {
   proxyUrl,
   domain,
-  isSatellite,
 });
 
 if (module.hot) {

--- a/packages/clerk-js/src/index.headless.browser.ts
+++ b/packages/clerk-js/src/index.headless.browser.ts
@@ -17,8 +17,18 @@ const proxyUrl =
   window.__clerk_proxy_url ||
   '';
 
+const domain =
+  document.querySelector('script[data-clerk-domain]')?.getAttribute('data-clerk-domain') || window.__clerk_domain || '';
+
+const isSatellite =
+  document.querySelector('script[data-clerk-is-satellite]')?.getAttribute('data-clerk-is-satellite') === 'true' ||
+  window.__clerk_is_satellite ||
+  false;
+
 window.Clerk = new Clerk(publishableKey || frontendApi, {
   proxyUrl,
+  domain,
+  isSatellite,
 });
 
 if (module.hot) {

--- a/packages/clerk-js/src/index.headless.browser.ts
+++ b/packages/clerk-js/src/index.headless.browser.ts
@@ -20,15 +20,9 @@ const proxyUrl =
 const domain =
   document.querySelector('script[data-clerk-domain]')?.getAttribute('data-clerk-domain') || window.__clerk_domain || '';
 
-const isSatellite =
-  document.querySelector('script[data-clerk-is-satellite]')?.getAttribute('data-clerk-is-satellite') === 'true' ||
-  window.__clerk_is_satellite ||
-  false;
-
 window.Clerk = new Clerk(publishableKey || frontendApi, {
   proxyUrl,
   domain,
-  isSatellite,
 });
 
 if (module.hot) {

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -4,6 +4,7 @@ const ClerkQueryParams = [
   '__clerk_invitation_token',
   '__clerk_ticket',
   '__clerk_modal_state',
+  '__clerk_synced',
 ] as const;
 
 type ClerkQueryParam = typeof ClerkQueryParams[number];
@@ -14,6 +15,7 @@ type ClerkQueryParamsToValuesMap = {
   __clerk_invitation_token: string;
   __clerk_ticket: string;
   __clerk_modal_state: string;
+  __clerk_synced: string;
 };
 
 export type VerificationStatus = 'expired' | 'failed' | 'loading' | 'verified' | 'verified_switch_tab';
@@ -28,4 +30,10 @@ export function removeClerkQueryParam<T extends ClerkQueryParam>(param: T) {
   url.searchParams.delete(param);
   window.history.replaceState({}, '', url);
   return;
+}
+
+export function createClerkQueryParam<T extends ClerkQueryParam>(param: T, value: string) {
+  const url = new URL(window.location.href);
+  url.searchParams.append(param, value);
+  return url;
 }

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -31,7 +31,6 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
     proxyUrl,
     // @ts-expect-error
     domain,
-    // @ts-expect-error
     isSatellite,
     // @ts-expect-error
     __clerk_ssr_state,

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -21,10 +21,23 @@ type NextClerkProviderProps = {
   Partial<PublishableKeyOrFrontendApi>;
 
 export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JSX.Element {
-  // @ts-expect-error
   // Allow for overrides without making the type public
-  const { authServerSideProps, frontendApi, publishableKey, proxyUrl, __clerk_ssr_state, clerkJSUrl, ...restProps } =
-    rest;
+  const {
+    // @ts-expect-error
+    authServerSideProps,
+    frontendApi,
+    publishableKey,
+    // @ts-expect-error
+    proxyUrl,
+    // @ts-expect-error
+    domain,
+    // @ts-expect-error
+    isSatellite,
+    // @ts-expect-error
+    __clerk_ssr_state,
+    clerkJSUrl,
+    ...restProps
+  } = rest;
   const { push } = useRouter();
 
   ReactClerkProvider.displayName = 'ReactClerkProvider';
@@ -39,7 +52,9 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
       publishableKey={publishableKey || process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || ''}
       clerkJSUrl={clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS}
       // @ts-expect-error
-      proxyUrl={proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL}
+      proxyUrl={proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || ''}
+      domain={domain || ''}
+      isSatellite={isSatellite || false}
       navigate={to => push(to)}
       // withServerSideAuth automatically injects __clerk_ssr_state
       // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -31,7 +31,6 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
     proxyUrl,
     // @ts-expect-error
     domain,
-    isSatellite,
     // @ts-expect-error
     __clerk_ssr_state,
     clerkJSUrl,
@@ -53,7 +52,6 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
       // @ts-expect-error
       proxyUrl={proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || ''}
       domain={domain || ''}
-      isSatellite={isSatellite || false}
       navigate={to => push(to)}
       // withServerSideAuth automatically injects __clerk_ssr_state
       // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -52,7 +52,6 @@ export default class IsomorphicClerk {
   private readonly publishableKey?: string;
   private readonly proxyUrl?: ClerkConstructorOptions['proxyUrl'];
   private readonly domain?: ClerkConstructorOptions['domain'];
-  private readonly isSatellite?: ClerkConstructorOptions['isSatellite'];
   private readonly options: IsomorphicClerkOptions;
   private readonly Clerk: ClerkProp;
   private clerkjs: BrowserClerk | HeadlessBrowserClerk | null = null;
@@ -94,7 +93,6 @@ export default class IsomorphicClerk {
     this.publishableKey = publishableKey;
     this.proxyUrl = (options as ClerkConstructorOptions | undefined)?.proxyUrl;
     this.domain = (options as ClerkConstructorOptions | undefined)?.domain;
-    this.isSatellite = (options as ClerkConstructorOptions | undefined)?.isSatellite;
     this.options = options;
     this.Clerk = Clerk;
     this.mode = inClientSide() ? 'browser' : 'server';
@@ -120,7 +118,6 @@ export default class IsomorphicClerk {
     window.__clerk_publishable_key = this.publishableKey;
     window.__clerk_proxy_url = this.proxyUrl;
     window.__clerk_domain = this.domain;
-    window.__clerk_is_satellite = this.isSatellite;
 
     try {
       if (this.Clerk) {
@@ -132,7 +129,6 @@ export default class IsomorphicClerk {
           c = new this.Clerk(this.publishableKey || this.frontendApi || '', {
             proxyUrl: this.proxyUrl,
             domain: this.domain,
-            isSatellite: this.isSatellite,
           });
           await c.load(this.options);
         } else {
@@ -152,7 +148,6 @@ export default class IsomorphicClerk {
           publishableKey: this.publishableKey,
           proxyUrl: this.proxyUrl,
           domain: this.domain,
-          isSatellite: this.isSatellite,
           scriptUrl: this.options.clerkJSUrl,
           scriptVariant: this.options.clerkJSVariant,
         });

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -159,7 +159,7 @@ export default class IsomorphicClerk {
         await global.Clerk.load(this.options);
       }
 
-      return this.hydrateClerkJS(global.Clerk);
+      return global.Clerk?.loaded ? this.hydrateClerkJS(global.Clerk) : undefined;
     } catch (err) {
       let message;
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -51,6 +51,8 @@ export default class IsomorphicClerk {
   private readonly frontendApi?: string;
   private readonly publishableKey?: string;
   private readonly proxyUrl?: ClerkConstructorOptions['proxyUrl'];
+  private readonly domain?: ClerkConstructorOptions['domain'];
+  private readonly isSatellite?: ClerkConstructorOptions['isSatellite'];
   private readonly options: IsomorphicClerkOptions;
   private readonly Clerk: ClerkProp;
   private clerkjs: BrowserClerk | HeadlessBrowserClerk | null = null;
@@ -91,6 +93,8 @@ export default class IsomorphicClerk {
     this.frontendApi = frontendApi;
     this.publishableKey = publishableKey;
     this.proxyUrl = (options as ClerkConstructorOptions | undefined)?.proxyUrl;
+    this.domain = (options as ClerkConstructorOptions | undefined)?.domain;
+    this.isSatellite = (options as ClerkConstructorOptions | undefined)?.isSatellite;
     this.options = options;
     this.Clerk = Clerk;
     this.mode = inClientSide() ? 'browser' : 'server';
@@ -115,6 +119,8 @@ export default class IsomorphicClerk {
     window.__clerk_frontend_api = this.frontendApi;
     window.__clerk_publishable_key = this.publishableKey;
     window.__clerk_proxy_url = this.proxyUrl;
+    window.__clerk_domain = this.domain;
+    window.__clerk_is_satellite = this.isSatellite;
 
     try {
       if (this.Clerk) {
@@ -125,6 +131,8 @@ export default class IsomorphicClerk {
           // Construct a new Clerk object if a constructor is passed
           c = new this.Clerk(this.publishableKey || this.frontendApi || '', {
             proxyUrl: this.proxyUrl,
+            domain: this.domain,
+            isSatellite: this.isSatellite,
           });
           await c.load(this.options);
         } else {
@@ -143,6 +151,8 @@ export default class IsomorphicClerk {
           frontendApi: this.frontendApi,
           publishableKey: this.publishableKey,
           proxyUrl: this.proxyUrl,
+          domain: this.domain,
+          isSatellite: this.isSatellite,
           scriptUrl: this.options.clerkJSUrl,
           scriptVariant: this.options.clerkJSVariant,
         });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -14,10 +14,12 @@ declare global {
     __clerk_frontend_api?: string;
     __clerk_publishable_key?: string;
     __clerk_proxy_url?: ClerkConstructorOptions['proxyUrl'];
+    __clerk_domain?: ClerkConstructorOptions['domain'];
+    __clerk_is_satellite?: ClerkConstructorOptions['isSatellite'];
   }
 }
 
-export type ClerkConstructorOptions = Pick<Clerk, 'proxyUrl'>;
+export type ClerkConstructorOptions = Pick<Clerk, 'proxyUrl' | 'domain' | 'isSatellite'>;
 
 export type IsomorphicClerkOptions = ClerkOptions & {
   Clerk?: ClerkProp;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -19,8 +19,9 @@ declare global {
 }
 
 export type ClerkConstructorOptions = Pick<Clerk, 'proxyUrl' | 'domain'>;
+export type NoExperimentalClerkOptions = Omit<ClerkOptions, 'isSatellite'>;
 
-export type IsomorphicClerkOptions = ClerkOptions & {
+export type IsomorphicClerkOptions = NoExperimentalClerkOptions & {
   Clerk?: ClerkProp;
   clerkJSUrl?: string;
   clerkJSVariant?: 'headless' | '';
@@ -49,7 +50,7 @@ export interface MountProps {
 }
 
 export interface HeadlessBrowserClerk extends Clerk {
-  load: (opts?: ClerkOptions) => Promise<void>;
+  load: (opts?: Omit<ClerkOptions, 'isSatellite'>) => Promise<void>;
   updateClient: (client: ClientResource) => void;
 }
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -15,11 +15,10 @@ declare global {
     __clerk_publishable_key?: string;
     __clerk_proxy_url?: ClerkConstructorOptions['proxyUrl'];
     __clerk_domain?: ClerkConstructorOptions['domain'];
-    __clerk_is_satellite?: ClerkConstructorOptions['isSatellite'];
   }
 }
 
-export type ClerkConstructorOptions = Pick<Clerk, 'proxyUrl' | 'domain' | 'isSatellite'>;
+export type ClerkConstructorOptions = Pick<Clerk, 'proxyUrl' | 'domain'>;
 
 export type IsomorphicClerkOptions = ClerkOptions & {
   Clerk?: ClerkProp;

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -1,4 +1,5 @@
 import { parsePublishableKey } from '@clerk/shared';
+import type { Clerk as ClerkInterface } from '@clerk/types';
 
 import { LIB_VERSION } from '../info';
 import type { BrowserClerk } from '../types';
@@ -69,13 +70,17 @@ export interface LoadScriptParams {
   frontendApi?: string;
   publishableKey?: string;
   proxyUrl?: string;
+
+  domain?: string;
+  isSatellite?: boolean;
   scriptUrl?: string;
+
   scriptVariant?: ScriptVariant;
 }
 
 export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptElement | null> {
   return new Promise((resolve, reject) => {
-    const { frontendApi, publishableKey, proxyUrl } = params;
+    const { frontendApi, publishableKey, proxyUrl, domain, isSatellite } = params;
 
     if (global.Clerk) {
       resolve(null);
@@ -95,6 +100,14 @@ export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptEl
     if (proxyUrl) {
       script.setAttribute('data-clerk-proxy-url', proxyUrl);
     }
+    if (domain) {
+      script.setAttribute('data-clerk-domain', domain);
+    }
+
+    if (isSatellite) {
+      script.setAttribute('data-clerk-is-satellite', isSatellite ? 'true' : 'false');
+    }
+
     script.setAttribute('crossorigin', 'anonymous');
     script.async = true;
 

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -1,5 +1,4 @@
 import { parsePublishableKey } from '@clerk/shared';
-import type { Clerk as ClerkInterface } from '@clerk/types';
 
 import { LIB_VERSION } from '../info';
 import type { BrowserClerk } from '../types';
@@ -72,7 +71,6 @@ export interface LoadScriptParams {
   proxyUrl?: string;
 
   domain?: string;
-  isSatellite?: boolean;
   scriptUrl?: string;
 
   scriptVariant?: ScriptVariant;
@@ -80,7 +78,7 @@ export interface LoadScriptParams {
 
 export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptElement | null> {
   return new Promise((resolve, reject) => {
-    const { frontendApi, publishableKey, proxyUrl, domain, isSatellite } = params;
+    const { frontendApi, publishableKey, proxyUrl, domain } = params;
 
     if (global.Clerk) {
       resolve(null);
@@ -102,10 +100,6 @@ export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptEl
     }
     if (domain) {
       script.setAttribute('data-clerk-domain', domain);
-    }
-
-    if (isSatellite) {
-      script.setAttribute('data-clerk-is-satellite', isSatellite ? 'true' : 'false');
     }
 
     script.setAttribute('crossorigin', 'anonymous');

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -72,7 +72,6 @@ export interface LoadScriptParams {
 
   domain?: string;
   scriptUrl?: string;
-
   scriptVariant?: ScriptVariant;
 }
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -67,6 +67,18 @@ export interface Clerk {
   /** Clerk Proxy url string. */
   proxyUrl?: string;
 
+  /**
+   * @experimental
+   * Clerk Satellite Frontend API string.
+   */
+  domain?: string;
+
+  /**
+   * @experimental
+   * Indicates if the app is a Satellite app.
+   */
+  isSatellite?: boolean;
+
   instanceType?: InstanceType;
 
   /** Client handling most Clerk operations. */

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -73,12 +73,6 @@ export interface Clerk {
    */
   domain?: string;
 
-  /**
-   * @experimental
-   * Indicates if the app is a Satellite app.
-   */
-  isSatellite?: boolean;
-
   instanceType?: InstanceType;
 
   /** Client handling most Clerk operations. */
@@ -472,6 +466,11 @@ export interface ClerkOptions {
   /** Optional support email for display in authentication screens */
   supportEmail?: string;
   touchSession?: boolean;
+  /**
+   * @experimental
+   * Indicates if the app is a Satellite app.
+   */
+  isSatellite?: boolean;
 }
 
 export interface Resources {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -468,7 +468,6 @@ export interface ClerkOptions {
   touchSession?: boolean;
   /**
    * @experimental
-   * Indicates if the app is a Satellite app.
    */
   isSatellite?: boolean;
 }

--- a/packages/types/src/key.ts
+++ b/packages/types/src/key.ts
@@ -14,3 +14,14 @@ export type PublishableKeyOrFrontendApi =
       frontendApi: string;
       publishableKey?: never;
     };
+
+// export type SatelliteApp =
+//   | { isSatellite?: never }
+//   | {
+//       isSatellite: ClerkInterface['isSatellite'];
+//       proxyUrl: ClerkInterface['proxyUrl'];
+//     }
+//   | {
+//       isSatellite: ClerkInterface['isSatellite'];
+//       domain?: ClerkInterface['domain'];
+//     };

--- a/packages/types/src/key.ts
+++ b/packages/types/src/key.ts
@@ -14,14 +14,3 @@ export type PublishableKeyOrFrontendApi =
       frontendApi: string;
       publishableKey?: never;
     };
-
-// export type SatelliteApp =
-//   | { isSatellite?: never }
-//   | {
-//       isSatellite: ClerkInterface['isSatellite'];
-//       proxyUrl: ClerkInterface['proxyUrl'];
-//     }
-//   | {
-//       isSatellite: ClerkInterface['isSatellite'];
-//       domain?: ClerkInterface['domain'];
-//     };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
As part of this PR we are introducing 2 new props for <ClerkProvider /> 
- isSatellite?: boolean → This prop will dictate whether or not we should perform Syncing with the primary app
- domain?: string → It should be the FAPI key of the satellite app e.g. clerk.satellite.dev 

Syncing with the primary app: 
- If isSatellite === true we should perform the syncing process to sync sessions with the primary app
  - Redirect to https://clerk.satellite.dev/v1/client/sync?redirect_url=https://clerk.satellite.dev?synced=true 
  - As part of the redirect_url we append ?synced=true as a way to determine that syncing was attempted
  
 In a following PR we will tackle the necessary changes for interstitial

<!-- Fixes # (issue number) -->
