### PR TITLE
Add dynamic localization keys in unstable_errors

### DIFF
--- a/packages/clerk-js/src/ui/localization/__tests__/makeLocalizable.test.tsx
+++ b/packages/clerk-js/src/ui/localization/__tests__/makeLocalizable.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { bindCreateFixtures, render, renderHook, screen } from '../../../testUtils';
 import {
   Badge,
@@ -90,5 +88,50 @@ describe('Test localizable components', () => {
     });
 
     screen.getByText('11/12/1999'); // this key makes use of numeric('en-US')
+  });
+
+  it('translates errors using the values provided in unstable_errors', async () => {
+    const { wrapper, fixtures } = await createFixtures();
+    fixtures.options.localization = {
+      unstable__errors: {
+        form_identifier_not_found: 'form_identifier_not_found',
+        form_password_pwned: 'form_password_pwned',
+        form_username_invalid_length: 'form_username_invalid_length',
+        form_param_format_invalid: 'form_param_format_invalid',
+        form_password_length_too_short: 'form_password_length_too_short',
+        form_param_nil: 'form_param_nil',
+        form_code_incorrect: 'form_code_incorrect',
+        form_password_incorrect: 'form_password_incorrect',
+        not_allowed_access: 'not_allowed_access',
+        form_identifier_exists: 'form_identifier_exists',
+        form_identifier_exists__username: 'form_identifier_exists__username',
+        form_identifier_exists__email_address: 'form_identifier_exists__email_address',
+      },
+    };
+    const { result } = renderHook(() => useLocalizations(), { wrapper });
+    const { translateError } = result.current;
+    expect(translateError({ code: 'code-does-not-exist', message: 'message' })).toBe('message');
+    expect(translateError({ code: 'form_identifier_not_found', message: 'message' } as any)).toBe(
+      'form_identifier_not_found',
+    );
+    expect(translateError({ code: 'form_password_pwned', message: 'message' })).toBe('form_password_pwned');
+    expect(translateError({ code: 'form_username_invalid_length', message: 'message' })).toBe(
+      'form_username_invalid_length',
+    );
+    expect(translateError({ code: 'form_param_format_invalid', message: 'message' })).toBe('form_param_format_invalid');
+    expect(translateError({ code: 'form_password_length_too_short', message: 'message' })).toBe(
+      'form_password_length_too_short',
+    );
+    expect(translateError({ code: 'form_param_nil', message: 'message' })).toBe('form_param_nil');
+    expect(translateError({ code: 'form_code_incorrect', message: 'message' })).toBe('form_code_incorrect');
+    expect(translateError({ code: 'form_password_incorrect', message: 'message' })).toBe('form_password_incorrect');
+    expect(translateError({ code: 'not_allowed_access', message: 'message' })).toBe('not_allowed_access');
+    expect(translateError({ code: 'form_identifier_exists', message: 'message' })).toBe('form_identifier_exists');
+    expect(
+      translateError({ code: 'form_identifier_exists', message: 'message', meta: { paramName: 'username' } }),
+    ).toBe('form_identifier_exists__username');
+    expect(
+      translateError({ code: 'form_identifier_exists', message: 'message', meta: { paramName: 'email_address' } }),
+    ).toBe('form_identifier_exists__email_address');
   });
 });

--- a/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
+++ b/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
@@ -71,11 +71,19 @@ export const useLocalizations = () => {
     if (!error || typeof error === 'string') {
       return t(error);
     }
-    const { code, message, longMessage } = error || {};
+    const { code, message, longMessage, meta } = error || {};
+    const { paramName = '' } = meta || {};
+
     if (!code) {
       return '';
     }
-    return t(localizationKeys(`unstable__errors.${code}` as any)) || longMessage || message;
+
+    return (
+      t(localizationKeys(`unstable__errors.${code}__${paramName}` as any)) ||
+      t(localizationKeys(`unstable__errors.${code}` as any)) ||
+      longMessage ||
+      message
+    );
   };
 
   return { t, translateError };

--- a/packages/clerk-js/src/ui/utils/test/createFixtures.tsx
+++ b/packages/clerk-js/src/ui/utils/test/createFixtures.tsx
@@ -74,7 +74,6 @@ const unboundCreateFixtures = <N extends UnpackContext<typeof ComponentContext>[
 
     const MockClerkProvider = (props: any) => {
       const { children } = props;
-      console.log(optionsMock);
       return (
         <CoreClerkContextWrapper clerk={clerkMock}>
           <EnvironmentProvider value={environmentMock}>

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -1,6 +1,6 @@
-import type { DeepRequired, LocalizationResource } from '@clerk/types';
+import type { LocalizationResource } from '@clerk/types';
 
-export const deDe: DeepRequired<LocalizationResource> = {
+export const deDe: LocalizationResource = {
   socialButtonsBlockButton: 'Weiter mit {{provider|titleize}}',
   dividerText: 'oder',
   formFieldLabel__emailAddress: 'E-Mail-Adresse',
@@ -278,8 +278,7 @@ export const deDe: DeepRequired<LocalizationResource> = {
           destructiveActionLabel: 'Telefonnummer entfernen',
           title__default: 'Standard',
           title__setDefault: 'Als Standard festlegen',
-          subtitle__default:
-            'Dieser Methode wird bei der Anmeldung als zweiter Faktor verwendet.',
+          subtitle__default: 'Dieser Methode wird bei der Anmeldung als zweiter Faktor verwendet.',
           subtitle__setDefault:
             'Legen Sie diese Methode als Standardmethode fest, um sie als standardmäßigen zweiten Faktor bei der Anmeldung zu verwenden.',
           actionLabel__setDefault: 'Als Standard einstellen',
@@ -294,8 +293,7 @@ export const deDe: DeepRequired<LocalizationResource> = {
         totp: {
           headerTitle: 'Authentifizierungs-App',
           title: 'Standardfaktor',
-          subtitle:
-            'Dieser Faktor wird bei der Anmeldung als standardmäßiger zweiter Faktor verwendet.',
+          subtitle: 'Dieser Faktor wird bei der Anmeldung als standardmäßiger zweiter Faktor verwendet.',
           destructiveActionTitle: 'Entfernen',
           destructiveActionSubtitle:
             'Entfernen Sie die Authentifizierungs-App aus den zweistufigen Überprüfungsmethoden',
@@ -423,7 +421,8 @@ export const deDe: DeepRequired<LocalizationResource> = {
       removeResource: {
         title: 'Entfernen Sie die Bestätigung in zwei Schritten',
         messageLine1: 'Bei der Anmeldung sind keine Bestätigungscodes von diesem Authentifikator mehr erforderlich.',
-        messageLine2: 'Ihr Konto ist möglicherweise nicht mehr so sicher. Sind Sie sich sicher, dass Sie fortfahren wollen?',
+        messageLine2:
+          'Ihr Konto ist möglicherweise nicht mehr so sicher. Sind Sie sich sicher, dass Sie fortfahren wollen?',
         successMessage: 'Die zweistufige Verifizierung über die Authentifizierungs-App wurde entfernt.',
       },
     },
@@ -544,6 +543,7 @@ export const deDe: DeepRequired<LocalizationResource> = {
     form_code_incorrect: '',
     form_password_incorrect: '',
     not_allowed_access: '',
+    form_identifier_exists: '',
   },
   dates: {
     previous6Days: "Letzte {{ date | weekday('de-DE','long') }} um {{ date | timeString('de-DE') }}",

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -1,4 +1,4 @@
-import type { DeepRequired, LocalizationResource } from '@clerk/types';
+import type { LocalizationResource } from '@clerk/types';
 
 const commonTexts = {
   signIn: {
@@ -12,7 +12,7 @@ const commonTexts = {
   },
 } as const;
 
-export const enUS: DeepRequired<LocalizationResource> = {
+export const enUS: LocalizationResource = {
   socialButtonsBlockButton: 'Continue with {{provider|titleize}}',
   dividerText: 'or',
   formFieldLabel__emailAddress: 'Email address',
@@ -535,6 +535,7 @@ export const enUS: DeepRequired<LocalizationResource> = {
     form_code_incorrect: '',
     form_password_incorrect: '',
     not_allowed_access: '',
+    form_identifier_exists: '',
   },
   dates: {
     previous6Days: "Last {{ date | weekday('en-US','long') }} at {{ date | timeString('en-US') }}",

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -1,4 +1,4 @@
-import type { DeepRequired, LocalizationResource } from '@clerk/types';
+import type { LocalizationResource } from '@clerk/types';
 
 const commonTexts = {
   signIn: {
@@ -12,7 +12,7 @@ const commonTexts = {
   },
 } as const;
 
-export const esES: DeepRequired<LocalizationResource> = {
+export const esES: LocalizationResource = {
   socialButtonsBlockButton: 'Continuar con {{provider|titleize}}',
   dividerText: 'o',
   formFieldLabel__emailAddress: 'Correo electrónico',
@@ -545,6 +545,7 @@ export const esES: DeepRequired<LocalizationResource> = {
     form_code_incorrect: '',
     form_password_incorrect: '',
     not_allowed_access: '',
+    form_identifier_exists: '',
   },
   dates: {
     previous6Days: "Último {{ date | weekday('es-ES','long') }} en {{ date | timeString('es-ES') }}",

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -1,6 +1,6 @@
-import type { DeepRequired, LocalizationResource } from '@clerk/types';
+import type { LocalizationResource } from '@clerk/types';
 
-export const frFR: DeepRequired<LocalizationResource> = {
+export const frFR: LocalizationResource = {
   socialButtonsBlockButton: 'Continuer avec {{provider|titleize}}',
   dividerText: 'ou',
   formFieldLabel__emailAddress: 'Adresse e-mail',
@@ -543,6 +543,7 @@ export const frFR: DeepRequired<LocalizationResource> = {
     form_code_incorrect: 'Code incorrect',
     form_password_incorrect: 'Mot de passe incorrect',
     not_allowed_access: '',
+    form_identifier_exists: '',
   },
   dates: {
     previous6Days: "{{ date | weekday('fr-FR','long') }} dernier à {{ date | timeString('fr-FR') }}",

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -1,4 +1,4 @@
-import type { DeepRequired, LocalizationResource } from '@clerk/types';
+import type { LocalizationResource } from '@clerk/types';
 
 const commonTexts = {
   signIn: {
@@ -12,7 +12,7 @@ const commonTexts = {
   },
 } as const;
 
-export const itIT: DeepRequired<LocalizationResource> = {
+export const itIT: LocalizationResource = {
   socialButtonsBlockButton: 'Continua con {{provider|titleize}}',
   dividerText: 'oppure',
   formFieldLabel__emailAddress: 'Indirizzo email',
@@ -539,6 +539,7 @@ export const itIT: DeepRequired<LocalizationResource> = {
     form_code_incorrect: '',
     form_password_incorrect: '',
     not_allowed_access: '',
+    form_identifier_exists: '',
   },
   dates: {
     previous6Days: "{{ date | weekday('it-IT','long') }} alle {{ date | timeString('it-IT') }}",

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -1,4 +1,4 @@
-import type { DeepRequired, LocalizationResource } from '@clerk/types';
+import type { LocalizationResource } from '@clerk/types';
 
 const commonTexts = {
   signIn: {
@@ -12,7 +12,7 @@ const commonTexts = {
   },
 } as const;
 
-export const ptBR: DeepRequired<LocalizationResource> = {
+export const ptBR: LocalizationResource = {
   socialButtonsBlockButton: 'Continuar com {{provider|titleize}}',
   dividerText: 'ou',
   formFieldLabel__emailAddress: 'Seu e-mail',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -1,4 +1,5 @@
-import type { DeepPartial } from './utils';
+import type { FieldId } from './appearance';
+import type { CamelToSnake, DeepPartial } from './utils';
 
 export type LocalizationValue = string;
 
@@ -524,17 +525,7 @@ type _LocalizationResource = {
       formButtonReset: LocalizationValue;
     };
   };
-  unstable__errors: {
-    form_identifier_not_found: LocalizationValue;
-    form_password_pwned: LocalizationValue;
-    form_username_invalid_length: LocalizationValue;
-    form_param_format_invalid: LocalizationValue;
-    form_password_length_too_short: LocalizationValue;
-    form_param_nil: LocalizationValue;
-    form_code_incorrect: LocalizationValue;
-    form_password_incorrect: LocalizationValue;
-    not_allowed_access: LocalizationValue;
-  };
+  unstable__errors: UnstableErrors;
   dates: {
     previous6Days: LocalizationValue;
     lastDay: LocalizationValue;
@@ -544,3 +535,18 @@ type _LocalizationResource = {
     numeric: LocalizationValue;
   };
 };
+
+type WithParamName<T> = T &
+  Partial<Record<`${keyof T & string}__${CamelToSnake<Exclude<FieldId, 'role'>>}`, LocalizationValue>>;
+type UnstableErrors = WithParamName<{
+  form_identifier_not_found: LocalizationValue;
+  form_password_pwned: LocalizationValue;
+  form_username_invalid_length: LocalizationValue;
+  form_param_format_invalid: LocalizationValue;
+  form_password_length_too_short: LocalizationValue;
+  form_param_nil: LocalizationValue;
+  form_code_incorrect: LocalizationValue;
+  form_password_incorrect: LocalizationValue;
+  not_allowed_access: LocalizationValue;
+  form_identifier_exists: LocalizationValue;
+}>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The field-related FAPI errors include a `meta.paramName` prop we can append to the keys within unstable_errors in order to allow for more fine-grained translations.

This commit adds the necessary infra to support the above.


Usage:
```tsx
    <ClerkProvider
      localization={{
        unstable__errors: {
          form_identifier_exists: 'Το πεδίο υπάρχει ήδη',
          form_identifier_exists__username: 'Το όνομα χρήστη υπάρχει ηδη',
        },
      }}
```

Example:
![image](https://user-images.githubusercontent.com/1811063/223383033-809506df-ba50-4ee0-8c08-dffa86d808e6.png)

<!-- Fixes # (issue number) -->
