### PR TITLE
fix(types): Add the `lastActiveAt` property in SessionResource

### DIFF
--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -10,6 +10,7 @@ export interface SessionResource extends ClerkResource {
   abandonAt: Date;
   lastActiveToken: TokenResource | null;
   lastActiveOrganizationId: string | null;
+  lastActiveAt: Date;
   actor: ActJWTClaim | null;
   user: UserResource | null;
   publicUserData: PublicUserData;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Adds the missing lastActiveAt property in SessionResource
<!-- Fixes # (issue number) -->
