### PR TITLE
Chore(repo): Fix fastify playground and yalc

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prerelease": "npx rimraf packages/*/dist && turbo run build test --concurrency=${TURBO_CONCURRENCY:-2} --force",
     "release:next": "lerna publish from-package --dist-tag next",
     "version": "./scripts/version-info.sh",
-    "nuke": "rm -r node_modules; for d in packages/*/node_modules; do echo $d; rm -r $d; done",
+    "nuke": "rm -r node_modules; for d in packages/*/node_modules; do echo $d; rm -r $d; done; packages/*/dist;",
     "yalc:all": "for d in packages/*/; do echo $d; cd $d; yalc push --replace; cd '../../'; done",
     "prepare": "husky install"
   }

--- a/playground/fastify/README.md
+++ b/playground/fastify/README.md
@@ -1,0 +1,31 @@
+## Setup development
+
+Execute in root folder:
+
+```bash
+npm i
+npm run build && npm run yalc:all
+```
+
+Execute in current folder:
+
+```bash
+touch .env # set PUBLISHABLE_KEY and SECRET_KEY from Clerk Dashboard API keys
+npm i
+rm -rf node_modules/@clerk
+yalc add @clerk/fastify @clerk/backend @clerk/types --pure
+```
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm run start
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Reload changes from packages/\* package
+
+Apply change in packages/\* project folder and run `npm run build`. Then restart Fastify server by killing the current and executing `npm run dev` and the change should be visible.

--- a/playground/fastify/package-lock.json
+++ b/playground/fastify/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@playground/fastify",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/fastify": "file:../../packages/fastify",
+        "@clerk/fastify": "*",
         "dotenv": "^16.0.3",
         "fastify": "^4.12.0",
         "ts-node": "^10.9.1"

--- a/playground/fastify/src/loadEnv.ts
+++ b/playground/fastify/src/loadEnv.ts
@@ -1,0 +1,2 @@
+import * as dotenv from 'dotenv';
+dotenv.config();

--- a/playground/fastify/src/routes/private.ts
+++ b/playground/fastify/src/routes/private.ts
@@ -4,6 +4,10 @@ import { clerkPlugin, getAuth } from '@clerk/fastify';
 export const privateRoutes = async (fastify: FastifyInstance, _opts: any) => {
   fastify.register(clerkPlugin);
 
+  fastify.get('/me', async (req, _reply) => {
+    return { auth: getAuth(req) };
+  });
+
   fastify.get('/private', async (req: FastifyRequest, reply: FastifyReply) => {
     const auth = getAuth(req);
 

--- a/playground/fastify/src/server.ts
+++ b/playground/fastify/src/server.ts
@@ -1,4 +1,5 @@
-import 'dotenv/config';
+import './loadEnv';
+
 import Fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import { privateRoutes, publicRoutes } from './routes';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

The most interesting part in this PR is the `playground/fastify/README.md` which indicates a way to use yalc to link packages and playground apps.