### PR TITLE
feat(clerk-js): Preserve sign up fields upon return to SignUpStart

### DIFF
--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -40,27 +40,27 @@ function _SignUpStart(): JSX.Element {
   const [missingRequirementsWithTicket, setMissingRequirementsWithTicket] = React.useState(false);
 
   const formState = {
-    firstName: useFormControl('firstName', '', {
+    firstName: useFormControl('firstName', signUp.firstName || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__firstName'),
       placeholder: localizationKeys('formFieldInputPlaceholder__firstName'),
     }),
-    lastName: useFormControl('lastName', '', {
+    lastName: useFormControl('lastName', signUp.lastName || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__lastName'),
       placeholder: localizationKeys('formFieldInputPlaceholder__lastName'),
     }),
-    emailAddress: useFormControl('emailAddress', '', {
+    emailAddress: useFormControl('emailAddress', signUp.emailAddress || '', {
       type: 'email',
       label: localizationKeys('formFieldLabel__emailAddress'),
       placeholder: localizationKeys('formFieldInputPlaceholder__emailAddress'),
     }),
-    username: useFormControl('username', '', {
+    username: useFormControl('username', signUp.username || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__username'),
       placeholder: localizationKeys('formFieldInputPlaceholder__username'),
     }),
-    phoneNumber: useFormControl('phoneNumber', '', {
+    phoneNumber: useFormControl('phoneNumber', signUp.phoneNumber || '', {
       type: 'tel',
       label: localizationKeys('formFieldLabel__phoneNumber'),
       placeholder: localizationKeys('formFieldInputPlaceholder__phoneNumber'),

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -146,4 +146,26 @@ describe('SignUpStart', () => {
       expect(signInLink?.getAttribute('href')).toMatch(fixtures.environment.displayConfig.signInUrl);
     });
   });
+
+  describe('Preserved values from FAPI', () => {
+    it('Shows the values from the sign up object as default prepopulated values', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress({ required: true });
+        f.withPhoneNumber({ required: true });
+        f.withName({ required: true });
+      });
+
+      fixtures.clerk.client.signUp.emailAddress = 'george@clerk.dev';
+      fixtures.clerk.client.signUp.firstName = 'George';
+      fixtures.clerk.client.signUp.lastName = 'Clerk';
+      fixtures.clerk.client.signUp.phoneNumber = '123456789';
+
+      const screen = render(<SignUpStart />, { wrapper });
+
+      expect(screen.getByRole('textbox', { name: 'Email address' })).toHaveValue('george@clerk.dev');
+      expect(screen.getByRole('textbox', { name: 'First name' })).toHaveValue('George');
+      expect(screen.getByRole('textbox', { name: 'Last name' })).toHaveValue('Clerk');
+      expect(screen.getByRole('textbox', { name: 'Phone number' })).toHaveValue('(123) 456-789');
+    });
+  });
 });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Preserve the sign up fields in SignUpStart by setting their `initialState` from the `sua` value returned from FAPI.
<!-- Fixes # (issue number) -->
