### PR TITLE
chore(repo): Drop unused tsconfig baseUrl param

### DIFF
--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -54,7 +54,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
       publishableKey: PUBLISHABLE_KEY,
       cookieToken,
       headerToken,
-      clientUat: getCookie(req, '__client_uat'),
+      clientUat: getCookie(req, constants.Cookies.ClientUat),
       origin: headers.get('origin') || undefined,
       host: headers.get('host') as string,
       forwardedPort: headers.get('x-forwarded-port') || undefined,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "alwaysStrict": false,
-    "baseUrl": "packages",
     "declaration": true,
     "declarationMap": false,
     "downlevelIteration": true,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This param causes issues in esm module resolution
when an app in the monorepo does not have a dedicated `tsconfig.json` and there is a dependency with the same name as a packages/<package> module.

Eg fastify import in playground/fastify app
