### PR TITLE
COR-152 fix(clerk-js): Read country code from FAPI response

### DIFF
--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -197,8 +197,15 @@ export default function createFapiClient(clerkInstance: Omit<Clerk, 'proxyUrl'>)
     } catch (e) {
       clerkNetworkError(urlStr, e);
     }
+
+    const responseHeaders = {
+      country: response.headers.get('x-country'),
+    };
+
     const json: FapiResponseJSON<T> = await response.json();
-    const fapiResponse: FapiResponse<T> = Object.assign(response, { payload: json });
+    const fapiResponse: FapiResponse<T> = Object.assign(response, {
+      payload: { ...json, response_headers: responseHeaders },
+    });
     await runAfterResponseCallbacks(requestInit, fapiResponse);
     return fapiResponse;
   }

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -2,6 +2,7 @@ import { camelToSnake } from '@clerk/shared';
 import type { Clerk, ClerkAPIErrorJSON, ClientJSON } from '@clerk/types';
 import qs from 'qs';
 
+import type { CountryIso } from '../ui/elements/PhoneInput/countryCodeData';
 import { buildEmailAddress as buildEmailAddressUtil, buildURL as buildUrlUtil } from '../utils';
 import { clerkNetworkError } from './errors';
 
@@ -43,6 +44,7 @@ export interface FapiResponseJSON<T> {
   meta?: {
     client?: ClientJSON;
     session_id?: string;
+    responseHeaders?: { country: CountryIso } | unknown;
   };
 }
 
@@ -204,7 +206,7 @@ export default function createFapiClient(clerkInstance: Omit<Clerk, 'proxyUrl'>)
 
     const json: FapiResponseJSON<T> = await response.json();
     const fapiResponse: FapiResponse<T> = Object.assign(response, {
-      payload: { ...json, response_headers: responseHeaders },
+      payload: { ...json, meta: { ...json?.meta, responseHeaders } },
     });
     await runAfterResponseCallbacks(requestInit, fapiResponse);
     return fapiResponse;

--- a/packages/clerk-js/src/core/resources/Base.ts
+++ b/packages/clerk-js/src/core/resources/Base.ts
@@ -111,7 +111,9 @@ export abstract class BaseResource {
       },
       opts,
     );
-    return this.fromJSON((json?.response || json) as J);
+
+    const data = json?.response ? { ...json.response, ...json.meta } : json;
+    return this.fromJSON(data as J);
   }
 
   protected async _baseMutate<J extends ClerkResourceJSON | null>({

--- a/packages/clerk-js/src/core/resources/Environment.ts
+++ b/packages/clerk-js/src/core/resources/Environment.ts
@@ -7,6 +7,7 @@ import type {
   UserSettingsResource,
 } from '@clerk/types';
 
+import type { CountryIso } from '../../ui/elements/PhoneInput/countryCodeData';
 import { AuthConfig, BaseResource, DisplayConfig, UserSettings } from './internal';
 import { OrganizationSettings } from './OrganizationSettings';
 
@@ -18,7 +19,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
   displayConfig!: DisplayConfigResource;
   userSettings!: UserSettingsResource;
   organizationSettings!: OrganizationSettingsResource;
-  responseHeaders: { country: string };
+  country!: CountryIso;
 
   public static getInstance(): Environment {
     if (!Environment.instance) {
@@ -59,7 +60,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
   protected fromJSON(data: EnvironmentJSON | null): this {
     if (data) {
       this.authConfig = new AuthConfig(data.auth_config);
-      this.responseHeaders = data.response_headers;
+      this.country = data.meta.responseHeaders.country;
       this.displayConfig = new DisplayConfig(data.display_config);
       this.userSettings = new UserSettings(data.user_settings);
       this.organizationSettings = new OrganizationSettings(data.organization_settings);

--- a/packages/clerk-js/src/core/resources/Environment.ts
+++ b/packages/clerk-js/src/core/resources/Environment.ts
@@ -18,6 +18,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
   displayConfig!: DisplayConfigResource;
   userSettings!: UserSettingsResource;
   organizationSettings!: OrganizationSettingsResource;
+  responseHeaders: { country: string };
 
   public static getInstance(): Environment {
     if (!Environment.instance) {
@@ -58,6 +59,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
   protected fromJSON(data: EnvironmentJSON | null): this {
     if (data) {
       this.authConfig = new AuthConfig(data.auth_config);
+      this.responseHeaders = data.response_headers;
       this.displayConfig = new DisplayConfig(data.display_config);
       this.userSettings = new UserSettings(data.user_settings);
       this.organizationSettings = new OrganizationSettings(data.organization_settings);

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useEnvironment } from '../../../ui/contexts';
 import { useAppearance } from '../../customizables';
 import { Form } from '../../elements';
 import type { FormControlState } from '../../utils';
@@ -16,6 +17,7 @@ type SignUpFormProps = {
 export const SignUpForm = (props: SignUpFormProps) => {
   const { handleSubmit, fields, formState, canToggleEmailPhone, handleEmailPhoneToggle } = props;
   const { showOptionalFields } = useAppearance().parsedLayout;
+  const { country } = useEnvironment();
 
   const shouldShow = (name: keyof typeof fields) => {
     // In case both email & phone are optional, then don't take into account the
@@ -83,6 +85,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
               isRequired: fields.phoneNumber!.required,
               isOptional: !fields.phoneNumber!.required,
             }}
+            defaultSelectedIso={country}
             actionLabel={canToggleEmailPhone ? 'Use email instead' : undefined}
             onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('emailAddress') : undefined}
           />

--- a/packages/clerk-js/src/ui/components/UserProfile/PhonePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PhonePage.tsx
@@ -53,7 +53,7 @@ export const AddPhone = (props: AddPhoneProps) => {
   const { title, onSuccess, resourceRef } = props;
   const card = useCardState();
   const user = useCoreUser();
-  const { responseHeaders } = useEnvironment();
+  const { country } = useEnvironment();
 
   const phoneField = useFormControl('phoneNumber', '', {
     type: 'tel',
@@ -83,7 +83,7 @@ export const AddPhone = (props: AddPhoneProps) => {
         <Form.ControlRow elementId={phoneField.id}>
           <Form.Control
             {...phoneField.props}
-            defaultSelectedIso={responseHeaders?.country}
+            defaultSelectedIso={country}
             required
             autoFocus
           />

--- a/packages/clerk-js/src/ui/components/UserProfile/PhonePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PhonePage.tsx
@@ -2,7 +2,7 @@ import type { PhoneNumberResource } from '@clerk/types';
 import React from 'react';
 
 import { useWizard, Wizard } from '../../common';
-import { useCoreUser } from '../../contexts';
+import { useCoreUser, useEnvironment } from '../../contexts';
 import type { LocalizationKey } from '../../customizables';
 import { localizationKeys, Text } from '../../customizables';
 import { ContentPage, Form, FormButtons, SuccessPage, useCardState, withCardStateProvider } from '../../elements';
@@ -53,6 +53,7 @@ export const AddPhone = (props: AddPhoneProps) => {
   const { title, onSuccess, resourceRef } = props;
   const card = useCardState();
   const user = useCoreUser();
+  const { responseHeaders } = useEnvironment();
 
   const phoneField = useFormControl('phoneNumber', '', {
     type: 'tel',
@@ -82,6 +83,7 @@ export const AddPhone = (props: AddPhoneProps) => {
         <Form.ControlRow elementId={phoneField.id}>
           <Form.Control
             {...phoneField.props}
+            defaultSelectedIso={responseHeaders?.country}
             required
             autoFocus
           />

--- a/packages/clerk-js/src/ui/elements/FormControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FormControl.tsx
@@ -1,6 +1,7 @@
 import type { FieldId } from '@clerk/types';
 import React from 'react';
 
+import type { CountryIso } from '../../ui/elements/PhoneInput/countryCodeData';
 import type { LocalizationKey } from '../customizables';
 import {
   descriptors,
@@ -29,6 +30,7 @@ type FormControlProps = Omit<PropsOfComponent<typeof Input>, 'label' | 'placehol
   label: string | LocalizationKey;
   placeholder?: string | LocalizationKey;
   actionLabel?: string | LocalizationKey;
+  defaultSelectedIso?: CountryIso;
 };
 
 // TODO: Convert this into a Component?

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -20,14 +20,15 @@ const createSelectOption = (country: CountryEntry) => {
 
 const countryOptions = [...IsoToCountryMap.values()].map(createSelectOption);
 
-type PhoneInputProps = PropsOfComponent<typeof Input>;
+type PhoneInputProps = PropsOfComponent<typeof Input> & { defaultSelectedIso?: CountryIso };
 
 export const PhoneInput = (props: PhoneInputProps) => {
-  const { onChange: onChangeProp, value, ...rest } = props;
+  const { onChange: onChangeProp, value, defaultSelectedIso = 'us', ...rest } = props;
   const phoneInputRef = React.useRef<HTMLInputElement>(null);
   const { setPhoneNumber, cleanPhoneNumber, formattedPhoneNumber, selectedIso, setSelectedIso } =
     useFormattedPhoneNumber({
       defaultPhone: value as string,
+      defaultSelectedIso: defaultSelectedIso.toLowerCase() as CountryIso,
     });
 
   const callOnChangeProp = () => {

--- a/packages/clerk-js/src/ui/elements/PhoneInput/useFormattedPhoneNumber.ts
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/useFormattedPhoneNumber.ts
@@ -5,7 +5,7 @@ import { extractDigits, formatPhoneNumber } from '../../utils';
 import type { CountryIso } from './countryCodeData';
 import { IsoToCountryMap } from './countryCodeData';
 
-type UseFormattedPhoneNumberProps = { defaultPhone?: string };
+type UseFormattedPhoneNumberProps = { defaultPhone?: string; defaultSelectedIso?: CountryIso };
 
 const format = (str: string, iso: CountryIso) => {
   if (!str) {
@@ -16,7 +16,10 @@ const format = (str: string, iso: CountryIso) => {
 };
 
 export const useFormattedPhoneNumber = (props: UseFormattedPhoneNumberProps = {}) => {
-  const [selectedIso, setSelectedIso] = useLocalStorage<CountryIso>('selectedCountryIso', 'us');
+  const [selectedIso, setSelectedIso] = useLocalStorage<CountryIso>(
+    'selectedCountryIso',
+    props.defaultSelectedIso || 'us',
+  );
   const [phoneNum, setPhoneNum] = React.useState(() => format(props.defaultPhone || '', selectedIso));
 
   React.useEffect(() => {

--- a/packages/clerk-js/src/ui/utils/test/fixtures.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtures.ts
@@ -18,6 +18,7 @@ export const createBaseEnvironmentJSON = (): EnvironmentJSON => {
     display_config: createBaseDisplayConfig(),
     organization_settings: createBaseOrganizationSettings(),
     user_settings: createBaseUserSettings(),
+    meta: { responseHeaders: { country: 'us' } },
   };
 };
 

--- a/packages/types/src/environment.ts
+++ b/packages/types/src/environment.ts
@@ -1,5 +1,6 @@
 import type { AuthConfigResource } from './authConfig';
 import type { DisplayConfigResource } from './displayConfig';
+import type { ResponseHeaderOptionsJSON } from './json';
 import type { OrganizationSettingsResource } from './organizationSettings';
 import type { ClerkResource } from './resource';
 import type { UserSettingsResource } from './userSettings';
@@ -13,4 +14,5 @@ export interface EnvironmentResource extends ClerkResource {
   isProduction: () => boolean;
   isDevelopmentOrStaging: () => boolean;
   onWindowLocationHost: () => boolean;
+  responseHeaders: ResponseHeaderOptionsJSON;
 }

--- a/packages/types/src/environment.ts
+++ b/packages/types/src/environment.ts
@@ -1,6 +1,5 @@
 import type { AuthConfigResource } from './authConfig';
 import type { DisplayConfigResource } from './displayConfig';
-import type { ResponseHeaderOptionsJSON } from './json';
 import type { OrganizationSettingsResource } from './organizationSettings';
 import type { ClerkResource } from './resource';
 import type { UserSettingsResource } from './userSettings';
@@ -14,5 +13,5 @@ export interface EnvironmentResource extends ClerkResource {
   isProduction: () => boolean;
   isDevelopmentOrStaging: () => boolean;
   onWindowLocationHost: () => boolean;
-  responseHeaders: ResponseHeaderOptionsJSON;
+  country: any;
 }

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -52,8 +52,10 @@ export interface ImageJSON {
   public_url: string;
 }
 
+// move CountryIso types from clerkjs to this repo. Hence the any type in country
+// packages/clerk-js/src/ui/elements/PhoneInput/countryCodeData.ts
 export interface ResponseHeaderOptionsJSON {
-  country: string;
+  responseHeaders: { country: any };
 }
 
 export interface EnvironmentJSON extends ClerkResourceJSON {
@@ -61,7 +63,7 @@ export interface EnvironmentJSON extends ClerkResourceJSON {
   display_config: DisplayConfigJSON;
   user_settings: UserSettingsJSON;
   organization_settings: OrganizationSettingsJSON;
-  response_headers: ResponseHeaderOptionsJSON;
+  meta: ResponseHeaderOptionsJSON;
 }
 
 export interface ClientJSON extends ClerkResourceJSON {

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -52,11 +52,16 @@ export interface ImageJSON {
   public_url: string;
 }
 
+export interface ResponseHeaderOptionsJSON {
+  country: string;
+}
+
 export interface EnvironmentJSON extends ClerkResourceJSON {
   auth_config: AuthConfigJSON;
   display_config: DisplayConfigJSON;
   user_settings: UserSettingsJSON;
   organization_settings: OrganizationSettingsJSON;
+  response_headers: ResponseHeaderOptionsJSON;
 }
 
 export interface ClientJSON extends ClerkResourceJSON {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Read the country code from FAPI response and make it the default value. This is a change that will only affect newcomers. 
<!-- Fixes # (issue number) -->
