### PR TITLE
fix(types): Make DomainOrProxyUrl optional

### DIFF
--- a/packages/expo/src/ClerkProvider.tsx
+++ b/packages/expo/src/ClerkProvider.tsx
@@ -14,7 +14,6 @@ __internal__setErrorThrowerOptions({
 });
 
 export type ClerkProviderProps = ClerkReactProviderProps & {
-  children: React.ReactNode;
   tokenCache?: TokenCache;
 };
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -128,11 +128,9 @@ export default class IsomorphicClerk {
         if (isConstructor<BrowserClerkConstructor | HeadlessBrowserClerkConstrutor>(this.Clerk)) {
           // Construct a new Clerk object if a constructor is passed
           c = new this.Clerk(this.publishableKey || this.frontendApi || '', {
-            // @ts-expect-error
             proxyUrl: this.proxyUrl,
-            // @ts-expect-error
             domain: this.domain,
-          });
+          } as any);
           await c.load(this.options);
         } else {
           // Otherwise use the instantiated Clerk object

--- a/packages/types/src/multiDomain.ts
+++ b/packages/types/src/multiDomain.ts
@@ -1,9 +1,9 @@
 export type DomainOrProxyUrl =
   | {
       proxyUrl?: never;
-      domain: string;
+      domain?: string;
     }
   | {
-      proxyUrl: string;
+      proxyUrl?: string;
       domain?: never;
     };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Otherwise, TS will complain if `domain` or `proxyUrl` is missing for  apps not using the multi domain feature. 
<!-- Fixes # (issue number) -->
