### PR TITLE
FAPI determines if we're synced

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -955,6 +955,10 @@ export default class Clerk implements ClerkInterface {
     this.#componentControls?.updateProps(props);
   };
 
+  #hasSynced = () => getClerkQueryParam(clerkSyncedParam) === 'true';
+
+  #clearSynced = () => removeClerkQueryParam(clerkSyncedParam);
+
   #syncWithPrimary = async () => {
     const q = new URLSearchParams({
       redirect_url: window.location.href,
@@ -967,21 +971,14 @@ export default class Clerk implements ClerkInterface {
     }
   };
 
-  #handleSyncedQueryParam = () => {
-    const paramName = '__clerk_synced';
-    if (getClerkQueryParam(paramName) !== 'true') {
-      return true;
-    }
-    removeClerkQueryParam(paramName);
-    return false;
-  };
-
-  #shouldSyncWithPrimary = () => this.#options.isSatellite && this.#handleSyncedQueryParam();
-
   #loadInStandardBrowser = async (): Promise<boolean> => {
-    if (this.#shouldSyncWithPrimary()) {
-      await this.#syncWithPrimary();
-      return false;
+    if (this.#options.isSatellite) {
+      if (!this.#hasSynced()) {
+        await this.#syncWithPrimary();
+        return false;
+      }
+
+      this.#clearSynced();
     }
 
     this.#authService = new AuthenticationService(this);
@@ -1166,3 +1163,5 @@ export default class Clerk implements ClerkInterface {
     }
   }
 }
+
+const clerkSyncedParam = '__clerk_synced';

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -51,7 +51,6 @@ import {
   appendAsQueryParams,
   buildURL,
   createBeforeUnloadTracker,
-  createClerkQueryParam,
   createPageLifecycle,
   errorThrower,
   getClerkQueryParam,
@@ -72,7 +71,7 @@ import {
   windowNavigate,
 } from '../utils';
 import { memoizeListenerCallback } from '../utils/memoizeStateListenerCallback';
-import { DEV_BROWSER_SSO_JWT_PARAMETER, ERROR_CODES } from './constants';
+import { CLERK_SYNCED, DEV_BROWSER_SSO_JWT_PARAMETER, ERROR_CODES } from './constants';
 import type { DevBrowserHandler } from './devBrowserHandler';
 import createDevBrowserHandler from './devBrowserHandler';
 import {
@@ -955,9 +954,9 @@ export default class Clerk implements ClerkInterface {
     this.#componentControls?.updateProps(props);
   };
 
-  #hasSynced = () => getClerkQueryParam(clerkSyncedParam) === 'true';
+  #hasSynced = () => getClerkQueryParam(CLERK_SYNCED) === 'true';
 
-  #clearSynced = () => removeClerkQueryParam(clerkSyncedParam);
+  #clearSynced = () => removeClerkQueryParam(CLERK_SYNCED);
 
   #syncWithPrimary = async () => {
     const q = new URLSearchParams({
@@ -1163,5 +1162,3 @@ export default class Clerk implements ClerkInterface {
     }
   }
 }
-
-const clerkSyncedParam = '__clerk_synced';

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -957,7 +957,7 @@ export default class Clerk implements ClerkInterface {
 
   #syncWithPrimary = async () => {
     const q = new URLSearchParams({
-      redirect_url: createClerkQueryParam('__clerk_synced', 'true').toString(),
+      redirect_url: window.location.href,
     });
     if (this.proxyUrl) {
       const proxy = new URL(this.proxyUrl);
@@ -968,10 +968,11 @@ export default class Clerk implements ClerkInterface {
   };
 
   #handleSyncedQueryParam = () => {
-    if (getClerkQueryParam('__clerk_synced') !== 'true') {
+    const paramName = '__clerk_synced';
+    if (getClerkQueryParam(paramName) !== 'true') {
       return true;
     }
-    removeClerkQueryParam('__clerk_synced');
+    removeClerkQueryParam(paramName);
     return false;
   };
 

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -9,3 +9,4 @@ export const DEV_BROWSER_SSO_JWT_HTTP_HEADER = 'Clerk-Cookie';
 export { ERROR_CODES } from '../ui/common/constants';
 
 export const CLERK_MODAL_STATE = '__clerk_modal_state';
+export const CLERK_SYNCED = '__clerk_synced';

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -1,10 +1,12 @@
+import { CLERK_SYNCED } from '../core/constants';
+
 const ClerkQueryParams = [
   '__clerk_status',
   '__clerk_created_session',
   '__clerk_invitation_token',
   '__clerk_ticket',
   '__clerk_modal_state',
-  '__clerk_synced',
+  CLERK_SYNCED,
 ] as const;
 
 type ClerkQueryParam = typeof ClerkQueryParams[number];

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -31,9 +31,3 @@ export function removeClerkQueryParam<T extends ClerkQueryParam>(param: T) {
   window.history.replaceState({}, '', url);
   return;
 }
-
-export function createClerkQueryParam<T extends ClerkQueryParam>(param: T, value: string) {
-  const url = new URL(window.location.href);
-  url.searchParams.append(param, value);
-  return url;
-}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

FAPI now appends the `__clerk_synced` query string parameter as a result of syncing a satellite domain with its primary. 

There's no need to include it in the `redirect_url` parameter, but we still have to check its value to determine if a sync has completed.

Refactored the logic a bit so that each function does only one thing.
<!-- Fixes # (issue number) -->
