### PR TITLE
fix(backend): Pass multi-domain attributes to load BAPI interstitial

### DIFF
--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -122,7 +122,7 @@ export async function loadInterstitialFromBAPI(options: LoadInterstitialOptions)
 
 export function buildPublicInterstitialUrl(options: LoadInterstitialOptions) {
   options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
-  const { apiUrl, frontendApi, pkgVersion, publishableKey, proxyUrl } = options;
+  const { apiUrl, frontendApi, pkgVersion, publishableKey, proxyUrl, debugData, isSatellite, domain } = options;
   const url = new URL(apiUrl);
   url.pathname = joinPaths(url.pathname, API_VERSION, '/public/interstitial');
   url.searchParams.append('clerk_js_version', getClerkJsMajorVersionOrTag(frontendApi, pkgVersion));
@@ -134,6 +134,20 @@ export function buildPublicInterstitialUrl(options: LoadInterstitialOptions) {
   if (proxyUrl) {
     url.searchParams.append('proxy_url', proxyUrl);
   }
+
+  const shouldSync = isSatellite && debugData?.reason === 'satellite-cookie-missing';
+  if (shouldSync) {
+    url.searchParams.append('should_sync_link', 'true');
+  }
+
+  if (isSatellite) {
+    url.searchParams.append('is_satellite', 'true');
+  }
+
+  if (domain) {
+    url.searchParams.append('domain', domain);
+  }
+
   return url.href;
 }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
