### PR TITLE
fix(backend): Convert all methods of SessionApi to class methods

### DIFF
--- a/packages/backend/src/api/endpoints/SessionApi.ts
+++ b/packages/backend/src/api/endpoints/SessionApi.ts
@@ -14,39 +14,40 @@ type QueryParams = {
 };
 
 export class SessionAPI extends AbstractAPI {
-  public getSessionList = async (queryParams?: QueryParams) =>
-    this.request<Session[]>({
+  public async getSessionList(queryParams?: QueryParams) {
+    return this.request<Session[]>({
       method: 'GET',
       path: basePath,
       queryParams: queryParams,
     });
+  }
 
-  public getSession = async (sessionId: string) => {
+  public async getSession(sessionId: string) {
     this.requireId(sessionId);
     return this.request<Session>({
       method: 'GET',
       path: joinPaths(basePath, sessionId),
     });
-  };
+  }
 
-  public revokeSession = async (sessionId: string) => {
+  public async revokeSession(sessionId: string) {
     this.requireId(sessionId);
     return this.request<Session>({
       method: 'POST',
       path: joinPaths(basePath, sessionId, 'revoke'),
     });
-  };
+  }
 
-  public verifySession = async (sessionId: string, token: string) => {
+  public async verifySession(sessionId: string, token: string) {
     this.requireId(sessionId);
     return this.request<Session>({
       method: 'POST',
       path: joinPaths(basePath, sessionId, 'verify'),
       bodyParams: { token },
     });
-  };
+  }
 
-  public getToken = async (sessionId: string, template: string) => {
+  public async getToken(sessionId: string, template: string) {
     this.requireId(sessionId);
     return (
       (await this.request<Token>({
@@ -54,5 +55,5 @@ export class SessionAPI extends AbstractAPI {
         path: joinPaths(basePath, sessionId, 'tokens', template || ''),
       })) as any
     ).jwt;
-  };
+  }
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Deploying to the edge (or `experimental-edge`) runtime on Vercel currently fails with a couple of cryptic errors, however the real cause of the issue is is a "Must call super constructor in derived class before accessing 'this' or returning from derived constructor" error we get from within the `@clerk/backend` package.

I've found out that the SessionApi class has a couple of methods defined as class properties (arrow functions defined as class properties rather than class methods).

With out current settings, (target ES2020) the build results in the following code:
```tsx
var SessionAPI = class extends AbstractAPI {
  constructor() {
    super(...arguments);
    this.getSessionList = async (queryParams) => this.request({
      method: "GET",
      path: basePath9,
      queryParams
    });
    this.getSession = async (sessionId) => {
      this.requireId(sessionId);
      return this.request({
        method: "GET",
        path: joinPaths(basePath9, sessionId)
      });
    };
    this.revokeSession = async (sessionId) => {
      this.requireId(sessionId);
      return this.request({
        method: "POST",
        path: joinPaths(basePath9, sessionId, "revoke")
      });
    };
    this.verifySession = async (sessionId, token) => {
      this.requireId(sessionId);
      return this.request({
        method: "POST",
        path: joinPaths(basePath9, sessionId, "verify"),
        bodyParams: { token }
      });
    };
  }
...
};
```
which fails when run on a v8 runtime with the error described above

Targetting ESNEXT results in code that differs slightly from the es2020 variant as seen below, but it does work on v8:

```tsx
var SessionAPI = class extends AbstractAPI {
  getSessionList = async (queryParams) => this.request({
    method: "GET",
    path: basePath9,
    queryParams
  });
  getSession = async (sessionId) => {
    this.requireId(sessionId);
    return this.request({
      method: "GET",
      path: joinPaths(basePath9, sessionId)
    });
  };
  revokeSession = async (sessionId) => {
    this.requireId(sessionId);
    return this.request({
      method: "POST",
      path: joinPaths(basePath9, sessionId, "revoke")
    });
  };
  verifySession = async (sessionId, token) => {
    this.requireId(sessionId);
    return this.request({
      method: "POST",
      path: joinPaths(basePath9, sessionId, "verify"),
      bodyParams: { token }
    });
  };
```

Converting the props to class methods brings us closer to the esnext output and it does resolve the lexical scoping issues we've faced. While more research needs to be done, the `this` within the arrow functions seem to be different between node and v8 environments. More details will be posted as part of an internal doc/ style guide once we verify the validity of this fix

<!-- Fixes # (issue number) -->
