### PR TITLE
fix(clerk-js): Set initials color to colorText

### DIFF
--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -92,7 +92,6 @@ const InitialsAvatarFallback = (props: { initials: string }) => {
   return (
     <Text
       as='span'
-      colorScheme='inherit'
       sx={{ ...common.centeredFlex('inline-flex'), width: '100%' }}
     >
       {initials}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Before (the color is inherited, so it may be inconsistent with the theme): 
<img width="574" alt="Screenshot 2023-02-15 at 16 50 18" src="https://user-images.githubusercontent.com/73396808/219061628-1ff431a3-894b-47db-86fa-6b5f64a08437.png">

After:
<img width="487" alt="Screenshot 2023-02-15 at 16 53 17" src="https://user-images.githubusercontent.com/73396808/219062474-3a4fc72c-bc56-499b-b3e7-f91b3793bf7c.png">


<!-- Fixes # (issue number) -->
