### PR TITLE
feat(clerk-js): Lazy load clerk ui components

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -25,7 +25,8 @@
   },
   "scripts": {
     "build": "npm run build:bundle && (npm run build:declarations || true) && npm run bundlewatch",
-    "build:stats": "webpack --config webpack.dev.js --env production --json | tail -n +2 > stats.json",
+    "build:stats": "webpack --config webpack.dev.js --env production --profile --json=stats.json",
+    "build:analyze": "webpack-bundle-analyzer stats.json dist/",
     "bundlewatch": "bundlewatch",
     "build:bundle": "webpack --config webpack.dev.js --env production",
     "build:declarations": "tsc -p tsconfig.declarations.json",

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -16,32 +16,63 @@ import { createRoot } from 'react-dom/client';
 import { PRESERVED_QUERYSTRING_PARAMS } from '../core/constants';
 import { clerkUIErrorDOMElementNotFound } from '../core/errors';
 import { buildVirtualRouterUrl } from '../utils';
-const SignIn = lazy(() => import('./components/SignIn').then(module => ({ default: module.SignIn })));
-const SignInModal = lazy(() => import('./components/SignIn').then(module => ({ default: module.SignInModal })));
-const SignUp = lazy(() => import('./components/SignUp').then(module => ({ default: module.SignUp })));
-const SignUpModal = lazy(() => import('./components/SignUp').then(module => ({ default: module.SignUpModal })));
-const UserButton = lazy(() => import('./components/UserButton').then(module => ({ default: module.UserButton })));
-const UserProfile = lazy(() => import('./components/UserProfile').then(module => ({ default: module.UserProfile })));
+
+const SignIn = lazy(() =>
+  import(/* webpackChunkName: "SignIn" */ './components/SignIn').then(module => ({ default: module.SignIn })),
+);
+const SignInModal = lazy(() =>
+  import(/* webpackChunkName: "SignInModal" */ './components/SignIn').then(module => ({ default: module.SignInModal })),
+);
+const SignUp = lazy(() =>
+  import(/* webpackChunkName: "SignUp" */ './components/SignUp').then(module => ({ default: module.SignUp })),
+);
+const SignUpModal = lazy(() =>
+  import(/* webpackChunkName: "SignUpModal" */ './components/SignUp').then(module => ({ default: module.SignUpModal })),
+);
+const UserButton = lazy(() =>
+  import(/* webpackChunkName: "UserButton" */ './components/UserButton').then(module => ({
+    default: module.UserButton,
+  })),
+);
+const UserProfile = lazy(() =>
+  import(/* webpackChunkName: "UserProfile" */ './components/UserProfile').then(module => ({
+    default: module.UserProfile,
+  })),
+);
 const UserProfileModal = lazy(() =>
-  import('./components/UserProfile').then(module => ({ default: module.UserProfileModal })),
+  import(/* webpackChunkName: "UserProfileModal" */ './components/UserProfile').then(module => ({
+    default: module.UserProfileModal,
+  })),
 );
 const CreateOrganization = lazy(() =>
-  import('./components/CreateOrganization').then(module => ({ default: module.CreateOrganization })),
+  import(/* webpackChunkName: "CreateOrganization" */ './components/CreateOrganization').then(module => ({
+    default: module.CreateOrganization,
+  })),
 );
 const CreateOrganizationModal = lazy(() =>
-  import('./components/CreateOrganization').then(module => ({ default: module.CreateOrganizationModal })),
+  import(/* webpackChunkName: "CreateOrganizationModal" */ './components/CreateOrganization').then(module => ({
+    default: module.CreateOrganizationModal,
+  })),
 );
 const OrganizationProfile = lazy(() =>
-  import('./components/OrganizationProfile').then(module => ({ default: module.OrganizationProfile })),
+  import(/* webpackChunkName: "OrganizationProfile" */ './components/OrganizationProfile').then(module => ({
+    default: module.OrganizationProfile,
+  })),
 );
 const OrganizationProfileModal = lazy(() =>
-  import('./components/OrganizationProfile').then(module => ({ default: module.OrganizationProfileModal })),
+  import(/* webpackChunkName: "OrganizationProfileModal" */ './components/OrganizationProfile').then(module => ({
+    default: module.OrganizationProfileModal,
+  })),
 );
 const OrganizationSwitcher = lazy(() =>
-  import('./components/OrganizationSwitcher').then(module => ({ default: module.OrganizationSwitcher })),
+  import(/* webpackChunkName: "OrganizationSwitcher" */ './components/OrganizationSwitcher').then(module => ({
+    default: module.OrganizationSwitcher,
+  })),
 );
 const ImpersonationFab = lazy(() =>
-  import('./components/ImpersonationFab').then(module => ({ default: module.ImpersonationFab })),
+  import(/* webpackChunkName: "ImpersonationFab" */ './components/ImpersonationFab').then(module => ({
+    default: module.ImpersonationFab,
+  })),
 );
 
 import { EnvironmentProvider, OptionsProvider } from './contexts';

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -10,20 +10,40 @@ import type {
   SignUpProps,
   UserProfileProps,
 } from '@clerk/types';
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { PRESERVED_QUERYSTRING_PARAMS } from '../core/constants';
 import { clerkUIErrorDOMElementNotFound } from '../core/errors';
 import { buildVirtualRouterUrl } from '../utils';
-import { CreateOrganization, CreateOrganizationModal } from './components/CreateOrganization';
-import { ImpersonationFab } from './components/ImpersonationFab';
-import { OrganizationProfile, OrganizationProfileModal } from './components/OrganizationProfile';
-import { OrganizationSwitcher } from './components/OrganizationSwitcher';
-import { SignIn, SignInModal } from './components/SignIn';
-import { SignUp, SignUpModal } from './components/SignUp';
-import { UserButton } from './components/UserButton';
-import { UserProfile, UserProfileModal } from './components/UserProfile';
+const SignIn = lazy(() => import('./components/SignIn').then(module => ({ default: module.SignIn })));
+const SignInModal = lazy(() => import('./components/SignIn').then(module => ({ default: module.SignInModal })));
+const SignUp = lazy(() => import('./components/SignUp').then(module => ({ default: module.SignUp })));
+const SignUpModal = lazy(() => import('./components/SignUp').then(module => ({ default: module.SignUpModal })));
+const UserButton = lazy(() => import('./components/UserButton').then(module => ({ default: module.UserButton })));
+const UserProfile = lazy(() => import('./components/UserProfile').then(module => ({ default: module.UserProfile })));
+const UserProfileModal = lazy(() =>
+  import('./components/UserProfile').then(module => ({ default: module.UserProfileModal })),
+);
+const CreateOrganization = lazy(() =>
+  import('./components/CreateOrganization').then(module => ({ default: module.CreateOrganization })),
+);
+const CreateOrganizationModal = lazy(() =>
+  import('./components/CreateOrganization').then(module => ({ default: module.CreateOrganizationModal })),
+);
+const OrganizationProfile = lazy(() =>
+  import('./components/OrganizationProfile').then(module => ({ default: module.OrganizationProfile })),
+);
+const OrganizationProfileModal = lazy(() =>
+  import('./components/OrganizationProfile').then(module => ({ default: module.OrganizationProfileModal })),
+);
+const OrganizationSwitcher = lazy(() =>
+  import('./components/OrganizationSwitcher').then(module => ({ default: module.OrganizationSwitcher })),
+);
+const ImpersonationFab = lazy(() =>
+  import('./components/ImpersonationFab').then(module => ({ default: module.ImpersonationFab })),
+);
+
 import { EnvironmentProvider, OptionsProvider } from './contexts';
 import { CoreClerkContextWrapper } from './contexts/CoreClerkContextWrapper';
 import { AppearanceProvider } from './customizables';
@@ -375,12 +395,14 @@ const Components = (props: ComponentsProps) => {
             );
           })}
 
-          {signInModal && mountedSignInModal}
-          {signUpModal && mountedSignUpModal}
-          {userProfileModal && mountedUserProfileModal}
-          {organizationProfileModal && mountedOrganizationProfileModal}
-          {createOrganizationModal && mountedCreateOrganizationModal}
-          {mountedImpersonationFab}
+          <Suspense fallback={''}>
+            {signInModal && mountedSignInModal}
+            {signUpModal && mountedSignUpModal}
+            {userProfileModal && mountedUserProfileModal}
+            {organizationProfileModal && mountedOrganizationProfileModal}
+            {createOrganizationModal && mountedCreateOrganizationModal}
+            {mountedImpersonationFab}
+          </Suspense>
         </OptionsProvider>
       </EnvironmentProvider>
     </CoreClerkContextWrapper>

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -273,12 +273,17 @@ const Components = (props: ComponentsProps) => {
               onExternalNavigate={() => componentsControls.closeModal('signIn')}
               startPath={buildVirtualRouterUrl({ base: '/sign-in', path: urlStateParam?.path })}
             >
-              <SignInModal {...signInModal} />
-              <SignUpModal
-                afterSignInUrl={signInModal?.afterSignInUrl}
-                afterSignUpUrl={signInModal?.afterSignUpUrl}
-                redirectUrl={signInModal?.redirectUrl}
-              />
+              <Suspense fallback={''}>
+                <SignInModal {...signInModal} />
+              </Suspense>
+
+              <Suspense fallback={''}>
+                <SignUpModal
+                  afterSignInUrl={signInModal?.afterSignInUrl}
+                  afterSignUpUrl={signInModal?.afterSignUpUrl}
+                  redirectUrl={signInModal?.redirectUrl}
+                />
+              </Suspense>
             </VirtualRouter>
           </Modal>
         </InternalThemeProvider>
@@ -300,12 +305,14 @@ const Components = (props: ComponentsProps) => {
               onExternalNavigate={() => componentsControls.closeModal('signUp')}
               startPath={buildVirtualRouterUrl({ base: '/sign-up', path: urlStateParam?.path })}
             >
-              <SignInModal
-                afterSignInUrl={signUpModal?.afterSignInUrl}
-                afterSignUpUrl={signUpModal?.afterSignUpUrl}
-                redirectUrl={signUpModal?.redirectUrl}
-              />
-              <SignUpModal {...signUpModal} />
+              <Suspense fallback={''}>
+                <SignInModal
+                  afterSignInUrl={signUpModal?.afterSignInUrl}
+                  afterSignUpUrl={signUpModal?.afterSignUpUrl}
+                  redirectUrl={signUpModal?.redirectUrl}
+                />
+                <SignUpModal {...signUpModal} />
+              </Suspense>
             </VirtualRouter>
           </Modal>
         </InternalThemeProvider>
@@ -331,7 +338,9 @@ const Components = (props: ComponentsProps) => {
               onExternalNavigate={() => componentsControls.closeModal('userProfile')}
               startPath={buildVirtualRouterUrl({ base: '/user', path: urlStateParam?.path })}
             >
-              <UserProfileModal />
+              <Suspense fallback={''}>
+                <UserProfileModal />
+              </Suspense>
             </VirtualRouter>
           </Modal>
         </InternalThemeProvider>
@@ -357,7 +366,9 @@ const Components = (props: ComponentsProps) => {
               onExternalNavigate={() => componentsControls.closeModal('organizationProfile')}
               startPath={buildVirtualRouterUrl({ base: '/organizationProfile', path: urlStateParam?.path })}
             >
-              <OrganizationProfileModal {...organizationProfileModal} />
+              <Suspense fallback={''}>
+                <OrganizationProfileModal {...organizationProfileModal} />
+              </Suspense>
             </VirtualRouter>
           </Modal>
         </InternalThemeProvider>
@@ -383,7 +394,9 @@ const Components = (props: ComponentsProps) => {
               onExternalNavigate={() => componentsControls.closeModal('createOrganization')}
               startPath={buildVirtualRouterUrl({ base: '/createOrganization', path: urlStateParam?.path })}
             >
-              <CreateOrganizationModal {...createOrganizationModal} />
+              <Suspense fallback={''}>
+                <CreateOrganizationModal {...createOrganizationModal} />
+              </Suspense>
             </VirtualRouter>
           </Modal>
         </InternalThemeProvider>
@@ -397,7 +410,9 @@ const Components = (props: ComponentsProps) => {
       appearanceKey='impersonationFab'
     >
       <InternalThemeProvider>
-        <ImpersonationFab />
+        <Suspense fallback={''}>
+          <ImpersonationFab />
+        </Suspense>
       </InternalThemeProvider>
     </AppearanceProvider>
   );
@@ -426,14 +441,12 @@ const Components = (props: ComponentsProps) => {
             );
           })}
 
-          <Suspense fallback={''}>
-            {signInModal && mountedSignInModal}
-            {signUpModal && mountedSignUpModal}
-            {userProfileModal && mountedUserProfileModal}
-            {organizationProfileModal && mountedOrganizationProfileModal}
-            {createOrganizationModal && mountedCreateOrganizationModal}
-            {mountedImpersonationFab}
-          </Suspense>
+          {signInModal && mountedSignInModal}
+          {signUpModal && mountedSignUpModal}
+          {userProfileModal && mountedUserProfileModal}
+          {organizationProfileModal && mountedOrganizationProfileModal}
+          {createOrganizationModal && mountedCreateOrganizationModal}
+          {mountedImpersonationFab}
         </OptionsProvider>
       </EnvironmentProvider>
     </CoreClerkContextWrapper>

--- a/packages/clerk-js/src/ui/portal/index.tsx
+++ b/packages/clerk-js/src/ui/portal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom';
 
 import { clerkErrorPathRouterMissingPath } from '../../core/errors';
@@ -19,7 +19,7 @@ export default class Portal<CtxType extends AvailableComponentCtx> extends React
 
     const el = (
       <ComponentContext.Provider value={{ componentName: componentName, ...props } as CtxType}>
-        {React.createElement(component, props)}
+        <Suspense fallback={''}>{React.createElement(component, props)}</Suspense>
       </ComponentContext.Provider>
     );
 

--- a/packages/clerk-js/webpack.dev.js
+++ b/packages/clerk-js/webpack.dev.js
@@ -35,15 +35,17 @@ const getProductionConfig = (mode = 'production') => {
     },
     output: {
       path: path.resolve(__dirname, 'dist'),
-      chunkFilename: `[name].[fullhash:6].${packageJSON.version}.js`,
+      chunkFilename: pathData =>
+        !(pathData.chunk.name || '').startsWith('shared')
+          ? `[name].[fullhash:6].${packageJSON.version}.js`
+          : `shared-[id].[fullhash:6].${packageJSON.version}.js`,
       filename: '[name].js',
       libraryTarget: 'umd',
       globalObject: 'globalThis',
     },
     optimization: {
       splitChunks: {
-        name: (module, chunks) =>
-          chunks.map(chunk => chunk.name.replace('Organization', 'Org').replace('User', 'Us').slice(0, 4)).join('-'),
+        name: (module, chunks) => (chunks.length > 0 ? `shared-${chunks.map(chunk => chunk.name).join('-')}` : ''),
       },
     },
   };

--- a/packages/clerk-js/webpack.dev.js
+++ b/packages/clerk-js/webpack.dev.js
@@ -35,20 +35,26 @@ const getProductionConfig = (mode = 'production') => {
     },
     output: {
       path: path.resolve(__dirname, 'dist'),
+      chunkFilename: `[name].[fullhash:6].${packageJSON.version}.js`,
       filename: '[name].js',
       libraryTarget: 'umd',
       globalObject: 'globalThis',
+    },
+    optimization: {
+      splitChunks: {
+        name: (module, chunks) =>
+          chunks.map(chunk => chunk.name.replace('Organization', 'Org').replace('User', 'Us').slice(0, 4)).join('-'),
+      },
     },
   };
 };
 
 const getDevelopmentConfig = (mode = 'development', env) => {
-  const serveAnalyzer = env.serveAnalyzer;
   return {
     plugins: [
       new ReactRefreshWebpackPlugin({ overlay: { sockHost: 'js.lclclerk.com' } }),
       ...defineConstants({ mode, packageJSON }),
-      ...(serveAnalyzer ? [new BundleAnalyzerPlugin()] : []),
+      ...(env.serveAnalyzer ? [new BundleAnalyzerPlugin()] : []),
     ],
     devtool: 'eval-cheap-source-map',
     entry: './src/index.browser.ts',
@@ -110,6 +116,13 @@ const devServerOutput = {
     crossOriginLoading: 'anonymous',
     filename: 'clerk.browser.js',
     libraryTarget: 'umd',
+    chunkFilename: `[name].[fullhash:6].${packageJSON.version}.js`,
+  },
+  optimization: {
+    splitChunks: {
+      name: (module, chunks) =>
+        chunks.map(chunk => chunk.name.replace('Organization', 'Org').replace('User', 'Us').slice(0, 4)).join('-'),
+    },
   },
   devServer: {
     // https: true,

--- a/packages/sdk-node/tsconfig.json
+++ b/packages/sdk-node/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "sourceMap": false,
     "strict": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "types": ["jest"]
   },
   "exclude": ["node_modules"],
   "include": ["src/index.ts", "src/instance.ts"]


### PR DESCRIPTION
Lazy loading our own components inside the clerk-js bundle, decreases the bundle size by 10% from 185KB to 165KB

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Lazy loading our own components inside the clerk-js bundle, decreases the bundle size by 10% from 185KB to 165KB

Bundle analyser displaying all chunks (not clerk.*.js)
![image](https://user-images.githubusercontent.com/19269911/220628763-3495854a-4ee6-4844-a464-64d9053eb9c2.png)

<!-- Fixes # (issue number) -->
