### PR TITLE
Allow absolute and relative paths for ProxyUrl

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1,5 +1,12 @@
 import type { LocalStorageBroadcastChannel } from '@clerk/shared';
-import { inClientSide, isLegacyFrontendApiKey, noop, parsePublishableKey } from '@clerk/shared';
+import {
+  inClientSide,
+  isLegacyFrontendApiKey,
+  isValidProxyUrl,
+  noop,
+  parsePublishableKey,
+  proxyUrlToAbsoluteURL,
+} from '@clerk/shared';
 import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
@@ -138,7 +145,12 @@ export default class Clerk implements ClerkInterface {
   public constructor(key: string, options?: unknown) {
     key = (key || '').trim();
 
-    this.proxyUrl = (options as ClerkConstructorOptions | undefined)?.proxyUrl;
+    const _unfilteredProxy = (options as ClerkConstructorOptions | undefined)?.proxyUrl;
+
+    if (!isValidProxyUrl(_unfilteredProxy)) {
+      errorThrower.throwInvalidProxyUrl({ url: _unfilteredProxy });
+    }
+    this.proxyUrl = proxyUrlToAbsoluteURL(this.proxyUrl);
 
     if (isLegacyFrontendApiKey(key)) {
       if (!validateFrontendApi(key)) {

--- a/packages/clerk-js/src/core/fapiClient.test.ts
+++ b/packages/clerk-js/src/core/fapiClient.test.ts
@@ -10,29 +10,11 @@ const fapiClient = createFapiClient({
   },
 } as Clerk);
 
-const proxyUrl = 'example.com/__clerk';
+const proxyUrl = 'https://clerk.dev/api/__clerk';
 
 const fapiClientWithProxy = createFapiClient({
   frontendApi: 'clerk.example.com',
-  proxyUrl: `example.com`,
-  version: '42.0.0',
-  session: {
-    id: 'deadbeef',
-  },
-} as Clerk);
-
-const fapiClientWithProxyPath = createFapiClient({
-  frontendApi: 'clerk.example.com',
   proxyUrl,
-  version: '42.0.0',
-  session: {
-    id: 'deadbeef',
-  },
-} as Clerk);
-
-const fapiClientWithProxyPath2 = createFapiClient({
-  frontendApi: 'clerk.example.com',
-  proxyUrl: 'example.com/api/__clerk',
   version: '42.0.0',
   session: {
     id: 'deadbeef',
@@ -98,20 +80,7 @@ describe('buildUrl(options)', () => {
   });
 
   it('returns the full frontend API URL using proxy url', () => {
-    expect(fapiClientWithProxy.buildUrl({ path: '/foo' }).href).toBe(
-      `https://example.com/v1/foo?_clerk_js_version=42.0.0`,
-    );
-  });
-
-  it('returns the full frontend API URL using proxy url path', () => {
-    expect(fapiClientWithProxyPath.buildUrl({ path: '/foo' }).href).toBe(
-      `https://${proxyUrl}/v1/foo?_clerk_js_version=42.0.0`,
-    );
-  });
-  it('returns the full frontend API URL using proxy url path 2', () => {
-    expect(fapiClientWithProxyPath2.buildUrl({ path: '/foo' }).href).toBe(
-      `https://example.com/api/__clerk/v1/foo?_clerk_js_version=42.0.0`,
-    );
+    expect(fapiClientWithProxy.buildUrl({ path: '/foo' }).href).toBe(`${proxyUrl}/v1/foo?_clerk_js_version=42.0.0`);
   });
 
   it('adds _clerk_session_id as a query parameter if provided and path does not start with client', () => {
@@ -166,7 +135,7 @@ describe('request', () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      'https://example.com/v1/foo?_clerk_js_version=42.0.0&_clerk_session_id=deadbeef',
+      `${proxyUrl}/v1/foo?_clerk_js_version=42.0.0&_clerk_session_id=deadbeef`,
       expect.objectContaining({
         credentials: 'include',
         method: 'GET',

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -123,8 +123,10 @@ export default function createFapiClient(clerkInstance: Omit<Clerk, 'proxyUrl'>)
   function buildUrl(requestInit: FapiRequestInit): URL {
     const { path } = requestInit;
 
-    if ((clerkInstance as Clerk).proxyUrl) {
-      const proxyBase = new URL(`https://${(clerkInstance as Clerk).proxyUrl}`);
+    const { proxyUrl } = clerkInstance as Clerk;
+
+    if (proxyUrl) {
+      const proxyBase = new URL(proxyUrl);
       const proxyPath = proxyBase.pathname.slice(1, proxyBase.pathname.length);
       return buildUrlUtil(
         {

--- a/packages/shared/src/errors/thrower.ts
+++ b/packages/shared/src/errors/thrower.ts
@@ -1,5 +1,6 @@
 const DefaultMessages = Object.freeze({
   InvalidFrontendApiErrorMessage: `The frontendApi passed to Clerk is invalid. You can get your Frontend API key at https://dashboard.clerk.dev/last-active?path=api-keys. (key={{key}})`,
+  InvalidProxyUrlErrorMessage: `The proxyUrl passed to Clerk is invalid. The expected value for proxyUrl is an absolute URL or a relative path with a leading '/'. (key={{url}})`,
   InvalidPublishableKeyErrorMessage: `The publishableKey passed to Clerk is invalid. You can get your Publishable key at https://dashboard.clerk.dev/last-active?path=api-keys. (key={{key}})`,
   MissingPublishableKeyErrorMessage: `Missing publishableKey. You can get your key at https://dashboard.clerk.dev/last-active?path=api-keys.`,
 });
@@ -20,6 +21,7 @@ export interface ErrorThrower {
   setMessages(options: ErrorThrowerOptions): ErrorThrower;
   throwInvalidPublishableKeyError(params: { key?: string }): never;
   throwInvalidFrontendApiError(params: { key?: string }): never;
+  throwInvalidProxyUrl(params: { url?: string }): never;
   throwMissingPublishableKeyError(): never;
 }
 
@@ -66,6 +68,10 @@ export function buildErrorThrower({ packageName, customMessages }: ErrorThrowerO
 
     throwInvalidFrontendApiError(params: { key?: string }): never {
       throw new Error(buildMessage(messages.InvalidFrontendApiErrorMessage, params));
+    },
+
+    throwInvalidProxyUrl(params: { url?: string }): never {
+      throw new Error(buildMessage(messages.InvalidProxyUrlErrorMessage, params));
     },
 
     throwMissingPublishableKeyError(): never {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from './mimeTypeExtensions';
 export * from './noop';
 export * from './object';
 export * from './poller';
+export * from './proxy';
 export * from './ssr';
 export * from './string';
 export * from './url';

--- a/packages/shared/src/utils/proxy.test.ts
+++ b/packages/shared/src/utils/proxy.test.ts
@@ -1,0 +1,43 @@
+import { isProxyUrlRelative, isValidProxyUrl, proxyUrlToAbsoluteURL } from './proxy';
+
+describe.concurrent('isValidProxyUrl(key)', () => {
+  it('returns true if the proxyUrl is valid', () => {
+    expect(isValidProxyUrl('https://proxy-app.dev/api/__clerk')).toBe(true);
+  });
+
+  it('returns true if the proxyUrl is valid', () => {
+    expect(isValidProxyUrl('/api/__clerk')).toBe(true);
+  });
+
+  it('returns false if the proxyUrl is invalid', () => {
+    expect(isValidProxyUrl('proxy-app.dev/api/__clerk')).toBe(false);
+  });
+});
+
+describe.concurrent('isProxyUrlRelative(key)', () => {
+  it('returns true if the proxyUrl starts with `/`', () => {
+    expect(isProxyUrlRelative('/api/__clerk')).toBe(true);
+  });
+
+  it('returns false if the proxyUrl does not starts with `/`', () => {
+    expect(isProxyUrlRelative('proxy-app.dev/api/__clerk==')).toBe(false);
+  });
+});
+
+describe.concurrent('proxyUrlToAbsoluteURL(url)', () => {
+  global.window = Object.create(window);
+  // @ts-ignore
+  global.window.location = {
+    origin: 'https://clerk.dev',
+  };
+  it('returns an absolute URL made from window.location.origin and the partial a path', () => {
+    expect(proxyUrlToAbsoluteURL('/api/__clerk')).toBe('https://clerk.dev/api/__clerk');
+  });
+
+  it('returns the same value as the parameter given as it already an absolute URL', () => {
+    expect(proxyUrlToAbsoluteURL('https://clerk.dev/api/__clerk')).toBe('https://clerk.dev/api/__clerk');
+  });
+  it('returns empty string if parameter is undefined', () => {
+    expect(proxyUrlToAbsoluteURL(undefined)).toBe('');
+  });
+});

--- a/packages/shared/src/utils/proxy.ts
+++ b/packages/shared/src/utils/proxy.ts
@@ -1,0 +1,18 @@
+export function isValidProxyUrl(key: string | undefined) {
+  if (!key) {
+    return true;
+  }
+
+  return key.startsWith('https://') || isProxyUrlRelative(key);
+}
+
+export function isProxyUrlRelative(key: string) {
+  return key.startsWith('/');
+}
+
+export function proxyUrlToAbsoluteURL(url: string | undefined): string {
+  if (!url) {
+    return '';
+  }
+  return isProxyUrlRelative(url) ? new URL(url, window.location.origin).toString() : url;
+}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR allows users to use the following values for the proxyUrl prop
- `https://my-clerk-app.dev/api/__clerk` (useful for Expo)
- `/api/__clerk` (useful for web)

The previous pattern of `my-clerk-app.dev/api/__clerk` is no longer valid
<!-- Fixes # (issue number) -->
