### PR TITLE
fix(remix): Use CLERK_API_URL internally

### DIFF
--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -32,13 +32,15 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
 
   const jwtKey = getEnvVariable('CLERK_JWT_KEY') || (context?.CLERK_JWT_KEY as string) || opts.jwtKey;
 
+  const apiUrl = getEnvVariable('CLERK_API_URL') || (context?.CLERK_API_URL as string);
+
   const { headers } = request;
   const cookies = parseCookies(request);
 
   const cookieToken = cookies['__session'];
   const headerToken = headers.get('authorization')?.replace('Bearer ', '');
 
-  return Clerk({ apiKey, secretKey, jwtKey }).authenticateRequest({
+  return Clerk({ apiUrl, apiKey, secretKey, jwtKey }).authenticateRequest({
     apiKey,
     secretKey,
     jwtKey,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Allowing to bypass the default api url (set in @clerk/backend) by using the `CLERK_API_URL` in remix
<!-- Fixes # (issue number) -->
