### PR TITLE
COR-159 fix(clerk-js): Add environment option

### DIFF
--- a/packages/clerk-js/src/core/clerk.redirects.test.ts
+++ b/packages/clerk-js/src/core/clerk.redirects.test.ts
@@ -97,8 +97,10 @@ describe('Clerk singleton - Redirects', () => {
           Promise.resolve({
             authConfig: {},
             displayConfig: mockDisplayConfigWithSameOrigin,
+            isProduction: () => false,
           }),
         );
+
         mockUsesUrlBasedSessionSync.mockReturnValue(true);
 
         clerkForProductionInstance = new Clerk(productionFrontendApi);
@@ -110,6 +112,10 @@ describe('Clerk singleton - Redirects', () => {
         await clerkForDevelopmentInstance.load({
           navigate: mockNavigate,
         });
+      });
+
+      afterEach(() => {
+        mockEnvironmentFetch.mockRestore();
       });
 
       it('redirects to signInUrl', async () => {
@@ -167,8 +173,10 @@ describe('Clerk singleton - Redirects', () => {
           Promise.resolve({
             authConfig: {},
             displayConfig: mockDisplayConfigWithDifferentOrigin,
+            isProduction: () => false,
           }),
         );
+
         mockUsesUrlBasedSessionSync.mockReturnValue(true);
 
         clerkForProductionInstance = new Clerk(productionFrontendApi);
@@ -180,6 +188,10 @@ describe('Clerk singleton - Redirects', () => {
         await clerkForDevelopmentInstance.load({
           navigate: mockNavigate,
         });
+      });
+
+      afterEach(() => {
+        mockEnvironmentFetch.mockRestore();
       });
 
       it('redirects to signInUrl', async () => {

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -89,6 +89,7 @@ describe('Clerk singleton', () => {
         authConfig: {},
         displayConfig: mockDisplayConfig,
         isSingleSession: () => false,
+        isProduction: () => false,
       }),
     );
 
@@ -270,16 +271,6 @@ describe('Clerk singleton', () => {
 
   describe('.load()', () => {
     it('gracefully handles an incorrect value returned from the user provided selectInitialSession', async () => {
-      mockEnvironmentFetch.mockReturnValue(
-        Promise.resolve({
-          authConfig: {},
-          displayConfig: mockDisplayConfig,
-          isSingleSession: () => false,
-          isProduction: () => false,
-          onWindowLocationHost: () => false,
-        }),
-      );
-
       mockClientFetch.mockReturnValue(
         Promise.resolve({
           activeSessions: [],

--- a/packages/clerk-js/src/core/services/authentication/AuthenticationService.ts
+++ b/packages/clerk-js/src/core/services/authentication/AuthenticationService.ts
@@ -23,6 +23,7 @@ export class AuthenticationService {
 
   public initAuth = (opts: InitParams): void => {
     this.enablePolling = opts.enablePolling ?? true;
+    this.environment = opts.environment;
     this.setAuthCookiesFromSession(this.clerk.session);
     this.setClientUatCookieForDevelopmentInstances();
     this.clearLegacyAuthV1Cookies();


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Add environment option in `AuthenticatedServices`. 
This also fixes the issue of client uat cookie being set twice for proxied apps
<!-- Fixes # (issue number) -->
