### PR TITLE
COR-121: Include isSatellite, domain, proxy for remotePublicInterstitialUrl

### DIFF
--- a/packages/backend/src/tokens/factory.ts
+++ b/packages/backend/src/tokens/factory.ts
@@ -71,15 +71,23 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
   const remotePublicInterstitial = ({
     frontendApi: runtimeFrontendApi,
     publishableKey: runtimePublishableKey,
+    // @ts-expect-error
     proxyUrl: runtimeProxyUrl,
+    // @ts-expect-error
+    isSatellite: runtimeIsSatellite,
+    // @ts-expect-error
+    domain: runtimeDomain,
     ...rest
-  }: LoadInterstitialOptions) => {
+  }: Omit<LoadInterstitialOptions, 'isSatellite' | 'domain' | 'proxyUrl'>) => {
     return loadInterstitialFromBAPI({
       ...rest,
       apiUrl,
       frontendApi: runtimeFrontendApi || buildtimeFrontendApi,
-      proxyUrl: runtimeProxyUrl || buildProxyUrl,
       publishableKey: runtimePublishableKey || buildtimePublishableKey,
+      // @ts-expect-error
+      proxyUrl: runtimeProxyUrl || buildProxyUrl,
+      isSatellite: runtimeIsSatellite || buildtimeIsSatellite,
+      domain: runtimeDomain || buildtimeDomain,
     });
   };
 

--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -104,7 +104,9 @@ export function loadInterstitialFromLocal(
 }
 
 // TODO: Add caching to Interstitial
-export async function loadInterstitialFromBAPI(options: LoadInterstitialOptions) {
+export async function loadInterstitialFromBAPI(
+  options: Omit<LoadInterstitialOptions, 'isSatellite' | 'domain' | 'proxyUrl'>,
+) {
   options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
   const url = buildPublicInterstitialUrl(options);
   const response = await callWithRetry(() => runtime.fetch(buildPublicInterstitialUrl(options)));
@@ -120,9 +122,12 @@ export async function loadInterstitialFromBAPI(options: LoadInterstitialOptions)
   return response.text();
 }
 
-export function buildPublicInterstitialUrl(options: LoadInterstitialOptions) {
+export function buildPublicInterstitialUrl(
+  options: Omit<LoadInterstitialOptions, 'isSatellite' | 'domain' | 'proxyUrl'>,
+) {
   options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
-  const { apiUrl, frontendApi, pkgVersion, publishableKey, proxyUrl, debugData, isSatellite, domain } = options;
+  const { apiUrl, frontendApi, pkgVersion, publishableKey, proxyUrl, debugData, isSatellite, domain } =
+    options as LoadInterstitialOptions;
   const url = new URL(apiUrl);
   url.pathname = joinPaths(url.pathname, API_VERSION, '/public/interstitial');
   url.searchParams.append('clerk_js_version', getClerkJsMajorVersionOrTag(frontendApi, pkgVersion));

--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -1,5 +1,5 @@
 import type { RequestState } from '@clerk/backend';
-import { constants } from '@clerk/backend';
+import { constants, debugRequestState } from '@clerk/backend';
 import type { ServerResponse } from 'http';
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
@@ -8,7 +8,6 @@ import {
   clerkClient,
   FRONTEND_API,
   makeAuthObjectSerializable,
-  PROXY_URL,
   PUBLISHABLE_KEY,
   sanitizeAuthObject,
 } from '../server/clerk';
@@ -62,7 +61,11 @@ export const withServerSideAuth: WithServerSideAuth = (cbOrOptions: any, options
         apiUrl: API_URL,
         publishableKey: PUBLISHABLE_KEY,
         frontendApi: FRONTEND_API,
-        proxyUrl: PROXY_URL,
+        // @ts-ignore
+        proxyUrl: requestState.proxyUrl,
+        isSatellite: requestState.isSatellite,
+        domain: requestState.domain,
+        debugData: debugRequestState(requestState),
       });
       ctx.res.end(interstitial);
       return EMPTY_GSSP_RESPONSE;

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -88,6 +88,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
           apiUrl: API_URL,
           frontendApi: FRONTEND_API,
           publishableKey: PUBLISHABLE_KEY,
+          // @ts-expect-error
           proxyUrl: requestState.proxyUrl,
           isSatellite: requestState.isSatellite,
           domain: requestState.domain,

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -1,5 +1,6 @@
 import type { AuthStatus, RequestState } from '@clerk/backend';
 import { constants } from '@clerk/backend';
+import { debugRequestState } from '@clerk/backend';
 import type { NextMiddleware, NextMiddlewareResult } from 'next/dist/server/web/types';
 import type { NextFetchEvent, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -87,6 +88,10 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
           apiUrl: API_URL,
           frontendApi: FRONTEND_API,
           publishableKey: PUBLISHABLE_KEY,
+          proxyUrl: requestState.proxyUrl,
+          isSatellite: requestState.isSatellite,
+          domain: requestState.domain,
+          debugData: debugRequestState(requestState),
         }),
         { status: 401 },
       );


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR will pass the correct params down to interstitial when it is loaded from BAPI

<!-- Fixes # (issue number) -->
