### PR TITLE
Add extra checks before throwing error on ClerkJS initial network calls

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -2,6 +2,7 @@ import type { LocalStorageBroadcastChannel } from '@clerk/shared';
 import {
   inClientSide,
   isLegacyFrontendApiKey,
+  isValidBrowserOnline,
   isValidProxyUrl,
   noop,
   parsePublishableKey,
@@ -437,7 +438,7 @@ export default class Clerk implements ClerkInterface {
       session = (this.client.sessions.find(x => x.id === session) as ActiveSessionResource) || null;
     }
 
-    let newSession = (session === undefined ? this.session : session) as ActiveSessionResource | null;
+    let newSession = session === undefined ? this.session : session;
 
     // At this point, the `session` variable should contain either an `ActiveSessionResource`
     // or `null`.
@@ -999,6 +1000,9 @@ export default class Clerk implements ClerkInterface {
           // Purge and try setup again
           await this.#devBrowserHandler.clear();
           await this.#devBrowserHandler.setup();
+        } else if (!isValidBrowserOnline()) {
+          console.warn(err);
+          break;
         } else {
           throw err;
         }

--- a/packages/shared/src/utils/browser.test.ts
+++ b/packages/shared/src/utils/browser.test.ts
@@ -1,7 +1,99 @@
-import { inBrowser } from './browser';
+import { vi } from 'vitest';
+
+import { detectUserAgentRobot, inBrowser, isValidBrowserOnline } from './browser';
 
 describe.concurrent('inBrowser()', () => {
   it('returns true if window is defined', () => {
     expect(inBrowser()).toBe(true);
+  });
+});
+
+describe('detectUserAgentRobot', () => {
+  const botAgents = [
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    'DoCoMo/2.0 N905i(c100;TB;W24H16) (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)',
+    'Mozilla/5.0 (compatible; adidxbot/2.0;  http://www.bing.com/bingbot.htm)',
+    'LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)',
+    'msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36 (compatible; YandexScreenshotBot/3.0; +http://yandex.com/bots)',
+    'Mozilla/5.0 (compatible; spbot/1.0; +http://www.seoprofiler.com/bot/ )',
+  ];
+
+  it.each(botAgents)('returns true if User Agent name includes keyword that suggests automation/bot', agent => {
+    expect(detectUserAgentRobot(agent)).toBe(true);
+  });
+
+  const realAgents = [
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+  ];
+
+  it.each(realAgents)(
+    'returns false if User Agent name does not include keyword that suggests automation/bot',
+    agent => {
+      expect(detectUserAgentRobot(agent)).toBe(false);
+    },
+  );
+});
+
+describe('isValidBrowserOnline', () => {
+  let userAgentGetter: any;
+  let webdriverGetter: any;
+  let connectionGetter: any;
+
+  beforeEach(() => {
+    userAgentGetter = vi.spyOn(window.navigator, 'userAgent', 'get');
+    webdriverGetter = vi.spyOn(window.navigator, 'webdriver', 'get');
+    // @ts-ignore
+    connectionGetter = vi.spyOn(window.navigator, 'connection', 'get');
+  });
+
+  it('returns TRUE if user agent is online, has disabled webdriver, and not a bot', () => {
+    userAgentGetter.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
+    );
+    webdriverGetter.mockReturnValue(false);
+    connectionGetter.mockReturnValue({ downlink: 10, rtt: 100 });
+
+    expect(isValidBrowserOnline()).toBe(true);
+  });
+
+  it('returns FALSE if user agent is online, has disabled webdriver, and is a bot', () => {
+    userAgentGetter.mockReturnValue('msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)');
+    webdriverGetter.mockReturnValue(false);
+    connectionGetter.mockReturnValue({ downlink: 10, rtt: 100 });
+
+    expect(isValidBrowserOnline()).toBe(false);
+  });
+
+  it('returns FALSE if user agent is online, has ENABLED the webdriver flag, and is not a bot', () => {
+    userAgentGetter.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
+    );
+    webdriverGetter.mockReturnValue(true);
+    connectionGetter.mockReturnValue({ downlink: 10, rtt: 100 });
+
+    expect(isValidBrowserOnline()).toBe(false);
+  });
+
+  it('returns FALSE if user agent is NOT online, has disabled the webdriver flag, and is not a bot', () => {
+    userAgentGetter.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
+    );
+    webdriverGetter.mockReturnValue(false);
+    connectionGetter.mockReturnValue({ downlink: 0, rtt: 0 });
+
+    expect(isValidBrowserOnline()).toBe(false);
+  });
+
+  it('fallbacks to TRUE if the experimental connection property is not defined', () => {
+    userAgentGetter.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
+    );
+    webdriverGetter.mockReturnValue(false);
+    connectionGetter.mockReturnValue(undefined);
+
+    expect(isValidBrowserOnline()).toBe(true);
   });
 });

--- a/packages/shared/src/utils/browser.ts
+++ b/packages/shared/src/utils/browser.ts
@@ -1,3 +1,62 @@
 export function inBrowser(): boolean {
   return typeof window !== 'undefined';
 }
+
+export function detectUserAgentRobot(userAgent: string): boolean {
+  const robots = new RegExp(
+    (
+      [
+        /bot/,
+        /spider/,
+        /crawl/,
+        /APIs-Google/,
+        /AdsBot/,
+        /Googlebot/,
+        /mediapartners/,
+        /Google Favicon/,
+        /FeedFetcher/,
+        /Google-Read-Aloud/,
+        /DuplexWeb-Google/,
+        /googleweblight/,
+        /bing/,
+        /yandex/,
+        /baidu/,
+        /duckduck/,
+        /yahoo/,
+        /ecosia/,
+        /ia_archiver/,
+        /facebook/,
+        /instagram/,
+        /pinterest/,
+        /reddit/,
+        /slack/,
+        /twitter/,
+        /whatsapp/,
+        /youtube/,
+        /semrush/,
+      ] as RegExp[]
+    )
+      .map(r => r.source)
+      .join('|'),
+    'i',
+  );
+
+  return robots.test(userAgent);
+}
+
+export function isValidBrowserOnline(): boolean {
+  const navigator = window?.navigator;
+  if (!inBrowser() || !navigator) {
+    return false;
+  }
+
+  const isUserAgentRobot = detectUserAgentRobot(navigator?.userAgent);
+  const isWebDriver = navigator?.webdriver;
+
+  // Being extra safe with the experimental `connection` property, as it is not defined in all browsers
+  // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/connection#browser_compatibility
+  // @ts-ignore
+  const isUserAgentOnline = navigator?.connection?.rtt !== 0 && navigator?.connection?.downlink !== 0;
+
+  return !isUserAgentRobot && !isWebDriver && isUserAgentOnline;
+}

--- a/packages/shared/testUtils/setupGlobals.ts
+++ b/packages/shared/testUtils/setupGlobals.ts
@@ -1,0 +1,10 @@
+const navigatorMock = {
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
+  webdriver: false,
+  connection: { downlink: 10, rtt: 100 },
+};
+
+Object.defineProperty(window, 'navigator', {
+  value: navigatorMock,
+  writable: true,
+});

--- a/packages/shared/vite.config.ts
+++ b/packages/shared/vite.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: './testUtils/setupGlobals.ts',
   },
 });


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR tries to reduce the errors thrown when ClerkJS tries to initialize and fails on the first `/environment` and `/client` API calls to FAPI.

The following properties of the Navigator API have been used:
- [Navigator.userAgent](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent), to determine if the page is accessed by web crawlers/bots.
- [Navigator.webdriver](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver): This flag is enabled by automated tools (e.g. puppeteer) when accessing a web app.
- [Navigator.connection](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/connection): This **experimental** property holds information about the browser's network connection. As it is still an experimental feature, we use it with caution.

If the user trying to initialize ClerkJS, meets one of the above criteria (is offline or bot/automated tool), then the error will be shown as a console warning instead of throwing an actual error.