### PR TITLE
COR-121 Prevent infinite loop from interstitial in nextjs

### DIFF
--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -93,7 +93,7 @@ export function loadInterstitialFromLocal(
                 ${domain ? `script.setAttribute('data-clerk-domain', '${domain}');` : ''}
                 ${proxyUrl ? `script.setAttribute('data-clerk-proxy-url', '${proxyUrl}')` : ''};
                 script.async = true;
-                script.src = '${getScriptUrl(domain || frontendApi, pkgVersion)}';
+                script.src = '${getScriptUrl(frontendApi, pkgVersion)}';
                 script.crossOrigin = 'anonymous';
                 script.addEventListener('load', startClerk);
                 document.body.appendChild(script);
@@ -140,7 +140,7 @@ export function buildPublicInterstitialUrl(
     url.searchParams.append('proxy_url', proxyUrl);
   }
 
-  const shouldSync = isSatellite && debugData?.reason === 'satellite-cookie-missing';
+  const shouldSync = isSatellite && debugData?.reason !== 'satellite-cookie-missing';
   if (shouldSync) {
     url.searchParams.append('should_sync_link', 'true');
   }

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -985,7 +985,8 @@ export default class Clerk implements ClerkInterface {
         await this.#syncWithPrimary();
         return false;
       }
-
+    }
+    if (this.isSatellite && this.#hasSynced()) {
       this.#clearSynced();
     }
 

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -30,6 +30,6 @@ export function getClerkQueryParam<T extends ClerkQueryParam>(param: T): ClerkQu
 export function removeClerkQueryParam<T extends ClerkQueryParam>(param: T) {
   const url = new URL(window.location.href);
   url.searchParams.delete(param);
-  window.history.replaceState({}, '', url);
+  window.history.replaceState(null, '', url);
   return;
 }

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -52,7 +52,6 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     // get auth state, check if we need to return an interstitial
     const cookieToken = getCookie(req, constants.Cookies.Session);
     const headerToken = headers.get('authorization')?.replace('Bearer ', '');
-
     const requestState = await clerkClient.authenticateRequest({
       ...opts,
       apiKey: API_KEY,
@@ -72,6 +71,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
       // @ts-expect-error
       isSatellite,
       domain: DOMAIN,
+      isSynced: new URL(req.url).searchParams.get('__clerk_synced') === 'true',
     });
 
     // Interstitial case


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Further changes required to ensure that 
- remix and local interstitial  
- nextjs and BAPI interstitial 

have the same behaviour

<!-- Fixes # (issue number) -->
