### PR TITLE
fix(shared): Add support for clerk.com domain in addClerkPredix() utility

### DIFF
--- a/packages/shared/src/utils/url.test.ts
+++ b/packages/shared/src/utils/url.test.ts
@@ -44,6 +44,7 @@ describe('addClerkPrefix(str)', () => {
     ['clerk.example.com', 'clerk.example.com'],
     ['clerk.clerk.example.com', 'clerk.example.com'],
     ['clerk.dev', 'clerk.clerk.dev'],
+    ['clerk.com', 'clerk.clerk.com'],
     ['clerk.clerk.dev', 'clerk.clerk.dev'],
     ['satellite.dev', 'clerk.satellite.dev'],
     ['clerk.satellite.dev', 'clerk.satellite.dev'],

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -14,7 +14,7 @@ export function addClerkPrefix(str: string | undefined) {
     return '';
   }
   let regex;
-  if (str?.match(/(clerk\.)+dev$/)) {
+  if (str.match(/(clerk\.)+(dev|com)$/)) {
     regex = /(clerk\.)*(?=clerk\.)/;
   } else {
     regex = /clerk\./gi;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Add support for `clerk.com` domain in `addClerkPredix()` utility

<!-- Fixes # (issue number) -->
