### PR TITLE
fix(nextjs): Correct currentUser() return type

### DIFF
--- a/packages/nextjs/src/app-beta/currentUser.ts
+++ b/packages/nextjs/src/app-beta/currentUser.ts
@@ -1,7 +1,9 @@
+import type { User } from '@clerk/backend';
+
 import { auth } from './auth';
 import { clerkClient } from './clerkClient';
 
-export function currentUser() {
+export async function currentUser(): Promise<User | null> {
   const { userId } = auth();
   return userId ? clerkClient.users.getUser(userId) : null;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
`currentUser` should always return a promise, otherwise its signature would change depending on whether the user is signed in or not. 

Explanation:
`auth` is a sync method, and since we check `userId` before returning a `Promise`, `currentUser` would be sync when `userId` is `null` and async otherwise. 

This PR makes this method async and adds an explicit return type to avoid this issue in the future.
<!-- Fixes # (issue number) -->
