### PR TITLE
fix(nextjs): Use useSafeLayoutEffect to mute Nextjs warning

### DIFF
--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -6,6 +6,9 @@ import React from 'react';
 
 import { invalidateNextRouterCache } from './invalidateNextRouterCache';
 
+// TODO: Import from shared once [JS-118] is done
+export const useSafeLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
 __internal__setErrorThrowerOptions({
   packageName: '@clerk/nextjs',
 });
@@ -26,7 +29,7 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
 
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 
-  React.useLayoutEffect(() => {
+  useSafeLayoutEffect(() => {
     window.__unstable__onBeforeSetActive = invalidateNextRouterCache;
   }, []);
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
