### PR TITLE
fix(clerk-js): Add margin for clerk tag and refactor the modal close button

### DIFF
--- a/packages/clerk-js/src/ui/elements/Card.tsx
+++ b/packages/clerk-js/src/ui/elements/Card.tsx
@@ -15,6 +15,7 @@ import { PoweredByClerkTag } from './PoweredByClerk';
 type CardProps = PropsOfComponent<typeof BaseCard> & React.PropsWithChildren<Record<never, never>>;
 
 export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
+  const { sx, children, ...rest } = props;
   const appearance = useAppearance();
   const flowMetadata = useFlowMetadata();
   const { branded } = useEnvironment().displayConfig;
@@ -35,7 +36,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => 
         elementDescriptor={descriptors.card}
         className={generateFlowPartClassname(flowMetadata)}
         gap={8}
-        {...props}
+        {...rest}
         sx={[
           t => ({
             width: t.sizes.$100,
@@ -49,12 +50,12 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => 
               padding: `${t.space.$8} ${t.space.$5} ${t.space.$10} ${t.space.$5}`,
             },
           }),
-          props.sx,
+          sx,
         ]}
         ref={ref}
       >
         {appearance.parsedLayout.logoPlacement === 'inside' && <ApplicationLogo />}
-        {props.children}
+        {children}
         {branded && <PoweredByClerkTag />}
       </BaseCard>
     </>
@@ -92,7 +93,7 @@ export const ProfileCard = React.forwardRef<HTMLDivElement, CardProps>((props, r
 type BaseCardProps = PropsOfComponent<typeof Flex>;
 
 export const BaseCard = React.forwardRef<HTMLDivElement, BaseCardProps>((props, ref) => {
-  const { children, ...rest } = props;
+  const { children, sx, ...rest } = props;
   const flowMetadata = useFlowMetadata();
   const { toggle } = useUnsafeModalContext();
 
@@ -112,7 +113,7 @@ export const BaseCard = React.forwardRef<HTMLDivElement, BaseCardProps>((props, 
           boxShadow: t.shadows.$cardDropShadow,
           border: '1px solid transparent',
         }),
-        rest.sx,
+        sx,
       ]}
       ref={ref}
     >

--- a/packages/clerk-js/src/ui/elements/Card.tsx
+++ b/packages/clerk-js/src/ui/elements/Card.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
 import { useEnvironment } from '../contexts';
-import { descriptors, Flex, generateFlowPartClassname, useAppearance } from '../customizables';
+import { descriptors, Flex, generateFlowPartClassname, Icon, useAppearance } from '../customizables';
 import type { ElementDescriptor } from '../customizables/elementDescriptors';
+import { Close } from '../icons';
 import type { PropsOfComponent } from '../styledSystem';
 import { mqu } from '../styledSystem';
 import { ApplicationLogo } from './ApplicationLogo';
 import { useFlowMetadata } from './contexts';
+import { IconButton } from './IconButton';
+import { useUnsafeModalContext } from './Modal';
 import { PoweredByClerkTag } from './PoweredByClerk';
 
 type CardProps = PropsOfComponent<typeof BaseCard> & React.PropsWithChildren<Record<never, never>>;
@@ -39,6 +42,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => 
             maxWidth: `calc(100vw - ${t.sizes.$20})`,
             [mqu.sm]: {
               maxWidth: `calc(100vw - ${t.sizes.$3})`,
+              margin: branded ? `0 0 ${t.space.$7} 0` : '0',
             },
             padding: `${t.space.$9x5} ${t.space.$8} ${t.space.$12} ${t.space.$8}`,
             [mqu.xs]: {
@@ -68,8 +72,10 @@ export const ProfileCard = React.forwardRef<HTMLDivElement, CardProps>((props, r
           padding: 0,
           width: t.sizes.$220,
           maxWidth: `calc(100vw - ${t.sizes.$20})`,
+          margin: branded ? `0 ${t.space.$7}` : undefined,
           [mqu.sm]: {
             maxWidth: `calc(100vw - ${t.sizes.$3})`,
+            margin: branded ? `0 0 ${t.space.$7} 0` : '0',
           },
         }),
         sx,
@@ -86,12 +92,15 @@ export const ProfileCard = React.forwardRef<HTMLDivElement, CardProps>((props, r
 type BaseCardProps = PropsOfComponent<typeof Flex>;
 
 export const BaseCard = React.forwardRef<HTMLDivElement, BaseCardProps>((props, ref) => {
+  const { children, ...rest } = props;
   const flowMetadata = useFlowMetadata();
+  const { toggle } = useUnsafeModalContext();
+
   return (
     <Flex
       direction='col'
       className={generateFlowPartClassname(flowMetadata)}
-      {...props}
+      {...rest}
       elementDescriptor={[descriptors.card, props.elementDescriptor as ElementDescriptor]}
       sx={[
         t => ({
@@ -103,9 +112,37 @@ export const BaseCard = React.forwardRef<HTMLDivElement, BaseCardProps>((props, 
           boxShadow: t.shadows.$cardDropShadow,
           border: '1px solid transparent',
         }),
-        props.sx,
+        rest.sx,
       ]}
       ref={ref}
-    />
+    >
+      {toggle && (
+        <IconButton
+          elementDescriptor={descriptors.modalCloseButton}
+          variant='ghost'
+          colorScheme='neutral'
+          aria-label='Close modal'
+          onClick={toggle}
+          icon={
+            <Icon
+              icon={Close}
+              size='sm'
+            />
+          }
+          sx={t => ({
+            zIndex: t.zIndices.$modal,
+            opacity: t.opacity.$inactive,
+            ':hover': {
+              opacity: 0.8,
+            },
+            position: 'absolute',
+            top: t.space.$3,
+            padding: t.space.$3,
+            right: t.space.$3,
+          })}
+        />
+      )}
+      {children}
+    </Flex>
   );
 });

--- a/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
+++ b/packages/clerk-js/src/ui/elements/InputWithIcon.tsx
@@ -6,7 +6,7 @@ import type { PropsOfComponent } from '../styledSystem';
 type InputWithIcon = PropsOfComponent<typeof Input> & { leftIcon?: React.ReactElement };
 
 export const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIcon>((props, ref) => {
-  const { leftIcon, ...rest } = props;
+  const { leftIcon, sx, ...rest } = props;
   return (
     <Flex
       center
@@ -29,7 +29,7 @@ export const InputWithIcon = React.forwardRef<HTMLInputElement, InputWithIcon>((
             width: '100%',
             paddingLeft: theme.space.$10,
           }),
-          rest.sx,
+          sx,
         ]}
         ref={ref}
       />

--- a/packages/clerk-js/src/ui/elements/Modal.tsx
+++ b/packages/clerk-js/src/ui/elements/Modal.tsx
@@ -1,14 +1,16 @@
-import { useSafeLayoutEffect } from '@clerk/shared';
+import { createContextAndHook, useSafeLayoutEffect } from '@clerk/shared';
 import React from 'react';
 
-import { descriptors, Flex, Icon } from '../customizables';
+import { descriptors, Flex } from '../customizables';
 import { usePopover, useScrollLock } from '../hooks';
-import { Close } from '../icons';
 import type { ThemableCssProp } from '../styledSystem';
 import { animations, mqu } from '../styledSystem';
 import { withFloatingTree } from './contexts';
-import { IconButton } from './IconButton';
 import { Popover } from './Popover';
+
+export const [ModalContext, useModalContext, useUnsafeModalContext] = createContextAndHook<{ toggle: () => void }>(
+  'ModalContext',
+);
 
 type ModalProps = React.PropsWithChildren<{
   handleOpen?: () => void;
@@ -38,6 +40,8 @@ export const Modal = withFloatingTree((props: ModalProps) => {
     return () => enableScroll();
   });
 
+  const modalCtx = React.useMemo(() => ({ value: { toggle } }), [toggle]);
+
   return (
     <Popover
       nodeId={nodeId}
@@ -45,72 +49,51 @@ export const Modal = withFloatingTree((props: ModalProps) => {
       isOpen={isOpen}
       order={['floating', 'content']}
     >
-      <Flex
-        aria-hidden
-        elementDescriptor={descriptors.modalBackdrop}
-        sx={[
-          t => ({
-            animation: `${animations.fadeIn} 150ms ${t.transitionTiming.$common}`,
-            zIndex: t.zIndices.$modal,
-            backgroundColor: t.colors.$modalBackdrop,
-            // ...common.centeredFlex(),
-            alignItems: 'flex-start',
-            justifyContent: 'center',
-            overflow: 'auto',
-            width: '100vw',
-            height: ['100vh', '-webkit-fill-available'],
-            position: 'fixed',
-            left: 0,
-            top: 0,
-          }),
-          containerSx,
-        ]}
-      >
+      <ModalContext.Provider value={modalCtx}>
         <Flex
-          elementDescriptor={descriptors.modalContent}
-          ref={floating}
-          tabIndex={0}
-          aria-modal='true'
-          role='dialog'
+          aria-hidden
+          elementDescriptor={descriptors.modalBackdrop}
           sx={[
             t => ({
-              position: 'relative',
-              outline: 0,
-              animation: `${animations.modalSlideAndFade} 180ms ${t.transitionTiming.$easeOut}`,
-              margin: `${t.space.$16} 0`,
-              [mqu.sm]: {
-                margin: `${t.space.$10} 0`,
-              },
+              animation: `${animations.fadeIn} 150ms ${t.transitionTiming.$common}`,
+              zIndex: t.zIndices.$modal,
+              backgroundColor: t.colors.$modalBackdrop,
+              // ...common.centeredFlex(),
+              alignItems: 'flex-start',
+              justifyContent: 'center',
+              overflow: 'auto',
+              width: '100vw',
+              height: ['100vh', '-webkit-fill-available'],
+              position: 'fixed',
+              left: 0,
+              top: 0,
             }),
-            contentSx,
+            containerSx,
           ]}
         >
-          {props.children}
-          <IconButton
-            elementDescriptor={descriptors.modalCloseButton}
-            variant='ghost'
-            colorScheme='neutral'
-            aria-label='Close modal'
-            onClick={toggle}
-            icon={
-              <Icon
-                icon={Close}
-                size='sm'
-              />
-            }
-            sx={t => ({
-              opacity: t.opacity.$inactive,
-              ':hover': {
-                opacity: 0.8,
-              },
-              position: 'absolute',
-              top: t.space.$3,
-              padding: t.space.$3,
-              right: t.space.$3,
-            })}
-          />
+          <Flex
+            elementDescriptor={descriptors.modalContent}
+            ref={floating}
+            tabIndex={0}
+            aria-modal='true'
+            role='dialog'
+            sx={[
+              t => ({
+                position: 'relative',
+                outline: 0,
+                animation: `${animations.modalSlideAndFade} 180ms ${t.transitionTiming.$easeOut}`,
+                margin: `${t.space.$16} 0`,
+                [mqu.sm]: {
+                  margin: `${t.space.$10} 0`,
+                },
+              }),
+              contentSx,
+            ]}
+          >
+            {props.children}
+          </Flex>
         </Flex>
-      </Flex>
+      </ModalContext.Provider>
     </Popover>
   );
 });

--- a/packages/clerk-js/src/ui/elements/Modal.tsx
+++ b/packages/clerk-js/src/ui/elements/Modal.tsx
@@ -8,9 +8,7 @@ import { animations, mqu } from '../styledSystem';
 import { withFloatingTree } from './contexts';
 import { Popover } from './Popover';
 
-export const [ModalContext, useModalContext, useUnsafeModalContext] = createContextAndHook<{ toggle: () => void }>(
-  'ModalContext',
-);
+export const [ModalContext, _, useUnsafeModalContext] = createContextAndHook<{ toggle: () => void }>('ModalContext');
 
 type ModalProps = React.PropsWithChildren<{
   handleOpen?: () => void;

--- a/packages/shared/src/hooks/createContextAndHook.ts
+++ b/packages/shared/src/hooks/createContextAndHook.ts
@@ -1,4 +1,3 @@
-import type { DeepPartial } from '@clerk/types';
 import React from 'react';
 
 export function assertContextExists(contextVal: unknown, msgOrCtx: string | React.Context<any>): asserts contextVal {
@@ -20,7 +19,7 @@ type UseCtxFn<T> = () => T;
 export const createContextAndHook = <CtxVal>(
   displayName: string,
   options?: Options,
-): [ContextOf<CtxVal>, UseCtxFn<CtxVal>, UseCtxFn<CtxVal | DeepPartial<CtxVal>>] => {
+): [ContextOf<CtxVal>, UseCtxFn<CtxVal>, UseCtxFn<CtxVal | Partial<CtxVal>>] => {
   const { assertCtxFn = assertContextExists } = options || {};
   const Ctx = React.createContext<{ value: CtxVal } | undefined>(undefined);
   Ctx.displayName = displayName;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
* Add a new `ModalContext` that contains information about the most recent modal opened. We can close the modal using the hook. 
* Place the close modal button inside the `BaseCard` and only show it if we can find the `ModalContext`. It toggles the modal upon click(retrieves the `toggle` function from the context).

<!-- Fixes # (issue number) -->
