### PR TITLE
fix(types): Remove oauth Instagram strategy

### DIFF
--- a/packages/types/src/oauth.ts
+++ b/packages/types/src/oauth.ts
@@ -160,12 +160,6 @@ export const OAUTH_PROVIDERS: OAuthProviderData[] = [
     docsUrl: 'https://clerk.dev/docs/authentication/social-connection-with-line',
   },
   {
-    provider: 'instagram',
-    strategy: 'oauth_instagram',
-    name: 'Instagram',
-    docsUrl: 'https://clerk.dev/docs/authentication/social-connection-with-instagram',
-  },
-  {
     provider: 'coinbase',
     strategy: 'oauth_coinbase',
     name: 'Coinbase',


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`

## Description

Instagram doesn't support authentication oauth flows anymore. https://i.stack.imgur.com/xJCy5.png

This was reported in [Discord](https://discord.com/channels/856971667393609759/1073338318323982468/1075017878748790874).