### PR TITLE
AUTH-134 fix(clerk-js,types): Resume an existing sign-up on SignUpStart only i…

### DIFF
--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -178,10 +178,14 @@ export class SignUp extends BaseResource implements SignUpResource {
     return this.authenticateWithWeb3({ identifier, generateSignature: generateSignatureWithMetamask });
   };
 
-  public authenticateWithRedirect = async (params: AuthenticateWithRedirectParams): Promise<void> => {
-    const { redirectUrl, redirectUrlComplete, strategy } = params || {};
+  public authenticateWithRedirect = async ({
+    redirectUrl,
+    redirectUrlComplete,
+    strategy,
+    continueSignUp = false,
+  }: AuthenticateWithRedirectParams): Promise<void> => {
     const authenticateFn = (args: SignUpCreateParams | SignUpUpdateParams) =>
-      this.id ? this.update(args) : this.create(args);
+      continueSignUp && this.id ? this.update(args) : this.create(args);
     const { verifications } = await authenticateFn({
       strategy,
       redirectUrl,

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpSocialButtons.tsx
@@ -10,7 +10,9 @@ import { SocialButtons } from '../../elements/SocialButtons';
 import { useNavigate } from '../../hooks';
 import { handleError } from '../../utils';
 
-export const SignUpSocialButtons = React.memo((props: SocialButtonsProps) => {
+export type SignUpSocialButtonsProps = SocialButtonsProps & { continueSignUp?: boolean };
+
+export const SignUpSocialButtons = React.memo((props: SignUpSocialButtonsProps) => {
   const clerk = useCoreClerk();
   const { navigate } = useNavigate();
   const card = useCardState();
@@ -19,13 +21,14 @@ export const SignUpSocialButtons = React.memo((props: SocialButtonsProps) => {
   const signUp = useCoreSignUp();
   const redirectUrl = buildSSOCallbackURL(ctx, displayConfig.signUpUrl);
   const redirectUrlComplete = ctx.afterSignUpUrl || displayConfig.afterSignUpUrl;
+  const { continueSignUp = false, ...rest } = props;
 
   return (
     <SocialButtons
-      {...props}
+      {...rest}
       oauthCallback={(strategy: OAuthStrategy) => {
         return signUp
-          .authenticateWithRedirect({ strategy, redirectUrl, redirectUrlComplete })
+          .authenticateWithRedirect({ strategy, redirectUrl, redirectUrlComplete, continueSignUp })
           .catch(err => handleError(err, [], card.setError));
       }}
       web3Callback={() => {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -236,6 +236,7 @@ function _SignUpStart(): JSX.Element {
               <SignUpSocialButtons
                 enableOAuthProviders={showOauthProviders}
                 enableWeb3Providers={showWeb3Providers}
+                continueSignUp={missingRequirementsWithTicket}
               />
             )}
             {shouldShowForm && (

--- a/packages/types/src/oauth.ts
+++ b/packages/types/src/oauth.ts
@@ -244,4 +244,8 @@ export type AuthenticateWithRedirectParams = {
    * Full URL or path to navigate after the OAuth flow completes.
    */
   redirectUrlComplete: string;
+  /**
+   * Whether to continue (i.e. PATCH) an existing SignUp (if present) or create a new SignUp
+   */
+  continueSignUp?: boolean;
 };


### PR DESCRIPTION
…f it's a ticket flow

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [X] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.

In the case of a ticket flow with missing requirements, the sign-up created for the ticket will be resumed when a social connection is initiated (since it may help complete the setup).

However this was done unconditionally in `authenticateWithRedirect()` and introduced an interaction with back button navigation from a verification screen back to the initial sign-up screen.

This PR explicitly instructs `authenticateWithRedirect()` to resume an existing sign-up if it's a ticket flow scenario, otherwise it will default to creating a new sign-up.

Note: Needs further manual testing & unit tests.
