### PR TITLE
COR-136 Use proxyUrl for as src for script

### DIFF
--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -93,7 +93,7 @@ export function loadInterstitialFromLocal(
                 ${domain ? `script.setAttribute('data-clerk-domain', '${domain}');` : ''}
                 ${proxyUrl ? `script.setAttribute('data-clerk-proxy-url', '${proxyUrl}')` : ''};
                 script.async = true;
-                script.src = '${getScriptUrl(frontendApi, pkgVersion)}';
+                script.src = '${getScriptUrl(proxyUrl || frontendApi, pkgVersion)}';
                 script.crossOrigin = 'anonymous';
                 script.addEventListener('load', startClerk);
                 document.body.appendChild(script);
@@ -174,6 +174,7 @@ const getClerkJsMajorVersionOrTag = (frontendApi: string, pkgVersion?: string) =
 };
 
 const getScriptUrl = (frontendApi: string, pkgVersion?: string) => {
+  const noSchemeFrontendApi = frontendApi.replace(/http(s)?:\/\//, '');
   const major = getClerkJsMajorVersionOrTag(frontendApi, pkgVersion);
-  return `https://${frontendApi}/npm/@clerk/clerk-js@${major}/dist/clerk.browser.js`;
+  return `https://${noSchemeFrontendApi}/npm/@clerk/clerk-js@${major}/dist/clerk.browser.js`;
 };

--- a/packages/backend/src/util/parsePublishableKey.ts
+++ b/packages/backend/src/util/parsePublishableKey.ts
@@ -13,7 +13,7 @@ export function buildPublishableKey(frontendApi: string): string {
   return `${keyPrefix}${btoa(`${frontendApi}$`)}`;
 }
 
-export function parsePublishableKey(key: string): PublishableKey | null {
+export function parsePublishableKey(key: string | undefined): PublishableKey | null {
   key = key || '';
 
   if (!isPublishableKey(key)) {

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -144,3 +144,8 @@ export const handleIsSatelliteBooleanOrFn = (opts: WithAuthOptionsExperimental, 
   }
   return opts.isSatellite || false;
 };
+
+// TODO: use @clerk/shared once is tree-shakeable
+export function isHttpOrHttps(key: string | undefined) {
+  return key?.startsWith('https://') || key?.startsWith('http://') || false;
+}

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -25,6 +25,7 @@ import {
   setAuthStatusOnRequest,
   setRequestHeadersOnNextResponse,
 } from './utils';
+import { isHttpOrHttps } from './utils';
 
 interface WithClerkMiddleware {
   (handler: NextMiddleware, opts?: WithAuthOptions): NextMiddleware;
@@ -43,6 +44,10 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
   const [handler = noop, opts = {}] = args as [NextMiddleware, WithAuthOptions] | [];
 
   const proxyUrl = opts?.proxyUrl || PROXY_URL;
+
+  if (!!proxyUrl && !isHttpOrHttps(proxyUrl)) {
+    throw new Error(`Only a absolute URL that starts with https is allowed to be used in SSR`);
+  }
 
   return async (req: NextRequest, event: NextFetchEvent) => {
     const { headers } = req;

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -74,3 +74,7 @@ A secretKey or apiKey must be provided in order to use SSR and the exports from 
 If your runtime supports environment variables, you can add a CLERK_SECRET_KEY or CLERK_API_KEY variable to your config.
 Otherwise, you can pass a secretKey parameter to rootAuthLoader or getAuth.
 `);
+
+export const noRelativeProxyInSSR = createErrorMessage(
+  `Only a absolute URL that starts with https is allowed to be used in SSR`,
+);

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -1,7 +1,8 @@
 import type { RequestState } from '@clerk/backend';
 import { Clerk } from '@clerk/backend';
+import { isHttpOrHttps } from '@clerk/shared';
 
-import { noSecretKeyOrApiKeyError } from '../errors';
+import { noRelativeProxyInSSR, noSecretKeyOrApiKeyError } from '../errors';
 import { getEnvVariable } from '../utils';
 import type { LoaderFunctionArgs, RootAuthLoaderOptions, RootAuthLoaderOptionsWithExperimental } from './types';
 import { handleIsSatelliteBooleanOrFn, parseCookies } from './utils';
@@ -51,6 +52,10 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     (context?.CLERK_PROXY_URL as string) ||
     (opts as RootAuthLoaderOptionsWithExperimental).proxyUrl ||
     '';
+
+  if (!!proxyUrl && !isHttpOrHttps(proxyUrl)) {
+    throw new Error(noRelativeProxyInSSR);
+  }
 
   const { headers } = request;
   const cookies = parseCookies(request);

--- a/packages/shared/src/utils/keys.ts
+++ b/packages/shared/src/utils/keys.ts
@@ -15,7 +15,7 @@ export function buildPublishableKey(frontendApi: string): string {
   return `${keyPrefix}${btoa(`${frontendApi}$`)}`;
 }
 
-export function parsePublishableKey(key: string): PublishableKey | null {
+export function parsePublishableKey(key: string | undefined): PublishableKey | null {
   key = key || '';
 
   if (!isPublishableKey(key)) {

--- a/packages/shared/src/utils/proxy.ts
+++ b/packages/shared/src/utils/proxy.ts
@@ -3,7 +3,11 @@ export function isValidProxyUrl(key: string | undefined) {
     return true;
   }
 
-  return key.startsWith('https://') || isProxyUrlRelative(key);
+  return isHttpOrHttps(key) || isProxyUrlRelative(key);
+}
+
+export function isHttpOrHttps(key: string | undefined) {
+  return key?.startsWith('https://') || key?.startsWith('http://') || false;
 }
 
 export function isProxyUrlRelative(key: string) {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Uses proxyUrl as src of clerk script
- Validates for absoluteUrl proxyUrl and throws error in Remix & nextjs

<!-- Fixes # (issue number) -->
