### PR TITLE
chore(clerk-expo): Add try/catch blocks in SecureStore code snippet

### DIFF
--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -101,10 +101,20 @@ import { ClerkProvider } from "@clerk/clerk-expo";
 
 + const tokenCache = {
 +  getToken(key) {
-+    return SecureStore.getItemAsync(key);
++    try {
++     return SecureStore.getItemAsync(key);
++    }
++    catch (err) {
++     return null;
++    }
 +  },
 +  saveToken(key, value) {
-+    return SecureStore.setItemAsync(key, value);
++    try {
++     return SecureStore.setItemAsync(key, value);
++    }
++    catch (err) {
++     return null;
++    }
 +  },
 +};
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR updates the README file of the Expo package, adding a try/catch block when using SecureStore methods because, on Android, they happen to fail sometimes. ([See here](https://github.com/expo/expo/issues/19018) for more)
<!-- Fixes # (issue number) -->
