### PR TITLE
fix(clerk-react): Make all component props reactive

### DIFF
--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -40,13 +40,11 @@ import { withClerk } from './withClerk';
 // });
 
 // Portal.displayName = 'ClerkPortal';
-class Portal extends React.PureComponent<MountProps, {}> {
+class Portal extends React.PureComponent<MountProps, Record<never, never>> {
   private portalRef = React.createRef<HTMLDivElement>();
 
-  componentDidUpdate(prevProps: Readonly<MountProps>) {
-    if (prevProps.props.appearance !== this.props.props.appearance) {
-      this.props.updateProps({ node: this.portalRef.current, props: this.props.props });
-    }
+  componentDidUpdate() {
+    this.props.updateProps({ node: this.portalRef.current, props: this.props.props });
   }
 
   componentDidMount() {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Passing dynamic props besides the appearance object should now work as expected.

If the decision to memoize these props was for performance reasons, we shouldn't be looking at any bugs here. If not, we need to assess this more carefully before merging.

Theoretically, this is a breaking change, considering that a developer might be hitting on the existing issue and might have worked around this behaviour, and this behaviour will now change.
<!-- Fixes # (issue number) -->
