### PR TITLE
fix(backend): Fix missing secretKey from signedInAuthObject

### DIFF
--- a/packages/backend/src/tokens/authStatus.ts
+++ b/packages/backend/src/tokens/authStatus.ts
@@ -117,6 +117,7 @@ export async function signedIn<T>(options: T, sessionClaims: JwtPayload): Promis
   const authObject = signedInAuthObject(
     sessionClaims,
     {
+      secretKey,
       apiKey,
       apiUrl,
       apiVersion,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

The missing secretKey was causing the following error:
```
Missing Clerk Secret Key or API Key. Go to https://dashboard.clerk.dev ...
```
Since the backendApi created to be used in getToken when template was provided did not have in scope the secretKey.

Fixes https://github.com/clerkinc/javascript/issues/850