### PR TITLE
fix(clerk-js): Fix infinite loading of active devices in user profile

### DIFF
--- a/packages/clerk-js/src/core/fapiClient.test.ts
+++ b/packages/clerk-js/src/core/fapiClient.test.ts
@@ -144,6 +144,33 @@ describe('request', () => {
     );
   });
 
+  it('returns payload and meta', async () => {
+    const resp = await fapiClientWithProxy.request({
+      path: '/foo',
+    });
+
+    expect(resp.payload?.meta).toBeDefined();
+  });
+
+  it('returns array response as array', async () => {
+    // @ts-ignore
+    global.fetch.mockResolvedValueOnce(
+      Promise.resolve<RecursivePartial<Response>>({
+        headers: {
+          get: jest.fn(() => 'sess_43'),
+        },
+        json: () => Promise.resolve([{ foo: 42 }]),
+      }),
+    );
+
+    const resp = await fapiClientWithProxy.request({
+      path: '/foo',
+    });
+
+    expect(Array.isArray(resp.payload)).toEqual(true);
+    expect(resp.payload?.meta).toBeDefined();
+  });
+
   describe('for production instances', () => {
     it.todo('does not append the __dev_session cookie value to the query string');
     it.todo('does not set the __dev_session cookie from the response Clerk-Cookie header');

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -204,9 +204,10 @@ export default function createFapiClient(clerkInstance: Omit<Clerk, 'proxyUrl'>)
     };
 
     const json: FapiResponseJSON<T> = await response.json();
-    const fapiResponse: FapiResponse<T> = Object.assign(response, {
-      payload: { ...json, meta: { ...json?.meta, responseHeaders } },
-    });
+    const fapiResponse: FapiResponse<T> = Object.assign(response, { payload: json });
+    if (fapiResponse.payload) {
+      fapiResponse.payload.meta = { ...json?.meta, responseHeaders };
+    }
     await runAfterResponseCallbacks(requestInit, fapiResponse);
     return fapiResponse;
   }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

This issue was introduced by the commit that added meta in response payload and is caused by the destructuring of the array json response which converts the array response payload to object.
Issue:
<img width="1436" alt="Screenshot 2023-03-13 at 15 49 30" src="https://user-images.githubusercontent.com/3936408/224743527-04e6419f-2ba2-47e9-b518-30bd7df254b8.png">


