### PR TITLE
fix(shared,nextjs): Tests for `isHttpOrHttps` utility

### DIFF
--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -145,7 +145,7 @@ export const handleIsSatelliteBooleanOrFn = (opts: WithAuthOptionsExperimental, 
   return opts.isSatellite || false;
 };
 
-// TODO: use @clerk/shared once is tree-shakeable
+// TODO: use @clerk/shared once it is tree-shakeable
 export function isHttpOrHttps(key: string | undefined) {
-  return key?.startsWith('https://') || key?.startsWith('http://') || false;
+  return /^http(s)?:\/\//.test(key || '');
 }

--- a/packages/shared/src/utils/proxy.test.ts
+++ b/packages/shared/src/utils/proxy.test.ts
@@ -1,4 +1,4 @@
-import { isProxyUrlRelative, isValidProxyUrl, proxyUrlToAbsoluteURL } from './proxy';
+import { isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl, proxyUrlToAbsoluteURL } from './proxy';
 
 describe('isValidProxyUrl(key)', () => {
   it('returns true if the proxyUrl is valid', () => {
@@ -21,6 +21,18 @@ describe('isProxyUrlRelative(key)', () => {
 
   it('returns false if the proxyUrl does not starts with `/`', () => {
     expect(isProxyUrlRelative('proxy-app.dev/api/__clerk==')).toBe(false);
+  });
+});
+
+describe('isHttpOrHttps(key)', () => {
+  it.each([
+    ['http://clerk.dev/api/__clerk', true],
+    ['http://clerk.dev/api/__clerk', true],
+    [undefined, false],
+    ['/api/__clerk', false],
+    ['', false],
+  ])('.isHttpOrHttps(%s)', (key, expected) => {
+    expect(isHttpOrHttps(key)).toBe(expected);
   });
 });
 

--- a/packages/shared/src/utils/proxy.ts
+++ b/packages/shared/src/utils/proxy.ts
@@ -7,7 +7,7 @@ export function isValidProxyUrl(key: string | undefined) {
 }
 
 export function isHttpOrHttps(key: string | undefined) {
-  return key?.startsWith('https://') || key?.startsWith('http://') || false;
+  return /^http(s)?:\/\//.test(key || '');
 }
 
 export function isProxyUrlRelative(key: string) {


### PR DESCRIPTION
## Type of change

- [] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR adds tests for `isHttpOrHttps` utility
and  isHttpOrHttps now uses regex instead of .startsWith()

<!-- Fixes # (issue number) -->
