### PR TITLE
Allow function to be passed in isSatellite prop

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -147,6 +147,13 @@ export default class Clerk implements ClerkInterface {
     return this.#isReady;
   }
 
+  get isSatellite(): boolean {
+    if (typeof this.#options.isSatellite === 'function') {
+      return this.#options.isSatellite(new URL(window.location.href));
+    }
+    return this.#options.isSatellite || false;
+  }
+
   public constructor(key: string, options?: unknown) {
     key = (key || '').trim();
 
@@ -971,7 +978,7 @@ export default class Clerk implements ClerkInterface {
   };
 
   #loadInStandardBrowser = async (): Promise<boolean> => {
-    if (this.#options.isSatellite) {
+    if (this.isSatellite) {
       if (!this.#hasSynced()) {
         await this.#syncWithPrimary();
         return false;

--- a/packages/nextjs/src/server/clerk.ts
+++ b/packages/nextjs/src/server/clerk.ts
@@ -8,6 +8,7 @@ export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
 export const DOMAIN = process.env.NEXT_PUBLIC_CLERK_DOMAIN || '';
 export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';
+export const IS_SATELLITE = process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true' || false;
 
 const clerkClient = Clerk({
   apiKey: API_KEY,
@@ -19,6 +20,7 @@ const clerkClient = Clerk({
   proxyUrl: PROXY_URL,
   // @ts-expect-error
   domain: DOMAIN,
+  isSatellite: IS_SATELLITE,
 });
 
 const createClerkClient = Clerk;

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -5,7 +5,17 @@ import type { NextFetchEvent, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 import { constants as nextConstants } from '../constants';
-import { API_KEY, API_URL, clerkClient, FRONTEND_API, PROXY_URL, PUBLISHABLE_KEY, SECRET_KEY } from './clerk';
+import {
+  API_KEY,
+  API_URL,
+  clerkClient,
+  DOMAIN,
+  FRONTEND_API,
+  IS_SATELLITE,
+  PROXY_URL,
+  PUBLISHABLE_KEY,
+  SECRET_KEY,
+} from './clerk';
 import {
   getCookie,
   nextJsVersionCanOverrideRequestHeaders,
@@ -50,6 +60,9 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
       referrer: headers.get('referer') || undefined,
       userAgent: headers.get('user-agent') || undefined,
       proxyUrl,
+      // @ts-expect-error
+      isSatellite: IS_SATELLITE,
+      domain: DOMAIN,
     });
 
     // Interstitial case

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -4,15 +4,14 @@ import { Clerk } from '@clerk/backend';
 import { noSecretKeyOrApiKeyError } from '../errors';
 import { getEnvVariable } from '../utils';
 import type { LoaderFunctionArgs, RootAuthLoaderOptions, RootAuthLoaderOptionsWithExperimental } from './types';
-import { parseCookies } from './utils';
+import { handleIsSatelliteBooleanOrFn, parseCookies } from './utils';
 
 /**
  * @internal
  */
 export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoaderOptions = {}): Promise<RequestState> {
   const { request, context } = args;
-  const { loadSession, loadUser, loadOrganization, authorizedParties, isSatellite } =
-    opts as RootAuthLoaderOptionsWithExperimental;
+  const { loadSession, loadUser, loadOrganization, authorizedParties } = opts as RootAuthLoaderOptionsWithExperimental;
 
   // Fetch environment variables across Remix runtimes.
   // 1. First try from process.env if exists (Node).
@@ -41,7 +40,17 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     (opts as RootAuthLoaderOptionsWithExperimental).domain ||
     '';
 
-  const proxyUrl = getEnvVariable('CLERK_PROXY_URL') || (context?.CLERK_PROXY_URL as string) || opts.proxyUrl || '';
+  const isSatellite =
+    getEnvVariable('CLERK_IS_SATELLITE') === 'true' ||
+    (context?.CLERK_IS_SATELLITE as string) === 'true' ||
+    handleIsSatelliteBooleanOrFn((opts as RootAuthLoaderOptionsWithExperimental).isSatellite, new URL(request.url)) ||
+    false;
+
+  const proxyUrl =
+    getEnvVariable('CLERK_PROXY_URL') ||
+    (context?.CLERK_PROXY_URL as string) ||
+    (opts as RootAuthLoaderOptionsWithExperimental).proxyUrl ||
+    '';
 
   const { headers } = request;
   const cookies = parseCookies(request);

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -13,12 +13,13 @@ import {
 } from './utils';
 
 interface RootAuthLoader {
-  <Options extends Omit<RootAuthLoaderOptions, 'proxyUrl'>>(
+  <Options extends RootAuthLoaderOptions>(
     args: LoaderFunctionArgs,
     callback: RootAuthLoaderCallback<Options>,
     options?: Options,
   ): Promise<LoaderFunctionReturn>;
-  (args: LoaderFunctionArgs, options?: Omit<RootAuthLoaderOptions, 'proxyUrl'>): Promise<LoaderFunctionReturn>;
+
+  (args: LoaderFunctionArgs, options?: RootAuthLoaderOptions): Promise<LoaderFunctionReturn>;
 }
 
 export const rootAuthLoader: RootAuthLoader = async (

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -1,4 +1,5 @@
 import type { AuthObject, Organization, Session, User } from '@clerk/backend';
+import type { ClerkOptions } from '@clerk/types/src';
 import type { DataFunctionArgs, LoaderFunction } from '@remix-run/server-runtime';
 
 export type GetAuthReturn = Promise<AuthObject>;
@@ -7,11 +8,15 @@ export type RootAuthLoaderOptionsWithExperimental = RootAuthLoaderOptions & {
   /**
    * @experimental
    */
-  isSatellite?: boolean;
+  isSatellite?: ClerkOptions['isSatellite'];
   /**
    * @experimental
    */
   domain?: string;
+  /**
+   * @experimental
+   */
+  proxyUrl?: string;
 };
 
 export type RootAuthLoaderOptions = {
@@ -21,7 +26,6 @@ export type RootAuthLoaderOptions = {
   frontendApi?: string;
   publishableKey?: string;
   jwtKey?: string;
-  proxyUrl?: string;
   /**
    * @deprecated Use `secretKey` instead.
    */

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -5,6 +5,7 @@ import { json } from '@remix-run/server-runtime';
 import cookie from 'cookie';
 
 import type { LoaderFunctionArgs, LoaderFunctionArgsWithAuth } from './types';
+import type { RootAuthLoaderOptionsWithExperimental } from './types';
 
 /**
  * Inject `auth`, `user` and `session` properties into `request`
@@ -91,4 +92,14 @@ export const injectRequestStateIntoResponse = async (response: Response, request
  */
 export const wrapWithClerkState = (data: any) => {
   return { clerkState: { __internal_clerk_state: { ...data } } };
+};
+
+export const handleIsSatelliteBooleanOrFn = (
+  isSatellite: RootAuthLoaderOptionsWithExperimental['isSatellite'],
+  url: URL,
+) => {
+  if (typeof isSatellite === 'function') {
+    return isSatellite(url);
+  }
+  return isSatellite;
 };

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -36,6 +36,7 @@ export type SignOutOptions = {
 
 export interface SignOut {
   (options?: SignOutOptions): Promise<void>;
+
   (signOutCallback?: SignOutCallback, options?: SignOutOptions): Promise<void>;
 }
 
@@ -469,7 +470,7 @@ export interface ClerkOptions {
   /**
    * @experimental
    */
-  isSatellite?: boolean;
+  isSatellite?: boolean | ((url: URL) => boolean);
 }
 
 export interface Resources {
@@ -642,7 +643,7 @@ export type UserButtonProps = {
    */
   showName?: boolean;
   /**
-    Controls the default state of the UserButton
+   Controls the default state of the UserButton
    */
   defaultOpen?: boolean;
   /**


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

After this PR, you should be able to pass function that accepts a parameter of type `URL` and returns a boolean

```typescript
isSatellite={(url) => url.hostname !== 'exaple.com'}
```

We are also introducing the `CLERK_IS_SATELLITE` environment variable with expected values of `'true'` `'false'`

<!-- Fixes # (issue number) -->
