### PR TITLE
feat(clerk-js): Scroll to connected account after success in mounted UserProfile

### DIFF
--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -4,7 +4,7 @@ export const DEV_BROWSER_SSO_JWT_KEY = 'clerk-db-jwt';
 export const DEV_BROWSER_SSO_JWT_PARAMETER = '__dev_session';
 export const DEV_BROWSER_SSO_JWT_HTTP_HEADER = 'Clerk-Cookie';
 
-export const CLERK_MODAL_STATE = '__clerk_modal_state';
+export const CLERK_REDIRECT_STATE = '__clerk_redirect_state';
 export const CLERK_SYNCED = '__clerk_synced';
 export const CLERK_SATELLITE_URL = '__clerk_satellite_url';
 export const ERROR_CODES = {

--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -169,7 +169,7 @@ const Components = (props: ComponentsProps) => {
     if (decodedRedirectParams) {
       setState(s => ({
         ...s,
-        [componentNodes[decodedRedirectParams.componentName]]: true,
+        [componentNodes[decodedRedirectParams.componentName]]: decodedRedirectParams.modal,
       }));
     }
 

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileAccordion.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileAccordion.tsx
@@ -1,12 +1,10 @@
-import { useUserProfileContext } from '../../contexts';
 import { AccordionItem } from '../../elements';
 import type { PropsOfComponent } from '../../styledSystem';
 
 export const UserProfileAccordion = (props: PropsOfComponent<typeof AccordionItem>) => {
-  const isModal = useUserProfileContext().mode === 'modal';
   return (
     <AccordionItem
-      scrollOnOpen={isModal}
+      scrollOnOpen={true}
       {...props}
     />
   );

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsPage.test.tsx
@@ -3,6 +3,7 @@ import { describe, it } from '@jest/globals';
 import React from 'react';
 
 import { bindCreateFixtures, render, screen } from '../../../../testUtils';
+import { appendAsQueryParams } from '../../../../utils';
 import { ConnectedAccountsPage } from '../ConnectedAccountsPage';
 
 const { createFixtures } = bindCreateFixtures('UserProfile');
@@ -44,7 +45,8 @@ describe('ConnectedAccountsPage', () => {
 
       await userEvent.click(screen.getByText(/connect google account/i));
       expect(fixtures.clerk.user?.createExternalAccount).toHaveBeenCalledWith({
-        redirectUrl: window.location.href,
+        redirectUrl:
+          'http://localhost/?__clerk_redirect_state=eyJwYXRoIjoiIiwiY29tcG9uZW50TmFtZSI6IlVzZXJQcm9maWxlIiwic3RhcnRQYXRoIjoiL3VzZXIiLCJzb2NpYWxQcm92aWRlciI6Imdvb2dsZSIsIm1vZGFsIjpmYWxzZX0%3D',
         strategy: 'oauth_google',
         additionalScopes: [],
       });

--- a/packages/clerk-js/src/ui/hooks/useClerkModalStateParams.tsx
+++ b/packages/clerk-js/src/ui/hooks/useClerkModalStateParams.tsx
@@ -1,26 +1,32 @@
 import React from 'react';
 
-import { CLERK_MODAL_STATE } from '../../core/constants';
+import { CLERK_REDIRECT_STATE } from '../../core/constants';
 import { readStateParam, removeClerkQueryParam } from '../../utils';
 
 export const useClerkModalStateParams = () => {
-  const contentRef = React.useRef({ startPath: '', path: '', componentName: '', socialProvider: '' });
+  const [params, setParams] = React.useState({
+    startPath: '',
+    path: '',
+    componentName: '',
+    socialProvider: '',
+    modal: false,
+  });
   const decodedRedirectParams = readStateParam();
 
   React.useLayoutEffect(() => {
     if (decodedRedirectParams) {
-      contentRef.current = decodedRedirectParams;
+      setParams(decodedRedirectParams);
     }
   }, []);
 
   const clearUrlStateParam = () => {
-    contentRef.current = { startPath: '', path: '', componentName: '', socialProvider: '' };
+    setParams({ startPath: '', path: '', componentName: '', socialProvider: '', modal: false });
   };
 
-  const removeQueryParam = () => removeClerkQueryParam(CLERK_MODAL_STATE);
+  const removeQueryParam = () => removeClerkQueryParam(CLERK_REDIRECT_STATE);
 
   return {
-    urlStateParam: { ...contentRef.current, clearUrlStateParam },
+    urlStateParam: { ...params, clearUrlStateParam },
     decodedRedirectParams,
     clearUrlStateParam,
     removeQueryParam,

--- a/packages/clerk-js/src/ui/router/BaseRouter.tsx
+++ b/packages/clerk-js/src/ui/router/BaseRouter.tsx
@@ -1,9 +1,10 @@
+import type { RoutingStrategy } from '@clerk/types';
 import qs from 'qs';
 import React from 'react';
 
 import { getQueryParams, trimTrailingSlash } from '../../utils';
 import { useCoreClerk } from '../contexts';
-import { useWindowEventListener } from '../hooks';
+import { useClerkModalStateParams, useWindowEventListener } from '../hooks';
 import { newPaths } from './newPaths';
 import { match } from './pathToRegexp';
 import { Route } from './Route';
@@ -19,13 +20,7 @@ interface BaseRouterProps {
   onExternalNavigate?: () => any;
   refreshEvents?: Array<keyof WindowEventMap>;
   preservedParams?: string[];
-  urlStateParam?: {
-    startPath: string;
-    path: string;
-    componentName: string;
-    clearUrlStateParam: () => void;
-    socialProvider: string;
-  };
+  routing: RoutingStrategy;
   children: React.ReactNode;
 }
 
@@ -39,10 +34,15 @@ export const BaseRouter = ({
   onExternalNavigate,
   refreshEvents,
   preservedParams,
-  urlStateParam,
+  routing,
   children,
 }: BaseRouterProps): JSX.Element => {
   const { navigate: externalNavigate } = useCoreClerk();
+  const { urlStateParam, removeQueryParam } = useClerkModalStateParams();
+
+  if (urlStateParam.componentName) {
+    removeQueryParam();
+  }
 
   const [routeParts, setRouteParts] = React.useState({
     path: getPath(),
@@ -141,6 +141,7 @@ export const BaseRouter = ({
         resolve: resolve.bind(this),
         refresh: refresh.bind(this),
         params: {},
+        routing: routing,
         urlStateParam: urlStateParam,
       }}
     >

--- a/packages/clerk-js/src/ui/router/HashRouter.tsx
+++ b/packages/clerk-js/src/ui/router/HashRouter.tsx
@@ -47,6 +47,7 @@ export const HashRouter = ({ preservedParams, children }: HashRouterProps): JSX.
       internalNavigate={internalNavigate}
       refreshEvents={['popstate', 'hashchange']}
       preservedParams={preservedParams}
+      routing={'hash'}
     >
       {children}
     </BaseRouter>

--- a/packages/clerk-js/src/ui/router/PathRouter.tsx
+++ b/packages/clerk-js/src/ui/router/PathRouter.tsx
@@ -59,6 +59,7 @@ export const PathRouter = ({ basePath, preservedParams, children }: PathRouterPr
       internalNavigate={internalNavigate}
       refreshEvents={['popstate']}
       preservedParams={preservedParams}
+      routing={'path'}
     >
       {children}
     </BaseRouter>

--- a/packages/clerk-js/src/ui/router/Route.tsx
+++ b/packages/clerk-js/src/ui/router/Route.tsx
@@ -115,6 +115,7 @@ export function Route(props: RouteProps): JSX.Element | null {
         refresh: router.refresh,
         params: paramsDict,
         urlStateParam: router.urlStateParam,
+        routing: router.routing,
       }}
     >
       {props.canActivate ? (

--- a/packages/clerk-js/src/ui/router/RouteContext.tsx
+++ b/packages/clerk-js/src/ui/router/RouteContext.tsx
@@ -1,3 +1,4 @@
+import type { RoutingStrategy } from '@clerk/types';
 import type { ParsedQs } from 'qs';
 import React from 'react';
 
@@ -18,6 +19,7 @@ export interface RouteContextValue {
   queryParams: ParsedQs;
   preservedParams?: string[];
   getMatchData: (path?: string, index?: boolean) => false | object;
+  routing: RoutingStrategy;
   urlStateParam?: {
     startPath: string;
     path: string;

--- a/packages/clerk-js/src/ui/router/VirtualRouter.tsx
+++ b/packages/clerk-js/src/ui/router/VirtualRouter.tsx
@@ -20,11 +20,6 @@ export const VirtualRouter = ({
   const [currentURL, setCurrentURL] = React.useState(
     new URL('/' + VIRTUAL_ROUTER_BASE_PATH + startPath, window.location.origin),
   );
-  const { urlStateParam, removeQueryParam } = useClerkModalStateParams();
-
-  if (urlStateParam.componentName) {
-    removeQueryParam();
-  }
 
   const internalNavigate = (toURL: URL | undefined) => {
     if (!toURL) {
@@ -47,7 +42,7 @@ export const VirtualRouter = ({
       internalNavigate={internalNavigate}
       onExternalNavigate={onExternalNavigate}
       preservedParams={preservedParams}
-      urlStateParam={urlStateParam}
+      routing={'virtual'}
     >
       {children}
     </BaseRouter>

--- a/packages/clerk-js/src/utils/__tests__/queryStateParams.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/queryStateParams.test.ts
@@ -1,15 +1,16 @@
-import { appendModalState } from '../queryStateParams';
+import { appendRedirectState } from '../queryStateParams';
 
-describe('appendModalState function', () => {
+describe('appendRedirectState function', () => {
   it('returns url with query param', () => {
     expect(
-      appendModalState({
+      appendRedirectState({
         url: 'https://accounts.helping.dory-0.dev.lclclerk.com/preview/default-redirect',
         componentName: 'UserProfile',
         socialProvider: 'github',
+        modal: true,
       }),
     ).toEqual(
-      'https://accounts.helping.dory-0.dev.lclclerk.com/preview/default-redirect?__clerk_modal_state=eyJwYXRoIjoiIiwiY29tcG9uZW50TmFtZSI6IlVzZXJQcm9maWxlIiwic3RhcnRQYXRoIjoiL3VzZXIiLCJzb2NpYWxQcm92aWRlciI6ImdpdGh1YiJ9',
+      'https://accounts.helping.dory-0.dev.lclclerk.com/preview/default-redirect?__clerk_redirect_state=eyJwYXRoIjoiIiwiY29tcG9uZW50TmFtZSI6IlVzZXJQcm9maWxlIiwic3RhcnRQYXRoIjoiL3VzZXIiLCJzb2NpYWxQcm92aWRlciI6ImdpdGh1YiIsIm1vZGFsIjp0cnVlfQ%3D%3D',
     );
   });
 
@@ -17,9 +18,9 @@ describe('appendModalState function', () => {
     expect(
       JSON.parse(
         atob(
-          'eyJwYXRoIjoiIiwiY29tcG9uZW50TmFtZSI6IlVzZXJQcm9maWxlIiwic3RhcnRQYXRoIjoiL3VzZXIiLCJzb2NpYWxQcm92aWRlciI6ImdpdGh1YiJ9',
+          'eyJwYXRoIjoiIiwiY29tcG9uZW50TmFtZSI6IlVzZXJQcm9maWxlIiwic3RhcnRQYXRoIjoiL3VzZXIiLCJzb2NpYWxQcm92aWRlciI6ImdpdGh1YiIsIm1vZGFsIjp0cnVlfQ==',
         ),
       ),
-    ).toEqual({ componentName: 'UserProfile', path: '', startPath: '/user', socialProvider: 'github' });
+    ).toEqual({ componentName: 'UserProfile', path: '', startPath: '/user', socialProvider: 'github', modal: true });
   });
 });

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -5,7 +5,7 @@ const ClerkQueryParams = [
   '__clerk_created_session',
   '__clerk_invitation_token',
   '__clerk_ticket',
-  '__clerk_modal_state',
+  '__clerk_redirect_state',
   CLERK_SYNCED,
   CLERK_SATELLITE_URL,
 ] as const;
@@ -17,7 +17,7 @@ type ClerkQueryParamsToValuesMap = {
   __clerk_created_session: string;
   __clerk_invitation_token: string;
   __clerk_ticket: string;
-  __clerk_modal_state: string;
+  __clerk_redirect_state: string;
   __clerk_synced: string;
   __clerk_satellite_url: string;
 };

--- a/packages/clerk-js/src/utils/queryStateParams.ts
+++ b/packages/clerk-js/src/utils/queryStateParams.ts
@@ -1,4 +1,4 @@
-import { CLERK_MODAL_STATE } from '../core/constants';
+import { CLERK_REDIRECT_STATE } from '../core/constants';
 import { encodeB64, getClerkQueryParam } from '../utils';
 
 export const buildVirtualRouterUrl = ({ base, path }: { base: string; path: string | undefined }) => {
@@ -9,34 +9,45 @@ export const buildVirtualRouterUrl = ({ base, path }: { base: string; path: stri
   return base + path;
 };
 
-export const readStateParam = () => {
-  const urlClerkState = getClerkQueryParam(CLERK_MODAL_STATE) ?? '';
-
-  return urlClerkState ? JSON.parse(atob(urlClerkState)) : null;
+type RedirectStateParam = {
+  startPath: string;
+  path: string;
+  componentName: string;
+  socialProvider: string;
+  modal: boolean;
 };
 
-type SerializeAndAppendModalStateProps = {
+export const readStateParam = () => {
+  const urlClerkState = getClerkQueryParam(CLERK_REDIRECT_STATE) ?? '';
+
+  return (urlClerkState ? JSON.parse(atob(urlClerkState)) : null) as RedirectStateParam | null;
+};
+
+type SerializeAndAppendRedirectStateProps = {
   url: string;
   startPath?: string;
   currentPath?: string;
-  componentName: string;
+  componentName?: string;
   socialProvider?: string;
+  modal?: boolean;
 };
 
-export const appendModalState = ({
+export const appendRedirectState = ({
   url,
   startPath = '/user',
   currentPath = '',
-  componentName,
+  componentName = '',
   socialProvider = '',
-}: SerializeAndAppendModalStateProps) => {
-  const regexPattern = /CLERK-ROUTER\/VIRTUAL\/.*\//;
+  modal = false,
+}: SerializeAndAppendRedirectStateProps) => {
+  const regexPattern = /CLERK-ROUTER\/(.*?)\/.*\//;
 
   const redirectParams = {
     path: currentPath.replace(regexPattern, '') || '',
     componentName,
     startPath,
     socialProvider,
+    modal,
   };
 
   const encodedRedirectParams = encodeB64(JSON.stringify(redirectParams));
@@ -44,7 +55,7 @@ export const appendModalState = ({
   const urlWithParams = new URL(url);
   const searchParams = urlWithParams.searchParams;
 
-  searchParams.set(CLERK_MODAL_STATE, encodedRedirectParams);
+  searchParams.set(CLERK_REDIRECT_STATE, encodedRedirectParams);
 
   urlWithParams.search = searchParams.toString();
 

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -1,5 +1,5 @@
 import { camelToSnake, createDevOrStagingUrlCache, isIPV4Address } from '@clerk/shared';
-import type { SignUpResource } from '@clerk/types';
+import type { RoutingStrategy, SignUpResource } from '@clerk/types';
 
 import { loadScript } from '../utils';
 import { joinPaths } from './path';
@@ -315,4 +315,12 @@ export const generateSrcSet = ({
   }
 
   return xDescriptors.map(i => `${generateSrc({ src, width: width * i })} ${i}x`).toString();
+};
+
+export const buildExternalAccountRedirectUrl = ({ routing, path }: { routing: RoutingStrategy; path?: string }) => {
+  return routing === 'hash'
+    ? window.location.href.replace(window.location.hash, '')
+    : routing === 'path' && path
+    ? path
+    : window.location.href;
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR refactors and re-uses the mechanism used to reopen the modal and scroll to the newly added external account for mounted components. A new router property has been added called `routing` and it refers to the routing strategy.

Essentially, we pass a base64 encoded object as a query parameter along with the `redirectUrl` for the oauth attempt. This will give us back information about the state the user was in before the attempt, so we can either scroll to the appropriate connected account in the mounted component, or open the modal and scroll there.
<!-- Fixes # (issue number) -->
