### PR TITLE
fix(clerk-js): Do not modify src if it is data

### DIFF
--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -287,9 +287,30 @@ export function removeSearchParameterFromHash({
   return dummyUrlForHash.href.replace(DUMMY_URL_BASE, '');
 }
 
+export function isValidUrl(val?: string): val is string {
+  if (!val) {
+    return false;
+  }
+
+  try {
+    new URL(val);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function isDataUri(val?: string): val is string {
+  if (val?.startsWith('data:')) {
+    return true;
+  }
+
+  return false;
+}
+
 export const generateSrc = ({ src, width }: { src?: string; width: number }) => {
-  if (!src) {
-    return '';
+  if (!isValidUrl(src) || isDataUri(src)) {
+    return src;
   }
 
   const newSrc = new URL(src);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
When a new image is uploaded, we show the base64 encoded image. In that case, we don't want to append any search params. 
<!-- Fixes # (issue number) -->
