### PR TITLE
fix(clerk-js): Add missing autoFocus prop to inputs

### DIFF
--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationPage.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationPage.tsx
@@ -78,6 +78,7 @@ export const CreateOrganizationPage = withCardStateProvider(() => {
           <Form.ControlRow elementId={nameField.id}>
             <Form.Control
               sx={{ flexBasis: '80%' }}
+              autoFocus
               {...nameField.props}
               required
             />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -111,6 +111,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
             <Text localizationKey={localizationKeys('formFieldLabel__emailAddresses')} />
             <TagInput
               {...emailAddressField.props}
+              autoFocus
               validate={isEmail}
               sx={{ width: '100%' }}
             />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileSettingsPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileSettingsPage.tsx
@@ -76,6 +76,7 @@ export const ProfileSettingsPage = withCardStateProvider(() => {
           <Form.ControlRow elementId={nameField.id}>
             <Form.Control
               {...nameField.props}
+              autoFocus
               required
             />
           </Form.ControlRow>

--- a/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
@@ -91,6 +91,7 @@ export const ProfilePage = withCardStateProvider(() => {
           {showFirstName && (
             <Form.ControlRow elementId={firstNameField.id}>
               <Form.Control
+                autoFocus
                 {...firstNameField.props}
                 required={first_name.required}
               />

--- a/packages/clerk-js/src/ui/elements/TagInput.tsx
+++ b/packages/clerk-js/src/ui/elements/TagInput.tsx
@@ -15,11 +15,20 @@ type TagInputProps = Pick<PropsOfComponent<typeof Flex>, 'sx'> & {
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   validate?: (tag: Tag) => boolean;
   placeholder?: LocalizationKey | string;
+  autoFocus?: boolean;
 };
 
 export const TagInput = (props: TagInputProps) => {
   const { t } = useLocalizations();
-  const { sx, placeholder, validate = () => true, value: valueProp, onChange: onChangeProp, ...rest } = props;
+  const {
+    sx,
+    placeholder,
+    validate = () => true,
+    value: valueProp,
+    onChange: onChangeProp,
+    autoFocus,
+    ...rest
+  } = props;
   const tags = valueProp.split(',').map(sanitize).filter(Boolean);
   const tagsSet = new Set(tags);
   const keyReleasedRef = React.useRef(true);
@@ -138,6 +147,7 @@ export const TagInput = (props: TagInputProps) => {
         onChange={handleChange}
         onPaste={handlePaste}
         focusRing={false}
+        autoFocus={autoFocus}
         sx={t => ({
           flexGrow: 1,
           border: 'none',


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
