### PR TITLE
fix(clerk-js): Fix modals not closing in firefox when focus is lost

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -44,8 +44,7 @@
     "@clerk/types": "^3.25.0",
     "@emotion/cache": "11.10.5",
     "@emotion/react": "11.10.5",
-    "@floating-ui/react-dom-interactions": "0.6.6",
-    "@popperjs/core": "2.11.6",
+    "@floating-ui/react": "0.19.0",
     "browser-tabs-lock": "1.2.15",
     "classnames": "2.3.2",
     "copy-to-clipboard": "3.3.3",
@@ -56,7 +55,6 @@
     "qs": "6.11.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-popper": "2.3.0",
     "regenerator-runtime": "0.13.11"
   },
   "devDependencies": {
@@ -118,7 +116,7 @@
     "files": [
       {
         "path": "./dist/clerk.browser.js",
-        "maxSize": "181kB"
+        "maxSize": "185kB"
       },
       {
         "path": "./dist/clerk.headless.js",

--- a/packages/clerk-js/src/ui/elements/Menu.tsx
+++ b/packages/clerk-js/src/ui/elements/Menu.tsx
@@ -23,6 +23,7 @@ export const Menu = withFloatingTree((props: MenuProps) => {
   const popoverCtx = usePopover({
     placement: 'right-start',
     offset: 8,
+    bubbles: false,
   });
 
   const value = React.useMemo(() => ({ value: { popoverCtx } }), [{ ...popoverCtx }]);

--- a/packages/clerk-js/src/ui/elements/Modal.tsx
+++ b/packages/clerk-js/src/ui/elements/Modal.tsx
@@ -19,7 +19,6 @@ export const Modal = withFloatingTree((props: ModalProps) => {
   const { floating, isOpen, context, nodeId } = usePopover({
     defaultOpen: true,
     autoUpdate: false,
-    bubbles: false,
   });
   const { disableScroll, enableScroll } = useScrollLock(document.body);
 

--- a/packages/clerk-js/src/ui/elements/Popover.tsx
+++ b/packages/clerk-js/src/ui/elements/Popover.tsx
@@ -1,7 +1,7 @@
-import type { FloatingContext, ReferenceType } from '@floating-ui/react-dom-interactions';
-import { FloatingFocusManager, FloatingNode, FloatingPortal } from '@floating-ui/react-dom-interactions';
-import React from 'react';
+import type { FloatingContext, ReferenceType } from '@floating-ui/react';
+import { FloatingFocusManager, FloatingNode, FloatingPortal } from '@floating-ui/react';
 import type { PropsWithChildren } from 'react';
+import React from 'react';
 
 type PopoverProps = PropsWithChildren<{
   context: FloatingContext<ReferenceType>;

--- a/packages/clerk-js/src/ui/elements/Select.tsx
+++ b/packages/clerk-js/src/ui/elements/Select.tsx
@@ -82,7 +82,7 @@ export const Select = withFloatingTree(<O extends Option>(props: PropsWithChildr
     children,
     ...rest
   } = props;
-  const popoverCtx = usePopover({ autoUpdate: false });
+  const popoverCtx = usePopover({ autoUpdate: false, bubbles: false });
   const togglePopover = popoverCtx.toggle;
   const focusedItemRef = React.useRef<HTMLDivElement>(null);
   const searchInputCtx = useSearchInput({

--- a/packages/clerk-js/src/ui/elements/contexts/FloatingTreeContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/FloatingTreeContext.tsx
@@ -1,4 +1,4 @@
-import { FloatingTree, useFloatingParentNodeId } from '@floating-ui/react-dom-interactions';
+import { FloatingTree, useFloatingParentNodeId } from '@floating-ui/react';
 import React from 'react';
 
 export const withFloatingTree = <T,>(Component: React.ComponentType<T>): React.ComponentType<T> => {

--- a/packages/clerk-js/src/ui/hooks/usePopover.ts
+++ b/packages/clerk-js/src/ui/hooks/usePopover.ts
@@ -1,13 +1,5 @@
-import type { UseFloatingProps } from '@floating-ui/react-dom-interactions';
-import {
-  autoUpdate,
-  flip,
-  offset,
-  shift,
-  useDismiss,
-  useFloating,
-  useFloatingNodeId,
-} from '@floating-ui/react-dom-interactions';
+import type { UseFloatingProps } from '@floating-ui/react';
+import { autoUpdate, flip, offset, shift, useDismiss, useFloating, useFloatingNodeId } from '@floating-ui/react';
 import React, { useEffect } from 'react';
 
 type UsePopoverProps = {
@@ -15,7 +7,12 @@ type UsePopoverProps = {
   placement?: UseFloatingProps['placement'];
   offset?: Parameters<typeof offset>[0];
   autoUpdate?: boolean;
-  bubbles?: boolean;
+  bubbles?:
+    | boolean
+    | {
+        escapeKey?: boolean;
+        outsidePress?: boolean;
+      };
 };
 
 export type UsePopoverReturn = ReturnType<typeof usePopover>;
@@ -24,7 +21,7 @@ export const usePopover = (props: UsePopoverProps = {}) => {
   const { bubbles = true } = props;
   const [isOpen, setIsOpen] = React.useState(props.defaultOpen || false);
   const nodeId = useFloatingNodeId();
-  const { update, reference, floating, strategy, x, y, context, refs } = useFloating({
+  const { update, reference, floating, strategy, x, y, context } = useFloating({
     open: isOpen,
     onOpenChange: setIsOpen,
     nodeId,
@@ -34,24 +31,6 @@ export const usePopover = (props: UsePopoverProps = {}) => {
   });
 
   useDismiss(context, { bubbles });
-
-  useEffect(() => {
-    const handleFocus = (e: FocusEvent) => {
-      if (!e.relatedTarget) {
-        (refs.floating.current as HTMLElement | null)?.focus();
-      }
-    };
-
-    if (!bubbles) {
-      window.addEventListener('focusout', handleFocus);
-    }
-
-    return () => {
-      if (!bubbles) {
-        window.removeEventListener('focusout', handleFocus);
-      }
-    };
-  }, [bubbles]);
 
   useEffect(() => {
     if (props.defaultOpen) {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This will increase our bundlesize a bit since the floating-ui package has increased in size. Their implementation change that enables us to do this is quite recent as well. If the firefox issue (https://bugzilla.mozilla.org/show_bug.cgi?id=1363964) were to be resolved, we would not really need this, but the updates from floating-ui make our lives a little bit easier nonetheless.
<!-- Fixes # (issue number) -->
