### PR TITLE
Only set client uat cookie for dev instances when environment is defined

### DIFF
--- a/packages/clerk-js/src/core/clerk.redirects.test.ts
+++ b/packages/clerk-js/src/core/clerk.redirects.test.ts
@@ -98,6 +98,7 @@ describe('Clerk singleton - Redirects', () => {
             authConfig: {},
             displayConfig: mockDisplayConfigWithSameOrigin,
             isProduction: () => false,
+            isDevelopmentOrStaging: () => true,
           }),
         );
 
@@ -174,6 +175,7 @@ describe('Clerk singleton - Redirects', () => {
             authConfig: {},
             displayConfig: mockDisplayConfigWithDifferentOrigin,
             isProduction: () => false,
+            isDevelopmentOrStaging: () => true,
           }),
         );
 

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -92,6 +92,7 @@ describe('Clerk singleton', () => {
         displayConfig: mockDisplayConfig,
         isSingleSession: () => false,
         isProduction: () => false,
+        isDevelopmentOrStaging: () => true,
       }),
     );
 
@@ -482,6 +483,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -541,6 +543,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -596,6 +599,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -663,6 +667,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -713,6 +718,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -768,6 +774,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -808,6 +815,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -851,6 +859,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -906,6 +915,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -962,6 +972,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -1010,6 +1021,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );
@@ -1058,6 +1070,7 @@ describe('Clerk singleton', () => {
           displayConfig: mockDisplayConfig,
           isSingleSession: () => false,
           isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
           onWindowLocationHost: () => false,
         }),
       );

--- a/packages/clerk-js/src/core/resources/Environment.ts
+++ b/packages/clerk-js/src/core/resources/Environment.ts
@@ -47,6 +47,10 @@ export class Environment extends BaseResource implements EnvironmentResource {
     return this.displayConfig.instanceEnvironmentType === 'production';
   };
 
+  isDevelopmentOrStaging = (): boolean => {
+    return !this.isProduction();
+  };
+
   onWindowLocationHost = (): boolean => {
     return this.displayConfig.backendHost === window.location.host;
   };

--- a/packages/clerk-js/src/core/services/authentication/AuthenticationService.ts
+++ b/packages/clerk-js/src/core/services/authentication/AuthenticationService.ts
@@ -99,7 +99,7 @@ export class AuthenticationService {
   }
 
   private setClientUatCookieForDevelopmentInstances() {
-    if (!this.environment?.isProduction() && this.inCustomDevelopmentDomain()) {
+    if (this.environment && this.environment.isDevelopmentOrStaging() && this.inCustomDevelopmentDomain()) {
       this.cookies.setClientUatCookie(this.clerk.client);
     }
   }

--- a/packages/types/src/environment.ts
+++ b/packages/types/src/environment.ts
@@ -11,5 +11,6 @@ export interface EnvironmentResource extends ClerkResource {
   displayConfig: DisplayConfigResource;
   isSingleSession: () => boolean;
   isProduction: () => boolean;
+  isDevelopmentOrStaging: () => boolean;
   onWindowLocationHost: () => boolean;
 }


### PR DESCRIPTION




## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
 Environment should exist and not be production to prevent setting `__client_uat` with value of 0
<!-- Fixes # (issue number) -->
