### PR TITLE
[JS-167] Implement the `reload` method for Organization and OrganizationMembership

### DIFF
--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -1,4 +1,5 @@
 import type {
+  ClerkResourceReloadParams,
   MembershipRole,
   OrganizationMembershipJSON,
   OrganizationMembershipResource,
@@ -70,6 +71,22 @@ export class OrganizationMembership extends BaseResource implements Organization
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     return this;
+  }
+
+  public async reload(params?: ClerkResourceReloadParams): Promise<this> {
+    const { rotatingTokenNonce } = params || {};
+    const json = await BaseResource._fetch(
+      {
+        method: 'GET',
+        path: `/me/organization_memberships`,
+        rotatingTokenNonce,
+      },
+      { forceUpdateClient: true },
+    );
+    const currentMembership = (json?.response as unknown as OrganizationMembershipJSON[]).find(
+      orgMem => orgMem.id === this.id,
+    );
+    return this.fromJSON(currentMembership as OrganizationMembershipJSON);
   }
 }
 

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -13,7 +13,7 @@ Organization {
   "logoUrl": "https://url-for-logo.png",
   "membersCount": 1,
   "name": "test_name",
-  "pathRoot": "/organizations",
+  "pathRoot": "",
   "pendingInvitationsCount": 10,
   "publicMetadata": {
     "public": "metadata",

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -17,7 +17,7 @@ OrganizationMembership {
     "logoUrl": "https://path-to-logo.png",
     "membersCount": 1,
     "name": "test_name",
-    "pathRoot": "/organizations",
+    "pathRoot": "",
     "pendingInvitationsCount": 10,
     "publicMetadata": {
       "public": "metadata",

--- a/packages/types/src/deletedObject.ts
+++ b/packages/types/src/deletedObject.ts
@@ -1,4 +1,6 @@
-export interface DeletedObjectResource {
+import type { ClerkResource } from './resource';
+
+export interface DeletedObjectResource extends ClerkResource {
   object: string;
   id?: string;
   slug?: string;

--- a/packages/types/src/externalAccount.ts
+++ b/packages/types/src/externalAccount.ts
@@ -1,7 +1,8 @@
 import type { OAuthProvider } from './oauth';
+import type { ClerkResource } from './resource';
 import type { VerificationResource } from './verification';
 
-export interface ExternalAccountResource {
+export interface ExternalAccountResource extends ClerkResource {
   id: string;
   identificationId: string;
   provider: OAuthProvider;

--- a/packages/types/src/identificationLink.ts
+++ b/packages/types/src/identificationLink.ts
@@ -1,4 +1,6 @@
-export interface IdentificationLinkResource {
+import type { ClerkResource } from './resource';
+
+export interface IdentificationLinkResource extends ClerkResource {
   id: string;
   type: string;
 }

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -1,6 +1,7 @@
 import type { ClerkPaginationParams } from './api';
 import type { OrganizationInvitationResource } from './organizationInvitation';
 import type { MembershipRole, OrganizationMembershipResource } from './organizationMembership';
+import type { ClerkResource } from './resource';
 
 declare global {
   /**
@@ -13,7 +14,7 @@ declare global {
   }
 }
 
-export interface OrganizationResource {
+export interface OrganizationResource extends ClerkResource {
   id: string;
   name: string;
   slug: string | null;

--- a/packages/types/src/organizationInvitation.ts
+++ b/packages/types/src/organizationInvitation.ts
@@ -1,4 +1,5 @@
 import type { MembershipRole } from './organizationMembership';
+import type { ClerkResource } from './resource';
 
 declare global {
   /**
@@ -11,7 +12,7 @@ declare global {
   }
 }
 
-export interface OrganizationInvitationResource {
+export interface OrganizationInvitationResource extends ClerkResource {
   id: string;
   emailAddress: string;
   organizationId: string;

--- a/packages/types/src/organizationMembership.ts
+++ b/packages/types/src/organizationMembership.ts
@@ -1,4 +1,5 @@
 import type { OrganizationResource } from './organization';
+import type { ClerkResource } from './resource';
 import type { PublicUserData } from './session';
 
 declare global {
@@ -12,7 +13,7 @@ declare global {
   }
 }
 
-export interface OrganizationMembershipResource {
+export interface OrganizationMembershipResource extends ClerkResource {
   id: string;
   organization: OrganizationResource;
   publicMetadata: OrganizationMembershipPublicMetadata;

--- a/packages/types/src/verification.ts
+++ b/packages/types/src/verification.ts
@@ -1,6 +1,7 @@
 import type { ClerkAPIError } from './api';
+import type { ClerkResource } from './resource';
 
-export interface VerificationResource {
+export interface VerificationResource extends ClerkResource {
   attempts: number | null;
   error: ClerkAPIError | null;
   expireAt: Date | null;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR implements the `reload` method for **OrganizationResource** and **OrganizationMembershipResource**, as it is needed for reloading the resource when `publicMetadata` gets updated.

We also update all resource types to extend the `ClerkResource`.
<!-- Fixes # (issue number) -->
