### PR TITLE
Ability to define additional OAuth scopes in UserProfile & reauthorize existing account

### DIFF
--- a/packages/clerk-js/src/core/resources/ExternalAccount.test.ts
+++ b/packages/clerk-js/src/core/resources/ExternalAccount.test.ts
@@ -1,6 +1,31 @@
 import { BaseResource, ExternalAccount } from './internal';
 
 describe('External account', () => {
+  it('reauthorize', async () => {
+    const targetId = 'test_id';
+
+    const externalAccountJSON = {
+      object: 'external_account',
+      id: targetId,
+    };
+
+    // @ts-ignore
+    BaseResource._fetch = jest.fn().mockReturnValue(Promise.resolve({ response: externalAccountJSON }));
+
+    const externalAccount = new ExternalAccount({ id: targetId }, '/me/external_accounts');
+    await externalAccount.reauthorize({ additionalScopes: ['read', 'write'], redirectUrl: 'https://test.com' });
+
+    // @ts-ignore
+    expect(BaseResource._fetch).toHaveBeenCalledWith({
+      method: 'PATCH',
+      path: `/me/external_accounts/${targetId}/reauthorize`,
+      body: {
+        additional_scope: ['read', 'write'],
+        redirect_url: 'https://test.com',
+      },
+    });
+  });
+
   it('destroy', async () => {
     const targetId = 'test_id';
 

--- a/packages/clerk-js/src/core/resources/ExternalAccount.ts
+++ b/packages/clerk-js/src/core/resources/ExternalAccount.ts
@@ -1,5 +1,11 @@
 import { titleize } from '@clerk/shared';
-import type { ExternalAccountJSON, ExternalAccountResource, OAuthProvider, VerificationResource } from '@clerk/types';
+import type {
+  ExternalAccountJSON,
+  ExternalAccountResource,
+  OAuthProvider,
+  ReauthorizeExternalAccountParams,
+  VerificationResource,
+} from '@clerk/types';
 
 import { BaseResource } from './Base';
 import { Verification } from './Verification';
@@ -26,6 +32,14 @@ export class ExternalAccount extends BaseResource implements ExternalAccountReso
     this.fromJSON(data);
   }
 
+  reauthorize = (params: ReauthorizeExternalAccountParams): Promise<ExternalAccountResource> => {
+    const { additionalScopes, redirectUrl } = params;
+
+    return this._basePatch({
+      action: 'reauthorize',
+      body: { additional_scope: additionalScopes, redirect_url: redirectUrl },
+    });
+  };
   destroy = (): Promise<void> => this._baseDelete();
 
   protected fromJSON(data: ExternalAccountJSON): this {

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -1,4 +1,4 @@
-import type { OAuthStrategy } from '@clerk/types';
+import type { OAuthProvider, OAuthStrategy } from '@clerk/types';
 import type { ExternalAccountResource } from '@clerk/types/src';
 
 import { useRouter } from '../../../ui/router';
@@ -50,9 +50,39 @@ const ConnectedAccountAccordion = ({ account }: { account: ExternalAccountResour
   const error = account.verification?.error?.longMessage;
   const label = account.username || account.emailAddress;
   const defaultOpen = !!router.urlStateParam?.componentName;
-  const { componentName, mode } = useUserProfileContext();
+  const { additionalOAuthScopes, componentName, mode } = useUserProfileContext();
   const isModal = mode === 'modal';
   const visitedProvider = account.provider === router.urlStateParam?.socialProvider;
+  const [reauthorizationRequired, additionalScopes] = isReauthorizationRequired(account, additionalOAuthScopes);
+  const title = !reauthorizationRequired
+    ? localizationKeys('userProfile.start.connectedAccountsSection.title__conectionFailed')
+    : localizationKeys('userProfile.start.connectedAccountsSection.title__reauthorize');
+  const subtitle = !reauthorizationRequired
+    ? (error as any)
+    : localizationKeys('userProfile.start.connectedAccountsSection.subtitle__reauthorize');
+  const actionLabel = !reauthorizationRequired
+    ? localizationKeys('userProfile.start.connectedAccountsSection.actionLabel__conectionFailed')
+    : localizationKeys('userProfile.start.connectedAccountsSection.actionLabel__reauthorize');
+
+  const handleOnClick = async () => {
+    const redirectUrl = isModal ? appendModalState({ url: window.location.href, componentName }) : window.location.href;
+
+    try {
+      let response: ExternalAccountResource;
+      if (reauthorizationRequired) {
+        response = await account.reauthorize({ additionalScopes, redirectUrl });
+      } else {
+        response = await user.createExternalAccount({
+          strategy: account.verification!.strategy as OAuthStrategy,
+          redirect_url: redirectUrl,
+        });
+      }
+
+      navigate(response.verification!.externalVerificationRedirectURL);
+    } catch (err) {
+      handleError(err, [], card.setError);
+    }
+  };
 
   return (
     <UserProfileAccordion
@@ -73,7 +103,7 @@ const ConnectedAccountAccordion = ({ account }: { account: ExternalAccountResour
           center
         >
           {`${providerToDisplayData[account.provider].name} ${label ? `(${label})` : ''}`}
-          {error && (
+          {(error || reauthorizationRequired) && (
             <Badge
               colorScheme='danger'
               localizationKey={localizationKeys('badge__requiresAction')}
@@ -83,35 +113,23 @@ const ConnectedAccountAccordion = ({ account }: { account: ExternalAccountResour
       }
     >
       <Col gap={4}>
-        {!error && (
-          <UserPreview
-            externalAccount={account}
-            size='lg'
-            icon={
-              <Image
-                alt={providerToDisplayData[account.provider].name}
-                src={providerToDisplayData[account.provider].iconUrl}
-                sx={theme => ({ width: theme.sizes.$4 })}
-              />
-            }
-          />
-        )}
-        {error && (
+        <UserPreview
+          externalAccount={account}
+          size='lg'
+          icon={
+            <Image
+              alt={providerToDisplayData[account.provider].name}
+              src={providerToDisplayData[account.provider].iconUrl}
+              sx={theme => ({ width: theme.sizes.$4 })}
+            />
+          }
+        />
+        {(error || reauthorizationRequired) && (
           <LinkButtonWithDescription
-            title={localizationKeys('userProfile.start.connectedAccountsSection.title__conectionFailed')}
-            subtitle={error as any}
-            actionLabel={localizationKeys('userProfile.start.connectedAccountsSection.actionLabel__conectionFailed')}
-            onClick={() => {
-              return user
-                .createExternalAccount({
-                  strategy: account.verification!.strategy as OAuthStrategy,
-                  redirect_url: isModal
-                    ? appendModalState({ url: window.location.href, componentName })
-                    : window.location.href,
-                })
-                .then(res => navigate(res.verification!.externalVerificationRedirectURL))
-                .catch(err => handleError(err, [], card.setError));
-            }}
+            title={title}
+            subtitle={subtitle}
+            actionLabel={actionLabel}
+            onClick={handleOnClick}
           />
         )}
 
@@ -128,3 +146,22 @@ const ConnectedAccountAccordion = ({ account }: { account: ExternalAccountResour
     </UserProfileAccordion>
   );
 };
+
+function isReauthorizationRequired(
+  account: ExternalAccountResource,
+  scopes?: Record<OAuthProvider, string[]>,
+): [boolean, string[]] {
+  if (!account.approvedScopes || !scopes) {
+    // OAuth flow has not been completed yet OR no additional scopes have been injected, return early
+    return [false, []];
+  }
+
+  const additionalScopes = scopes[account.provider] || [];
+  const currentScopes = account.approvedScopes.split(' ');
+  const missingScopes = additionalScopes.filter(scope => !currentScopes.includes(scope));
+  if (missingScopes.length === 0) {
+    return [false, []];
+  }
+
+  return [true, additionalScopes];
+}

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -256,7 +256,11 @@ export const enUS: LocalizationResource = {
         title: 'Connected accounts',
         primaryButton: 'Connect account',
         title__conectionFailed: 'Retry failed connection',
+        title__reauthorize: 'Reauthorization required',
+        subtitle__reauthorize:
+          'The required scopes have been updated, and you may be experiencing limited functionality. Please re-authorize this application to avoid any issues',
         actionLabel__conectionFailed: 'Try again',
+        actionLabel__reauthorize: 'Authorize now',
         destructiveActionTitle: 'Remove',
         destructiveActionSubtitle: 'Remove this connected account from your account',
         destructiveActionAccordionSubtitle: 'Remove connected account',

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -11,6 +11,7 @@ import type {
 import type { ClientResource } from './client';
 import type { DisplayThemeJSON } from './json';
 import type { LocalizationResource } from './localization';
+import type { OAuthProvider } from './oauth';
 import type { OrganizationResource } from './organization';
 import type { OrganizationInvitationResource } from './organizationInvitation';
 import type { MembershipRole, OrganizationMembershipResource } from './organizationMembership';
@@ -587,6 +588,11 @@ export type UserProfileProps = {
    * prop of ClerkProvided (if one is provided)
    */
   appearance?: UserProfileTheme;
+  /*
+   * Specify additional scopes per OAuth provider that your users would like to provide if not already approved.
+   * e.g. <UserProfile additionalOAuthScopes={{google: ['foo', 'bar'], github: ['qux']}} />
+   */
+  additionalOAuthScopes?: Record<OAuthProvider, string[]>;
 };
 
 export type OrganizationProfileProps = {

--- a/packages/types/src/externalAccount.ts
+++ b/packages/types/src/externalAccount.ts
@@ -2,6 +2,11 @@ import type { OAuthProvider } from './oauth';
 import type { ClerkResource } from './resource';
 import type { VerificationResource } from './verification';
 
+export type ReauthorizeExternalAccountParams = {
+  additionalScopes: string[];
+  redirectUrl?: string;
+};
+
 export interface ExternalAccountResource extends ClerkResource {
   id: string;
   identificationId: string;
@@ -16,6 +21,7 @@ export interface ExternalAccountResource extends ClerkResource {
   publicMetadata: Record<string, unknown>;
   label?: string;
   verification: VerificationResource | null;
+  reauthorize: (params: ReauthorizeExternalAccountParams) => Promise<ExternalAccountResource>;
   destroy: () => Promise<void>;
   providerSlug: () => OAuthProvider;
   providerTitle: () => string;

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -266,7 +266,10 @@ type _LocalizationResource = {
         title: LocalizationValue;
         primaryButton: LocalizationValue;
         title__conectionFailed: LocalizationValue;
+        title__reauthorize: LocalizationValue;
+        subtitle__reauthorize: LocalizationValue;
         actionLabel__conectionFailed: LocalizationValue;
+        actionLabel__reauthorize: LocalizationValue;
         destructiveActionTitle: LocalizationValue;
         destructiveActionSubtitle: LocalizationValue;
         destructiveActionAccordionSubtitle: LocalizationValue;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Enables users to be able to pass during runtime, additional scopes for each OAuth provider in the UserProfile component. This can be useful in the scenario where a user has already connected an account, and the application requires more scopes for its functionality.
In this case, the component will understand that more scopes are required and will prompt the user to reauthorize their account to grand all the new necessary scopes.

The underlaying implementation is using the new clerk.js `externalAccount.reauthorize()` method

<img width="879" alt="Screenshot 2023-03-08 at 10 26 55 AM" src="https://user-images.githubusercontent.com/22435234/223661672-d6d25603-a606-4cee-9edd-1cbfd93a1dbf.png">

<!-- Fixes # (issue number) -->
