### PR TITLE
COR-164 Accept the search params of request in `authenticateRequest`

### DIFF
--- a/packages/backend/src/tokens/factory.ts
+++ b/packages/backend/src/tokens/factory.ts
@@ -19,7 +19,6 @@ export type CreateAuthenticateRequestOptions = {
       | 'proxyUrl'
       | 'domain'
       | 'isSatellite'
-      | 'hasJustSynced'
     >
   >;
   apiClient: ApiClient;
@@ -38,7 +37,6 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
     publishableKey: buildtimePublishableKey = '',
     isSatellite: buildtimeIsSatellite = false,
     domain: buildtimeDomain = '',
-    hasJustSynced: buildtimeHasJustSynced = false,
   } = params.options;
 
   const authenticateRequest = ({
@@ -50,7 +48,7 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
     jwtKey: runtimeJwtKey,
     isSatellite: runtimeIsSatellite,
     domain: runtimeDomain,
-    hasJustSynced: runtimeHasJustSynced,
+    searchParams,
     ...rest
   }: Omit<AuthenticateRequestOptions, 'apiUrl' | 'apiVersion'>) => {
     return authenticateRequestOriginal({
@@ -65,7 +63,7 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
       isSatellite: runtimeIsSatellite || buildtimeIsSatellite,
       domain: runtimeDomain || buildtimeDomain,
       jwtKey: runtimeJwtKey || buildtimeJwtKey,
-      hasJustSynced: runtimeHasJustSynced || buildtimeHasJustSynced,
+      searchParams,
     });
   };
 

--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -149,7 +149,9 @@ async function verifyRequestState(options: AuthenticateRequestOptions, token: st
 }
 
 export const isSatelliteAndNeedsSyncing: InterstitialRule = options => {
-  const { clientUat, isSatellite, hasJustSynced = false } = options;
+  const { clientUat, isSatellite, searchParams } = options;
+
+  const hasJustSynced = searchParams?.get('__clerk_synced') === 'true';
 
   if (isSatellite && (!clientUat || clientUat === '0') && !hasJustSynced) {
     return interstitial(options, AuthErrorReason.SatelliteCookieNeedsSyncing);

--- a/packages/backend/src/tokens/request.test.ts
+++ b/packages/backend/src/tokens/request.test.ts
@@ -125,7 +125,7 @@ export default (QUnit: QUnit) => {
     skipJwksCache: true,
     isSatellite: false,
     domain: '',
-    hasJustSynced: false,
+    searchParams: new URLSearchParams(),
   } satisfies AuthenticateRequestOptions;
 
   module('tokens.authenticateRequest(options)', hooks => {
@@ -264,7 +264,6 @@ export default (QUnit: QUnit) => {
         apiKey: 'deadbeef',
         clientUat: '0',
         isSatellite: true,
-        hasJustSynced: false,
       });
 
       assertInterstitial(assert, requestState, {

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -74,7 +74,7 @@ export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
     /**
      * @experimental
      */
-    hasJustSynced?: boolean;
+    searchParams?: URLSearchParams;
   };
 
 export async function authenticateRequest(options: AuthenticateRequestOptions): Promise<RequestState> {

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -75,7 +75,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
       proxyUrl,
       isSatellite,
       domain: DOMAIN,
-      hasJustSynced: new URL(req.url).searchParams.get('__clerk_synced') === 'true',
+      searchParams: new URL(req.url).searchParams,
     });
 
     // Interstitial case

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -77,6 +77,6 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     proxyUrl,
     isSatellite,
     domain,
-    hasJustSynced: new URL(request.url).searchParams.get('__clerk_synced') === 'true',
+    searchParams: new URL(request.url).searchParams,
   });
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This is a necessary step in order to hide the logic of we handle the sync with primary process from the end users.

<!-- Fixes # (issue number) -->
