### PR TITLE
chore(repo): Remove turbo cache and reset playground yalc with nuke command

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prerelease": "npx rimraf packages/*/dist && turbo run build test --concurrency=${TURBO_CONCURRENCY:-2} --force",
     "release:next": "lerna publish from-package --dist-tag next",
     "version": "./scripts/version-info.sh",
-    "nuke": "rm -r node_modules; for d in packages/*; do echo $d; rm -r $d/node_modules $d/dist; done;",
+    "nuke": "./scripts/nuke.sh",
     "yalc:all": "for d in packages/*/; do echo $d; cd $d; yalc push --replace; cd '../../'; done",
     "prepare": "husky install"
   }

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,0 +1,13 @@
+rm -r node_modules
+
+for d in packages/*
+do
+    echo $d
+    rm -r $d/node_modules $d/dist $d/.turbo
+done
+
+for d in playground/*
+do
+    echo $d
+    yalc remove --all
+done


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

