### PR TITLE
fix(clerk-js): Pass unsafe metadata to sign up methods

### DIFF
--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -28,6 +28,17 @@ import type { SnakeToCamel } from './utils';
 import type { CreateMagicLinkFlowReturn, StartMagicLinkFlowParams, VerificationResource } from './verification';
 import type { AttemptWeb3WalletVerificationParams, AuthenticateWithWeb3Params } from './web3Wallet';
 
+declare global {
+  /**
+   * If you want to provide custom types for the user.unsafeMetadata object,
+   * simply redeclare this rule in the global namespace.
+   * Every user object will use the provided type.
+   */
+  interface SignUpUnsafeMetadata {
+    [k: string]: unknown;
+  }
+}
+
 export interface SignUpResource extends ClerkResource {
   status: SignUpStatus | null;
   requiredFields: SignUpField[];
@@ -70,11 +81,15 @@ export interface SignUpResource extends ClerkResource {
 
   createMagicLinkFlow: () => CreateMagicLinkFlowReturn<StartMagicLinkFlowParams, SignUpResource>;
 
-  authenticateWithRedirect: (params: AuthenticateWithRedirectParams) => Promise<void>;
+  authenticateWithRedirect: (
+    params: AuthenticateWithRedirectParams & { unsafeMetadata: SignUpUnsafeMetadata },
+  ) => Promise<void>;
 
-  authenticateWithWeb3: (params: AuthenticateWithWeb3Params) => Promise<SignUpResource>;
+  authenticateWithWeb3: (
+    params: AuthenticateWithWeb3Params & { unsafeMetadata: SignUpUnsafeMetadata },
+  ) => Promise<SignUpResource>;
 
-  authenticateWithMetamask: () => Promise<SignUpResource>;
+  authenticateWithMetamask: (params: { unsafeMetadata: SignUpUnsafeMetadata }) => Promise<SignUpResource>;
 }
 
 export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';
@@ -143,13 +158,16 @@ export type SignUpCreateParams = Partial<
     redirectUrl: string;
     actionCompleteRedirectUrl: string;
     transfer: boolean;
-    unsafeMetadata: Record<string, unknown>;
+    unsafeMetadata: SignUpUnsafeMetadata;
     ticket: string;
   } & SnakeToCamel<Record<SignUpAttributeField | SignUpVerifiableField, string>>
 >;
 
 export type SignUpUpdateParams = SignUpCreateParams;
 
+export type SignUpAuthenticateWithMetamaskParams = {
+  unsafeMetadata?: SignUpUnsafeMetadata;
+};
 export interface SignUpVerificationsResource {
   emailAddress: SignUpVerificationResource;
   phoneNumber: SignUpVerificationResource;


### PR DESCRIPTION
Unsafe metadata can be set by developers using authenticateWithWeb3 and authenticateWithRedirect custom flows.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Unsafe metadata can be set by developers using authenticateWithWeb3 and authenticateWithRedirect custom flows.