### PR TITLE
Chore(remix): Add observability headers in unknown and interstitial

### DIFF
--- a/packages/remix/src/ssr/getAuth.ts
+++ b/packages/remix/src/ssr/getAuth.ts
@@ -14,7 +14,7 @@ export async function getAuth(args: LoaderFunctionArgs, opts?: GetAuthOptions): 
   const requestState = await authenticateRequest(args, opts);
 
   if (requestState.isUnknown) {
-    throw unknownResponse();
+    throw unknownResponse(requestState);
   }
 
   if (requestState.isInterstitial) {

--- a/packages/remix/src/ssr/index.ts
+++ b/packages/remix/src/ssr/index.ts
@@ -1,2 +1,3 @@
 export * from './rootAuthLoader';
 export * from './getAuth';
+export { getClerkDebugHeaders } from './utils';

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -38,7 +38,7 @@ export const rootAuthLoader: RootAuthLoader = async (
   const requestState = await authenticateRequest(args, opts);
 
   if (requestState.isUnknown) {
-    throw unknownResponse();
+    throw unknownResponse(requestState);
   }
 
   if (requestState.isInterstitial) {

--- a/playground/remix-node/app/root.tsx
+++ b/playground/remix-node/app/root.tsx
@@ -1,6 +1,7 @@
-import type { LoaderFunction, MetaFunction } from '@remix-run/node';
+import type { LoaderFunction, MetaFunction, Headers } from '@remix-run/node';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
 import { rootAuthLoader } from '@clerk/remix/ssr.server';
+import { getClerkDebugHeaders } from '@clerk/remix/ssr.server';
 import { ClerkApp, ClerkCatchBoundary } from '@clerk/remix';
 
 export const loader: LoaderFunction = args => {
@@ -16,6 +17,21 @@ export const loader: LoaderFunction = args => {
     { loadUser: true },
   );
 };
+
+export function headers({
+  actionHeaders,
+  loaderHeaders,
+  parentHeaders,
+}: {
+  actionHeaders: Headers;
+  loaderHeaders: Headers;
+  parentHeaders: Headers;
+}) {
+  return {
+    'x-parent-header': parentHeaders.get('x-parent-header'),
+    ...getClerkDebugHeaders(loaderHeaders),
+  };
+}
 
 export const meta: MetaFunction = () => ({
   charset: 'utf-8',


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
Even though we can add the observability headers in the Response object of remix, they are not returned to the client response. 
To return them from the loader function the customers should explicitly add the headers from there `headers` function in the endpoint or from the root level (`root.tsx`) using the following lines of code (also used in playground/remix-node):
```
import { getClerkDebugHeaders } from '@clerk/remix/ssr.server';

export function headers({
  actionHeaders,
  loaderHeaders,
  parentHeaders,
}: {
  actionHeaders: Headers;
  loaderHeaders: Headers;
  parentHeaders: Headers;
}) {
  return {
    // other headers from parent or action
    ...getClerkDebugHeaders(loaderHeaders)
  }
}
```
To help customers add those debugging headers i exposed a new function `getClerkDebugHeaders(headers: Headers)` from `@clerk/remix/ssr.server` to return the clerk debug headers to avoid any unwanted header merges.

ref: https://remix.run/docs/en/v1/route/headers