### PR TITLE
fix(clerk-js): Parse all search params in hash-based router

### DIFF
--- a/packages/clerk-js/src/ui/router/HashRouter.tsx
+++ b/packages/clerk-js/src/ui/router/HashRouter.tsx
@@ -34,7 +34,14 @@ export const HashRouter = ({ preservedParams, children }: HashRouterProps): JSX.
   };
 
   const getQueryString = (): string => {
-    return fakeUrl().search;
+    // Construct a search string that combines all search params of the current url
+    // and all search params found within the fragment part of the current url, which is normally ignored.
+    // The search params from the fragment need to be appending last, so they take priority over any other params,
+    // so we can be sure that we introduce no changes to the existing behavior
+    const tempUrl = new URL(window.location.href);
+    const urlWithFragmentPart = fakeUrl();
+    urlWithFragmentPart.searchParams.forEach((value, key) => tempUrl.searchParams.set(key, value));
+    return tempUrl.search;
   };
 
   return (


### PR DESCRIPTION


## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The hash-based router takes into account the fragment part of the url - that is the part after the first #.

All native browser APIs ignore the fragment part because the spec states that this contains user-defined data. As a result, trying to read the search params using `new URL().searchParams` for a URL that contains search params in its fragment won't work.

In this commit we update the hash-based router to read all search params, defined in the URL or its fragment, so all redirect options passed by the user are respected.
<!-- Fixes # (issue number) -->
