### PR TITLE
fix(clerk-js): Add session cookie before sync/link

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -980,8 +980,11 @@ export default class Clerk implements ClerkInterface {
   };
 
   #loadInStandardBrowser = async (): Promise<boolean> => {
+    this.#authService = new AuthenticationService(this);
     if (this.isSatellite && this.#options.shouldSyncLink) {
       if (!this.#hasSynced()) {
+        // set session cookie to avoid throwing an extra interstitial
+        this.#authService?.setAuthCookiesFromSession(this.session);
         await this.#syncWithPrimary();
         return false;
       }
@@ -990,7 +993,6 @@ export default class Clerk implements ClerkInterface {
       this.#clearSynced();
     }
 
-    this.#authService = new AuthenticationService(this);
     this.#pageLifecycle = createPageLifecycle();
 
     this.#devBrowserHandler = createDevBrowserHandler({

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -980,19 +980,11 @@ export default class Clerk implements ClerkInterface {
   };
 
   #loadInStandardBrowser = async (): Promise<boolean> => {
-    this.#authService = new AuthenticationService(this);
-    if (this.isSatellite && this.#options.shouldSyncLink) {
-      if (!this.#hasSynced()) {
-        // set session cookie to avoid throwing an extra interstitial
-        this.#authService?.setAuthCookiesFromSession(this.session);
-        await this.#syncWithPrimary();
-        return false;
-      }
-    }
     if (this.isSatellite && this.#hasSynced()) {
       this.#clearSynced();
     }
 
+    this.#authService = new AuthenticationService(this);
     this.#pageLifecycle = createPageLifecycle();
 
     this.#devBrowserHandler = createDevBrowserHandler({
@@ -1026,6 +1018,15 @@ export default class Clerk implements ClerkInterface {
 
         this.#environment = environment;
         this.updateClient(client);
+
+        if (this.isSatellite && this.#options.shouldSyncLink) {
+          if (!this.#hasSynced()) {
+            // set session cookie to avoid throwing an extra interstitial
+            this.#authService?.setAuthCookiesFromSession(this.session);
+            await this.#syncWithPrimary();
+            return false;
+          }
+        }
 
         this.#authService.initAuth({
           enablePolling: this.#options.polling,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The reasoning behind this, is to avoid throwing an extra interstitial because the session cookies was missing

<!-- Fixes # (issue number) -->
