### PR TITLE
refactor(backend): Correct spelling of potentialRequestAfterSignInOrO…

### DIFF
--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -53,7 +53,7 @@ export const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = options =
   return undefined;
 };
 
-export const potentialRequestAfterSignInOrOurFromClerkHostedUiInDev: InterstitialRule = options => {
+export const potentialRequestAfterSignInOrOutFromClerkHostedUiInDev: InterstitialRule = options => {
   const { apiKey, secretKey, referrer, host, forwardedHost, forwardedPort, forwardedProto } = options;
   const crossOriginReferrer =
     referrer && checkCrossOrigin({ originURL: new URL(referrer), host, forwardedHost, forwardedPort, forwardedProto });
@@ -90,7 +90,7 @@ export const isNormalSignedOutState: InterstitialRule = options => {
 };
 
 // This happens when a signed in user visits a new subdomain for the first time. The uat will be available because it's set on naked domain, but session will be missing. It can also happen if the cookieToken is manually removed during development.
-export const hasPositiveClientUatButCookieIsMissing: InterstitialRule = async options => {
+export const hasPositiveClientUatButCookieIsMissing: InterstitialRule = options => {
   const { clientUat, cookieToken } = options as AuthenticateRequestOptionsWithExperimental;
 
   if (clientUat && Number.parseInt(clientUat) > 0 && !cookieToken) {

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -15,7 +15,7 @@ import {
   nonBrowserRequestInDevRule,
   potentialFirstLoadInDevWhenUATMissing,
   potentialFirstRequestOnProductionEnvironment,
-  potentialRequestAfterSignInOrOurFromClerkHostedUiInDev,
+  potentialRequestAfterSignInOrOutFromClerkHostedUiInDev,
   runInterstitialRules,
 } from './interstitialRule';
 import type { VerifyTokenOptions } from './verify';
@@ -108,7 +108,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
         isSatelliteAndNeedsSync,
         potentialFirstRequestOnProductionEnvironment,
         potentialFirstLoadInDevWhenUATMissing,
-        potentialRequestAfterSignInOrOurFromClerkHostedUiInDev,
+        potentialRequestAfterSignInOrOutFromClerkHostedUiInDev,
         isSatelliteAlreadySyncedButCookieIsMissing,
         hasPositiveClientUatButCookieIsMissing,
         isNormalSignedOutState,


### PR DESCRIPTION
…utFromClerkHostedUiInDev

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR corrects the spelling of a function name

<!-- Fixes # (issue number) -->
