### PR TITLE
feat(clerk-js): Pass additional OAuth scopes while connecting an extenal account in UserProfile

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/ConnectedAccountsPage.test.tsx
@@ -44,8 +44,9 @@ describe('ConnectedAccountsPage', () => {
 
       await userEvent.click(screen.getByText(/connect google account/i));
       expect(fixtures.clerk.user?.createExternalAccount).toHaveBeenCalledWith({
-        redirect_url: window.location.href,
+        redirectUrl: window.location.href,
         strategy: 'oauth_google',
+        additionalScopes: [],
       });
     });
   });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

While connecting an external account via the UserProfile, we take into account if additional scopes have been provided for this provider. If yes, pass them along so the user will approve those as well

<!-- Fixes # (issue number) -->
