### PR TITLE
fix(backend,nextjs): Serialize auth objects before sending to client

### DIFF
--- a/packages/backend/src/tokens/authObjects.ts
+++ b/packages/backend/src/tokens/authObjects.ts
@@ -147,6 +147,20 @@ export function sanitizeAuthObject<T extends Record<any, any>>(authObject: T): T
   return { ...authObject, user, organization };
 }
 
+/**
+ * Auth objects moving through the server -> client boundary need to be serializable
+ * as we need to ensure that they can be transferred via the network as pure strings.
+ * Some frameworks like Remix or Next (/pages dir only) handle this serialization by simply
+ * ignoring any non-serializable keys, however Nextjs /app directory is stricter and
+ * throws an error if a non-serializable value is found.
+ */
+export const makeAuthObjectSerializable = <T extends Record<string, unknown>>(obj: T): T => {
+  // remove any non-serializable props from the returned object
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { debug, getToken, ...rest } = obj as unknown as AuthObject;
+  return rest as unknown as T;
+};
+
 type TokenFetcher = (sessionId: string, template: string) => Promise<string>;
 
 type CreateGetToken = (params: { sessionId: string; sessionToken: string; fetcher: TokenFetcher }) => ServerGetToken;

--- a/packages/nextjs/src/api/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/nextjs/src/api/__tests__/__snapshots__/exports.test.ts.snap
@@ -40,6 +40,7 @@ Array [
   "hasValidSignature",
   "invitations",
   "loadInterstitialFromLocal",
+  "makeAuthObjectSerializable",
   "organizations",
   "phoneNumbers",
   "prunePrivateMetadata",

--- a/packages/nextjs/src/edge-middleware/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/nextjs/src/edge-middleware/__tests__/__snapshots__/exports.test.ts.snap
@@ -41,6 +41,7 @@ Array [
   "hasValidSignature",
   "invitations",
   "loadInterstitialFromLocal",
+  "makeAuthObjectSerializable",
   "organizations",
   "phoneNumbers",
   "prunePrivateMetadata",

--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -1,7 +1,14 @@
 import { constants } from '@clerk/backend';
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
-import { API_URL, clerkClient, FRONTEND_API, PUBLISHABLE_KEY, sanitizeAuthObject } from '../server/clerk';
+import {
+  API_URL,
+  clerkClient,
+  FRONTEND_API,
+  makeAuthObjectSerializable,
+  PUBLISHABLE_KEY,
+  sanitizeAuthObject,
+} from '../server/clerk';
 import type { WithServerSideAuthCallback, WithServerSideAuthOptions, WithServerSideAuthResult } from './types';
 import { authenticateRequest, injectAuthIntoRequest, injectSSRStateIntoProps } from './utils';
 
@@ -45,6 +52,6 @@ export const withServerSideAuth: WithServerSideAuth = (cbOrOptions: any, options
     const legacyAuthData = { ...requestState.toAuth(), claims: requestState.toAuth().sessionClaims };
     const contextWithAuth = injectAuthIntoRequest(ctx, legacyAuthData);
     const callbackResult = (await cb?.(contextWithAuth)) || {};
-    return injectSSRStateIntoProps(callbackResult, sanitizeAuthObject(legacyAuthData));
+    return injectSSRStateIntoProps(callbackResult, makeAuthObjectSerializable(sanitizeAuthObject(legacyAuthData)));
   };
 };

--- a/packages/nextjs/src/server/getAuth.ts
+++ b/packages/nextjs/src/server/getAuth.ts
@@ -1,4 +1,4 @@
-import type { Organization, Session, User, SignedInAuthObject, SignedOutAuthObject } from '@clerk/backend';
+import type { Organization, Session, SignedInAuthObject, SignedOutAuthObject, User } from '@clerk/backend';
 import {
   AuthStatus,
   constants,
@@ -7,6 +7,7 @@ import {
   signedInAuthObject,
   signedOutAuthObject,
 } from '@clerk/backend';
+import { makeAuthObjectSerializable } from '@clerk/backend/src';
 
 import { API_KEY, API_URL, API_VERSION, SECRET_KEY } from './clerk';
 import type { RequestLike } from './types';
@@ -76,7 +77,7 @@ export const buildClerkProps: BuildClerkProps = (req, initState = {}) => {
     token: raw.text,
   });
 
-  const sanitizedAuthObject = sanitizeAuthObject({ ...authObject, ...initState });
+  const sanitizedAuthObject = makeAuthObjectSerializable(sanitizeAuthObject({ ...authObject, ...initState }));
   return injectSSRStateIntoObject({}, sanitizedAuthObject);
 };
 

--- a/packages/sdk-node/src/__tests__/__snapshots__/exports.test.ts.snap
+++ b/packages/sdk-node/src/__tests__/__snapshots__/exports.test.ts.snap
@@ -45,6 +45,7 @@ Array [
   "hasValidSignature",
   "invitations",
   "loadInterstitialFromLocal",
+  "makeAuthObjectSerializable",
   "organizations",
   "phoneNumbers",
   "prunePrivateMetadata",


### PR DESCRIPTION

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Auth objects moving through the server -> client boundary need to be serializable as we need to ensure that they can be transfered via the network as pure strings. Some frameworks like Remix or Next (/pages dir only) handle this serialization by simply ignoring any non-serializable keys, however Nextjs /app directory is stricter and throws an error if a non-serializable value is found.

<!-- Fixes # (issue number) -->
