### PR TITLE
fix(nextjs): Introduce CLERK_JS_VERSION env

### DIFF
--- a/packages/nextjs/src/middleware/withServerSideAuth.ts
+++ b/packages/nextjs/src/middleware/withServerSideAuth.ts
@@ -7,6 +7,7 @@ import {
   API_URL,
   clerkClient,
   FRONTEND_API,
+  JS_VERSION,
   makeAuthObjectSerializable,
   PUBLISHABLE_KEY,
   sanitizeAuthObject,
@@ -61,6 +62,7 @@ export const withServerSideAuth: WithServerSideAuth = (cbOrOptions: any, options
         apiUrl: API_URL,
         publishableKey: PUBLISHABLE_KEY,
         frontendApi: FRONTEND_API,
+        pkgVersion: JS_VERSION,
         // @ts-ignore
         proxyUrl: requestState.proxyUrl,
         isSatellite: requestState.isSatellite,

--- a/packages/nextjs/src/server/clerk.ts
+++ b/packages/nextjs/src/server/clerk.ts
@@ -1,5 +1,6 @@
 import { Clerk } from '@clerk/backend';
 
+export const JS_VERSION = process.env.CLERK_JS_VERSION || '';
 export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
 export const API_KEY = process.env.CLERK_API_KEY || '';

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -12,6 +12,7 @@ import {
   DOMAIN,
   FRONTEND_API,
   IS_SATELLITE,
+  JS_VERSION,
   PROXY_URL,
   PUBLISHABLE_KEY,
   SECRET_KEY,
@@ -92,6 +93,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
           apiUrl: API_URL,
           frontendApi: FRONTEND_API,
           publishableKey: PUBLISHABLE_KEY,
+          pkgVersion: JS_VERSION,
           // @ts-expect-error
           proxyUrl: requestState.proxyUrl,
           isSatellite: requestState.isSatellite,


### PR DESCRIPTION
We can use CLERK_JS_VERSION to populate pkgVersion when `remotePublicInterstitialUrl` is called and middleware returns the interstitial

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Currently we do not offer a way for passing a value set by the developers as `pkgVersion` when [remotePublicInterstitialUrl](https://github.com/clerkinc/javascript/blob/1d1b937318c427abcf559341bb39c044f1070e24/packages/nextjs/src/server/withClerkMiddleware.ts#L91) is called.

Using the env variable CLERK_JS_VERSION, the developers can solve the problem mentioned above.
That way they can control the version of clerk-js that will be used as the `src` when loading clerk-js from the BAPI interstitial

<!-- Fixes # (issue number) -->
