### PR TITLE
COR-189 Include isSatellite in DomainOrProxyUrl

### DIFF
--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -19,7 +19,7 @@ declare global {
   }
 }
 
-export type IsomorphicClerkOptions = ClerkOptions & {
+export type IsomorphicClerkOptions = Omit<ClerkOptions, 'isSatellite'> & {
   Clerk?: ClerkProp;
   clerkJSUrl?: string;
   clerkJSVariant?: 'headless' | '';

--- a/packages/types/src/multiDomain.ts
+++ b/packages/types/src/multiDomain.ts
@@ -1,9 +1,25 @@
+import type { ClerkOptions } from './clerk';
+
+/**
+ * DomainOrProxyUrl supports the following cases
+ * 1) none of them are set
+ * 2) only proxyUrl is set
+ * 3) isSatellite and proxy is set
+ * 4) isSatellite and domain is set
+ */
 export type DomainOrProxyUrl =
   | {
-      proxyUrl?: never;
-      domain?: string;
+      isSatellite?: never;
+      proxyUrl?: never | string;
+      domain?: never;
     }
   | {
-      proxyUrl?: string;
+      isSatellite: ClerkOptions['isSatellite'];
+      proxyUrl?: never;
+      domain: string;
+    }
+  | {
+      isSatellite: ClerkOptions['isSatellite'];
+      proxyUrl: string;
       domain?: never;
     };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This is an attempt to improve typesafety for the props that were introduced for the proxy and multi-domain features

Before someone was allowed to have the following config 
```jsx
<ClerkProvider domain={'satellite.dev'} />
```
This is perfectly valid, but a user should use this in combination with `isSatellite` prop in order to ensure the the mutl-domain feature in a satellite application will work.

After this PR the above code will result in a type error which is a hint for the developers that they've missed a prop.

Here's a list of configuration someone is allowed to use related to types

- NONE of them (regular app)
```jsx
<ClerkProvider />
```

- proxyUrl (primary app)
```jsx
<ClerkProvider proxyUrl={'/__clerk'} />
```

- proxyUrl  + isSatellite (satellite app)
```jsx
<ClerkProvider isSatellite={true} proxyUrl={'/__clerk'} />
```

- domain  + isSatellite (satellite app)
```jsx
<ClerkProvider isSatellite={(_)=> true} domain={'satellite.dev} />
```


Here's a list of configuration that is **NOT** allowed:

- Only domain 
```jsx
<ClerkProvider domain={'satellite.dev'} />
```

- Only isSatellite 
```jsx
<ClerkProvider isSatellite={true} />
```

- proxyUrl + domain 
```jsx
<ClerkProvider domain={'satellite.dev'} proxyUrl={'/__clerk'} />
```

- proxyUrl + domain  + isSatellite
```jsx
<ClerkProvider isSatellite={true} domain={'satellite.dev'} proxyUrl={'/__clerk'} />
```

<!-- Fixes # (issue number) -->
