### PR TITLE
Add the ability to pass additionalOAuthScopes prop to <UserButton />

### DIFF
--- a/packages/clerk-js/src/ui/Components.tsx
+++ b/packages/clerk-js/src/ui/Components.tsx
@@ -239,7 +239,7 @@ const Components = (props: ComponentsProps) => {
       startPath={buildVirtualRouterUrl({ base: '/sign-up', path: urlStateParam?.path })}
       componentName={'SignUpModal'}
     >
-      <SignInModal {...signUpModal} />
+      <SignInModal {...signInModal} />
       <SignUpModal {...signUpModal} />
     </LazyModalRenderer>
   );
@@ -257,7 +257,7 @@ const Components = (props: ComponentsProps) => {
       modalContainerSx={{ alignItems: 'center' }}
       modalContentSx={t => ({ height: `min(${t.sizes.$176}, calc(100% - ${t.sizes.$12}))`, margin: 0 })}
     >
-      <UserProfileModal />
+      <UserProfileModal {...userProfileModal} />
     </LazyModalRenderer>
   );
 

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -14,7 +14,7 @@ type UseMultisessionActionsParams = {
   navigateAfterSwitchSession?: () => any;
   userProfileUrl?: string;
   signInUrl?: string;
-} & Pick<UserButtonProps, 'userProfileMode' | 'appearance'>;
+} & Pick<UserButtonProps, 'userProfileMode' | 'appearance' | 'userProfileProps'>;
 
 export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
   const { setActive, signOut, openUserProfile } = useCoreClerk();
@@ -42,7 +42,7 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
     }
 
     // The UserButton can also accept an appearance object for the nested UserProfile modal
-    openUserProfile({ appearance: opts.appearance?.userProfile });
+    openUserProfile({ ...opts.userProfileProps, appearance: opts.appearance?.userProfile });
     return opts.actionCompleteCallback?.();
   };
 

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -1,4 +1,4 @@
-import type { OAuthProvider, OAuthStrategy } from '@clerk/types';
+import type { OAuthProvider, OAuthScope, OAuthStrategy } from '@clerk/types';
 import type { ExternalAccountResource } from '@clerk/types/src';
 
 import { useRouter } from '../../../ui/router';
@@ -151,7 +151,7 @@ const ConnectedAccountAccordion = ({ account }: { account: ExternalAccountResour
 
 function findAdditionalScopes(
   account: ExternalAccountResource,
-  scopes?: Partial<Record<OAuthProvider, string[]>>,
+  scopes?: Partial<Record<OAuthProvider, OAuthScope[]>>,
 ): string[] {
   if (!scopes) {
     return [];

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -149,7 +149,10 @@ const ConnectedAccountAccordion = ({ account }: { account: ExternalAccountResour
   );
 };
 
-function findAdditionalScopes(account: ExternalAccountResource, scopes?: Record<OAuthProvider, string[]>): string[] {
+function findAdditionalScopes(
+  account: ExternalAccountResource,
+  scopes?: Partial<Record<OAuthProvider, string[]>>,
+): string[] {
   if (!scopes) {
     return [];
   }

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -11,7 +11,7 @@ import type {
 import type { ClientResource } from './client';
 import type { DisplayThemeJSON } from './json';
 import type { LocalizationResource } from './localization';
-import type { OAuthProvider } from './oauth';
+import type { OAuthProvider, OAuthScope } from './oauth';
 import type { OrganizationResource } from './organization';
 import type { OrganizationInvitationResource } from './organizationInvitation';
 import type { MembershipRole, OrganizationMembershipResource } from './organizationMembership';
@@ -592,7 +592,7 @@ export type UserProfileProps = {
    * Specify additional scopes per OAuth provider that your users would like to provide if not already approved.
    * e.g. <UserProfile additionalOAuthScopes={{google: ['foo', 'bar'], github: ['qux']}} />
    */
-  additionalOAuthScopes?: Partial<Record<OAuthProvider, string[]>>;
+  additionalOAuthScopes?: Partial<Record<OAuthProvider, OAuthScope[]>>;
 };
 
 export type OrganizationProfileProps = {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -685,6 +685,12 @@ export type UserButtonProps = {
    * prop of ClerkProvided (if one is provided)
    */
   appearance?: UserButtonTheme & { userProfile?: UserProfileTheme };
+
+  /*
+   * Specify options for the underlying <UserProfile /> component.
+   * e.g. <UserButton userProfileProps={{additionalOAuthScopes: {google: ['foo', 'bar'], github: ['qux']}}} />
+   */
+  userProfileProps?: Pick<UserProfileProps, 'additionalOAuthScopes'>;
 };
 
 export type OrganizationSwitcherProps = {

--- a/packages/types/src/externalAccount.ts
+++ b/packages/types/src/externalAccount.ts
@@ -1,9 +1,9 @@
-import type { OAuthProvider } from './oauth';
+import type { OAuthProvider, OAuthScope } from './oauth';
 import type { ClerkResource } from './resource';
 import type { VerificationResource } from './verification';
 
 export type ReauthorizeExternalAccountParams = {
-  additionalScopes: string[];
+  additionalScopes: OAuthScope[];
   redirectUrl?: string;
 };
 

--- a/packages/types/src/oauth.ts
+++ b/packages/types/src/oauth.ts
@@ -1,5 +1,7 @@
 import type { OAuthStrategy } from './strategies';
 
+export type OAuthScope = string;
+
 export interface OAuthProviderData {
   provider: OAuthProvider;
   strategy: OAuthStrategy;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -4,6 +4,7 @@ import type { EmailAddressResource } from './emailAddress';
 import type { ExternalAccountResource } from './externalAccount';
 import type { ImageResource } from './image';
 import type { UserJSON } from './json';
+import type { OAuthScope } from './oauth';
 import type { OrganizationMembershipResource } from './organizationMembership';
 import type { PhoneNumberResource } from './phoneNumber';
 import type { ClerkResource } from './resource';
@@ -87,7 +88,7 @@ export type SetProfileImageParams = { file: Blob | File | null };
 export type CreateExternalAccountParams = {
   strategy: OAuthStrategy;
   redirectUrl?: string;
-  additionalScopes?: string[];
+  additionalScopes?: OAuthScope[];
   /**
    * @deprecated Use `redirectUrl` instead.
    */


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

As we allow users to pass any additional OAuth scopes to the <UserProfile /> component, we now allow users to define the same prop in the <UserButton /> component as well.

<!-- Fixes # (issue number) -->
