### PR TITLE
fix(nextjs): Encode debug headers to avoid encoding issues

### DIFF
--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -28,9 +28,9 @@ interface WithServerSideAuth {
 }
 
 const decorateResponseWithObservabilityHeaders = (res: ServerResponse, requestState: RequestState) => {
-  requestState.message && res.setHeader(constants.Headers.AuthMessage, requestState.message);
-  requestState.reason && res.setHeader(constants.Headers.AuthReason, requestState.reason);
-  requestState.status && res.setHeader(constants.Headers.AuthStatus, requestState.status);
+  requestState.message && res.setHeader(constants.Headers.AuthMessage, encodeURIComponent(requestState.message));
+  requestState.reason && res.setHeader(constants.Headers.AuthReason, encodeURIComponent(requestState.reason));
+  requestState.status && res.setHeader(constants.Headers.AuthStatus, encodeURIComponent(requestState.status));
 };
 
 /**

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -33,9 +33,9 @@ interface WithClerkMiddleware {
 }
 
 export const decorateResponseWithObservabilityHeaders = (res: NextResponse, requestState: RequestState) => {
-  requestState.message && res.headers.set(constants.Headers.AuthMessage, requestState.message);
-  requestState.reason && res.headers.set(constants.Headers.AuthReason, requestState.reason);
-  requestState.status && res.headers.set(constants.Headers.AuthStatus, requestState.status);
+  requestState.message && res.headers.set(constants.Headers.AuthMessage, encodeURIComponent(requestState.message));
+  requestState.reason && res.headers.set(constants.Headers.AuthReason, encodeURIComponent(requestState.reason));
+  requestState.status && res.headers.set(constants.Headers.AuthStatus, encodeURIComponent(requestState.status));
 };
 
 export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Encoding error caused by non latin1 (ISO-8859-1) value in headers:
Cannot convert argument to a ByteString because the character atindex {} has a value of {} which is
greater than 255.

https://github.com/clerkinc/javascript/issues/840