### PR TITLE
Expect actual satellite domain and not FAPI

### DIFF
--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -21,11 +21,19 @@ export type LoadInterstitialOptions = {
 } & DomainOrProxyUrl;
 
 // TODO: use the same function from @clerk/shared once treeshakable
-function addClerkPrefix(str: string | undefined) {
-  if (typeof str === 'undefined') {
-    return undefined;
+export function addClerkPrefix(str: string | undefined) {
+  if (!str) {
+    return '';
   }
-  return `clerk.${str}`;
+  let regex;
+  if (str?.match(/(clerk\.)?dev$/)) {
+    regex = /(clerk\.)*(?=clerk\.)/;
+  } else {
+    regex = /clerk\./gi;
+  }
+
+  const stripped = str.replace(regex, '');
+  return `clerk.${stripped}`;
 }
 
 export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions, 'apiUrl'>) {

--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -82,7 +82,7 @@ export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions,
                 ${domain ? `script.setAttribute('data-clerk-domain', '${domain}');` : ''}
                 ${proxyUrl ? `script.setAttribute('data-clerk-proxy-url', '${proxyUrl}')` : ''};
                 script.async = true;
-                script.src = '${getScriptUrl(proxyUrl || frontendApi, pkgVersion)}';
+                script.src = '${getScriptUrl(proxyUrl || `clerk.${domain}` || frontendApi, pkgVersion)}';
                 script.crossOrigin = 'anonymous';
                 script.addEventListener('load', startClerk);
                 document.body.appendChild(script);

--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -20,6 +20,14 @@ export type LoadInterstitialOptions = {
   isSatellite?: boolean;
 } & DomainOrProxyUrl;
 
+// TODO: use the same function from @clerk/shared once treeshakable
+function addClerkPrefix(str: string | undefined) {
+  if (typeof str === 'undefined') {
+    return undefined;
+  }
+  return `clerk.${str}`;
+}
+
 export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions, 'apiUrl'>) {
   options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
   const { debugData, frontendApi, pkgVersion, publishableKey, proxyUrl, isSatellite = false, domain } = options;
@@ -82,7 +90,7 @@ export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions,
                 ${domain ? `script.setAttribute('data-clerk-domain', '${domain}');` : ''}
                 ${proxyUrl ? `script.setAttribute('data-clerk-proxy-url', '${proxyUrl}')` : ''};
                 script.async = true;
-                script.src = '${getScriptUrl(proxyUrl || `clerk.${domain}` || frontendApi, pkgVersion)}';
+                script.src = '${getScriptUrl(proxyUrl || addClerkPrefix(domain) || frontendApi, pkgVersion)}';
                 script.crossOrigin = 'anonymous';
                 script.addEventListener('load', startClerk);
                 document.body.appendChild(script);

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -78,8 +78,7 @@ export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
   };
 
 export async function authenticateRequest(options: AuthenticateRequestOptions): Promise<RequestState> {
-  options.frontendApi =
-    options.domain || parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
+  options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
   options.apiUrl = options.apiUrl || API_URL;
   options.apiVersion = options.apiVersion || API_VERSION;
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -168,7 +168,9 @@ export default class Clerk implements ClerkInterface {
     }
     this.proxyUrl = proxyUrlToAbsoluteURL(_unfilteredProxy);
 
-    this.domain = options?.domain;
+    this.domain = (options)?.domain
+      ? `clerk.${(options).domain}`
+      : undefined;
 
     if (isLegacyFrontendApiKey(key)) {
       if (!validateFrontendApi(key)) {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1,5 +1,6 @@
 import type { LocalStorageBroadcastChannel } from '@clerk/shared';
 import {
+  addClerkPrefix,
   inClientSide,
   isLegacyFrontendApiKey,
   isValidBrowserOnline,
@@ -168,9 +169,7 @@ export default class Clerk implements ClerkInterface {
     }
     this.proxyUrl = proxyUrlToAbsoluteURL(_unfilteredProxy);
 
-    this.domain = (options)?.domain
-      ? `clerk.${(options).domain}`
-      : undefined;
+    this.domain = addClerkPrefix(options?.domain);
 
     if (isLegacyFrontendApiKey(key)) {
       if (!validateFrontendApi(key)) {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -169,7 +169,7 @@ export default class Clerk implements ClerkInterface {
     }
     this.proxyUrl = proxyUrlToAbsoluteURL(_unfilteredProxy);
 
-    this.domain = addClerkPrefix(options?.domain);
+    this.domain = stripScheme(addClerkPrefix(options?.domain));
 
     if (isLegacyFrontendApiKey(key)) {
       if (!validateFrontendApi(key)) {
@@ -976,7 +976,7 @@ export default class Clerk implements ClerkInterface {
       const proxy = new URL(this.proxyUrl);
       primarySyncUrl = new URL(`${proxy.pathname}/v1/client/sync`, proxy.origin);
     } else if (this.domain) {
-      primarySyncUrl = new URL(`/v1/client/sync`, `https://${stripScheme(this.domain)}`);
+      primarySyncUrl = new URL(`/v1/client/sync`, `https://${this.domain}`);
     } else {
       clerkMissingProxyUrlAndDomain();
     }

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -44,6 +44,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
   const [handler = noop, opts = {}] = args as [NextMiddleware, WithAuthOptions] | [];
 
   const proxyUrl = opts?.proxyUrl || PROXY_URL;
+  const domain = (opts)?.domain || DOMAIN;
 
   if (!!proxyUrl && !isHttpOrHttps(proxyUrl)) {
     throw new Error(`Only a absolute URL that starts with https is allowed to be used in SSR`);
@@ -74,7 +75,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
       userAgent: headers.get('user-agent') || undefined,
       proxyUrl,
       isSatellite,
-      domain: DOMAIN,
+      domain,
       searchParams: new URL(req.url).searchParams,
     });
 

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -36,6 +36,7 @@ const forceStagingReleaseForClerkFapi = (frontendApi: string): boolean => {
 function getScriptSrc({
   publishableKey,
   frontendApi,
+  domain,
   scriptUrl,
   scriptVariant = '',
   proxyUrl,
@@ -47,6 +48,8 @@ function getScriptSrc({
   let scriptHost = '';
   if (!!proxyUrl && isValidProxyUrl(proxyUrl)) {
     scriptHost = proxyUrlToAbsoluteURL(proxyUrl).replace(/http(s)?:\/\//, '');
+  } else if (domain) {
+    scriptHost = domain;
   } else {
     scriptHost = parsePublishableKey(publishableKey)?.frontendApi || frontendApi || '';
   }
@@ -110,7 +113,7 @@ export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptEl
       script.setAttribute('data-clerk-proxy-url', proxyUrl);
     }
     if (domain) {
-      script.setAttribute('data-clerk-domain', domain);
+      script.setAttribute('data-clerk-domain', domain.replace('clerk.', ''));
     }
 
     script.setAttribute('crossorigin', 'anonymous');

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -1,4 +1,4 @@
-import { isValidProxyUrl, parsePublishableKey, proxyUrlToAbsoluteURL } from '@clerk/shared';
+import { addClerkPrefix, isValidProxyUrl, parsePublishableKey, proxyUrlToAbsoluteURL } from '@clerk/shared';
 
 import { LIB_VERSION } from '../info';
 import type { BrowserClerk } from '../types';
@@ -49,7 +49,7 @@ function getScriptSrc({
   if (!!proxyUrl && isValidProxyUrl(proxyUrl)) {
     scriptHost = proxyUrlToAbsoluteURL(proxyUrl).replace(/http(s)?:\/\//, '');
   } else if (domain) {
-    scriptHost = domain;
+    scriptHost = addClerkPrefix(domain);
   } else {
     scriptHost = parsePublishableKey(publishableKey)?.frontendApi || frontendApi || '';
   }
@@ -113,7 +113,7 @@ export async function loadScript(params: LoadScriptParams): Promise<HTMLScriptEl
       script.setAttribute('data-clerk-proxy-url', proxyUrl);
     }
     if (domain) {
-      script.setAttribute('data-clerk-domain', domain.replace('clerk.', ''));
+      script.setAttribute('data-clerk-domain', domain);
     }
 
     script.setAttribute('crossorigin', 'anonymous');

--- a/packages/shared/src/utils/url.test.ts
+++ b/packages/shared/src/utils/url.test.ts
@@ -1,4 +1,4 @@
-import { parseSearchParams, stripScheme } from './url';
+import { addClerkPrefix, parseSearchParams, stripScheme } from './url';
 
 describe('parseSearchParams(queryString)', () => {
   it('parses query string and returns a URLSearchParams object', () => {
@@ -28,5 +28,21 @@ describe('stripScheme(url)', () => {
 
   it.each(cases)('removes scheme from url: %p', (urlInput, urlOutput) => {
     expect(stripScheme(urlInput)).toBe(urlOutput);
+  });
+});
+
+describe('addClerkPrefix(str)', () => {
+  const undefinedCase = [[undefined, undefined]];
+
+  it.each(undefinedCase)('attempts to the prefix clerk. to %p', (urlInput, urlOutput) => {
+    expect(addClerkPrefix(urlInput)).toBe(urlOutput);
+  });
+
+  const cases = [
+    ['', 'clerk.'],
+    ['example.com', 'clerk.example.com'],
+  ];
+  it.each(cases)('attempts to the prefix clerk. to %p', (urlInput, urlOutput) => {
+    expect(addClerkPrefix(urlInput)).toBe(urlOutput);
   });
 });

--- a/packages/shared/src/utils/url.test.ts
+++ b/packages/shared/src/utils/url.test.ts
@@ -32,15 +32,19 @@ describe('stripScheme(url)', () => {
 });
 
 describe('addClerkPrefix(str)', () => {
-  const undefinedCase = [[undefined, undefined]];
+  const undefinedCase = [[undefined, '']];
 
   it.each(undefinedCase)('attempts to the prefix clerk. to %p', (urlInput, urlOutput) => {
     expect(addClerkPrefix(urlInput)).toBe(urlOutput);
   });
 
   const cases = [
-    ['', 'clerk.'],
+    ['', ''],
     ['example.com', 'clerk.example.com'],
+    ['clerk.example.com', 'clerk.example.com'],
+    ['clerk.clerk.example.com', 'clerk.example.com'],
+    ['clerk.dev', 'clerk.clerk.dev'],
+    ['clerk.clerk.dev', 'clerk.clerk.dev'],
   ];
   it.each(cases)('attempts to the prefix clerk. to %p', (urlInput, urlOutput) => {
     expect(addClerkPrefix(urlInput)).toBe(urlOutput);

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -8,3 +8,10 @@ export function parseSearchParams(queryString = ''): URLSearchParams {
 export function stripScheme(url = ''): string {
   return (url || '').replace(/^.+:\/\//, '');
 }
+
+export function addClerkPrefix(str: string | undefined) {
+  if (typeof str === 'undefined') {
+    return undefined;
+  }
+  return `clerk.${str}`;
+}

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -10,8 +10,16 @@ export function stripScheme(url = ''): string {
 }
 
 export function addClerkPrefix(str: string | undefined) {
-  if (typeof str === 'undefined') {
-    return undefined;
+  if (!str) {
+    return '';
   }
-  return `clerk.${str}`;
+  let regex;
+  if (str?.match(/(clerk\.)?dev$/)) {
+    regex = /(clerk\.)*(?=clerk\.)/;
+  } else {
+    regex = /clerk\./gi;
+  }
+
+  const stripped = str.replace(regex, '');
+  return `clerk.${stripped}`;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x]  `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR supports an actual domain to be passed for a satellite and and not FAPI. 

Before: `CLERK_DOMAIN=clerk.satellite.dev`
After: `CLERK_DOMAIN=satellite.dev`

This changes applies for the environment variable, props, and options for wrapper functions.

We continue to pass around the domain value without the prefix and we add it when it is needed(clerk-js & clerk-react)
It will be used when constructing the src url of for clerk-js script and inside Clerk class by clerk-js

We also send the domain to BAPI without the prefix and the endpoint will handle the rest.

While this solution may not seem ideal, because we need to construct the correct url each time we want to use it, the other approach of constructing the url at top level creates more issues than it solves. Happy to talk more about it in the comments if anyone wants to know more

<!-- Fixes # (issue number) -->
