### PR TITLE
Include isSatellite and domain to interstitial and authenticateRequest

### DIFF
--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -1,9 +1,9 @@
 import type { JwtPayload } from '@clerk/types';
-import type { SignedInAuthObject, SignedOutAuthObject } from './authObjects';
-import type { TokenVerificationErrorReason } from './errors';
 
 import { createBackendApiClient } from '../api';
+import type { SignedInAuthObject, SignedOutAuthObject } from './authObjects';
 import { signedInAuthObject, signedOutAuthObject } from './authObjects';
+import type { TokenVerificationErrorReason } from './errors';
 
 export enum AuthStatus {
   SignedIn = 'signed-in',
@@ -19,6 +19,8 @@ export type SignedInState = {
   frontendApi: string;
   proxyUrl?: string;
   publishableKey: string;
+  isSatellite: boolean;
+  domain: string;
   isSignedIn: true;
   isInterstitial: false;
   isUnknown: false;
@@ -32,6 +34,8 @@ export type SignedOutState = {
   frontendApi: string;
   proxyUrl?: string;
   publishableKey: string;
+  isSatellite: boolean;
+  domain: string;
   isSignedIn: false;
   isInterstitial: false;
   isUnknown: false;
@@ -78,6 +82,8 @@ export async function signedIn<T>(options: T, sessionClaims: JwtPayload): Promis
     frontendApi,
     proxyUrl,
     publishableKey,
+    domain,
+    isSatellite,
     headerToken,
     loadSession,
     loadUser,
@@ -127,6 +133,8 @@ export async function signedIn<T>(options: T, sessionClaims: JwtPayload): Promis
     frontendApi,
     proxyUrl,
     publishableKey,
+    domain,
+    isSatellite,
     isSignedIn: true,
     isInterstitial: false,
     isUnknown: false,
@@ -135,7 +143,7 @@ export async function signedIn<T>(options: T, sessionClaims: JwtPayload): Promis
 }
 
 export function signedOut<T>(options: T, reason: AuthReason, message = ''): SignedOutState {
-  const { frontendApi, publishableKey, proxyUrl } = options as any;
+  const { frontendApi, publishableKey, proxyUrl, isSatellite, domain } = options as any;
 
   return {
     status: AuthStatus.SignedOut,
@@ -144,6 +152,8 @@ export function signedOut<T>(options: T, reason: AuthReason, message = ''): Sign
     frontendApi,
     proxyUrl,
     publishableKey,
+    isSatellite,
+    domain,
     isSignedIn: false,
     isInterstitial: false,
     isUnknown: false,
@@ -152,14 +162,16 @@ export function signedOut<T>(options: T, reason: AuthReason, message = ''): Sign
 }
 
 export function interstitial<T>(options: T, reason: AuthReason, message = ''): InterstitialState {
-  const { frontendApi, publishableKey, proxyUrl } = options as any;
+  const { frontendApi, publishableKey, proxyUrl, isSatellite, domain } = options as any;
   return {
     status: AuthStatus.Interstitial,
     reason,
     message,
-    frontendApi: frontendApi,
+    frontendApi,
+    publishableKey,
+    isSatellite,
+    domain,
     proxyUrl,
-    publishableKey: publishableKey,
     isSignedIn: false,
     isInterstitial: true,
     isUnknown: false,
@@ -168,13 +180,15 @@ export function interstitial<T>(options: T, reason: AuthReason, message = ''): I
 }
 
 export function unknownState<T>(options: T, reason: AuthReason, message = ''): UnknownState {
-  const { frontendApi, publishableKey } = options as any;
+  const { frontendApi, publishableKey, isSatellite, domain } = options as any;
   return {
     status: AuthStatus.Unknown,
     reason,
     message,
-    frontendApi: frontendApi,
-    publishableKey: publishableKey,
+    frontendApi,
+    publishableKey,
+    isSatellite,
+    domain,
     isSignedIn: false,
     isInterstitial: false,
     isUnknown: true,

--- a/packages/backend/src/tokens/factory.ts
+++ b/packages/backend/src/tokens/factory.ts
@@ -2,7 +2,7 @@ import type { ApiClient } from '../api';
 import { API_URL, API_VERSION } from '../constants';
 import type { LoadInterstitialOptions } from './interstitial';
 import { buildPublicInterstitialUrl, loadInterstitialFromBAPI, loadInterstitialFromLocal } from './interstitial';
-import type { AuthenticateRequestOptions } from './request';
+import type { AuthenticateRequestOptions, AuthenticateRequestOptionsWithExperimental } from './request';
 import { authenticateRequest as authenticateRequestOriginal, debugRequestState } from './request';
 
 export type CreateAuthenticateRequestOptions = {
@@ -26,6 +26,10 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
     frontendApi: buildtimeFrontendApi = '',
     proxyUrl: buildProxyUrl = '',
     publishableKey: buildtimePublishableKey = '',
+    // @ts-expect-error
+    isSatellite: buildtimeIsSatellite = false,
+    // @ts-expect-error
+    domain: buildtimeDomain = '',
   } = params.options;
 
   const authenticateRequest = ({
@@ -37,6 +41,9 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
     jwtKey: runtimeJwtKey,
     ...rest
   }: Omit<AuthenticateRequestOptions, 'apiUrl' | 'apiVersion'>) => {
+    const { isSatellite: runtimeIsSatellite, domain: runtimeDomain } =
+      rest as Partial<AuthenticateRequestOptionsWithExperimental>;
+
     return authenticateRequestOriginal({
       ...rest,
       apiKey: runtimeApiKey || buildtimeApiKey,
@@ -46,6 +53,9 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
       frontendApi: runtimeFrontendApi || buildtimeFrontendApi,
       proxyUrl: runtimeProxyUrl || buildProxyUrl,
       publishableKey: runtimePublishableKey || buildtimePublishableKey,
+      // @ts-expect-error
+      isSatellite: runtimeIsSatellite || buildtimeIsSatellite,
+      domain: runtimeDomain || buildtimeDomain,
       jwtKey: runtimeJwtKey || buildtimeJwtKey,
     });
   };

--- a/packages/backend/src/tokens/request.test.ts
+++ b/packages/backend/src/tokens/request.test.ts
@@ -6,7 +6,8 @@ import { jsonOk } from '../util/mockFetch';
 import { type AuthReason, type RequestState, AuthErrorReason, AuthStatus } from './authStatus';
 import { TokenVerificationErrorReason } from './errors';
 import { mockInvalidSignatureJwt, mockJwks, mockJwt, mockJwtPayload, mockMalformedJwt } from './fixtures';
-import { type AuthenticateRequestOptions, authenticateRequest } from './request';
+import type { AuthenticateRequestOptionsWithExperimental } from './request';
+import { authenticateRequest } from './request';
 
 function assertSignedOut(assert, requestState: RequestState, reason: AuthReason, message = '') {
   assert.propEqual(requestState, {
@@ -17,6 +18,8 @@ function assertSignedOut(assert, requestState: RequestState, reason: AuthReason,
     isSignedIn: false,
     isInterstitial: false,
     isUnknown: false,
+    isSatellite: false,
+    domain: '',
     message,
     reason,
     toAuth: {},
@@ -47,6 +50,8 @@ function assertInterstitial(assert, requestState: RequestState, reason: AuthReas
     isSignedIn: false,
     isInterstitial: true,
     isUnknown: false,
+    isSatellite: false,
+    domain: '',
     reason,
     toAuth: {},
   });
@@ -60,6 +65,8 @@ function assertUnknown(assert, requestState: RequestState, reason: AuthReason) {
     isSignedIn: false,
     isInterstitial: false,
     isUnknown: true,
+    isSatellite: false,
+    domain: '',
     reason,
     toAuth: {},
   });
@@ -89,6 +96,8 @@ function assertSignedIn(assert, requestState: RequestState) {
     isSignedIn: true,
     isInterstitial: false,
     isUnknown: false,
+    isSatellite: false,
+    domain: '',
   });
 }
 
@@ -96,7 +105,7 @@ export default (QUnit: QUnit) => {
   const { module, test, skip } = QUnit;
 
   /* An otherwise bare state on a request. */
-  const defaultMockAuthenticateRequestOptions: AuthenticateRequestOptions = {
+  const defaultMockAuthenticateRequestOptions: AuthenticateRequestOptionsWithExperimental = {
     apiKey: 'deadbeef',
     secretKey: '',
     apiUrl: 'https://api.clerk.test',
@@ -107,6 +116,8 @@ export default (QUnit: QUnit) => {
     host: 'example.com',
     userAgent: 'Mozilla/TestAgent',
     skipJwksCache: true,
+    isSatellite: false,
+    domain: '',
   };
 
   module('tokens.authenticateRequest(options)', hooks => {

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -35,6 +35,20 @@ export type OptionalVerifyTokenOptions = Partial<
   >
 >;
 
+export type AuthenticateRequestOptionsWithExperimental = {
+  /**
+   * @experimental
+   */
+  domain?: string;
+  /**
+   * @experimental
+   */
+  isSatellite?: boolean;
+
+  /* Proxy url for FAPI requests */
+  proxyUrl?: string;
+} & AuthenticateRequestOptions;
+
 export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
   OptionalVerifyTokenOptions &
   LoadResourcesOptions & {
@@ -62,12 +76,14 @@ export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
     referrer?: string;
     /* Request user-agent value */
     userAgent?: string;
-    /* Proxy url for FAPI requests */
-    proxyUrl?: string;
   };
 
 export async function authenticateRequest(options: AuthenticateRequestOptions): Promise<RequestState> {
-  options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
+  options.frontendApi =
+    (options as AuthenticateRequestOptionsWithExperimental).domain ||
+    parsePublishableKey(options.publishableKey)?.frontendApi ||
+    options.frontendApi ||
+    '';
   options.apiUrl = options.apiUrl || API_URL;
   options.apiVersion = options.apiVersion || API_VERSION;
 
@@ -126,6 +142,6 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
 }
 
 export const debugRequestState = (params: RequestState) => {
-  const { frontendApi, isSignedIn, proxyUrl, isInterstitial, reason, message, publishableKey } = params;
-  return { frontendApi, isSignedIn, proxyUrl, isInterstitial, reason, message, publishableKey };
+  const { frontendApi, isSignedIn, proxyUrl, isInterstitial, reason, message, publishableKey, isSatellite, domain } = params;
+  return { frontendApi, isSignedIn, proxyUrl, isInterstitial, reason, message, publishableKey, isSatellite, domain };
 };

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -955,11 +955,16 @@ export default class Clerk implements ClerkInterface {
     this.#componentControls?.updateProps(props);
   };
 
-  #syncWithPrimary = () => {
+  #syncWithPrimary = async () => {
     const q = new URLSearchParams({
       redirect_url: createClerkQueryParam('__clerk_synced', 'true').toString(),
     });
-    window.location.replace(new URL(`/v1/client/sync?${q.toString()}`, `https://${this.domain}`).toString());
+    if (this.proxyUrl) {
+      const proxy = new URL(this.proxyUrl);
+      windowNavigate(new URL(`${proxy.pathname}/v1/client/sync?${q.toString()}`, proxy.origin).toString());
+    } else {
+      await this.navigate(new URL(`/v1/client/sync?${q.toString()}`, `https://${this.domain}`).toString());
+    }
   };
 
   #handleSyncedQueryParam = () => {
@@ -974,7 +979,7 @@ export default class Clerk implements ClerkInterface {
 
   #loadInStandardBrowser = async (): Promise<boolean> => {
     if (this.#shouldSyncWithPrimary()) {
-      this.#syncWithPrimary();
+      await this.#syncWithPrimary();
       return false;
     }
 

--- a/packages/nextjs/src/server/clerk.ts
+++ b/packages/nextjs/src/server/clerk.ts
@@ -6,6 +6,7 @@ export const API_KEY = process.env.CLERK_API_KEY || '';
 export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
 export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
+export const DOMAIN = process.env.NEXT_PUBLIC_CLERK_DOMAIN || '';
 export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';
 
 const clerkClient = Clerk({
@@ -16,6 +17,8 @@ const clerkClient = Clerk({
   // TODO: Fetch version from package.json
   userAgent: '@clerk/nextjs',
   proxyUrl: PROXY_URL,
+  // @ts-expect-error
+  domain: DOMAIN,
 });
 
 const createClerkClient = Clerk;

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -3,6 +3,17 @@ import type { DataFunctionArgs, LoaderFunction } from '@remix-run/server-runtime
 
 export type GetAuthReturn = Promise<AuthObject>;
 
+export type RootAuthLoaderOptionsWithExperimental = RootAuthLoaderOptions & {
+  /**
+   * @experimental
+   */
+  isSatellite?: boolean;
+  /**
+   * @experimental
+   */
+  domain?: string;
+};
+
 export type RootAuthLoaderOptions = {
   /**
    * @deprecated Use `publishableKey` instead.

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -54,9 +54,12 @@ export const interstitialJsonResponse = (requestState: RequestState, opts: { loa
       __clerk_ssr_interstitial_html: loadInterstitialFromLocal({
         debugData: debugRequestState(requestState),
         frontendApi: requestState.frontendApi,
-        proxyUrl: requestState.proxyUrl || '',
         publishableKey: requestState.publishableKey,
         pkgVersion: LIB_VERSION,
+        // @ts-expect-error
+        proxyUrl: requestState.proxyUrl,
+        isSatellite: requestState.isSatellite,
+        domain: requestState.domain,
       }),
     }),
     { status: 401 },


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

How to use in a Remix app 
```typescript
export const loader: LoaderFunction = args => {
  return rootAuthLoader(
    args,
    ({ request }) => {....},
    { loadUser: true, isSatellite: true, domain: 'clerk.satellite.dev' },
  );
};
```
and also 
```typescript
export default ClerkApp(App, {
  isSatellite: true,
  domain: 'clerk.satellite.dev',
});
```
⚠️ This is an experimental feature under active development
- You can use these properties and their values when this PR is merged
- You will receive type errors as `isSatellite` & `domain` are not available in types yet

<!-- Fixes # (issue number) -->
