### PR TITLE
chore(repo): Fix playground apps using local packages and their deps

### DIFF
--- a/packages/sdk-node/examples/express/package-lock.json
+++ b/packages/sdk-node/examples/express/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "clerk-sdk-node-express-example",
       "dependencies": {
-        "@clerk/clerk-sdk-node": "file:../../dist",
+        "@clerk/clerk-sdk-node": "latest",
         "dotenv": "latest",
         "express": "latest"
       },
@@ -20,7 +20,6 @@
         "typescript": "4.7.4"
       }
     },
-    "../../dist": {},
     "node_modules/@babel/runtime": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
@@ -46,9 +45,92 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@clerk/backend": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.6.2.tgz",
+      "integrity": "sha512-xXjKMseugG2gSYtLMUzoDs+o4EWJmO7wbzG4DZb/Utry6dUlm0Iz6Vjgw+F+0dvicHcAjF729H7I2N3qG+tCPg==",
+      "dependencies": {
+        "@clerk/types": "^3.27.0",
+        "@peculiar/webcrypto": "1.4.1",
+        "@types/node": "16.18.6",
+        "deepmerge": "4.2.2",
+        "node-fetch-native": "1.0.1",
+        "rfc4648": "1.5.2",
+        "snakecase-keys": "5.4.4",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/@types/node": {
+      "version": "16.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
+      "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
+    },
+    "node_modules/@clerk/backend/node_modules/snakecase-keys": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@clerk/backend/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@clerk/clerk-sdk-node": {
-      "resolved": "../../dist",
-      "link": true
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-4.7.2.tgz",
+      "integrity": "sha512-T/fx2JSzNqXAlql7OWlPkv72o6k2iNibsUXbhgVhoNG9EsoSkgReesu3d9Y0TCosTO0DQ8N+5FgJKn+moJuoCw==",
+      "dependencies": {
+        "@clerk/backend": "^0.6.2",
+        "@clerk/types": "^3.27.0",
+        "@types/cookies": "0.7.7",
+        "@types/express": "4.17.14",
+        "@types/node-fetch": "2.6.2",
+        "camelcase-keys": "6.2.2",
+        "cookie": "0.5.0",
+        "snakecase-keys": "3.2.1",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/clerk-sdk-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@clerk/types": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.27.0.tgz",
+      "integrity": "sha512-0mkJvmb1aNnURCoItSMt0pzAh0yPOXu3WPiRoLJwBamqcfLnss1UrfWZdRi++lR8rjoFj9IwJZvSeWRCBqleNw==",
+      "dependencies": {
+        "csstype": "3.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -181,6 +263,57 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz",
+      "integrity": "sha512-6GptMYDMyWBHTUKndHaDsRZUO/XMSgIns2krxcm2L7SEExRHwawFvSwNBhqNPR9HJwv3MruAiF1bhN0we6j6GQ==",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/json-schema/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.1.tgz",
+      "integrity": "sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.1",
+        "webcrypto-core": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
@@ -215,7 +348,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -225,16 +357,25 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookies": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "dev": true,
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -246,7 +387,6 @@
       "version": "4.17.30",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
       "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -259,35 +399,44 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
     "node_modules/@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "node_modules/@types/node": {
       "version": "18.6.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
-      "dev": true
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -589,11 +738,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axe-core": {
       "version": "4.4.3",
@@ -712,6 +884,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -785,6 +981,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -854,6 +1061,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -883,6 +1095,14 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -897,6 +1117,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -948,6 +1176,20 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dot-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/dotenv": {
       "version": "16.0.1",
@@ -1759,6 +2001,19 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2433,6 +2688,19 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2450,6 +2718,17 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -2561,6 +2840,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
+      "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg=="
     },
     "node_modules/nodemon": {
       "version": "2.0.19",
@@ -2961,6 +3259,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -2994,6 +3313,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -3105,6 +3432,11 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+      "integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -3307,6 +3639,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snake-case/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/snakecase-keys": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
+      "integrity": "sha512-CjU5pyRfwOtaOITYv5C8DzpZ8XA/ieRsDpr93HI2r6e3YInC6moZpSQbmUtg8cTk58tq2x3jcG2gv+p1IZGmMA==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "to-snake-case": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -3425,6 +3783,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3435,6 +3798,22 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "node_modules/to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "dependencies": {
+        "to-no-case": "^1.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -3648,6 +4027,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.6.tgz",
+      "integrity": "sha512-TBPiewB4Buw+HI3EQW+Bexm19/W4cP/qZG/02QJCXN+iN+T5sl074vZ3rJcle/ZtDBQSgjkbsQO/1eFcxnSBUA==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/webcrypto-core/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3742,8 +4138,78 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@clerk/backend": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.6.2.tgz",
+      "integrity": "sha512-xXjKMseugG2gSYtLMUzoDs+o4EWJmO7wbzG4DZb/Utry6dUlm0Iz6Vjgw+F+0dvicHcAjF729H7I2N3qG+tCPg==",
+      "requires": {
+        "@clerk/types": "^3.27.0",
+        "@peculiar/webcrypto": "1.4.1",
+        "@types/node": "16.18.6",
+        "deepmerge": "4.2.2",
+        "node-fetch-native": "1.0.1",
+        "rfc4648": "1.5.2",
+        "snakecase-keys": "5.4.4",
+        "tslib": "2.4.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
+          "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
+        },
+        "snakecase-keys": {
+          "version": "5.4.4",
+          "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+          "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+          "requires": {
+            "map-obj": "^4.1.0",
+            "snake-case": "^3.0.4",
+            "type-fest": "^2.5.2"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "@clerk/clerk-sdk-node": {
-      "version": "file:../../dist"
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-4.7.2.tgz",
+      "integrity": "sha512-T/fx2JSzNqXAlql7OWlPkv72o6k2iNibsUXbhgVhoNG9EsoSkgReesu3d9Y0TCosTO0DQ8N+5FgJKn+moJuoCw==",
+      "requires": {
+        "@clerk/backend": "^0.6.2",
+        "@clerk/types": "^3.27.0",
+        "@types/cookies": "0.7.7",
+        "@types/express": "4.17.14",
+        "@types/node-fetch": "2.6.2",
+        "camelcase-keys": "6.2.2",
+        "cookie": "0.5.0",
+        "snakecase-keys": "3.2.1",
+        "tslib": "2.4.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
+    },
+    "@clerk/types": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.27.0.tgz",
+      "integrity": "sha512-0mkJvmb1aNnURCoItSMt0pzAh0yPOXu3WPiRoLJwBamqcfLnss1UrfWZdRi++lR8rjoFj9IwJZvSeWRCBqleNw==",
+      "requires": {
+        "csstype": "3.1.1"
+      }
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3851,6 +4317,57 @@
         "fastq": "^1.6.0"
       }
     },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz",
+      "integrity": "sha512-6GptMYDMyWBHTUKndHaDsRZUO/XMSgIns2krxcm2L7SEExRHwawFvSwNBhqNPR9HJwv3MruAiF1bhN0we6j6GQ==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.1.tgz",
+      "integrity": "sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.1",
+        "webcrypto-core": "^1.7.4"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "@rushstack/eslint-patch": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
@@ -3885,7 +4402,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -3895,16 +4411,25 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
+    "@types/cookies": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "dev": true,
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -3916,7 +4441,6 @@
       "version": "4.17.30",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
       "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3929,35 +4453,44 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
     "@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
     "@types/node": {
       "version": "18.6.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
-      "dev": true
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
+    },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
       "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
-      "dev": true,
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -4157,11 +4690,33 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "requires": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axe-core": {
       "version": "4.4.3",
@@ -4260,6 +4815,21 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4311,6 +4881,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -4364,6 +4942,11 @@
         "which": "^2.0.1"
       }
     },
+    "csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4385,6 +4968,11 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -4394,6 +4982,11 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -4427,6 +5020,22 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
       }
     },
     "dotenv": {
@@ -5079,6 +5688,16 @@
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
     },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5560,6 +6179,21 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5574,6 +6208,11 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -5655,6 +6294,27 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "node-fetch-native": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
+      "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg=="
     },
     "nodemon": {
       "version": "2.0.19",
@@ -5941,6 +6601,26 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
+    },
     "qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -5954,6 +6634,11 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -6031,6 +6716,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rfc4648": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+      "integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -6175,6 +6865,31 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
+    },
+    "snakecase-keys": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
+      "integrity": "sha512-CjU5pyRfwOtaOITYv5C8DzpZ8XA/ieRsDpr93HI2r6e3YInC6moZpSQbmUtg8cTk58tq2x3jcG2gv+p1IZGmMA==",
+      "requires": {
+        "map-obj": "^4.1.0",
+        "to-snake-case": "^1.0.0"
+      }
+    },
     "statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -6260,6 +6975,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6267,6 +6987,22 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "requires": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "requires": {
+        "to-no-case": "^1.0.0"
       }
     },
     "toidentifier": {
@@ -6414,6 +7150,25 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "webcrypto-core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.6.tgz",
+      "integrity": "sha512-TBPiewB4Buw+HI3EQW+Bexm19/W4cP/qZG/02QJCXN+iN+T5sl074vZ3rJcle/ZtDBQSgjkbsQO/1eFcxnSBUA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/packages/sdk-node/examples/express/package.json
+++ b/packages/sdk-node/examples/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clerk-sdk-node-express-example",
   "dependencies": {
-    "@clerk/clerk-sdk-node": "file:../../dist",
+    "@clerk/clerk-sdk-node": "latest",
     "dotenv": "latest",
     "express": "latest"
   },

--- a/packages/sdk-node/examples/node/package-lock.json
+++ b/packages/sdk-node/examples/node/package-lock.json
@@ -7,7 +7,7 @@
       "name": "clerk-sdk-node-examples",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-sdk-node": "file:../../dist",
+        "@clerk/clerk-sdk-node": "latest",
         "dotenv": "^8.6.0",
         "log-that-http": "^1.0.1"
       },
@@ -17,10 +17,66 @@
         "typescript": "^4.4.4"
       }
     },
-    "../../dist": {},
+    "node_modules/@clerk/backend": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.6.2.tgz",
+      "integrity": "sha512-xXjKMseugG2gSYtLMUzoDs+o4EWJmO7wbzG4DZb/Utry6dUlm0Iz6Vjgw+F+0dvicHcAjF729H7I2N3qG+tCPg==",
+      "dependencies": {
+        "@clerk/types": "^3.27.0",
+        "@peculiar/webcrypto": "1.4.1",
+        "@types/node": "16.18.6",
+        "deepmerge": "4.2.2",
+        "node-fetch-native": "1.0.1",
+        "rfc4648": "1.5.2",
+        "snakecase-keys": "5.4.4",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/snakecase-keys": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@clerk/clerk-sdk-node": {
-      "resolved": "../../dist",
-      "link": true
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-4.7.2.tgz",
+      "integrity": "sha512-T/fx2JSzNqXAlql7OWlPkv72o6k2iNibsUXbhgVhoNG9EsoSkgReesu3d9Y0TCosTO0DQ8N+5FgJKn+moJuoCw==",
+      "dependencies": {
+        "@clerk/backend": "^0.6.2",
+        "@clerk/types": "^3.27.0",
+        "@types/cookies": "0.7.7",
+        "@types/express": "4.17.14",
+        "@types/node-fetch": "2.6.2",
+        "camelcase-keys": "6.2.2",
+        "cookie": "0.5.0",
+        "snakecase-keys": "3.2.1",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.27.0.tgz",
+      "integrity": "sha512-0mkJvmb1aNnURCoItSMt0pzAh0yPOXu3WPiRoLJwBamqcfLnss1UrfWZdRi++lR8rjoFj9IwJZvSeWRCBqleNw==",
+      "dependencies": {
+        "csstype": "3.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -41,6 +97,42 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz",
+      "integrity": "sha512-6GptMYDMyWBHTUKndHaDsRZUO/XMSgIns2krxcm2L7SEExRHwawFvSwNBhqNPR9HJwv3MruAiF1bhN0we6j6GQ==",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.1.tgz",
+      "integrity": "sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.1",
+        "webcrypto-core": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -67,11 +159,94 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+    },
+    "node_modules/@types/node": {
+      "version": "16.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
+      "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
       "dev": true
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
       "version": "17.0.38",
@@ -98,6 +273,15 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dependencies": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/acorn": {
       "version": "8.7.0",
@@ -126,6 +310,67 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -133,10 +378,25 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -147,12 +407,34 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/log-that-http": {
@@ -163,11 +445,134 @@
         "node": ">=8"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
+      "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg=="
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+      "integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg=="
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snakecase-keys": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
+      "integrity": "sha512-CjU5pyRfwOtaOITYv5C8DzpZ8XA/ieRsDpr93HI2r6e3YInC6moZpSQbmUtg8cTk58tq2x3jcG2gv+p1IZGmMA==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "to-snake-case": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
+    },
+    "node_modules/to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "node_modules/to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "dependencies": {
+        "to-no-case": "^1.0.0"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.4.0",
@@ -210,6 +615,22 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -223,6 +644,18 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.6.tgz",
+      "integrity": "sha512-TBPiewB4Buw+HI3EQW+Bexm19/W4cP/qZG/02QJCXN+iN+T5sl074vZ3rJcle/ZtDBQSgjkbsQO/1eFcxnSBUA==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -234,8 +667,56 @@
     }
   },
   "dependencies": {
+    "@clerk/backend": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-0.6.2.tgz",
+      "integrity": "sha512-xXjKMseugG2gSYtLMUzoDs+o4EWJmO7wbzG4DZb/Utry6dUlm0Iz6Vjgw+F+0dvicHcAjF729H7I2N3qG+tCPg==",
+      "requires": {
+        "@clerk/types": "^3.27.0",
+        "@peculiar/webcrypto": "1.4.1",
+        "@types/node": "16.18.6",
+        "deepmerge": "4.2.2",
+        "node-fetch-native": "1.0.1",
+        "rfc4648": "1.5.2",
+        "snakecase-keys": "5.4.4",
+        "tslib": "2.4.1"
+      },
+      "dependencies": {
+        "snakecase-keys": {
+          "version": "5.4.4",
+          "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+          "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+          "requires": {
+            "map-obj": "^4.1.0",
+            "snake-case": "^3.0.4",
+            "type-fest": "^2.5.2"
+          }
+        }
+      }
+    },
     "@clerk/clerk-sdk-node": {
-      "version": "file:../../dist"
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-sdk-node/-/clerk-sdk-node-4.7.2.tgz",
+      "integrity": "sha512-T/fx2JSzNqXAlql7OWlPkv72o6k2iNibsUXbhgVhoNG9EsoSkgReesu3d9Y0TCosTO0DQ8N+5FgJKn+moJuoCw==",
+      "requires": {
+        "@clerk/backend": "^0.6.2",
+        "@clerk/types": "^3.27.0",
+        "@types/cookies": "0.7.7",
+        "@types/express": "4.17.14",
+        "@types/node-fetch": "2.6.2",
+        "camelcase-keys": "6.2.2",
+        "cookie": "0.5.0",
+        "snakecase-keys": "3.2.1",
+        "tslib": "2.4.1"
+      }
+    },
+    "@clerk/types": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.27.0.tgz",
+      "integrity": "sha512-0mkJvmb1aNnURCoItSMt0pzAh0yPOXu3WPiRoLJwBamqcfLnss1UrfWZdRi++lR8rjoFj9IwJZvSeWRCBqleNw==",
+      "requires": {
+        "csstype": "3.1.1"
+      }
     },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -250,6 +731,36 @@
       "dev": true,
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.3.tgz",
+      "integrity": "sha512-6GptMYDMyWBHTUKndHaDsRZUO/XMSgIns2krxcm2L7SEExRHwawFvSwNBhqNPR9HJwv3MruAiF1bhN0we6j6GQ==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.1.tgz",
+      "integrity": "sha512-eK4C6WTNYxoI7JOabMoZICiyqRRtJB220bh0Mbj5RwRycleZf9BPyZoxsTvpP0FpmVS2aS13NKOuh5/tN3sIRw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.1",
+        "webcrypto-core": "^1.7.4"
       }
     },
     "@tsconfig/node10": {
@@ -276,11 +787,94 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cookies": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+    },
+    "@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+    },
+    "@types/node": {
+      "version": "16.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz",
+      "integrity": "sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA=="
+    },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
       "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
       "version": "17.0.38",
@@ -308,6 +902,15 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
+    "@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "requires": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
     "acorn": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -326,6 +929,49 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "requires": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -333,10 +979,19 @@
       "dev": true
     },
     "csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "diff": {
       "version": "4.0.2",
@@ -344,21 +999,142 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "log-that-http": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/log-that-http/-/log-that-http-1.0.1.tgz",
       "integrity": "sha512-m382CmTTsDdf288oUdQdYMBDUisiQgXkqIIPw8stFqjSZwjgrg4ap7S3viniy7qv3KTnv3CCb/GFQWAuqLJu3Q=="
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node-fetch-native": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
+      "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg=="
+    },
+    "pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
+    "rfc4648": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.2.tgz",
+      "integrity": "sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg=="
+    },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "snakecase-keys": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.2.1.tgz",
+      "integrity": "sha512-CjU5pyRfwOtaOITYv5C8DzpZ8XA/ieRsDpr93HI2r6e3YInC6moZpSQbmUtg8cTk58tq2x3jcG2gv+p1IZGmMA==",
+      "requires": {
+        "map-obj": "^4.1.0",
+        "to-snake-case": "^1.0.0"
+      }
+    },
+    "to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg=="
+    },
+    "to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha512-joRpzBAk1Bhi2eGEYBjukEWHOe/IvclOkiJl3DtA91jV6NwQ3MwXA4FHYeqk8BNp/D8bmi9tcNbRu/SozP0jbQ==",
+      "requires": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "requires": {
+        "to-no-case": "^1.0.0"
+      }
     },
     "ts-node": {
       "version": "10.4.0",
@@ -380,11 +1156,33 @@
         "yn": "3.1.1"
       }
     },
+    "tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+    },
     "typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
       "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
+    },
+    "webcrypto-core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.6.tgz",
+      "integrity": "sha512-TBPiewB4Buw+HI3EQW+Bexm19/W4cP/qZG/02QJCXN+iN+T5sl074vZ3rJcle/ZtDBQSgjkbsQO/1eFcxnSBUA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
     },
     "yn": {
       "version": "3.1.1",

--- a/packages/sdk-node/examples/node/package.json
+++ b/packages/sdk-node/examples/node/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
-    "@clerk/clerk-sdk-node": "file:../../dist",
+    "@clerk/clerk-sdk-node": "latest",
     "dotenv": "^8.6.0",
     "log-that-http": "^1.0.1"
   },

--- a/playground/cra-js/package.json
+++ b/playground/cra-js/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@clerk/clerk-react": "^4.5.1",
+    "@clerk/clerk-react": "*",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/playground/fastify/package.json
+++ b/playground/fastify/package.json
@@ -6,7 +6,7 @@
     "start": "ts-node ./src/server.ts"
   },
   "dependencies": {
-    "@clerk/fastify": "file:../../packages/fastify",
+    "@clerk/fastify": "*",
     "dotenv": "^16.0.3",
     "fastify": "^4.12.0",
     "ts-node": "^10.9.1"

--- a/playground/gatsby/package-lock.json
+++ b/playground/gatsby/package-lock.json
@@ -8,10 +8,10 @@
       "name": "my-gatsby-site",
       "version": "1.0.0",
       "dependencies": {
-        "@clerk/backend": "file:.yalc/@clerk/backend",
-        "@clerk/clerk-sdk-node": "file:.yalc/@clerk/clerk-sdk-node",
+        "@clerk/backend": "*",
+        "@clerk/clerk-sdk-node": "*",
         "gatsby": "5.4.2",
-        "gatsby-plugin-clerk": "file:.yalc/gatsby-plugin-clerk",
+        "gatsby-plugin-clerk": "*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -23,10 +23,10 @@
       }
     },
     ".yalc/@clerk/backend": {
-      "version": "0.5.0-staging.0",
+      "version": "0.6.2-staging.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/types": "^3.27.0-staging.0",
         "@peculiar/webcrypto": "1.4.1",
         "@types/node": "16.18.6",
         "deepmerge": "4.2.2",
@@ -69,14 +69,13 @@
       }
     },
     ".yalc/@clerk/clerk-sdk-node": {
-      "version": "4.6.4-staging.2",
+      "version": "4.7.2-staging.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^0.5.0-staging.0",
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/backend": "^0.6.2-staging.0",
+        "@clerk/types": "^3.27.0-staging.0",
         "@types/cookies": "0.7.7",
         "@types/express": "4.17.14",
-        "@types/jsonwebtoken": "8.5.9",
         "@types/node-fetch": "2.6.2",
         "camelcase-keys": "6.2.2",
         "cookie": "0.5.0",
@@ -88,13 +87,13 @@
       }
     },
     ".yalc/gatsby-plugin-clerk": {
-      "version": "4.0.0-staging.0",
+      "version": "4.1.2-staging.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^0.5.0-staging.0",
-        "@clerk/clerk-react": "^4.8.5-staging.2",
-        "@clerk/clerk-sdk-node": "^4.6.4-staging.2",
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/backend": "^0.6.2-staging.0",
+        "@clerk/clerk-react": "^4.11.2-staging.0",
+        "@clerk/clerk-sdk-node": "^4.7.2-staging.0",
+        "@clerk/types": "^3.27.0-staging.0",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       },
@@ -102,7 +101,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "gatsby": "^4.24.8"
+        "gatsby": "^4.24.8 || ^5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -250,9 +249,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "dependencies": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -2050,12 +2049,12 @@
       "link": true
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "4.8.5-staging.2",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.8.5-staging.2.tgz",
-      "integrity": "sha512-wCbEIhEnrXTZw7WbA7m6kswm365klU4iiYCSvs3DiNfILsF14PYJFHkbe7KO2s8cbde58A0XAxgh7hJcMLa//g==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.11.2.tgz",
+      "integrity": "sha512-3qNznZOd8mX4Q5dHKdRMpVM/HrxDC6dWws+NJjcUg55zl+uPg7kVVDDGzaifLZyD94O8NP/Fqy9JJ0xU8eJkLQ==",
       "dependencies": {
-        "@clerk/shared": "^0.9.3-staging.2",
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/shared": "^0.11.2",
+        "@clerk/types": "^3.27.0",
         "swr": "1.3.0",
         "tslib": "2.4.1"
       },
@@ -2072,9 +2071,9 @@
       "link": true
     },
     "node_modules/@clerk/shared": {
-      "version": "0.9.3-staging.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.9.3-staging.2.tgz",
-      "integrity": "sha512-yqVr8s2w+u8tDbQ9QJ79z7EN942/FNhz+Sp+NmFWBgKBzxLAqjIRB1IV71Ardt0iVQOLfa+F9jh0wfbAsiMqLA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.11.2.tgz",
+      "integrity": "sha512-aAb2DbspgBSbqVzyWND2vydmuGOMSWjQDL9GP1EkTJ9ScH/sRnJLFQRt7U16k8Q/w4kEh3THV9yL4FlJQ50tlw==",
       "peerDependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2082,9 +2081,9 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "3.24.2-staging.1",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.24.2-staging.1.tgz",
-      "integrity": "sha512-xA0Q6X9VNO+z5echfW9ahMZxADSyUK4iZSTKXTWsMBq94ZeQNGxNCwW6DVscnP21RlkHlAXPkdzA8nlXH4cKbg==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.27.0.tgz",
+      "integrity": "sha512-0mkJvmb1aNnURCoItSMt0pzAh0yPOXu3WPiRoLJwBamqcfLnss1UrfWZdRi++lR8rjoFj9IwJZvSeWRCBqleNw==",
       "dependencies": {
         "csstype": "3.1.1"
       },
@@ -2155,18 +2154,451 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-2.4.0.tgz",
-      "integrity": "sha512-awi7pNgqaR80+9CJcj5UUC4lZDpcoH2fJItqIHC+7VJLxQDxF27vYF8fMgUvqXjjpctro25jMtedd1/4u3G4Hg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-2.6.0.tgz",
+      "integrity": "sha512-RpP8ZGY5v/3lR+wmmGgobfZf4cDEYnBeo34C0H29FY5XIlLD6p4T/B84Qdw1P5I8FShQDado6aed2zNpnr9mvw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "@parcel/namer-default": "2.8.2",
-        "@parcel/plugin": "2.8.2",
-        "gatsby-core-utils": "^4.4.0"
+        "@babel/runtime": "^7.20.13",
+        "@parcel/namer-default": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "gatsby-core-utils": "^4.6.0"
       },
       "engines": {
         "node": ">=18.0.0",
         "parcel": "2.x"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/cache": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
+      "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
+      "dependencies": {
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "lmdb": "2.5.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/codeframe": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
+      "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.3.tgz",
+      "integrity": "sha512-Euf/un4ZAiClnlUXqPB9phQlKbveU+2CotZv7m7i+qkgvFn5nAGnrV4h1OzQU42j9dpgOxWi7AttUDMrvkbhCQ==",
+      "peer": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/graph": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "abortcontroller-polyfill": "^1.1.9",
+        "base-x": "^3.0.8",
+        "browserslist": "^4.6.6",
+        "clone": "^2.1.1",
+        "dotenv": "^7.0.0",
+        "dotenv-expand": "^5.1.0",
+        "json5": "^2.2.0",
+        "msgpackr": "^1.5.4",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/diagnostic": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
+      "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
+      "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w==",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/fs": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+      "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+      "dependencies": {
+        "@parcel/fs-search": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/watcher": "^2.0.7",
+        "@parcel/workers": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/fs-search": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
+      "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.3.tgz",
+      "integrity": "sha512-26GL8fYZPdsRhSXCZ0ZWliloK6DHlMJPWh6Z+3VVZ5mnDSbYg/rRKWmrkhnr99ZWmL9rJsv4G74ZwvDEXTMPBg==",
+      "peer": true,
+      "dependencies": {
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/hash": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
+      "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/logger": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+      "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/events": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/markdown-ansi": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
+      "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/namer-default": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.3.tgz",
+      "integrity": "sha512-tJ7JehZviS5QwnxbARd8Uh63rkikZdZs1QOyivUhEvhN+DddSAVEdQLHGPzkl3YRk0tjFhbqo+Jci7TpezuAMw==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.8.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/package-manager": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
+      "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "@parcel/workers": "2.8.3",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/plugin": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
+      "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
+      "dependencies": {
+        "@parcel/types": "2.8.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/types": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
+      "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
+      "dependencies": {
+        "@parcel/cache": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/fs": "2.8.3",
+        "@parcel/package-manager": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "@parcel/workers": "2.8.3",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/utils": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+      "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+      "dependencies": {
+        "@parcel/codeframe": "2.8.3",
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/hash": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/markdown-ansi": "2.8.3",
+        "@parcel/source-map": "^2.1.1",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/workers": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+      "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.8.3",
+        "@parcel/logger": "2.8.3",
+        "@parcel/types": "2.8.3",
+        "@parcel/utils": "2.8.3",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/lmdb": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@gatsbyjs/reach-router": {
@@ -4025,14 +4457,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
@@ -5130,13 +5554,13 @@
       }
     },
     "node_modules/babel-plugin-remove-graphql-queries": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.4.0.tgz",
-      "integrity": "sha512-+3e51jNoqtphSSOsES4FzlY5xOQXlsliw2daYzhP7QdfXB3ffBWDskqrsCv+9mug4VyWqIy7YXSQY4osEBA98A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.6.0.tgz",
+      "integrity": "sha512-8kLiQRdFPL5cy7IgEmNqsW6XpyM566xFnpnUmTYMdVST+GYDe9rFr0WDYdaQB8cgPRJyq0bbhasHnZbieIux+A==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.4.0"
+        "gatsby-core-utils": "^4.6.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5194,9 +5618,9 @@
       }
     },
     "node_modules/babel-preset-gatsby": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-3.4.0.tgz",
-      "integrity": "sha512-InyNQmv7ov5r0ZgXpw4vrgooKf5419/kdced0dqWgBOlm5/RIhRpyGhzVO3tfw744HhaagO+8NXi6t17AvkWUQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-3.6.0.tgz",
+      "integrity": "sha512-u+SRfhlgPfgd14iUukynIRpTeImYtbYQt5JhzD8ZPESktKwk5ND5ZT49pGwzq3kLu4oBxXoZYBbjAgE1cwXtjA==",
       "dependencies": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
@@ -5207,12 +5631,12 @@
         "@babel/plugin-transform-spread": "^7.20.7",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-legacy-polyfills": "^3.4.0"
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-legacy-polyfills": "^3.6.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6256,11 +6680,11 @@
       }
     },
     "node_modules/create-gatsby": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/create-gatsby/-/create-gatsby-3.4.0.tgz",
-      "integrity": "sha512-WD9WtsXzqa+5vMBF56iiq8IGdJQT7TlWGYLv1qeM5jgK7tCCFxHnzHZ/MnvTnwspeKGRQuFgWpbrnSgD4YyQdA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/create-gatsby/-/create-gatsby-3.6.0.tgz",
+      "integrity": "sha512-1bVBCDr7v+mPsgKIe4LvRG1y+FZv9oKMe1mdnhTtQ0EaKog8Jjp4C8rm+TcT5wTlEANotKbB6ku4WXkTjm0d1Q==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7"
+        "@babel/runtime": "^7.20.13"
       },
       "bin": {
         "create-gatsby": "cli.js"
@@ -8751,17 +9175,17 @@
       }
     },
     "node_modules/gatsby-cli": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-5.4.0.tgz",
-      "integrity": "sha512-3b6PGhv89mtIabur6Al7O/0cDoazgQfNjQzeKqsboRyaZCanJZsZnk6mDaHBYBSUfq6M+8TQWZvNlvxnF2kwig==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-5.6.0.tgz",
+      "integrity": "sha512-cvkZqAIVd7uoFQF2C0lJU57tya19GAWNJJP+DsHoalgGBjOPzfDzk1EN/xWnSDMUm4XM/+8PU3Ublz4dCWTI8w==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/core": "^7.20.7",
-        "@babel/generator": "^7.20.7",
+        "@babel/core": "^7.20.12",
+        "@babel/generator": "^7.20.14",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "@babel/template": "^7.20.7",
         "@babel/types": "^7.20.7",
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -8772,23 +9196,23 @@
         "clipboardy": "^2.3.0",
         "common-tags": "^1.8.2",
         "convert-hrtime": "^3.0.0",
-        "create-gatsby": "^3.4.0",
+        "create-gatsby": "^3.6.0",
         "envinfo": "^7.8.1",
         "execa": "^5.1.1",
         "fs-exists-cached": "^1.0.0",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-telemetry": "^4.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-telemetry": "^4.6.0",
         "hosted-git-info": "^3.0.8",
         "is-valid-path": "^0.1.1",
         "joi": "^17.7.0",
         "lodash": "^4.17.21",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.8",
         "opentracing": "^0.14.7",
         "pretty-error": "^2.1.2",
         "progress": "^2.0.3",
         "prompts": "^2.4.2",
-        "redux": "4.2.0",
+        "redux": "4.2.1",
         "resolve-cwd": "^3.0.0",
         "semver": "^7.3.8",
         "signal-exit": "^3.0.7",
@@ -8805,18 +9229,40 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/gatsby-core-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.4.0.tgz",
-      "integrity": "sha512-/ibilcGENKH6qqkcT17SIZgc2kjZn3HiGpD+ixbXYkMGqHiM5pj9XIHjy3DfvZvDt2ujkYV5EinmUdqx7CI81w==",
+    "node_modules/gatsby-cli/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/gatsby-cli/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/gatsby-core-utils": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.6.0.tgz",
+      "integrity": "sha512-wXqWZWn6VuL2caWHCryt/pYyJJxJiv2JKyzXlJ1mLac0ZB24PP3Uc9NXPgFy8XzEtcL+23+9i9CiIiz+VNgxpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
         "ci-info": "2.0.0",
         "configstore": "^5.0.1",
         "fastq": "^1.13.0",
         "file-type": "^16.5.3",
-        "fs-extra": "^10.1.0",
+        "fs-extra": "^11.1.0",
         "got": "^11.8.5",
+        "hash-wasm": "^4.9.0",
         "import-from": "^4.0.0",
         "lmdb": "2.5.3",
         "lock": "^1.1.0",
@@ -8830,6 +9276,19 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/gatsby-core-utils/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/gatsby-graphiql-explorer": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-3.4.0.tgz",
@@ -8839,11 +9298,11 @@
       }
     },
     "node_modules/gatsby-legacy-polyfills": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-3.4.0.tgz",
-      "integrity": "sha512-5ORvRO1ZpxqM4U9W1Da/ewYJpEm6/tSqAhw11yOLqf7GjJYW1Tc3GBPeY3EBvpU/GTAmQM6k9exS1xESAOrBAw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-3.6.0.tgz",
+      "integrity": "sha512-6z8zPrSOFLiZ+iRIxMjH79hvz37oef/BvALdut4CVVp5a6Pdv1n+cHss1pCKFzhBtOVwLbbonMpxXT/RBLvM3w==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "core-js-compat": "3.9.0"
       }
     },
@@ -8869,12 +9328,12 @@
       }
     },
     "node_modules/gatsby-link": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.4.0.tgz",
-      "integrity": "sha512-7JXCCEnlehmJ1MB8Y2/I3UxE8a3cKKOsGMX1DtuMs7t3StdOzBMjaiM2nzLUNRCLGBDpSE2kpk55aB2h+Xq3+Q==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.6.0.tgz",
+      "integrity": "sha512-kC/EUajQJGDyUMtdarDQkLaILfuhGNCVMOGs+Px5e/KxAQXmCzWbA0M7tr0i3awyW7Qj3JsBjaL6y3ePe4kzNg==",
       "dependencies": {
         "@types/reach__router": "^1.3.10",
-        "gatsby-page-utils": "^3.4.0",
+        "gatsby-page-utils": "^3.6.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -8887,15 +9346,15 @@
       }
     },
     "node_modules/gatsby-page-utils": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.4.0.tgz",
-      "integrity": "sha512-e/cIpnlQlACq30Ig5eS3ZQ7iTRuZyf3m93epW0MioQ8j9dYZkFJ/cHY1CKsTRZzi8FlZuy8wVr2YMkEzZveUlw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.6.0.tgz",
+      "integrity": "sha512-zRoRPm5fr/Cz2FFTNyK8vPmcFwyvRumNQa7H4SHg09+RYtawZE2Cs6elsYcBIL1bgDsWCxqGuZYC4Uarv41D0g==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "bluebird": "^3.7.2",
         "chokidar": "^3.5.3",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^4.4.0",
+        "gatsby-core-utils": "^4.6.0",
         "glob": "^7.2.3",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.5"
@@ -8934,20 +9393,20 @@
       "link": true
     },
     "node_modules/gatsby-plugin-page-creator": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-5.4.0.tgz",
-      "integrity": "sha512-OQ1bcUK/21e3OAUZNvm82Wkr8QtKzhD4nHThBHGIMtvfZN2dmzPqkds1b62jLGhaVGhevupBjBE00nr56IR/EA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-5.6.0.tgz",
+      "integrity": "sha512-WSCyxoAuF4DMBOPJfQpQzmq99nR3hVZBeKa0uWmFbSePouwtJ3tJadurNGgP5mzsG73HyKbwXPEcYHQy+LtrSg==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "@babel/traverse": "^7.20.10",
+        "@babel/runtime": "^7.20.13",
+        "@babel/traverse": "^7.20.13",
         "@sindresorhus/slugify": "^1.1.2",
         "chokidar": "^3.5.3",
         "fs-exists-cached": "^1.0.0",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-page-utils": "^3.4.0",
-        "gatsby-plugin-utils": "^4.4.0",
-        "gatsby-telemetry": "^4.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-page-utils": "^3.6.0",
+        "gatsby-plugin-utils": "^4.6.0",
+        "gatsby-telemetry": "^4.6.0",
         "globby": "^11.1.0",
         "lodash": "^4.17.21"
       },
@@ -8958,18 +9417,31 @@
         "gatsby": "^5.0.0-next"
       }
     },
-    "node_modules/gatsby-plugin-typescript": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.4.0.tgz",
-      "integrity": "sha512-BQqt7Sj9JRBOOq7sClwNNdAdtRkBi9Z/TkmdnWNQMeR4YcGI0GvEhSwOuQm4V9FeCFDnbWxmnZ7w9R7Bjl8NVA==",
+    "node_modules/gatsby-plugin-page-creator/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
-        "@babel/core": "^7.20.7",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/gatsby-plugin-typescript": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.6.0.tgz",
+      "integrity": "sha512-YsczXNnYldFx1mu+Q0Zx/dLMOuHCGBguh+P4EqVRoFJx30/EJtWrqZxqou5o5JwlU4115o8L4FLzFTHeuqwyWw==",
+      "dependencies": {
+        "@babel/core": "^7.20.12",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/plugin-proposal-numeric-separator": "^7.18.6",
         "@babel/plugin-proposal-optional-chaining": "^7.20.7",
         "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
-        "babel-plugin-remove-graphql-queries": "^5.4.0"
+        "@babel/runtime": "^7.20.13",
+        "babel-plugin-remove-graphql-queries": "^5.6.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -8979,15 +9451,15 @@
       }
     },
     "node_modules/gatsby-plugin-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-4.4.0.tgz",
-      "integrity": "sha512-oS96PobrmXyOIX6Cqo6RpHykBC8SbIYF6iZcIastR+bcFQRWojFaHP1euFHQ3sVyeVc9SyxBGDHRS5WG+SvAog==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-4.6.0.tgz",
+      "integrity": "sha512-CR+6lGnRlMUYbqM58sNBbQxCSkGm+ltqAfWWQTlnmYSpqmKxHLMpZ0F2KfxVXQOXRbtBNx1oXZWzbEzmydoXkA==",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "fastq": "^1.13.0",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-sharp": "^1.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-sharp": "^1.6.0",
         "graphql-compose": "^9.0.10",
         "import-from": "^4.0.0",
         "joi": "^17.7.0",
@@ -8999,6 +9471,19 @@
       "peerDependencies": {
         "gatsby": "^5.0.0-next",
         "graphql": "^16.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-utils/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/gatsby-plugin-utils/node_modules/mime": {
@@ -9043,11 +9528,11 @@
       }
     },
     "node_modules/gatsby-sharp": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.4.0.tgz",
-      "integrity": "sha512-41NY4mcgUsLs8q0XHgjLblQqQ2Ju6cn01b91g8KuVcPeXzZrgvCvCloZF4Ofxf7+CIYRSLVHizhtpPtLyzA6eg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.6.0.tgz",
+      "integrity": "sha512-VLOBnRnLEzGNiAfVLzYu8RDxTAww6R8epXqufLU0bWAg4DXBFHq8W6jA/av3A2Stm9PV/aBcgb/i8tVBFSoq0A==",
       "dependencies": {
-        "@types/sharp": "^0.31.0",
+        "@types/sharp": "^0.31.1",
         "sharp": "^0.31.3"
       },
       "engines": {
@@ -9055,75 +9540,39 @@
       }
     },
     "node_modules/gatsby-telemetry": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-4.4.0.tgz",
-      "integrity": "sha512-rcGMNa4fWIQSDqaUYjMXccrtVr71YQNzw01BfDZ6jxnSc7j29tZ8YXZZh+caS9Fc9cdLpQ2UabFcIp5vAtKQqA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-4.6.0.tgz",
+      "integrity": "sha512-4MpDqRkL+GJu0SdLKCuU0kOog1sKZBOY0e8rubn/mmKmhedItnlACQ4r88xqxwLPHtNweFNhmrTkS1moHmWh0w==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "@turist/fetch": "^7.2.0",
         "@turist/time": "^0.0.2",
-        "boxen": "^4.2.0",
+        "boxen": "^5.1.2",
         "configstore": "^5.0.1",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
         "git-up": "^7.0.0",
         "is-docker": "^2.2.1",
         "lodash": "^4.17.21",
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.8"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/gatsby-telemetry/node_modules/boxen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+    "node_modules/gatsby-telemetry/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gatsby-telemetry/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/gatsby-telemetry/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gatsby-telemetry/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "engines": {
-        "node": ">=8"
+        "node": ">=14.14"
       }
     },
     "node_modules/gatsby-worker": {
@@ -9513,6 +9962,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
+    },
     "node_modules/hasha": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -9604,9 +10058,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -10435,9 +10889,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
-      "integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -11556,16 +12010,16 @@
       }
     },
     "node_modules/package-json/node_modules/cacheable-request": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.2.tgz",
-      "integrity": "sha512-KxjQZM3UIo7/J6W4sLpwFvu1GB3Whv8NtZ8ZrUL284eiQjiXeeqWTdhixNrp/NLZ/JNuFBo6BD4ZaO8ZJ5BN8Q==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.7.tgz",
+      "integrity": "sha512-I4SA6mKgDxcxVbSt/UmIkb9Ny8qSkg6ReBHtAAXnZHk7KOSx5g3DTiAOaYzcHCs6oOdHn+bip9T48E6tMvK9hw==",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
-        "http-cache-semantics": "^4.1.0",
-        "keyv": "^4.5.0",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.2",
         "mimic-response": "^4.0.0",
-        "normalize-url": "^7.2.0",
+        "normalize-url": "^8.0.0",
         "responselike": "^3.0.0"
       },
       "engines": {
@@ -11631,11 +12085,11 @@
       }
     },
     "node_modules/package-json/node_modules/normalize-url": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz",
-      "integrity": "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12917,9 +13371,9 @@
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-      "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -14423,17 +14877,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/term-size": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/terser": {
       "version": "5.14.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
@@ -14662,9 +15105,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -15742,9 +16185,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
-      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
+      "version": "7.20.14",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
+      "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
       "requires": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -16959,7 +17402,7 @@
     "@clerk/backend": {
       "version": "file:.yalc/@clerk/backend",
       "requires": {
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/types": "^3.27.0-staging.0",
         "@peculiar/webcrypto": "1.4.1",
         "@types/node": "16.18.6",
         "deepmerge": "4.2.2",
@@ -16992,12 +17435,12 @@
       }
     },
     "@clerk/clerk-react": {
-      "version": "4.8.5-staging.2",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.8.5-staging.2.tgz",
-      "integrity": "sha512-wCbEIhEnrXTZw7WbA7m6kswm365klU4iiYCSvs3DiNfILsF14PYJFHkbe7KO2s8cbde58A0XAxgh7hJcMLa//g==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.11.2.tgz",
+      "integrity": "sha512-3qNznZOd8mX4Q5dHKdRMpVM/HrxDC6dWws+NJjcUg55zl+uPg7kVVDDGzaifLZyD94O8NP/Fqy9JJ0xU8eJkLQ==",
       "requires": {
-        "@clerk/shared": "^0.9.3-staging.2",
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/shared": "^0.11.2",
+        "@clerk/types": "^3.27.0",
         "swr": "1.3.0",
         "tslib": "2.4.1"
       }
@@ -17005,11 +17448,10 @@
     "@clerk/clerk-sdk-node": {
       "version": "file:.yalc/@clerk/clerk-sdk-node",
       "requires": {
-        "@clerk/backend": "^0.5.0-staging.0",
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/backend": "^0.6.2-staging.0",
+        "@clerk/types": "^3.27.0-staging.0",
         "@types/cookies": "0.7.7",
         "@types/express": "4.17.14",
-        "@types/jsonwebtoken": "8.5.9",
         "@types/node-fetch": "2.6.2",
         "camelcase-keys": "6.2.2",
         "cookie": "0.5.0",
@@ -17018,15 +17460,15 @@
       }
     },
     "@clerk/shared": {
-      "version": "0.9.3-staging.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.9.3-staging.2.tgz",
-      "integrity": "sha512-yqVr8s2w+u8tDbQ9QJ79z7EN942/FNhz+Sp+NmFWBgKBzxLAqjIRB1IV71Ardt0iVQOLfa+F9jh0wfbAsiMqLA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-0.11.2.tgz",
+      "integrity": "sha512-aAb2DbspgBSbqVzyWND2vydmuGOMSWjQDL9GP1EkTJ9ScH/sRnJLFQRt7U16k8Q/w4kEh3THV9yL4FlJQ50tlw==",
       "requires": {}
     },
     "@clerk/types": {
-      "version": "3.24.2-staging.1",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.24.2-staging.1.tgz",
-      "integrity": "sha512-xA0Q6X9VNO+z5echfW9ahMZxADSyUK4iZSTKXTWsMBq94ZeQNGxNCwW6DVscnP21RlkHlAXPkdzA8nlXH4cKbg==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.27.0.tgz",
+      "integrity": "sha512-0mkJvmb1aNnURCoItSMt0pzAh0yPOXu3WPiRoLJwBamqcfLnss1UrfWZdRi++lR8rjoFj9IwJZvSeWRCBqleNw==",
       "requires": {
         "csstype": "3.1.1"
       }
@@ -17076,14 +17518,279 @@
       }
     },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-2.4.0.tgz",
-      "integrity": "sha512-awi7pNgqaR80+9CJcj5UUC4lZDpcoH2fJItqIHC+7VJLxQDxF27vYF8fMgUvqXjjpctro25jMtedd1/4u3G4Hg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-2.6.0.tgz",
+      "integrity": "sha512-RpP8ZGY5v/3lR+wmmGgobfZf4cDEYnBeo34C0H29FY5XIlLD6p4T/B84Qdw1P5I8FShQDado6aed2zNpnr9mvw==",
       "requires": {
-        "@babel/runtime": "^7.20.7",
-        "@parcel/namer-default": "2.8.2",
-        "@parcel/plugin": "2.8.2",
-        "gatsby-core-utils": "^4.4.0"
+        "@babel/runtime": "^7.20.13",
+        "@parcel/namer-default": "2.8.3",
+        "@parcel/plugin": "2.8.3",
+        "gatsby-core-utils": "^4.6.0"
+      },
+      "dependencies": {
+        "@lmdb/lmdb-darwin-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+          "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+          "optional": true
+        },
+        "@lmdb/lmdb-darwin-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+          "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+          "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+          "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+          "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+          "optional": true
+        },
+        "@lmdb/lmdb-win32-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+          "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+          "optional": true
+        },
+        "@parcel/cache": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.8.3.tgz",
+          "integrity": "sha512-k7xv5vSQrJLdXuglo+Hv3yF4BCSs1tQ/8Vbd6CHTkOhf7LcGg6CPtLw053R/KdMpd/4GPn0QrAsOLdATm1ELtQ==",
+          "requires": {
+            "@parcel/fs": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "lmdb": "2.5.2"
+          }
+        },
+        "@parcel/codeframe": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.8.3.tgz",
+          "integrity": "sha512-FE7sY53D6n/+2Pgg6M9iuEC6F5fvmyBkRE4d9VdnOoxhTXtkEqpqYgX7RJ12FAQwNlxKq4suBJQMgQHMF2Kjeg==",
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/core": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.3.tgz",
+          "integrity": "sha512-Euf/un4ZAiClnlUXqPB9phQlKbveU+2CotZv7m7i+qkgvFn5nAGnrV4h1OzQU42j9dpgOxWi7AttUDMrvkbhCQ==",
+          "peer": true,
+          "requires": {
+            "@mischnic/json-sourcemap": "^0.1.0",
+            "@parcel/cache": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3",
+            "@parcel/fs": "2.8.3",
+            "@parcel/graph": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/package-manager": "2.8.3",
+            "@parcel/plugin": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/workers": "2.8.3",
+            "abortcontroller-polyfill": "^1.1.9",
+            "base-x": "^3.0.8",
+            "browserslist": "^4.6.6",
+            "clone": "^2.1.1",
+            "dotenv": "^7.0.0",
+            "dotenv-expand": "^5.1.0",
+            "json5": "^2.2.0",
+            "msgpackr": "^1.5.4",
+            "nullthrows": "^1.1.1",
+            "semver": "^5.7.1"
+          }
+        },
+        "@parcel/diagnostic": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
+          "integrity": "sha512-u7wSzuMhLGWZjVNYJZq/SOViS3uFG0xwIcqXw12w54Uozd6BH8JlhVtVyAsq9kqnn7YFkw6pXHqAo5Tzh4FqsQ==",
+          "requires": {
+            "@mischnic/json-sourcemap": "^0.1.0",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/events": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.8.3.tgz",
+          "integrity": "sha512-hoIS4tAxWp8FJk3628bsgKxEvR7bq2scCVYHSqZ4fTi/s0+VymEATrRCUqf+12e5H47uw1/ZjoqrGtBI02pz4w=="
+        },
+        "@parcel/fs": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.8.3.tgz",
+          "integrity": "sha512-y+i+oXbT7lP0e0pJZi/YSm1vg0LDsbycFuHZIL80pNwdEppUAtibfJZCp606B7HOjMAlNZOBo48e3hPG3d8jgQ==",
+          "requires": {
+            "@parcel/fs-search": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/watcher": "^2.0.7",
+            "@parcel/workers": "2.8.3"
+          }
+        },
+        "@parcel/fs-search": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.8.3.tgz",
+          "integrity": "sha512-DJBT2N8knfN7Na6PP2mett3spQLTqxFrvl0gv+TJRp61T8Ljc4VuUTb0hqBj+belaASIp3Q+e8+SgaFQu7wLiQ==",
+          "requires": {
+            "detect-libc": "^1.0.3"
+          }
+        },
+        "@parcel/graph": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.8.3.tgz",
+          "integrity": "sha512-26GL8fYZPdsRhSXCZ0ZWliloK6DHlMJPWh6Z+3VVZ5mnDSbYg/rRKWmrkhnr99ZWmL9rJsv4G74ZwvDEXTMPBg==",
+          "peer": true,
+          "requires": {
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/hash": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.8.3.tgz",
+          "integrity": "sha512-FVItqzjWmnyP4ZsVgX+G00+6U2IzOvqDtdwQIWisCcVoXJFCqZJDy6oa2qDDFz96xCCCynjRjPdQx2jYBCpfYw==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "xxhash-wasm": "^0.4.2"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.8.3.tgz",
+          "integrity": "sha512-Kpxd3O/Vs7nYJIzkdmB6Bvp3l/85ydIxaZaPfGSGTYOfaffSOTkhcW9l6WemsxUrlts4za6CaEWcc4DOvaMOPA==",
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/events": "2.8.3"
+          }
+        },
+        "@parcel/markdown-ansi": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.8.3.tgz",
+          "integrity": "sha512-4v+pjyoh9f5zuU/gJlNvNFGEAb6J90sOBwpKJYJhdWXLZMNFCVzSigxrYO+vCsi8G4rl6/B2c0LcwIMjGPHmFQ==",
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/namer-default": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.8.3.tgz",
+          "integrity": "sha512-tJ7JehZviS5QwnxbARd8Uh63rkikZdZs1QOyivUhEvhN+DddSAVEdQLHGPzkl3YRk0tjFhbqo+Jci7TpezuAMw==",
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/plugin": "2.8.3",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/package-manager": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.8.3.tgz",
+          "integrity": "sha512-tIpY5pD2lH53p9hpi++GsODy6V3khSTX4pLEGuMpeSYbHthnOViobqIlFLsjni+QA1pfc8NNNIQwSNdGjYflVA==",
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/fs": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "@parcel/workers": "2.8.3",
+            "semver": "^5.7.1"
+          }
+        },
+        "@parcel/plugin": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.8.3.tgz",
+          "integrity": "sha512-jZ6mnsS4D9X9GaNnvrixDQwlUQJCohDX2hGyM0U0bY2NWU8Km97SjtoCpWjq+XBCx/gpC4g58+fk9VQeZq2vlw==",
+          "requires": {
+            "@parcel/types": "2.8.3"
+          }
+        },
+        "@parcel/types": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.8.3.tgz",
+          "integrity": "sha512-FECA1FB7+0UpITKU0D6TgGBpGxYpVSMNEENZbSJxFSajNy3wrko+zwBKQmFOLOiPcEtnGikxNs+jkFWbPlUAtw==",
+          "requires": {
+            "@parcel/cache": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/fs": "2.8.3",
+            "@parcel/package-manager": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "@parcel/workers": "2.8.3",
+            "utility-types": "^3.10.0"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.8.3.tgz",
+          "integrity": "sha512-IhVrmNiJ+LOKHcCivG5dnuLGjhPYxQ/IzbnF2DKNQXWBTsYlHkJZpmz7THoeLtLliGmSOZ3ZCsbR8/tJJKmxjA==",
+          "requires": {
+            "@parcel/codeframe": "2.8.3",
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/hash": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/markdown-ansi": "2.8.3",
+            "@parcel/source-map": "^2.1.1",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.8.3.tgz",
+          "integrity": "sha512-+AxBnKgjqVpUHBcHLWIHcjYgKIvHIpZjN33mG5LG9XXvrZiqdWvouEzqEXlVLq5VzzVbKIQQcmsvRy138YErkg==",
+          "requires": {
+            "@parcel/diagnostic": "2.8.3",
+            "@parcel/logger": "2.8.3",
+            "@parcel/types": "2.8.3",
+            "@parcel/utils": "2.8.3",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "dotenv": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+          "peer": true
+        },
+        "lmdb": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+          "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+          "requires": {
+            "@lmdb/lmdb-darwin-arm64": "2.5.2",
+            "@lmdb/lmdb-darwin-x64": "2.5.2",
+            "@lmdb/lmdb-linux-arm": "2.5.2",
+            "@lmdb/lmdb-linux-arm64": "2.5.2",
+            "@lmdb/lmdb-linux-x64": "2.5.2",
+            "@lmdb/lmdb-win32-x64": "2.5.2",
+            "msgpackr": "^1.5.4",
+            "node-addon-api": "^4.3.0",
+            "node-gyp-build-optional-packages": "5.0.3",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
+          }
+        },
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@gatsbyjs/reach-router": {
@@ -18435,14 +19142,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
-    "@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
@@ -19277,13 +19976,13 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.4.0.tgz",
-      "integrity": "sha512-+3e51jNoqtphSSOsES4FzlY5xOQXlsliw2daYzhP7QdfXB3ffBWDskqrsCv+9mug4VyWqIy7YXSQY4osEBA98A==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.6.0.tgz",
+      "integrity": "sha512-8kLiQRdFPL5cy7IgEmNqsW6XpyM566xFnpnUmTYMdVST+GYDe9rFr0WDYdaQB8cgPRJyq0bbhasHnZbieIux+A==",
       "requires": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
-        "gatsby-core-utils": "^4.4.0"
+        "gatsby-core-utils": "^4.6.0"
       }
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -19331,9 +20030,9 @@
       }
     },
     "babel-preset-gatsby": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-3.4.0.tgz",
-      "integrity": "sha512-InyNQmv7ov5r0ZgXpw4vrgooKf5419/kdced0dqWgBOlm5/RIhRpyGhzVO3tfw744HhaagO+8NXi6t17AvkWUQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-3.6.0.tgz",
+      "integrity": "sha512-u+SRfhlgPfgd14iUukynIRpTeImYtbYQt5JhzD8ZPESktKwk5ND5ZT49pGwzq3kLu4oBxXoZYBbjAgE1cwXtjA==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
@@ -19344,12 +20043,12 @@
         "@babel/plugin-transform-spread": "^7.20.7",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-legacy-polyfills": "^3.4.0"
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-legacy-polyfills": "^3.6.0"
       }
     },
     "balanced-match": {
@@ -20137,11 +20836,11 @@
       }
     },
     "create-gatsby": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/create-gatsby/-/create-gatsby-3.4.0.tgz",
-      "integrity": "sha512-WD9WtsXzqa+5vMBF56iiq8IGdJQT7TlWGYLv1qeM5jgK7tCCFxHnzHZ/MnvTnwspeKGRQuFgWpbrnSgD4YyQdA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/create-gatsby/-/create-gatsby-3.6.0.tgz",
+      "integrity": "sha512-1bVBCDr7v+mPsgKIe4LvRG1y+FZv9oKMe1mdnhTtQ0EaKog8Jjp4C8rm+TcT5wTlEANotKbB6ku4WXkTjm0d1Q==",
       "requires": {
-        "@babel/runtime": "^7.20.7"
+        "@babel/runtime": "^7.20.13"
       }
     },
     "cross-fetch": {
@@ -22014,16 +22713,16 @@
       }
     },
     "gatsby-cli": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-5.4.0.tgz",
-      "integrity": "sha512-3b6PGhv89mtIabur6Al7O/0cDoazgQfNjQzeKqsboRyaZCanJZsZnk6mDaHBYBSUfq6M+8TQWZvNlvxnF2kwig==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-5.6.0.tgz",
+      "integrity": "sha512-cvkZqAIVd7uoFQF2C0lJU57tya19GAWNJJP+DsHoalgGBjOPzfDzk1EN/xWnSDMUm4XM/+8PU3Ublz4dCWTI8w==",
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/core": "^7.20.7",
-        "@babel/generator": "^7.20.7",
+        "@babel/core": "^7.20.12",
+        "@babel/generator": "^7.20.14",
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "@babel/template": "^7.20.7",
         "@babel/types": "^7.20.7",
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -22034,23 +22733,23 @@
         "clipboardy": "^2.3.0",
         "common-tags": "^1.8.2",
         "convert-hrtime": "^3.0.0",
-        "create-gatsby": "^3.4.0",
+        "create-gatsby": "^3.6.0",
         "envinfo": "^7.8.1",
         "execa": "^5.1.1",
         "fs-exists-cached": "^1.0.0",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-telemetry": "^4.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-telemetry": "^4.6.0",
         "hosted-git-info": "^3.0.8",
         "is-valid-path": "^0.1.1",
         "joi": "^17.7.0",
         "lodash": "^4.17.21",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.8",
         "opentracing": "^0.14.7",
         "pretty-error": "^2.1.2",
         "progress": "^2.0.3",
         "prompts": "^2.4.2",
-        "redux": "4.2.0",
+        "redux": "4.2.1",
         "resolve-cwd": "^3.0.0",
         "semver": "^7.3.8",
         "signal-exit": "^3.0.7",
@@ -22059,20 +22758,41 @@
         "yargs": "^15.4.1",
         "yoga-layout-prebuilt": "^1.10.0",
         "yurnalist": "^2.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "redux": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+          "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "gatsby-core-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.4.0.tgz",
-      "integrity": "sha512-/ibilcGENKH6qqkcT17SIZgc2kjZn3HiGpD+ixbXYkMGqHiM5pj9XIHjy3DfvZvDt2ujkYV5EinmUdqx7CI81w==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.6.0.tgz",
+      "integrity": "sha512-wXqWZWn6VuL2caWHCryt/pYyJJxJiv2JKyzXlJ1mLac0ZB24PP3Uc9NXPgFy8XzEtcL+23+9i9CiIiz+VNgxpQ==",
       "requires": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "ci-info": "2.0.0",
         "configstore": "^5.0.1",
         "fastq": "^1.13.0",
         "file-type": "^16.5.3",
-        "fs-extra": "^10.1.0",
+        "fs-extra": "^11.1.0",
         "got": "^11.8.5",
+        "hash-wasm": "^4.9.0",
         "import-from": "^4.0.0",
         "lmdb": "2.5.3",
         "lock": "^1.1.0",
@@ -22081,6 +22801,18 @@
         "resolve-from": "^5.0.0",
         "tmp": "^0.2.1",
         "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-graphiql-explorer": {
@@ -22089,11 +22821,11 @@
       "integrity": "sha512-rNTLw+P3qcbLKBGF+jRhZ2MerQw7Mq4VsmEaBVsvbEnlBVrz5N45ArV5yliqJ7e7pfvhPfkIbVlUhVQVHg25Cw=="
     },
     "gatsby-legacy-polyfills": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-3.4.0.tgz",
-      "integrity": "sha512-5ORvRO1ZpxqM4U9W1Da/ewYJpEm6/tSqAhw11yOLqf7GjJYW1Tc3GBPeY3EBvpU/GTAmQM6k9exS1xESAOrBAw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-3.6.0.tgz",
+      "integrity": "sha512-6z8zPrSOFLiZ+iRIxMjH79hvz37oef/BvALdut4CVVp5a6Pdv1n+cHss1pCKFzhBtOVwLbbonMpxXT/RBLvM3w==",
       "requires": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "core-js-compat": "3.9.0"
       },
       "dependencies": {
@@ -22114,25 +22846,25 @@
       }
     },
     "gatsby-link": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.4.0.tgz",
-      "integrity": "sha512-7JXCCEnlehmJ1MB8Y2/I3UxE8a3cKKOsGMX1DtuMs7t3StdOzBMjaiM2nzLUNRCLGBDpSE2kpk55aB2h+Xq3+Q==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.6.0.tgz",
+      "integrity": "sha512-kC/EUajQJGDyUMtdarDQkLaILfuhGNCVMOGs+Px5e/KxAQXmCzWbA0M7tr0i3awyW7Qj3JsBjaL6y3ePe4kzNg==",
       "requires": {
         "@types/reach__router": "^1.3.10",
-        "gatsby-page-utils": "^3.4.0",
+        "gatsby-page-utils": "^3.6.0",
         "prop-types": "^15.8.1"
       }
     },
     "gatsby-page-utils": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.4.0.tgz",
-      "integrity": "sha512-e/cIpnlQlACq30Ig5eS3ZQ7iTRuZyf3m93epW0MioQ8j9dYZkFJ/cHY1CKsTRZzi8FlZuy8wVr2YMkEzZveUlw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.6.0.tgz",
+      "integrity": "sha512-zRoRPm5fr/Cz2FFTNyK8vPmcFwyvRumNQa7H4SHg09+RYtawZE2Cs6elsYcBIL1bgDsWCxqGuZYC4Uarv41D0g==",
       "requires": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "bluebird": "^3.7.2",
         "chokidar": "^3.5.3",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^4.4.0",
+        "gatsby-core-utils": "^4.6.0",
         "glob": "^7.2.3",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.5"
@@ -22160,63 +22892,85 @@
     "gatsby-plugin-clerk": {
       "version": "file:.yalc/gatsby-plugin-clerk",
       "requires": {
-        "@clerk/backend": "^0.5.0-staging.0",
-        "@clerk/clerk-react": "^4.8.5-staging.2",
-        "@clerk/clerk-sdk-node": "^4.6.4-staging.2",
-        "@clerk/types": "^3.24.2-staging.1",
+        "@clerk/backend": "^0.6.2-staging.0",
+        "@clerk/clerk-react": "^4.11.2-staging.0",
+        "@clerk/clerk-sdk-node": "^4.7.2-staging.0",
+        "@clerk/types": "^3.27.0-staging.0",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-5.4.0.tgz",
-      "integrity": "sha512-OQ1bcUK/21e3OAUZNvm82Wkr8QtKzhD4nHThBHGIMtvfZN2dmzPqkds1b62jLGhaVGhevupBjBE00nr56IR/EA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-5.6.0.tgz",
+      "integrity": "sha512-WSCyxoAuF4DMBOPJfQpQzmq99nR3hVZBeKa0uWmFbSePouwtJ3tJadurNGgP5mzsG73HyKbwXPEcYHQy+LtrSg==",
       "requires": {
-        "@babel/runtime": "^7.20.7",
-        "@babel/traverse": "^7.20.10",
+        "@babel/runtime": "^7.20.13",
+        "@babel/traverse": "^7.20.13",
         "@sindresorhus/slugify": "^1.1.2",
         "chokidar": "^3.5.3",
         "fs-exists-cached": "^1.0.0",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-page-utils": "^3.4.0",
-        "gatsby-plugin-utils": "^4.4.0",
-        "gatsby-telemetry": "^4.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-page-utils": "^3.6.0",
+        "gatsby-plugin-utils": "^4.6.0",
+        "gatsby-telemetry": "^4.6.0",
         "globby": "^11.1.0",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-plugin-typescript": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.4.0.tgz",
-      "integrity": "sha512-BQqt7Sj9JRBOOq7sClwNNdAdtRkBi9Z/TkmdnWNQMeR4YcGI0GvEhSwOuQm4V9FeCFDnbWxmnZ7w9R7Bjl8NVA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.6.0.tgz",
+      "integrity": "sha512-YsczXNnYldFx1mu+Q0Zx/dLMOuHCGBguh+P4EqVRoFJx30/EJtWrqZxqou5o5JwlU4115o8L4FLzFTHeuqwyWw==",
       "requires": {
-        "@babel/core": "^7.20.7",
+        "@babel/core": "^7.20.12",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/plugin-proposal-numeric-separator": "^7.18.6",
         "@babel/plugin-proposal-optional-chaining": "^7.20.7",
         "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
-        "babel-plugin-remove-graphql-queries": "^5.4.0"
+        "@babel/runtime": "^7.20.13",
+        "babel-plugin-remove-graphql-queries": "^5.6.0"
       }
     },
     "gatsby-plugin-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-4.4.0.tgz",
-      "integrity": "sha512-oS96PobrmXyOIX6Cqo6RpHykBC8SbIYF6iZcIastR+bcFQRWojFaHP1euFHQ3sVyeVc9SyxBGDHRS5WG+SvAog==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-4.6.0.tgz",
+      "integrity": "sha512-CR+6lGnRlMUYbqM58sNBbQxCSkGm+ltqAfWWQTlnmYSpqmKxHLMpZ0F2KfxVXQOXRbtBNx1oXZWzbEzmydoXkA==",
       "requires": {
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "fastq": "^1.13.0",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
-        "gatsby-sharp": "^1.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
+        "gatsby-sharp": "^1.6.0",
         "graphql-compose": "^9.0.10",
         "import-from": "^4.0.0",
         "joi": "^17.7.0",
         "mime": "^3.0.0"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "mime": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -22240,66 +22994,42 @@
       "requires": {}
     },
     "gatsby-sharp": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.4.0.tgz",
-      "integrity": "sha512-41NY4mcgUsLs8q0XHgjLblQqQ2Ju6cn01b91g8KuVcPeXzZrgvCvCloZF4Ofxf7+CIYRSLVHizhtpPtLyzA6eg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.6.0.tgz",
+      "integrity": "sha512-VLOBnRnLEzGNiAfVLzYu8RDxTAww6R8epXqufLU0bWAg4DXBFHq8W6jA/av3A2Stm9PV/aBcgb/i8tVBFSoq0A==",
       "requires": {
-        "@types/sharp": "^0.31.0",
+        "@types/sharp": "^0.31.1",
         "sharp": "^0.31.3"
       }
     },
     "gatsby-telemetry": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-4.4.0.tgz",
-      "integrity": "sha512-rcGMNa4fWIQSDqaUYjMXccrtVr71YQNzw01BfDZ6jxnSc7j29tZ8YXZZh+caS9Fc9cdLpQ2UabFcIp5vAtKQqA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-4.6.0.tgz",
+      "integrity": "sha512-4MpDqRkL+GJu0SdLKCuU0kOog1sKZBOY0e8rubn/mmKmhedItnlACQ4r88xqxwLPHtNweFNhmrTkS1moHmWh0w==",
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/runtime": "^7.20.7",
+        "@babel/runtime": "^7.20.13",
         "@turist/fetch": "^7.2.0",
         "@turist/time": "^0.0.2",
-        "boxen": "^4.2.0",
+        "boxen": "^5.1.2",
         "configstore": "^5.0.1",
-        "fs-extra": "^10.1.0",
-        "gatsby-core-utils": "^4.4.0",
+        "fs-extra": "^11.1.0",
+        "gatsby-core-utils": "^4.6.0",
         "git-up": "^7.0.0",
         "is-docker": "^2.2.1",
         "lodash": "^4.17.21",
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.8"
       },
       "dependencies": {
-        "boxen": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-          "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
           "requires": {
-            "ansi-align": "^3.0.0",
-            "camelcase": "^5.3.1",
-            "chalk": "^3.0.0",
-            "cli-boxes": "^2.2.0",
-            "string-width": "^4.1.0",
-            "term-size": "^2.1.0",
-            "type-fest": "^0.8.1",
-            "widest-line": "^3.1.0"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
         }
       }
     },
@@ -22563,6 +23293,11 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
+    },
     "hasha": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -22633,9 +23368,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -23220,9 +23955,9 @@
       }
     },
     "keyv": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
-      "integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "requires": {
         "json-buffer": "3.0.1"
       }
@@ -24041,16 +24776,16 @@
           "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w=="
         },
         "cacheable-request": {
-          "version": "10.2.2",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.2.tgz",
-          "integrity": "sha512-KxjQZM3UIo7/J6W4sLpwFvu1GB3Whv8NtZ8ZrUL284eiQjiXeeqWTdhixNrp/NLZ/JNuFBo6BD4ZaO8ZJ5BN8Q==",
+          "version": "10.2.7",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.7.tgz",
+          "integrity": "sha512-I4SA6mKgDxcxVbSt/UmIkb9Ny8qSkg6ReBHtAAXnZHk7KOSx5g3DTiAOaYzcHCs6oOdHn+bip9T48E6tMvK9hw==",
           "requires": {
             "@types/http-cache-semantics": "^4.0.1",
             "get-stream": "^6.0.1",
-            "http-cache-semantics": "^4.1.0",
-            "keyv": "^4.5.0",
+            "http-cache-semantics": "^4.1.1",
+            "keyv": "^4.5.2",
             "mimic-response": "^4.0.0",
-            "normalize-url": "^7.2.0",
+            "normalize-url": "^8.0.0",
             "responselike": "^3.0.0"
           }
         },
@@ -24092,9 +24827,9 @@
           "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg=="
         },
         "normalize-url": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz",
-          "integrity": "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA=="
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+          "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw=="
         },
         "p-cancelable": {
           "version": "3.0.0",
@@ -24972,9 +25707,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-          "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ=="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+          "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw=="
         },
         "open": {
           "version": "8.4.0",
@@ -26113,11 +26848,6 @@
         }
       }
     },
-    "term-size": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="
-    },
     "terser": {
       "version": "5.14.2",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
@@ -26291,9 +27021,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "requires": {
             "minimist": "^1.2.0"
           }

--- a/playground/gatsby/package.json
+++ b/playground/gatsby/package.json
@@ -16,10 +16,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@clerk/backend": "file:.yalc/@clerk/backend",
-    "@clerk/clerk-sdk-node": "file:.yalc/@clerk/clerk-sdk-node",
+    "@clerk/backend": "*",
+    "@clerk/clerk-sdk-node": "*",
     "gatsby": "5.4.2",
-    "gatsby-plugin-clerk": "file:.yalc/gatsby-plugin-clerk",
+    "gatsby-plugin-clerk": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/playground/nextjs/package-lock.json
+++ b/playground/nextjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@playground/nextjs",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "file:../../packages/nextjs/",
+        "@clerk/nextjs": "*",
         "next": "^13.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -23,32 +23,32 @@
       }
     },
     "../../packages/nextjs": {
-      "version": "4.6.0",
+      "name": "@clerk/nextjs",
+      "version": "4.10.1-staging.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-react": "^4.4.2",
-        "@clerk/clerk-sdk-node": "^4.5.1",
-        "@clerk/edge": "^1.12.9",
-        "@clerk/types": "^3.16.0",
-        "tslib": "^2.3.1"
+        "@clerk/backend": "^0.6.3-staging.0",
+        "@clerk/clerk-react": "^4.11.3-staging.0",
+        "@clerk/clerk-sdk-node": "^4.7.3-staging.0",
+        "@clerk/types": "^3.27.1-staging.0",
+        "tslib": "2.4.1"
       },
       "devDependencies": {
-        "@types/jest": "^27.4.0",
         "@types/node": "^16.11.55",
         "@types/react": "*",
         "@types/react-dom": "*",
-        "jest": "^27.4.7",
-        "next": "^13.0.2",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "ts-jest": "^27.1.3",
+        "jest": "*",
+        "node-fetch-native": "^0.1.8",
+        "ts-jest": "*",
         "typescript": "*"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "next": ">=10"
+        "next": ">=10",
+        "react": "^17.0.2 || ^18.0.0-0",
+        "react-dom": "^17.0.2 || ^18.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3159,20 +3159,17 @@
     "@clerk/nextjs": {
       "version": "file:../../packages/nextjs",
       "requires": {
-        "@clerk/clerk-react": "^4.4.2",
-        "@clerk/clerk-sdk-node": "^4.5.1",
-        "@clerk/edge": "^1.12.9",
-        "@clerk/types": "^3.16.0",
-        "@types/jest": "^27.4.0",
+        "@clerk/backend": "^0.6.3-staging.0",
+        "@clerk/clerk-react": "^4.11.3-staging.0",
+        "@clerk/clerk-sdk-node": "^4.7.3-staging.0",
+        "@clerk/types": "^3.27.1-staging.0",
         "@types/node": "^16.11.55",
         "@types/react": "*",
         "@types/react-dom": "*",
-        "jest": "^27.4.7",
-        "next": "^13.0.2",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "ts-jest": "^27.1.3",
-        "tslib": "^2.3.1",
+        "jest": "*",
+        "node-fetch-native": "^0.1.8",
+        "ts-jest": "*",
+        "tslib": "2.4.1",
         "typescript": "*"
       }
     },

--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@clerk/nextjs": "file:../../packages/nextjs/",
+    "@clerk/nextjs": "*",
     "next": "^13.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/playground/nextjs12/package.json
+++ b/playground/nextjs12/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@clerk/nextjs": "file:../../packages/nextjs/",
+    "@clerk/nextjs": "*",
     "next": "^12.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/playground/remix-cf-pages/package.json
+++ b/playground/remix-cf-pages/package.json
@@ -11,9 +11,9 @@
     "yalc:add": "yalc add @clerk/types && yalc add @clerk/remix && yalc add @clerk/backend"
   },
   "dependencies": {
-    "@clerk/backend": "latest",
-    "@clerk/remix": "latest",
-    "@clerk/types": "latest",
+    "@clerk/backend": "*",
+    "@clerk/remix": "*",
+    "@clerk/types": "*",
     "@remix-run/cloudflare": "^1.7.5",
     "@remix-run/cloudflare-pages": "^1.7.5",
     "@remix-run/react": "^1.7.5",

--- a/playground/remix-cf-worker/package.json
+++ b/playground/remix-cf-worker/package.json
@@ -11,9 +11,9 @@
     "yalc:add": "yalc add @clerk/types && yalc add @clerk/remix && yalc add @clerk/backend"
   },
   "dependencies": {
-    "@clerk/backend": "file:.yalc/@clerk/backend",
-    "@clerk/remix": "file:.yalc/@clerk/remix",
-    "@clerk/types": "file:.yalc/@clerk/types",
+    "@clerk/backend": "*",
+    "@clerk/remix": "*",
+    "@clerk/types": "*",
     "@remix-run/cloudflare": "^1.7.5",
     "@remix-run/cloudflare-workers": "^1.7.5",
     "@remix-run/react": "^1.7.5",

--- a/playground/remix-node/package.json
+++ b/playground/remix-node/package.json
@@ -8,10 +8,10 @@
     "yalc:add": "yalc add @clerk/types && yalc add @clerk/remix && yalc add @clerk/backend"
   },
   "dependencies": {
-    "@clerk/backend": "file:.yalc/@clerk/backend",
-    "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
-    "@clerk/remix": "file:.yalc/@clerk/remix",
-    "@clerk/types": "file:.yalc/@clerk/types",
+    "@clerk/backend": "*",
+    "@clerk/clerk-react": "*",
+    "@clerk/remix": "*",
+    "@clerk/types": "*",
     "@remix-run/node": "^1.12.0",
     "@remix-run/react": "^1.12.0",
     "@remix-run/serve": "^1.12.0",


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

After this change we should just use once `yalc add --pure {sdk} {sdk-dependency}` per playground app and always run `npm run build` in `packages/<pkg>` when changes are made, for the playground app to be updated.

Also after this change the `npm audit` in the repo is in sync with dependabot reported issues.
see: https://www.notion.so/clerkdev/Testing-changes-in-clerk-javascript-d21ad8ca16fe447a813f67b9f1f6b16e

