### PR TITLE
test(clerk-js): Move initConfig block out of describe block

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInAccountSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInAccountSwitcher.test.tsx
@@ -1,22 +1,21 @@
 import { describe, it } from '@jest/globals';
-import React from 'react';
 
 import { bindCreateFixtures, render } from '../../../../testUtils';
 import { SignInAccountSwitcher } from '../SignInAccountSwitcher';
 
 const { createFixtures } = bindCreateFixtures('SignIn');
 
+const initConfig = createFixtures.config(f => {
+  f.withMultiSessionMode();
+  f.withUser({ first_name: 'Nick', last_name: 'Kouk', email_addresses: ['test1@clerk.dev'] });
+  f.withUser({ first_name: 'Mike', last_name: 'Lamar', email_addresses: ['test2@clerk.dev'] });
+  f.withUser({ first_name: 'Graciela', last_name: 'Brennan', email_addresses: ['test3@clerk.dev'] });
+});
+
 describe('SignInAccountSwitcher', () => {
   it('renders the component', async () => {
     const { wrapper } = await createFixtures();
     render(<SignInAccountSwitcher />, { wrapper });
-  });
-
-  const initConfig = createFixtures.config(f => {
-    f.withMultiSessionMode();
-    f.withUser({ first_name: 'Nick', last_name: 'Kouk', email_addresses: ['test1@clerk.dev'] });
-    f.withUser({ first_name: 'Mike', last_name: 'Lamar', email_addresses: ['test2@clerk.dev'] });
-    f.withUser({ first_name: 'Graciela', last_name: 'Brennan', email_addresses: ['test3@clerk.dev'] });
   });
 
   it('renders a list of buttons with all signed in accounts', async () => {

--- a/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
@@ -1,5 +1,4 @@
 import { describe } from '@jest/globals';
-import React from 'react';
 
 import { render } from '../../../../testUtils';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Nothing major, just a tiny "cleanup" - I just confirmed that initializing the config function within the describe block is safe. However, I did move it outside of the block just so we're aligned with other similar tests files.
<!-- Fixes # (issue number) -->
