### PR TITLE
fix(clerk-js): Decorate redirect urls for URL Based session syncing

### DIFF
--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { buildURL } from '../../utils/url';
-import { buildAuthQueryString, parseAuthProp } from '../common/authPropHelpers';
-import { useEnvironment } from '../contexts';
+import { buildAuthQueryString, extractAuthProp } from '../common/authPropHelpers';
+import { useCoreClerk, useEnvironment } from '../contexts';
 import { useNavigate } from '../hooks';
 import type { ParsedQs } from '../router';
 import { useRouter } from '../router';
@@ -32,26 +32,27 @@ export const useSignUpContext = (): SignUpContextType => {
   const { navigate } = useNavigate();
   const { displayConfig } = useEnvironment();
   const { queryParams } = useRouter();
+  const clerk = useCoreClerk();
 
   if (componentName !== 'SignUp') {
     throw new Error('Clerk: useSignUpContext called outside of the mounted SignUp component.');
   }
 
-  // Retrieve values passed through props or qs
-  // props always take priority over qs
-  const afterSignUpUrl = parseAuthProp({
-    ctx,
-    queryParams,
-    displayConfig,
-    field: 'afterSignUpUrl',
-  });
+  const afterSignUpUrl = clerk.buildUrlWithAuth(
+    extractAuthProp('afterSignUpUrl', {
+      ctx,
+      queryParams,
+      displayConfig,
+    }),
+  );
 
-  const afterSignInUrl = parseAuthProp({
-    ctx,
-    queryParams,
-    displayConfig,
-    field: 'afterSignInUrl',
-  });
+  const afterSignInUrl = clerk.buildUrlWithAuth(
+    extractAuthProp('afterSignInUrl', {
+      ctx,
+      queryParams,
+      displayConfig,
+    }),
+  );
 
   const navigateAfterSignUp = () => navigate(afterSignUpUrl);
 
@@ -98,26 +99,27 @@ export const useSignInContext = (): SignInContextType => {
   const { navigate } = useNavigate();
   const { displayConfig } = useEnvironment();
   const { queryParams } = useRouter();
+  const clerk = useCoreClerk();
 
   if (componentName !== 'SignIn') {
     throw new Error('Clerk: useSignInContext called outside of the mounted SignIn component.');
   }
 
-  // Retrieve values passed through props or qs
-  // props always take priority over qs
-  const afterSignUpUrl = parseAuthProp({
-    ctx,
-    queryParams,
-    displayConfig,
-    field: 'afterSignUpUrl',
-  });
+  const afterSignUpUrl = clerk.buildUrlWithAuth(
+    extractAuthProp('afterSignUpUrl', {
+      ctx,
+      queryParams,
+      displayConfig,
+    }),
+  );
 
-  const afterSignInUrl = parseAuthProp({
-    ctx,
-    queryParams,
-    displayConfig,
-    field: 'afterSignInUrl',
-  });
+  const afterSignInUrl = clerk.buildUrlWithAuth(
+    extractAuthProp('afterSignInUrl', {
+      ctx,
+      queryParams,
+      displayConfig,
+    }),
+  );
 
   const navigateAfterSignIn = () => navigate(afterSignInUrl);
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

We want to support the following session for URL-based session syncing for development instances:

1. Visit https://happy-hippo.accounts.dev?redirect_url=https://my-local-app.dev
2. Sign-in via Clerk Hosted Pages
3. Redirect to https://my-local-app.dev and preserve the same session from step 2

This fix ensures that users will land on https://my-local-app.dev?#__dev_session=dev_browser_jwt_goes_here.

The fix should also resolve the experimental_after_impersonation_url scenario.

<!-- Fixes # (issue number) -->
