### PR TITLE
fix(clerk-js): Display redirection warnings as info messages

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -91,6 +91,7 @@ import {
   OrganizationMembership,
 } from './resources/internal';
 import { AuthenticationService } from './services';
+import { warnings } from './warnings';
 
 export type ClerkCoreBroadcastChannelEvent = { type: 'signout' };
 
@@ -240,7 +241,7 @@ export default class Clerk implements ClerkInterface {
   public openSignIn = (props?: SignInProps): void => {
     this.assertComponentsReady(this.#componentControls);
     if (sessionExistsAndSingleSessionModeEnabled(this, this.#environment) && this.#instanceType === 'development') {
-      return console.warn('Cannot open SignIn because a session exists and single session mode is enabled.');
+      return console.info(warnings.cannotOpenSignUpOrSignUp);
     }
     this.#componentControls?.openModal('signIn', props || {});
   };
@@ -253,7 +254,7 @@ export default class Clerk implements ClerkInterface {
   public openSignUp = (props?: SignInProps): void => {
     this.assertComponentsReady(this.#componentControls);
     if (sessionExistsAndSingleSessionModeEnabled(this, this.#environment) && this.#instanceType === 'development') {
-      return console.warn('Cannot open SignUp because a session exists and single session mode is enabled.');
+      return console.info(warnings.cannotOpenSignUpOrSignUp);
     }
     this.#componentControls?.openModal('signUp', props || {});
   };
@@ -266,7 +267,7 @@ export default class Clerk implements ClerkInterface {
   public openUserProfile = (props?: UserProfileProps): void => {
     this.assertComponentsReady(this.#componentControls);
     if (noUserExists(this) && this.#instanceType === 'development') {
-      return console.warn('Cannot open UserProfile because no session is present.');
+      return console.info(warnings.cannotOpenUserProfile);
     }
     this.#componentControls?.openModal('userProfile', props || {});
   };
@@ -279,7 +280,7 @@ export default class Clerk implements ClerkInterface {
   public openOrganizationProfile = (props?: OrganizationProfileProps): void => {
     this.assertComponentsReady(this.#componentControls);
     if (noOrganizationExists(this) && this.#instanceType === 'development') {
-      return console.warn('Cannot open OrganizationProfile because there is no active organization.');
+      return console.info(warnings.cannotOpenOrgProfile);
     }
     this.#componentControls?.openModal('organizationProfile', props || {});
   };

--- a/packages/clerk-js/src/core/warnings.ts
+++ b/packages/clerk-js/src/core/warnings.ts
@@ -1,0 +1,23 @@
+const formatWarning = (msg: string) => {
+  return `🔒 Clerk:\n${msg.trim()}\n(This notice only appears in development)`;
+};
+
+const warnings = {
+  cannotRenderComponentWhenSessionExists:
+    'The <SignUp/> and <SignIn/> components cannot render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, Clerk is redirecting to the Home URL instead.',
+  cannotRenderComponentWhenUserDoesNotExist:
+    '<UserProfile/> cannot render unless a user is signed in. Since no user is signed in, Clerk is redirecting to the Home URL instead. (This notice only appears in development.)',
+  cannotRenderComponentWhenOrgDoesNotExist: `<OrganizationProfile/> cannot render unless an organization is active. Since no organization is currently active, Clerk is redirecting to the Home URL instead.`,
+  cannotOpenOrgProfile:
+    'The OrganizationProfile cannot render unless an organization is active. Since no organization is currently active, this is no-op.',
+  cannotOpenUserProfile:
+    'The UserProfile modal cannot render unless a user is signed in. Since no user is signed in, this is no-op.',
+  cannotOpenSignUpOrSignUp:
+    'The SignIn or SignUp modals do not render when a user is already signed in, unless the application allows multiple sessions. Since a user is signed in and this application only allows a single session, this is no-op.',
+};
+
+for (const key of Object.keys(warnings)) {
+  warnings[key as keyof typeof warnings] = formatWarning(warnings[key as keyof typeof warnings]);
+}
+
+export { warnings };

--- a/packages/clerk-js/src/ui/common/withRedirectToHome.tsx
+++ b/packages/clerk-js/src/ui/common/withRedirectToHome.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 import React from 'react';
 
+import { warnings } from '../../core/warnings';
 import type { AvailableComponentProps } from '../../ui/types';
 import type { ComponentGuard } from '../../utils';
 import { noOrganizationExists, noUserExists, sessionExistsAndSingleSessionModeEnabled } from '../../utils';
@@ -25,7 +26,7 @@ function withRedirectToHome<P extends AvailableComponentProps>(
     React.useEffect(() => {
       if (shouldRedirect) {
         if (warning && environment.displayConfig.instanceEnvironmentType === 'development') {
-          console.warn(warning);
+          console.info(warning);
         }
         navigate(environment.displayConfig.homeUrl);
       }
@@ -47,19 +48,11 @@ export const withRedirectToHomeSingleSessionGuard = <P extends AvailableComponen
   withRedirectToHome(
     Component,
     sessionExistsAndSingleSessionModeEnabled,
-    'Cannot render the component as a session already exists and single session mode is enabled. Redirecting to the home url.',
+    warnings.cannotRenderComponentWhenSessionExists,
   );
 
 export const withRedirectToHomeUserGuard = <P extends AvailableComponentProps>(Component: ComponentType<P>) =>
-  withRedirectToHome(
-    Component,
-    noUserExists,
-    'Cannot render the component as no user exists. Redirecting to the home url.',
-  );
+  withRedirectToHome(Component, noUserExists, warnings.cannotRenderComponentWhenUserDoesNotExist);
 
 export const withRedirectToHomeOrganizationGuard = <P extends AvailableComponentProps>(Component: ComponentType<P>) =>
-  withRedirectToHome(
-    Component,
-    noOrganizationExists,
-    'Cannot render the component as there is no active organization. Redirecting to the home url.',
-  );
+  withRedirectToHome(Component, noOrganizationExists, warnings.cannotRenderComponentWhenOrgDoesNotExist);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Replace console.warn with console.info
- Change the wording used to demonstrate better that these messages are only used for documentation purposes, and they are not actual warnings.
<!-- Fixes # (issue number) -->
