### PR TITLE
feat(types): Support user defined types for auth.sessionClaims

### DIFF
--- a/packages/types/src/jwtv2.ts
+++ b/packages/types/src/jwtv2.ts
@@ -26,7 +26,17 @@ export interface JwtHeader {
   x5c?: string | string[];
 }
 
-export interface JwtPayload {
+declare global {
+  /**
+   * If you want to provide custom types for the getAuth().sessionClaims object,
+   * simply redeclare this interface in the global namespace and provide your own custom keys.
+   */
+  interface CustomJwtSessionClaims {
+    [k: string]: unknown;
+  }
+}
+
+export interface JwtPayload extends CustomJwtSessionClaims {
   /**
    * Encoded token supporting the `getRawString` method.
    */


### PR DESCRIPTION
…ject via CustomJwtSessionClaims

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Introduce the `CustomJwtSessionClaims` globally defined interface to allow user-defined types for the auth.sessionClaims objects, similar to `PublicUserMetadata` etc.

To use, re-declare `CustomJwtSessionClaims` as shown:

```ts
declare global {
  interface UserPublicMetadata {
    showAds: boolean;
  }

  interface CustomJwtSessionClaims {
    publicMetadata: UserPublicMetadata;
    anotherProp: { hello: string };
  }
}
```

Usage:
server-side:
![image](https://user-images.githubusercontent.com/1811063/218595687-9db2689f-6f0c-4bbe-9586-c67fa14f03a5.png)


client-side (public metadata example)
![image](https://user-images.githubusercontent.com/1811063/218595838-c241289f-2bca-40dd-9cf3-059aa068e2fb.png)

In the future, we might want to drop the `global` declaration and opt-in for a more explicit `declare module @clerk/types` instead - however, I expect that conflicts won't be common at all, and I prefer the DX of the global namespace.

My preferred way to go about it would be to bound the types with via a `createClerk`  factory call, but that's out of scope for now.
<!-- Fixes # (issue number) -->

