### PR TITLE
fix(clerk-js): Temporarily do not mark react as an external dep

### DIFF
--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -30,6 +30,7 @@
     "build:bundle": "npm run clean && webpack --config webpack.config.js --env production",
     "build:declarations": "tsc -p tsconfig.declarations.json",
     "dev": "webpack serve --config webpack.config.js",
+    "dev:headless": "webpack serve --config webpack.config.js --env variant=\"clerk.headless.browser\"",
     "clean": "rimraf ./dist",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
clerk-js depends on clerk/shared that currently, imports React.
As a result, we cannot mark React as an external dep unless we refactor the imports. Let's revisit this after the bundle-size changes are merged.

In this PR we also introduce `npm run dev:headless` for easier local testing and we also aligned the build config for prod and dev so the bundles used for local testing match the prod builds more closely.
<!-- Fixes # (issue number) -->
