### PR TITLE
fix(remix): Always use the latest useAwaitableNavigate reference

### DIFF
--- a/packages/remix/src/client/RemixClerkProvider.tsx
+++ b/packages/remix/src/client/RemixClerkProvider.tsx
@@ -13,8 +13,25 @@ export type RemixClerkProviderProps = {
   clerkState: ClerkState;
 } & IsomorphicClerkOptions;
 
+/**
+ * Remix hydration errors should not stop Clerk navigation from working, as the components mount only after
+ * hydration is done (in the case of a hydration error, the components will simply mount after client-side hydration)
+ * In the case of a hydration error, the first `navigate` function we get from the `useNavigate` hook will not work
+ * because the RemixClerkProvider (which is part of the host app) will unmount before the following useEffect within `navigate` fires:
+ * https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/hooks.tsx#L175
+ * so isomorphicClerk will initialise with a `navigate` function that will never have `activeRef.current` set to true.
+ * This variable is just an object ref/cache outside the React rendering cycle that holds a reference to the
+ * latest `navigate` function. After a hydration error occurs, RemixClerkProvider will *remount* and this variable
+ * will finally get a `navigate` function that has a `activeRef.current` to true so navigation will function as it should.
+ */
+const awaitableNavigateRef: { current: ReturnType<typeof useAwaitableNavigate> | undefined } = { current: undefined };
+
 export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): JSX.Element {
   const awaitableNavigate = useAwaitableNavigate();
+
+  React.useEffect(() => {
+    awaitableNavigateRef.current = awaitableNavigate;
+  }, [awaitableNavigate]);
 
   // @ts-expect-error
   const { clerkState, proxyUrl, domain, isSatellite, ...restProps } = rest;
@@ -34,7 +51,7 @@ export function ClerkProvider({ children, ...rest }: RemixClerkProviderProps): J
 
   return (
     <ReactClerkProvider
-      navigate={awaitableNavigate}
+      navigate={(to: string) => awaitableNavigateRef.current?.(to)}
       initialState={__clerk_ssr_state}
       frontendApi={__frontendApi as any}
       publishableKey={__publishableKey as any}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Remix hydration errors should not stop Clerk navigation from working, as the components mount only afterhydration is done (in the case of a hydration error, the components will simply mount after client-side hydration)In the case of a hydration error, the first `navigate` function we get from the `useNavigate` hook will not workbecause the RemixClerkProvider (which is part of the host app) will unmount before the following useEffect within `navigate` fires:https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/hooks.tsx#L175so isomorphicClerk will initialise with a `navigate` function that will never have `activeRef.current` set to true.This variable is just an object ref/cache outside the React rendering cycle that holds a reference to thelatest `navigate` function. After a hydration error occurs, RemixClerkProvider will *remount* and this variablewill finally get a `navigate` function that has a `activeRef.current` to true so navigation will function as it should.
<!-- Fixes # (issue number) -->
