### PR TITLE
Support custom responses and headers in Remix rootAuthLoader

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -25,10 +25,15 @@ const Headers = {
   UserAgent: 'user-agent',
   Origin: 'origin',
   Host: 'host',
+  ContentType: 'content-type',
 } as const;
 
 const SearchParams = {
   AuthStatus: Headers.AuthStatus,
+} as const;
+
+const ContentTypes = {
+  Json: 'application/json',
 } as const;
 
 export const constants = {
@@ -36,4 +41,5 @@ export const constants = {
   Cookies,
   Headers,
   SearchParams,
+  ContentTypes,
 } as const;

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -1,7 +1,7 @@
 const createErrorMessage = (msg: string) => {
   return `🔒 Clerk: ${msg.trim()}
 
-For more info, check out the docs: https://docs.clerk.dev,
+For more info, check out the docs: https://clerk.dev/docs,
 or come say hi in our discord server: https://rebrand.ly/clerk-discord
 
 `;
@@ -48,20 +48,23 @@ export const loader: LoaderFunction = async (args) => {
 };
 `);
 
-export const invalidRootLoaderCallbackResponseReturn = createErrorMessage(`
-You're returning an invalid 'Response' object from the 'rootAuthLoader' in root.tsx.
-You can return numbers, strings, objects, booleans, and redirect 'Response' objects (status codes in the range of 300 to 400)
-`);
-
 export const invalidRootLoaderCallbackReturn = createErrorMessage(`
-You're returning an invalid value from 'rootAuthLoader' in root.tsx.
-You can only return plain objects or redirect 'Response' objects (status codes in the range of 300 to 400).
-If you want to return a primitive value or an array, wrap the response with an object.
+You're returning an invalid response from the 'rootAuthLoader' called from the loader in root.tsx.
+You can only return plain objects, responses created using the Remix 'json()' and 'redirect()' helpers,
+custom redirect 'Response' instances (status codes in the range of 300 to 400),
+or custom json 'Response' instances (containing a body that is a valid json string).
+If you want to return a primitive value or an array, you can always wrap the response with an object.
+
 Example:
 
 export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) => {
     const { userId } = auth;
     const posts: Post[] = database.getPostsByUserId(userId);
+
+    return json({ data: posts })
+    // or
+    return new Response(JSON.stringify({ data: posts }), { headers: { 'Content-Type': 'application/json' } });
+    // or
     return { data: posts };
 })
 `);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
We used to accept only plain objects as valid return values from the Remix `rootAuthLoader` helper. This PR adds support for custom instances of the Response class and custom headers. 

It's also important to note with this change, the API of the root loader for Remix apps using Clerk is now aligned to the api of any other loader, as both can return the same type of responses.

One limitation that remains is that if a custom non-redirect response is returned, its body must be a valid json object or a valid json string; otherwise we won't be able to inject the Clerk state.

Example usage:

```ts
export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) => {
    const { userId } = auth;
    const posts: Post[] = database.getPostsByUserId(userId);

    return json({ data: posts })
})
```

```ts
export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) => {
    const { userId } = auth;
    const posts: Post[] = database.getPostsByUserId(userId);

    return new Response(JSON.stringify({ data: posts }), { headers: { 'Content-Type': 'application/json' } });
})
```

```ts
export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) => {
    const { userId } = auth;
    const posts: Post[] = database.getPostsByUserId(userId);

    return { data: posts };
})
```

```ts
export const loader: LoaderFunction = args => rootAuthLoader(args, ({ auth }) => {
    const { userId } = auth;
    ...
    return redirect('/sign-in');
})
```

Custom headers example:
root.tsx
```ts
export const loader: LoaderFunction = args => rootAuthLoader(args, args => {
  return json({ data: 'test' }, { headers: { 'x-custom-header-1': 'hello' } });
})

export const headers: HeadersFunction = args => {
  return args.loaderHeaders
};
```

hello.tsx
```ts
export const loader: LoaderFunction = async args => {
  const headers = new Headers({ 'x-custom-header-2': 'there' });
  return json({ loader: 'index' }, { headers });
};

// util to return all headers
export const headers: HeadersFunction = args => {
  const { parentHeaders, loaderHeaders, actionHeaders } = args;
  const get = (hdrs: Headers) => ({ ...Object.fromEntries(hdrs.entries()) });
  return { ...get(parentHeaders), ...get(loaderHeaders), ...get(actionHeaders) };
};
```

Result in browser:
<img width="293" alt="image" src="https://user-images.githubusercontent.com/1811063/216014189-94873663-e2e1-4aca-84ae-b8d5df4e43f6.png">


The error thrown is the user ends up returning an invalid value, eg: a number 

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/1811063/216012578-980643de-96e1-4bd5-90e4-8beb9cb8cb98.png">


<!-- Fixes # (issue number) -->
