### PR TITLE
COR-145: Hide children on sync/link

### DIFF
--- a/packages/react/src/contexts/ClerkContextProvider.tsx
+++ b/packages/react/src/contexts/ClerkContextProvider.tsx
@@ -76,7 +76,15 @@ export function ClerkContextProvider(props: ClerkContextProvider): JSX.Element |
         <SessionContext.Provider value={sessionCtx}>
           <OrganizationContext.Provider value={organizationCtx}>
             <AuthContext.Provider value={authCtx}>
-              <UserContext.Provider value={userCtx}>{children}</UserContext.Provider>
+              {/**
+               * This ensures that nothing will be displayed until clerk is loaded
+               * If the app requires for the sync/link to be performed, clerkLoaded will be false
+               * and none the content of the page will not flicker and no other request will be made
+               *
+               * At this moment checking clerkLoaded to achieve this makes sense because
+               * sync/link fires always by clerk-js
+               */}
+              <UserContext.Provider value={userCtx}>{clerkLoaded && children}</UserContext.Provider>
             </AuthContext.Provider>
           </OrganizationContext.Provider>
         </SessionContext.Provider>


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

 This ensures that nothing will be displayed until clerk is loaded
 If the app requires for the sync/link to be performed, clerkLoaded will be false
 and none the content of the page will not flicker and no other request will be made

 At this moment checking clerkLoaded to achieve this makes sense because
 sync/link fires always by clerk-js
 
 While for nextjs this works as expected, to make remix work I had to refactored my app as seen below, otherwise nothing was rendered in the browser and DOM was completely empty
 ```typescript
 const MyClerkApp = ClerkApp(() => {
  return (
    <>
      <Outlet />
    </>
  );
});

function App() {
  return (
    <html lang='en'>
      <head>
        <Meta />
        <Links />
      </head>
      <body>
        <MyClerkApp />
        <ScrollRestoration />
        <Scripts />
        <LiveReload />
      </body>
    </html>
  );
}

export default App;

 ```

<!-- Fixes # (issue number) -->
