### PR TITLE
fix(clerk-js): Fix undefined appearing after deleting a resource

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/RemoveResourcePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/RemoveResourcePage.tsx
@@ -7,13 +7,13 @@ import { localizationKeys, Text } from '../../customizables';
 import { ContentPage, Form, FormButtons, SuccessPage, useCardState, withCardStateProvider } from '../../elements';
 import { useEnabledThirdPartyProviders } from '../../hooks';
 import { useRouter } from '../../router';
-import { handleError } from '../../utils';
+import { fastDeepCopyAndReturn, handleError } from '../../utils';
 import { UserProfileBreadcrumbs } from './UserProfileNavbar';
 
 export const RemoveEmailPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(user.emailAddresses.find(e => e.id === id));
+  const ref = React.useRef(fastDeepCopyAndReturn(user.emailAddresses.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;
@@ -37,7 +37,7 @@ export const RemoveEmailPage = () => {
 export const RemovePhonePage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(user.phoneNumbers.find(e => e.id === id));
+  const ref = React.useRef(fastDeepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;
@@ -61,7 +61,7 @@ export const RemovePhonePage = () => {
 export const RemoveConnectedAccountPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(user.externalAccounts.find(e => e.id === id));
+  const ref = React.useRef(fastDeepCopyAndReturn(user.externalAccounts.find(e => e.id === id)));
   const { providerToDisplayData } = useEnabledThirdPartyProviders();
 
   if (!ref.current) {
@@ -86,7 +86,7 @@ export const RemoveConnectedAccountPage = () => {
 export const RemoveWeb3WalletPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(user.web3Wallets.find(e => e.id === id));
+  const ref = React.useRef(fastDeepCopyAndReturn(user.web3Wallets.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;
@@ -111,7 +111,7 @@ export const RemoveMfaPhoneCodePage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
   // TODO: This logic will need to change when we add more 2fa methods
-  const ref = React.useRef(user.phoneNumbers.find(e => e.id === id));
+  const ref = React.useRef(fastDeepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;

--- a/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
+++ b/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
@@ -42,3 +42,13 @@ export const fastDeepMergeAndKeep = (
     }
   }
 };
+
+export const fastDeepCopyAndReturn = <T extends Record<any, any> | undefined | null>(source: T): T => {
+  if (!source) {
+    return source;
+  }
+
+  const target = {};
+  fastDeepMergeAndReplace(source, target);
+  return target as T;
+};


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
When successfully deleting the resource, the properties of the object are overwritten by the response from FAPI. This seems to have been a "bug" for a long time, but was somehow working fine before React 18.
<!-- Fixes # (issue number) -->
