### PR TITLE
feat(types): Expose in sign in factor if identification is user's primary

### DIFF
--- a/packages/types/src/factors.ts
+++ b/packages/types/src/factors.ts
@@ -13,24 +13,28 @@ export type EmailCodeFactor = {
   strategy: EmailCodeStrategy;
   emailAddressId: string;
   safeIdentifier: string;
+  primary?: boolean;
 };
 
 export type EmailLinkFactor = {
   strategy: EmailLinkStrategy;
   emailAddressId: string;
   safeIdentifier: string;
+  primary?: boolean;
 };
 
 export type PhoneCodeFactor = {
   strategy: PhoneCodeStrategy;
   phoneNumberId: string;
   safeIdentifier: string;
+  primary?: boolean;
   default?: boolean;
 };
 
 export type Web3SignatureFactor = {
   strategy: Web3Strategy;
   web3WalletId: string;
+  primary?: boolean;
 };
 
 export type PasswordFactor = {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

We enhance the sign in supported first factors property, with a new field 'primary', which denotes if the corresponding identification is the user's primary

<!-- Fixes # (issue number) -->
