### PR TITLE
fix(clerk-js): Do not truncate badge in UserPreview

### DIFF
--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -96,9 +96,16 @@ export const UserPreview = (props: UserPreviewProps) => {
           elementId={descriptors.userPreviewMainIdentifier.setId(elementId)}
           variant={size === 'md' ? 'regularMedium' : 'smallMedium'}
           colorScheme='inherit'
-          truncate
+          sx={{ display: 'flex' }}
         >
-          {localizedTitle || name || identifier} {badge}
+          <Text
+            as='span'
+            truncate
+          >
+            {localizedTitle || name || identifier}
+          </Text>
+
+          {badge}
         </Text>
 
         {(subtitle || (name && identifier)) && (


### PR DESCRIPTION
When the text is too long, truncate only the identifier and still show the badge if provided.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Before: 
<img width="303" alt="Screenshot 2023-02-20 at 12 18 44" src="https://user-images.githubusercontent.com/73396808/220077938-21bbb098-7fce-4192-8bda-3c548c7c76de.png">

After:
<img width="297" alt="Screenshot 2023-02-20 at 12 18 28" src="https://user-images.githubusercontent.com/73396808/220077867-e48daf28-5dbc-4b44-9837-d9e7418d3c19.png">

<!-- Fixes # (issue number) -->
