### PR TITLE
fix(backend,shared): Updated tests for addClerkPrefix

### DIFF
--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -26,7 +26,7 @@ export function addClerkPrefix(str: string | undefined) {
     return '';
   }
   let regex;
-  if (str?.match(/(clerk\.)?dev$/)) {
+  if (str?.match(/(clerk\.)+dev$/)) {
     regex = /(clerk\.)*(?=clerk\.)/;
   } else {
     regex = /clerk\./gi;

--- a/packages/shared/src/utils/url.test.ts
+++ b/packages/shared/src/utils/url.test.ts
@@ -45,6 +45,8 @@ describe('addClerkPrefix(str)', () => {
     ['clerk.clerk.example.com', 'clerk.example.com'],
     ['clerk.dev', 'clerk.clerk.dev'],
     ['clerk.clerk.dev', 'clerk.clerk.dev'],
+    ['satellite.dev', 'clerk.satellite.dev'],
+    ['clerk.satellite.dev', 'clerk.satellite.dev'],
   ];
   it.each(cases)('attempts to the prefix clerk. to %p', (urlInput, urlOutput) => {
     expect(addClerkPrefix(urlInput)).toBe(urlOutput);

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -14,7 +14,7 @@ export function addClerkPrefix(str: string | undefined) {
     return '';
   }
   let regex;
-  if (str?.match(/(clerk\.)?dev$/)) {
+  if (str?.match(/(clerk\.)+dev$/)) {
     regex = /(clerk\.)*(?=clerk\.)/;
   } else {
     regex = /clerk\./gi;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The previous regex was also matching anything that ended with the top level domain `.dev`, and this behaviour is not correct

<!-- Fixes # (issue number) -->
