### PR TITLE
Pass env var for multi-domain and proxy in NextJS and Remix

### DIFF
--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -41,6 +41,8 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
     // @ts-expect-error
     domain,
     // @ts-expect-error
+    isSatellite,
+    // @ts-expect-error
     __clerk_ssr_state,
     clerkJSUrl,
     __unstable_invokeMiddlewareOnAuthStateChange = true,
@@ -69,7 +71,8 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
       clerkJSUrl={clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS}
       // @ts-expect-error
       proxyUrl={proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || ''}
-      domain={domain || ''}
+      domain={domain || process.env.NEXT_PUBLIC_CLERK_DOMAIN || ''}
+      isSatellite={isSatellite || process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true'}
       navigate={to => push(to)}
       // withServerSideAuth automatically injects __clerk_ssr_state
       // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state

--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -15,11 +15,13 @@ export type RemixClerkProviderProps = {
 
 export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): JSX.Element {
   const awaitableNavigate = useAwaitableNavigate();
-  const { clerkState, ...restProps } = rest;
+
+  // @ts-expect-error
+  const { clerkState, proxyUrl, domain, isSatellite, ...restProps } = rest;
   ReactClerkProvider.displayName = 'ReactClerkProvider';
 
   assertValidClerkState(clerkState);
-  const { __clerk_ssr_state, __frontendApi, __publishableKey, __clerk_debug } =
+  const { __clerk_ssr_state, __frontendApi, __publishableKey, __proxyUrl, __domain, __isSatellite, __clerk_debug } =
     clerkState?.__internal_clerk_state || {};
 
   React.useEffect(() => {
@@ -36,6 +38,10 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
       initialState={__clerk_ssr_state}
       frontendApi={__frontendApi as any}
       publishableKey={__publishableKey as any}
+      //@ts-expect-error
+      proxyUrl={proxyUrl || __proxyUrl}
+      domain={domain || __domain}
+      isSatellite={isSatellite || __isSatellite}
       {...restProps}
     >
       {children}

--- a/packages/remix/src/client/types.ts
+++ b/packages/remix/src/client/types.ts
@@ -7,6 +7,9 @@ export type ClerkState = {
     __clerk_ssr_state: InitialState;
     __frontendApi: string | undefined;
     __publishableKey: string | undefined;
+    __proxyUrl: string | undefined;
+    __domain: string | undefined;
+    __isSatellite: boolean;
     __clerk_debug: any;
   };
 };

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -76,6 +76,9 @@ export const injectRequestStateIntoResponse = async (response: Response, request
     __clerk_ssr_state: rest,
     __frontendApi: requestState.frontendApi,
     __publishableKey: requestState.publishableKey,
+    __proxyUrl: requestState.proxyUrl,
+    __domain: requestState.domain,
+    __isSatellite: requestState.isSatellite,
     __clerk_debug: debugRequestState(requestState),
   });
   // set the correct content-type header in case the user returned a `Response` directly


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR ensures that the  following env vars are used and passed correctly to ClerkProvider

- NextJS
  - NEXT_PUBLIC_CLERK_PROXY_URL
  - NEXT_PUBLIC_CLERK_IS_SATELLITE
  - NEXT_PUBLIC_CLERK_DOMAIN
- Remix
  - CLERK_PROXY_URL
  - CLERK_IS_SATELLITE
  - CLERK_DOMAIN

<!-- Fixes # (issue number) -->
