### PR TITLE
fix(backend): Support the `browser` and `worker` runtime keys

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -56,11 +56,15 @@
   "imports": {
     "#crypto": {
       "edge-light": "./dist/runtime/browser/crypto.mjs",
+      "worker": "./dist/runtime/browser/crypto.mjs",
+      "browser": "./dist/runtime/browser/crypto.mjs",
       "node": "./dist/runtime/node/crypto.js",
       "default": "./dist/runtime/browser/crypto.mjs"
     },
     "#fetch": {
       "edge-light": "./dist/runtime/browser/fetch.mjs",
+      "worker": "./dist/runtime/browser/fetch.mjs",
+      "browser": "./dist/runtime/browser/fetch.mjs",
       "node": "./dist/runtime/node/fetch.js",
       "default": "./dist/runtime/browser/fetch.mjs"
     }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Similar to: https://github.com/clerkinc/javascript/pull/841
<!-- Fixes # (issue number) -->
