### PR TITLE
fix(clerk-js): Include more error details when stringifying ClerkAPIResponseError

### DIFF
--- a/packages/clerk-js/src/core/resources/Error.ts
+++ b/packages/clerk-js/src/core/resources/Error.ts
@@ -60,6 +60,12 @@ export class ClerkAPIResponseError extends Error {
     this.clerkError = true;
     this.errors = parseErrors(data);
   }
+
+  public toString = () => {
+    return `[${this.name}]\nMessage:${this.message}\nStatus:${this.status}\nSerialized errors: ${this.errors.map(e =>
+      JSON.stringify(e),
+    )}`;
+  };
 }
 
 export class MagicLinkError extends Error {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Updates the `toString` implementation of the ClerkAPIResponseError class to include more error details. 

Before:

![image](https://user-images.githubusercontent.com/1811063/217669125-d4ff79d4-4a69-4792-a11f-f7b6fdbe71e2.png)

After:

![image](https://user-images.githubusercontent.com/1811063/217669160-092e2fde-f007-4fdf-aeac-85722534d19f.png)

<!-- Fixes # (issue number) -->
