### PR TITLE
fix(remix): Align request.auth object (add sessionClaims)

### DIFF
--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -7,19 +7,15 @@ import cookie from 'cookie';
 import type { LoaderFunctionArgs, LoaderFunctionArgsWithAuth, RootAuthLoaderOptionsWithExperimental } from './types';
 
 /**
- * Inject `auth`, `user` and `session` properties into `request`
+ * Inject `auth`, `user` , `organization` and `session` properties into request
  * @internal
  */
 export function injectAuthIntoRequest(args: LoaderFunctionArgs, authObject: AuthObject): LoaderFunctionArgsWithAuth {
-  const { user, session, userId, sessionId, getToken, sessionClaims } = authObject;
-  (args.request as any).auth = {
-    userId,
-    sessionId,
-    getToken,
-    actor: sessionClaims?.act || null,
-  };
-  (args.request as any).user = user;
-  (args.request as any).session = session;
+  const { user, session, organization, ...rest } = authObject;
+  const auth = { ...rest, actor: rest.sessionClaims?.act || null };
+
+  Object.assign(args.request, { user, session, organization, auth });
+
   return args as LoaderFunctionArgsWithAuth;
 }
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->

This PR adds the following to `request.auth`:
- sessionClaims: JwtPayload;
- orgId: string | undefined;
- orgRole: string | undefined;
- orgSlug: string | undefined;
- organization: Organization | undefined;
- debug: AuthObjectDebug;

Fixes https://github.com/clerkinc/javascript/issues/826