### PR TITLE
fix(clerk-js): Fix sign out of all accounts when there is no active session

### DIFF
--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -232,6 +232,7 @@ describe('Clerk singleton', () => {
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           activeSessions: [],
+          sessions: [],
           destroy: mockClientDestroy,
         }),
       );
@@ -247,6 +248,7 @@ describe('Clerk singleton', () => {
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           activeSessions: [mockSession1, mockSession2],
+          sessions: [mockSession1, mockSession2],
           destroy: mockClientDestroy,
         }),
       );
@@ -265,6 +267,7 @@ describe('Clerk singleton', () => {
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           activeSessions: [mockSession1],
+          sessions: [mockSession1],
           destroy: mockClientDestroy,
         }),
       );
@@ -284,6 +287,7 @@ describe('Clerk singleton', () => {
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           activeSessions: [mockSession1, mockSession2],
+          sessions: [mockSession1, mockSession2],
           destroy: mockClientDestroy,
         }),
       );
@@ -305,6 +309,7 @@ describe('Clerk singleton', () => {
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           activeSessions: [mockSession1, mockSession2],
+          sessions: [mockSession1, mockSession2],
           destroy: mockClientDestroy,
         }),
       );

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -202,7 +202,7 @@ export default class Clerk implements ClerkInterface {
     }
 
     const session = this.client.activeSessions.find(s => s.id === opts.sessionId);
-    const shouldSignOutCurrent = this.session?.id === session?.id;
+    const shouldSignOutCurrent = session?.id && this.session?.id === session.id;
     await session?.remove();
     if (shouldSignOutCurrent) {
       return this.setActive({

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -187,7 +187,7 @@ export default class Clerk implements ClerkInterface {
   };
 
   public signOut: SignOut = async (callbackOrOptions?: SignOutCallback | SignOutOptions, options?: SignOutOptions) => {
-    if (!this.client || !this.session) {
+    if (!this.client || this.client.sessions.length === 0) {
       return;
     }
     const cb = typeof callbackOrOptions === 'function' ? callbackOrOptions : undefined;
@@ -202,7 +202,7 @@ export default class Clerk implements ClerkInterface {
     }
 
     const session = this.client.activeSessions.find(s => s.id === opts.sessionId);
-    const shouldSignOutCurrent = this.session.id === session?.id;
+    const shouldSignOutCurrent = this.session?.id === session?.id;
     await session?.remove();
     if (shouldSignOutCurrent) {
       return this.setActive({


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Bug:
It seems that when signing out of one of the sessions, and now being in the "Choose a user to continue with" screen, the signout button does nothing. This happens because there is no session at that point and the function returns.

Fix:
Instead of checking that a session exists, check the number of the sessions and return based on that. 
<!-- Fixes # (issue number) -->
