### PR TITLE
fix(clerk-js): Fix UserProfile section scroll in mobile view

### DIFF
--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -10,7 +10,7 @@ import { Menu } from '../icons';
 import { useRouter } from '../router';
 import type { PropsOfComponent } from '../styledSystem';
 import { animations, mqu } from '../styledSystem';
-import { colors } from '../utils';
+import { colors, sleep } from '../utils';
 import { withFloatingTree } from './contexts';
 import { useNavigateToFlowStart } from './NavigateToFlowStartButton';
 import { Popover } from './Popover';
@@ -63,6 +63,8 @@ export const NavBar = (props: NavBarProps) => {
         await navigate(route.path);
       }
       const el = contentRef.current?.querySelector(getSectionId(route.id));
+      //sleep to avoid conflict with floating-ui close
+      await sleep(10);
       el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Seems like we're hitting some kind of conflict with the scrolling from floating-ui here when focus is returned. Found no way to turn it off, but a small timeout seems to fix the issue.
<!-- Fixes # (issue number) -->
