### PR TITLE
fix(clerk-js,backend): Only interstitial will dictate sync/link

### DIFF
--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -6,6 +6,7 @@ import { callWithRetry } from '../util/callWithRetry';
 import { isStaging } from '../util/instance';
 import { parsePublishableKey } from '../util/parsePublishableKey';
 import { joinPaths } from '../util/path';
+import { AuthErrorReason } from './authStatus';
 import { TokenVerificationError, TokenVerificationErrorAction, TokenVerificationErrorReason } from './errors';
 import type { DebugRequestSate } from './request';
 
@@ -67,7 +68,7 @@ export function loadInterstitialFromLocal(
                 try {
                     await Clerk.load({
                         isSatellite: ${isSatellite},
-                        shouldSyncLink: ${isSatellite && debugData?.reason !== 'satellite-cookie-missing'},
+                        shouldSyncLink: ${debugData?.reason === AuthErrorReason.SatelliteCookieNeedsSync},
                     });
                     if(Clerk.loaded){
                       if(window.location.href.indexOf("#") === -1){
@@ -140,7 +141,7 @@ export function buildPublicInterstitialUrl(
     url.searchParams.append('proxy_url', proxyUrl);
   }
 
-  const shouldSync = isSatellite && debugData?.reason !== 'satellite-cookie-missing';
+  const shouldSync = debugData?.reason === AuthErrorReason.SatelliteCookieNeedsSync;
   if (shouldSync) {
     url.searchParams.append('should_sync_link', 'true');
   }

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -112,7 +112,7 @@ const defaultOptions: ClerkOptions = {
   standardBrowser: true,
   touchSession: true,
   isSatellite: false,
-  shouldSyncLink: true,
+  shouldSyncLink: false,
 };
 
 export default class Clerk implements ClerkInterface {
@@ -980,7 +980,7 @@ export default class Clerk implements ClerkInterface {
   };
 
   #loadInStandardBrowser = async (): Promise<boolean> => {
-    if (this.isSatellite && this.#options.shouldSyncLink) {
+    if (this.#options.shouldSyncLink) {
       if (!this.#hasSynced()) {
         await this.#syncWithPrimary();
         return false;

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -92,6 +92,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
           apiUrl: API_URL,
           frontendApi: FRONTEND_API,
           publishableKey: PUBLISHABLE_KEY,
+          shouldSyncLink: requestState.reason === 'satellite-needs-sync',
           // @ts-expect-error
           proxyUrl: requestState.proxyUrl,
           isSatellite: requestState.isSatellite,

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -4,8 +4,7 @@ import { LIB_VERSION } from '@clerk/clerk-react/dist/info';
 import { json } from '@remix-run/server-runtime';
 import cookie from 'cookie';
 
-import type { LoaderFunctionArgs, LoaderFunctionArgsWithAuth } from './types';
-import type { RootAuthLoaderOptionsWithExperimental } from './types';
+import type { LoaderFunctionArgs, LoaderFunctionArgsWithAuth, RootAuthLoaderOptionsWithExperimental } from './types';
 
 /**
  * Inject `auth`, `user` and `session` properties into `request`
@@ -89,6 +88,7 @@ export const interstitialJsonResponse = (requestState: RequestState, opts: { loa
         frontendApi: requestState.frontendApi,
         publishableKey: requestState.publishableKey,
         pkgVersion: LIB_VERSION,
+        shouldSyncLink: requestState.reason === 'satellite-needs-sync',
         // @ts-expect-error
         proxyUrl: requestState.proxyUrl,
         isSatellite: requestState.isSatellite,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This is an attempt to be less aggressive when syncing with primary. We should let interstitial decide if the app should sync/link and not run this process on every page refresh

### Photos when the app has valid `__session` &`__client_uat` cookies and no interstitial is thrown
Before this PR 
<img width="918" alt="Screenshot 2023-02-20 at 5 39 33 PM" src="https://user-images.githubusercontent.com/19269911/220163514-1e6e4f88-2997-4e3e-8c24-a3b5a66e32ed.png">

After this PR 
<img width="823" alt="Screenshot 2023-02-20 at 5 33 34 PM" src="https://user-images.githubusercontent.com/19269911/220163388-b2164825-aac1-4733-8098-0c079c061f81.png">

### Photo when the app throws interstitial
Before this PR
<img width="945" alt="image" src="https://user-images.githubusercontent.com/19269911/220164486-3507275a-6c97-4fb6-ad6f-3db735e6eb40.png">


After this PR
<img width="915" alt="image" src="https://user-images.githubusercontent.com/19269911/220164201-85a1167e-73d4-4823-b7d9-8579565762d8.png">



<!-- Fixes # (issue number) -->
