### PR TITLE
fix(clerk-js): Fix error when removing an email linked to an external account

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/RemoveResourcePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/RemoveResourcePage.tsx
@@ -7,13 +7,14 @@ import { localizationKeys, Text } from '../../customizables';
 import { ContentPage, Form, FormButtons, SuccessPage, useCardState, withCardStateProvider } from '../../elements';
 import { useEnabledThirdPartyProviders } from '../../hooks';
 import { useRouter } from '../../router';
-import { deepCopyAndReturn, handleError } from '../../utils';
+import { handleError } from '../../utils';
 import { UserProfileBreadcrumbs } from './UserProfileNavbar';
 
 export const RemoveEmailPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(deepCopyAndReturn(user.emailAddresses.find(e => e.id === id)));
+  const resource = user.emailAddresses.find(e => e.id === id);
+  const ref = React.useRef(resource?.emailAddress);
 
   if (!ref.current) {
     return null;
@@ -23,13 +24,13 @@ export const RemoveEmailPage = () => {
     <RemoveResourcePage
       title={localizationKeys('userProfile.emailAddressPage.removeResource.title')}
       messageLine1={localizationKeys('userProfile.emailAddressPage.removeResource.messageLine1', {
-        identifier: ref.current.emailAddress,
+        identifier: ref.current,
       })}
       messageLine2={localizationKeys('userProfile.emailAddressPage.removeResource.messageLine2')}
       successMessage={localizationKeys('userProfile.emailAddressPage.removeResource.successMessage', {
-        emailAddress: ref.current.emailAddress,
+        emailAddress: ref.current,
       })}
-      deleteResource={() => Promise.resolve(ref.current?.destroy())}
+      deleteResource={() => Promise.resolve(resource?.destroy())}
     />
   );
 };
@@ -37,7 +38,8 @@ export const RemoveEmailPage = () => {
 export const RemovePhonePage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(deepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
+  const resource = user.phoneNumbers.find(e => e.id === id);
+  const ref = React.useRef(resource?.phoneNumber);
 
   if (!ref.current) {
     return null;
@@ -47,13 +49,13 @@ export const RemovePhonePage = () => {
     <RemoveResourcePage
       title={localizationKeys('userProfile.phoneNumberPage.removeResource.title')}
       messageLine1={localizationKeys('userProfile.phoneNumberPage.removeResource.messageLine1', {
-        identifier: ref.current.phoneNumber,
+        identifier: ref.current,
       })}
       messageLine2={localizationKeys('userProfile.phoneNumberPage.removeResource.messageLine2')}
       successMessage={localizationKeys('userProfile.phoneNumberPage.removeResource.successMessage', {
-        phoneNumber: ref.current.phoneNumber,
+        phoneNumber: ref.current,
       })}
-      deleteResource={() => Promise.resolve(ref.current?.destroy())}
+      deleteResource={() => Promise.resolve(resource?.destroy())}
     />
   );
 };
@@ -61,7 +63,8 @@ export const RemovePhonePage = () => {
 export const RemoveConnectedAccountPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(deepCopyAndReturn(user.externalAccounts.find(e => e.id === id)));
+  const resource = user.externalAccounts.find(e => e.id === id);
+  const ref = React.useRef(resource?.provider);
   const { providerToDisplayData } = useEnabledThirdPartyProviders();
 
   if (!ref.current) {
@@ -72,13 +75,13 @@ export const RemoveConnectedAccountPage = () => {
     <RemoveResourcePage
       title={localizationKeys('userProfile.connectedAccountPage.removeResource.title')}
       messageLine1={localizationKeys('userProfile.connectedAccountPage.removeResource.messageLine1', {
-        identifier: providerToDisplayData[ref.current.provider]?.name,
+        identifier: providerToDisplayData[ref.current]?.name,
       })}
       messageLine2={localizationKeys('userProfile.connectedAccountPage.removeResource.messageLine2')}
       successMessage={localizationKeys('userProfile.connectedAccountPage.removeResource.successMessage', {
-        connectedAccount: providerToDisplayData[ref.current.provider]?.name,
+        connectedAccount: providerToDisplayData[ref.current]?.name,
       })}
-      deleteResource={() => Promise.resolve(ref.current?.destroy())}
+      deleteResource={() => Promise.resolve(resource?.destroy())}
     />
   );
 };
@@ -86,7 +89,8 @@ export const RemoveConnectedAccountPage = () => {
 export const RemoveWeb3WalletPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(deepCopyAndReturn(user.web3Wallets.find(e => e.id === id)));
+  const resource = user.web3Wallets.find(e => e.id === id);
+  const ref = React.useRef(resource?.web3Wallet);
 
   if (!ref.current) {
     return null;
@@ -96,13 +100,13 @@ export const RemoveWeb3WalletPage = () => {
     <RemoveResourcePage
       title={localizationKeys('userProfile.web3WalletPage.removeResource.title')}
       messageLine1={localizationKeys('userProfile.web3WalletPage.removeResource.messageLine1', {
-        identifier: ref.current.web3Wallet,
+        identifier: ref.current,
       })}
       messageLine2={localizationKeys('userProfile.web3WalletPage.removeResource.messageLine2')}
       successMessage={localizationKeys('userProfile.web3WalletPage.removeResource.successMessage', {
-        web3Wallet: ref.current.web3Wallet,
+        web3Wallet: ref.current,
       })}
-      deleteResource={() => Promise.resolve(ref.current?.destroy())}
+      deleteResource={() => Promise.resolve(resource?.destroy())}
     />
   );
 };
@@ -111,7 +115,8 @@ export const RemoveMfaPhoneCodePage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
   // TODO: This logic will need to change when we add more 2fa methods
-  const ref = React.useRef(deepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
+  const resource = user.phoneNumbers.find(e => e.id === id);
+  const ref = React.useRef(resource?.phoneNumber);
 
   if (!ref.current) {
     return null;
@@ -121,13 +126,13 @@ export const RemoveMfaPhoneCodePage = () => {
     <RemoveResourcePage
       title={localizationKeys('userProfile.mfaPhoneCodePage.removeResource.title')}
       messageLine1={localizationKeys('userProfile.mfaPhoneCodePage.removeResource.messageLine1', {
-        identifier: ref.current.phoneNumber,
+        identifier: ref.current,
       })}
       messageLine2={localizationKeys('userProfile.mfaPhoneCodePage.removeResource.messageLine2')}
       successMessage={localizationKeys('userProfile.mfaPhoneCodePage.removeResource.successMessage', {
-        mfaPhoneCode: ref.current.phoneNumber,
+        mfaPhoneCode: ref.current,
       })}
-      deleteResource={() => Promise.resolve(ref.current?.setReservedForSecondFactor({ reserved: false }))}
+      deleteResource={() => Promise.resolve(resource?.setReservedForSecondFactor({ reserved: false }))}
     />
   );
 };

--- a/packages/clerk-js/src/ui/components/UserProfile/RemoveResourcePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/RemoveResourcePage.tsx
@@ -7,13 +7,13 @@ import { localizationKeys, Text } from '../../customizables';
 import { ContentPage, Form, FormButtons, SuccessPage, useCardState, withCardStateProvider } from '../../elements';
 import { useEnabledThirdPartyProviders } from '../../hooks';
 import { useRouter } from '../../router';
-import { fastDeepCopyAndReturn, handleError } from '../../utils';
+import { deepCopyAndReturn, handleError } from '../../utils';
 import { UserProfileBreadcrumbs } from './UserProfileNavbar';
 
 export const RemoveEmailPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(fastDeepCopyAndReturn(user.emailAddresses.find(e => e.id === id)));
+  const ref = React.useRef(deepCopyAndReturn(user.emailAddresses.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;
@@ -37,7 +37,7 @@ export const RemoveEmailPage = () => {
 export const RemovePhonePage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(fastDeepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
+  const ref = React.useRef(deepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;
@@ -61,7 +61,7 @@ export const RemovePhonePage = () => {
 export const RemoveConnectedAccountPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(fastDeepCopyAndReturn(user.externalAccounts.find(e => e.id === id)));
+  const ref = React.useRef(deepCopyAndReturn(user.externalAccounts.find(e => e.id === id)));
   const { providerToDisplayData } = useEnabledThirdPartyProviders();
 
   if (!ref.current) {
@@ -86,7 +86,7 @@ export const RemoveConnectedAccountPage = () => {
 export const RemoveWeb3WalletPage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
-  const ref = React.useRef(fastDeepCopyAndReturn(user.web3Wallets.find(e => e.id === id)));
+  const ref = React.useRef(deepCopyAndReturn(user.web3Wallets.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;
@@ -111,7 +111,7 @@ export const RemoveMfaPhoneCodePage = () => {
   const user = useCoreUser();
   const { id } = useRouter().params;
   // TODO: This logic will need to change when we add more 2fa methods
-  const ref = React.useRef(fastDeepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
+  const ref = React.useRef(deepCopyAndReturn(user.phoneNumbers.find(e => e.id === id)));
 
   if (!ref.current) {
     return null;

--- a/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
+++ b/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
@@ -46,35 +46,3 @@ export const fastDeepMergeAndKeep = (
     }
   }
 };
-
-function deepMerge(source: Record<any, any> | undefined | null, target: Record<any, any> | undefined | null) {
-  if (!source || !target) {
-    return;
-  }
-
-  if (isObject(target) && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (isObject(source[key])) {
-        if (!(key in target)) {
-          Object.assign(target, { [key]: source[key] });
-        } else {
-          target[key] = deepMerge(target[key], source[key]);
-        }
-      } else {
-        Object.assign(target, { [key]: source[key] });
-      }
-    });
-  }
-
-  return target;
-}
-
-export const deepCopyAndReturn = <T extends Record<any, any> | undefined | null>(source: T): T => {
-  if (!source) {
-    return source;
-  }
-
-  const target = {};
-  deepMerge(source, target);
-  return target as T;
-};

--- a/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
+++ b/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
@@ -23,6 +23,10 @@ export const fastDeepMergeAndReplace = (
   }
 };
 
+export function isObject(item: any) {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
 export const fastDeepMergeAndKeep = (
   source: Record<any, any> | undefined | null,
   target: Record<any, any> | undefined | null,
@@ -43,12 +47,34 @@ export const fastDeepMergeAndKeep = (
   }
 };
 
-export const fastDeepCopyAndReturn = <T extends Record<any, any> | undefined | null>(source: T): T => {
+function deepMerge(source: Record<any, any> | undefined | null, target: Record<any, any> | undefined | null) {
+  if (!source || !target) {
+    return;
+  }
+
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach(key => {
+      if (isObject(source[key])) {
+        if (!(key in target)) {
+          Object.assign(target, { [key]: source[key] });
+        } else {
+          target[key] = deepMerge(target[key], source[key]);
+        }
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    });
+  }
+
+  return target;
+}
+
+export const deepCopyAndReturn = <T extends Record<any, any> | undefined | null>(source: T): T => {
   if (!source) {
     return source;
   }
 
   const target = {};
-  fastDeepMergeAndReplace(source, target);
+  deepMerge(source, target);
   return target as T;
 };

--- a/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
+++ b/packages/clerk-js/src/ui/utils/fastDeepMerge.ts
@@ -23,10 +23,6 @@ export const fastDeepMergeAndReplace = (
   }
 };
 
-export function isObject(item: any) {
-  return item && typeof item === 'object' && !Array.isArray(item);
-}
-
 export const fastDeepMergeAndKeep = (
   source: Record<any, any> | undefined | null,
   target: Record<any, any> | undefined | null,


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This seems to happen as a result of this line https://github.com/clerkinc/javascript/blob/c85ca2c7a81298821100c7ca2467bc25ef074995/packages/clerk-js/src/ui/utils/fastDeepMerge.ts#L17

when the email is associated with an external account. We try to call the constructor for the `linkedTo` field which corresponds to an `IdentificationLink` and it fails. I suppose this function was not supposed to be a general utility and is probably best fitted for our theme utilities? @nikosdouvlis  Let me know on that. I'll make another simpler deepMerge utility for this case.
<!-- Fixes # (issue number) -->
