### PR TITLE
Add isSatellite as option in withClerkMiddleware

### DIFF
--- a/packages/nextjs/src/server/types.ts
+++ b/packages/nextjs/src/server/types.ts
@@ -1,3 +1,5 @@
+import type { OptionalVerifyTokenOptions } from '@clerk/backend';
+import type { ClerkOptions } from '@clerk/types';
 import type { IncomingMessage } from 'http';
 import type { NextApiRequest } from 'next';
 import type { NextApiRequestCookies } from 'next/dist/server/api-utils';
@@ -9,3 +11,8 @@ type GsspRequest = IncomingMessage & {
 };
 
 export type RequestLike = NextRequest | NextApiRequest | GsspRequest;
+
+export type WithAuthOptions = OptionalVerifyTokenOptions;
+export type WithAuthOptionsExperimental = WithAuthOptions & {
+  isSatellite?: ClerkOptions['isSatellite'];
+};

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -4,7 +4,7 @@ import type { RequestCookie } from 'next/dist/server/web/spec-extension/cookies'
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-import type { RequestLike } from './types';
+import type { RequestLike, WithAuthOptionsExperimental } from './types';
 
 export function setCustomAttributeOnRequest(req: RequestLike, key: string, value: string): void {
   Object.assign(req, { [key]: value });
@@ -135,4 +135,12 @@ export const injectSSRStateIntoObject = (obj: any, authObject: AuthObject) => {
   const __clerk_ssr_state =
     process.env.NODE_ENV !== 'production' ? JSON.parse(JSON.stringify({ ...authObject })) : { ...authObject };
   return { ...obj, __clerk_ssr_state };
+};
+
+// TODO: Make this a generic and move to @clerk/shared
+export const handleIsSatelliteBooleanOrFn = (opts: WithAuthOptionsExperimental, url: URL): boolean => {
+  if (typeof opts.isSatellite === 'function') {
+    return opts.isSatellite(url);
+  }
+  return opts.isSatellite || false;
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR introduces the behaviour listed bellow

- isSatellite as function
```typescript
export default withClerkMiddleware((req) => {
  return NextResponse.next()
}, {
  isSatellite: (url) => {
		return (url.hostname === "example.com")
	}
});
```
- isSatellite as boolean
```typescript
export default withClerkMiddleware((req) => {
  return NextResponse.next()
}, {
  isSatellite: true
});
```

<!-- Fixes # (issue number) -->
