### PR TITLE
Add an extra check for network status using the Navigator API `onLine` property

### DIFF
--- a/packages/shared/setupJest.ts
+++ b/packages/shared/setupJest.ts
@@ -14,6 +14,13 @@ Object.defineProperty(navigatorMock, 'webdriver', {
   configurable: true,
 });
 
+Object.defineProperty(navigatorMock, 'onLine', {
+  get() {
+    return true;
+  },
+  configurable: true,
+});
+
 Object.defineProperty(navigatorMock, 'connection', {
   get() {
     return { downlink: 10, rtt: 100 };

--- a/packages/shared/src/utils/browser.test.ts
+++ b/packages/shared/src/utils/browser.test.ts
@@ -38,49 +38,66 @@ describe('detectUserAgentRobot', () => {
 describe('isValidBrowserOnline', () => {
   let userAgentGetter: any;
   let webdriverGetter: any;
+  let onLineGetter: any;
   let connectionGetter: any;
 
   beforeEach(() => {
     userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
     webdriverGetter = jest.spyOn(window.navigator, 'webdriver', 'get');
+    onLineGetter = jest.spyOn(window.navigator, 'onLine', 'get');
     // @ts-ignore
     connectionGetter = jest.spyOn(window.navigator, 'connection', 'get');
   });
 
-  it('returns TRUE if user agent is online, has disabled webdriver, and not a bot', () => {
+  it('returns TRUE if connection is online, navigator is online, has disabled webdriver, and not a bot', () => {
     userAgentGetter.mockReturnValue(
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
     );
     webdriverGetter.mockReturnValue(false);
+    onLineGetter.mockReturnValue(true);
     connectionGetter.mockReturnValue({ downlink: 10, rtt: 100 });
 
     expect(isValidBrowserOnline()).toBe(true);
   });
 
-  it('returns FALSE if user agent is online, has disabled webdriver, and is a bot', () => {
+  it('returns FALSE if connection is online, navigator is online, has disabled webdriver, and is a bot', () => {
     userAgentGetter.mockReturnValue('msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)');
     webdriverGetter.mockReturnValue(false);
+    onLineGetter.mockReturnValue(true);
     connectionGetter.mockReturnValue({ downlink: 10, rtt: 100 });
 
     expect(isValidBrowserOnline()).toBe(false);
   });
 
-  it('returns FALSE if user agent is online, has ENABLED the webdriver flag, and is not a bot', () => {
+  it('returns FALSE if connection is online, navigator is online, has ENABLED the webdriver flag, and is not a bot', () => {
     userAgentGetter.mockReturnValue(
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
     );
     webdriverGetter.mockReturnValue(true);
+    onLineGetter.mockReturnValue(true);
     connectionGetter.mockReturnValue({ downlink: 10, rtt: 100 });
 
     expect(isValidBrowserOnline()).toBe(false);
   });
 
-  it('returns FALSE if user agent is NOT online, has disabled the webdriver flag, and is not a bot', () => {
+  it('returns FALSE if connection is NOT online, navigator is online, has disabled the webdriver flag, and is not a bot', () => {
     userAgentGetter.mockReturnValue(
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
     );
     webdriverGetter.mockReturnValue(false);
+    onLineGetter.mockReturnValue(true);
     connectionGetter.mockReturnValue({ downlink: 0, rtt: 0 });
+
+    expect(isValidBrowserOnline()).toBe(false);
+  });
+
+  it('returns FALSE if connection is online, navigator is NOT online, has disabled the webdriver flag, and is not a bot', () => {
+    userAgentGetter.mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
+    );
+    webdriverGetter.mockReturnValue(false);
+    onLineGetter.mockReturnValue(false);
+    connectionGetter.mockReturnValue({ downlink: 10, rtt: 100 });
 
     expect(isValidBrowserOnline()).toBe(false);
   });
@@ -90,6 +107,7 @@ describe('isValidBrowserOnline', () => {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0',
     );
     webdriverGetter.mockReturnValue(false);
+    onLineGetter.mockReturnValue(true);
     connectionGetter.mockReturnValue(undefined);
 
     expect(isValidBrowserOnline()).toBe(true);

--- a/packages/shared/src/utils/browser.ts
+++ b/packages/shared/src/utils/browser.ts
@@ -52,11 +52,12 @@ export function isValidBrowserOnline(): boolean {
 
   const isUserAgentRobot = detectUserAgentRobot(navigator?.userAgent);
   const isWebDriver = navigator?.webdriver;
+  const isNavigatorOnline = navigator?.onLine;
 
   // Being extra safe with the experimental `connection` property, as it is not defined in all browsers
   // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/connection#browser_compatibility
   // @ts-ignore
-  const isUserAgentOnline = navigator?.connection?.rtt !== 0 && navigator?.connection?.downlink !== 0;
+  const isExperimentalConnectionOnline = navigator?.connection?.rtt !== 0 && navigator?.connection?.downlink !== 0;
 
-  return !isUserAgentRobot && !isWebDriver && isUserAgentOnline;
+  return !isUserAgentRobot && !isWebDriver && isExperimentalConnectionOnline && isNavigatorOnline;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR adds the [Navigator API `onLine` property](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine) when isValidBrowserOnline utility function is deciding if the network status of the user agent is online.
<!-- Fixes # (issue number) -->
