### PR TITLE
chore(repo): Update miniflare@2.12.1 to resolve sec vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,27 +5171,27 @@
       "peer": true
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.11.0.tgz",
-      "integrity": "sha512-L/kc9AzidPwFuk2fwHpAEePi0kNBk6FWUq3ln+9beRCDrPEpfVrDRFpNleF1NFZz5//oeVMuo8F0IVUQGzR7+Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.1.tgz",
+      "integrity": "sha512-6Pj5avy53qULTa13gWxGTDBuwX0yAzr4Zkzb0ZBh40bcbHp4vRkOk7PvHBoxV0M76JxQDHotGaW+ik510z5Xrg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.11.0.tgz",
-      "integrity": "sha512-JUmyRzEGAS6CouvXJwBh8p44onfw3KRpfq5JGXEuHModOGjTp6li7PQyCTNPV2Hv/7StAXWnTFGXeAqyDHuTig==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.12.1.tgz",
+      "integrity": "sha512-iCh4wEyQow8Dha+zpKhjCCXEp6QWbsvE18H5CgeUFT1pX4B+akYIHzdn47Cr5zpuYyjenoL78bAz0IIHIeyeWw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/shared": "2.12.1",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -5199,20 +5199,20 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-UFMFiCG0co36VpZkgFrSBnrxo71uf1x+cjlzzJi3khmMyDlnLu4RuIQsAqvKbYom6fi3G9Q8lTgM7JuOXFyjhw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.12.1.tgz",
+      "integrity": "sha512-729xXL6uoMgtja5J7B2WdWAjFfxb74Pk2QqM3VqkWqY3XNlKWI7+ofvb8S6kI6uFEPGj4ma263uYkEAgsvzBWg==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/watcher": "2.11.0",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/watcher": "2.12.1",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "urlpattern-polyfill": "^4.0.3"
       },
       "engines": {
@@ -5220,60 +5220,60 @@
       }
     },
     "node_modules/@miniflare/d1": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.11.0.tgz",
-      "integrity": "sha512-aDdBVQZ2C0Zs3+Y9ZbRctmuQxozPfpumwJ/6NG6fBadANvune/hW7ddEoxyteIEU9W3IgzVj8s4by4VvasX90A==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.12.1.tgz",
+      "integrity": "sha512-2ldT7xEC7KxoaEJ7nCY9/AB/xwPjbm3mrmpiIspT0b5OgS640Pe9EU4c5bSmzGoUbLvwF+jb+LhLE1QaEbWkBw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.11.0.tgz",
-      "integrity": "sha512-0cKJaMgraTEU1b4kqK8cjD2oTeOjA6QU3Y+lWiZT/k1PMHZULovrSFnjii7qZ8npf4VHSIN6XYPxhyxRyEM65Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.12.1.tgz",
+      "integrity": "sha512-/n9WIxvHavVUgT+Nf280wNOcmJQBG+eZuqOlORWW9RmXXbAzqzS2Mk2lmRDCzbq3xTXAcsndx6cdarQLNRUzBg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/storage-memory": "2.11.0",
-        "undici": "5.9.1"
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.11.0.tgz",
-      "integrity": "sha512-olTqmuYTHnoTNtiA0vjQ/ixRfbwgPzDrAUbtXDCYW45VFbHfDVJrJGZX3Jg0HpSlxy86Zclle1SUxGbVDzxsBg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.12.1.tgz",
+      "integrity": "sha512-yezYzGRBxy7d/oomAUEftdnL4fq6YIek82LtQlXgzcdcbBDnkYADj8WqGV41tAI+V2+rjrFEc1RuCXx/I1yISw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.11.0.tgz",
-      "integrity": "sha512-sMLcrDFzqqAvnQmAUH0hRTo8sBjW79VZYfnIH5FAGSGcKX6kdAGs9RStdYZ4CftQCBAEQScX0KBsMx5FwJRe9Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.12.1.tgz",
+      "integrity": "sha512-nC6POgDKFHxnyXbKCdR9FGZSsu5frXQUETvSVcoETd5RP+Iws0xZ+XkzVMqiiIZk3ifUC9LzdGUOD0J2PlhHJw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/web-sockets": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       },
@@ -5282,62 +5282,62 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.11.0.tgz",
-      "integrity": "sha512-3m9dL2HBBN170V1JvwjjucR5zl4G3mlcsV6C1E7A2wLl2Z2TWvIx/tSY9hrhkD96dFnejwJ9qmPMbXMMuynhjg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.12.1.tgz",
+      "integrity": "sha512-8h8wLDMEaWaKAqYTwrckOcNjAz52bzDyLmU4t/lh1/AQOE9eSg/T+H6xQCv0fPGrWPeHmG8iXaFI1JQ+CtkcHw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/queues": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.11.0.tgz",
-      "integrity": "sha512-fLHjdrNLKhn0LZM/aii/9GsAttFd+lWlGzK8HOg1R0vhfKBwEub4zntjMmOfFbDm1ntc21tdMK7n3ldUphwh5w==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.12.1.tgz",
+      "integrity": "sha512-L/YJkWWvg1RS3sCB5DLZOsf/kAmkwhvshpl+LmGQT7z/PYXlplbBmuhPwVBXaHqZdYE7063XfTzgAIhVPoo72Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/r2": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.11.0.tgz",
-      "integrity": "sha512-MKuyJ/gGNsK3eWbGdygvozqcyaZhM3C6NGHvoaZwH503dwN569j5DpatTWiHGFeDeSu64VqcIsGehz05GDUaag==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.12.1.tgz",
+      "integrity": "sha512-xp8fSSap6o5xSAWp9BtOGgZ4tuf5iHTqrfbAH66LF151j8y69eQtQJ5pxpSvrDJok/F1VOLGc4ihSLmUqxyXhw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0",
-        "undici": "5.9.1"
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.11.0.tgz",
-      "integrity": "sha512-bkVSuvCf5+VylqN8lTiLxIYqYcKFbl+BywZGwGQndPC/3wh42J00mM0jw4hRbvXgwuBhlUyCVpEXtYlftFFT/g==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.12.1.tgz",
+      "integrity": "sha512-pGY/aoQzbvyXOGR6/d3hv5/QsyUXGGbOxAyXdvjlz8h7ZiKOX4dBRS5TUAPS0kb/ofUWCyoYJi8dCVwRGdTYRw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.11.0.tgz",
-      "integrity": "sha512-DPdzINhdWeS99eIicGoluMsD4pLTTAWNQbgCv3CTwgdKA3dxdvMSCkNqZzQLiALzvk9+rSfj46FlH++HE7o7/w==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.12.1.tgz",
+      "integrity": "sha512-AbOP8YpWNqR/t7zMuTmn6q27USCDBQaYaULRVaNNfCsxMTXAUjYfM85iFvnV9mshw+K0HIEU4zR4Xjd2FeJubg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -5345,14 +5345,14 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.11.0.tgz",
-      "integrity": "sha512-fWMqq3ZkWAg+k7CnyzMV/rZHugwn+/JxvVzCxrtvxzwotTN547THlOxgZe8JAP23U9BiTxOfpTfnLvFEjAmegw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.12.1.tgz",
+      "integrity": "sha512-N8sHNM5vcvjvO+znQ7Mbqf0FChRlWxy/svUpQf1GGpii9aTXzOTWB+WkFvJrJNx44SUReEGxUAzxpdeWnHahmA==",
       "dev": true,
       "dependencies": {
         "@types/better-sqlite3": "^7.6.0",
         "kleur": "^4.1.4",
-        "npx-import": "^1.1.3",
+        "npx-import": "^1.1.4",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -5360,65 +5360,65 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.11.0.tgz",
-      "integrity": "sha512-qbefKdWZUJgsdLf+kCw03sn3h/92LZgJAbkOpP6bCrfWkXlJ37EQXO4KWdhn4Ghc7A6GwU1s1I/mdB64B3AewQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.12.1.tgz",
+      "integrity": "sha512-LW4r82cfGJvmJFwoBdXfsRcdDggVf8ppjMZGU3zk7xo+u5yD1uHzO2Arf3XbKNiOp7f9WyC/mXxs4zxF605iLA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/storage-file": "2.11.0"
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-file": "2.12.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.11.0.tgz",
-      "integrity": "sha512-beWF/lTX74x7AiaSB+xQxywPSNdhtEKvqDkRui8eOJ5kqN2o4UaleLKQGgqmCw3WyHRIsckV7If1qpbNiLtWMw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.12.1.tgz",
+      "integrity": "sha512-eq5wzBwxQC5GVxBfji9svb9FRdSOlA8D8DTgzL29DDjuOYtG9j8ydOlo0J7/2MB/Gq0HYFUHYWHhrklzzwdKQQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/storage-memory": "2.11.0"
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.11.0.tgz",
-      "integrity": "sha512-s0AhPww7fq/Jz80NbPb+ffhcVRKnfPi7H1dHTRTre2Ud23EVJjAWl2gat42x8NOT/Fu3/o/7A72DWQQJqfO98A==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.12.1.tgz",
+      "integrity": "sha512-E9jbrX0L9N7YIHXj2G4td1EKboVLBdHkwh7RvKEZBwOhxDze5h+jMOou57NIbfC5kLOZPOC1fGXjzpp7xUUE6w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.11.0.tgz",
-      "integrity": "sha512-RUfjz2iYcsQXLcGySemJl98CJ2iierbWsPGWZhIVZI+NNhROkEy77g/Q+lvP2ATwexG3/dUSfdJ3P8aH+sI4Ig==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.12.1.tgz",
+      "integrity": "sha512-3IG/6g38id5ppbZHB/gMfEvoIEFYdmTTLRsHaPNyWIk/r3LMhHLluVsMcs+Lr/fphkPk6Diou4cBLD2GeeoP7A==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.11.0.tgz",
-      "integrity": "sha512-NC8RKrmxrO0hZmwpzn5g4hPGA2VblnFTIBobmWoxuK95eW49zfs7dtE/PyFs+blsGv3CjTIjHVSQ782K+C6HFA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.12.1.tgz",
+      "integrity": "sha512-Z+zqZqhVdrbmTQf+ETP5H1TPdXC2tUiYPiHRLWTHUks6VVkuwnUtIKxNPBEBXjCjKYYEm8VLclUAt+0yTucLWA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "undici": "5.9.1",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0",
         "ws": "^8.2.2"
       },
       "engines": {
@@ -7582,9 +7582,9 @@
       }
     },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-RgmaapusqTq6IMAr4McMyAsC6RshYTCjXCnzwVV59WctUxC8bNPyUfT9t5F81lKcU41lLurhjqjoMHfauzfqGg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -21418,32 +21418,32 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.11.0.tgz",
-      "integrity": "sha512-QA18I1VQXdCo4nBtPJUcUDxW8c9xbc5ex5F61jwhkGVOISSnYdEheolESmjr8MYk28xwi0XD1ozS4rLaTONd+w==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.12.1.tgz",
+      "integrity": "sha512-pym6gzg8AQZ1NRChRV1hC4K55N49wndoaDEVRMvZPJrFsmGkNnXkWmlvmZ7SB3BN5UkP5MZwKhLqiJ49Ry8tFA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/cache": "2.11.0",
-        "@miniflare/cli-parser": "2.11.0",
-        "@miniflare/core": "2.11.0",
-        "@miniflare/d1": "2.11.0",
-        "@miniflare/durable-objects": "2.11.0",
-        "@miniflare/html-rewriter": "2.11.0",
-        "@miniflare/http-server": "2.11.0",
-        "@miniflare/kv": "2.11.0",
-        "@miniflare/queues": "2.11.0",
-        "@miniflare/r2": "2.11.0",
-        "@miniflare/runner-vm": "2.11.0",
-        "@miniflare/scheduler": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/sites": "2.11.0",
-        "@miniflare/storage-file": "2.11.0",
-        "@miniflare/storage-memory": "2.11.0",
-        "@miniflare/web-sockets": "2.11.0",
+        "@miniflare/cache": "2.12.1",
+        "@miniflare/cli-parser": "2.12.1",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/d1": "2.12.1",
+        "@miniflare/durable-objects": "2.12.1",
+        "@miniflare/html-rewriter": "2.12.1",
+        "@miniflare/http-server": "2.12.1",
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/r2": "2.12.1",
+        "@miniflare/runner-vm": "2.12.1",
+        "@miniflare/scheduler": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/sites": "2.12.1",
+        "@miniflare/storage-file": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -21452,7 +21452,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.11.0",
+        "@miniflare/storage-redis": "2.12.1",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -29213,10 +29213,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
-      "integrity": "sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
       "engines": {
         "node": ">=12.18"
       }
@@ -30859,7 +30862,7 @@
         "edge-runtime": "^2.0.0",
         "esbuild": "^0.15.12",
         "esbuild-register": "^3.3.3",
-        "miniflare": "^2.11.0",
+        "miniflare": "^2.12.1",
         "npm-run-all": "^4.1.5",
         "qunit": "^2.19.3",
         "sinon": "^14.0.1",
@@ -36197,7 +36200,7 @@
         "edge-runtime": "^2.0.0",
         "esbuild": "^0.15.12",
         "esbuild-register": "^3.3.3",
-        "miniflare": "^2.11.0",
+        "miniflare": "^2.12.1",
         "node-fetch-native": "1.0.1",
         "npm-run-all": "^4.1.5",
         "qunit": "^2.19.3",
@@ -41549,203 +41552,203 @@
       "peer": true
     },
     "@miniflare/cache": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.11.0.tgz",
-      "integrity": "sha512-L/kc9AzidPwFuk2fwHpAEePi0kNBk6FWUq3ln+9beRCDrPEpfVrDRFpNleF1NFZz5//oeVMuo8F0IVUQGzR7+Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.1.tgz",
+      "integrity": "sha512-6Pj5avy53qULTa13gWxGTDBuwX0yAzr4Zkzb0ZBh40bcbHp4vRkOk7PvHBoxV0M76JxQDHotGaW+ik510z5Xrg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
         "http-cache-semantics": "^4.1.0",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/cli-parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.11.0.tgz",
-      "integrity": "sha512-JUmyRzEGAS6CouvXJwBh8p44onfw3KRpfq5JGXEuHModOGjTp6li7PQyCTNPV2Hv/7StAXWnTFGXeAqyDHuTig==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.12.1.tgz",
+      "integrity": "sha512-iCh4wEyQow8Dha+zpKhjCCXEp6QWbsvE18H5CgeUFT1pX4B+akYIHzdn47Cr5zpuYyjenoL78bAz0IIHIeyeWw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/shared": "2.12.1",
         "kleur": "^4.1.4"
       }
     },
     "@miniflare/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-UFMFiCG0co36VpZkgFrSBnrxo71uf1x+cjlzzJi3khmMyDlnLu4RuIQsAqvKbYom6fi3G9Q8lTgM7JuOXFyjhw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.12.1.tgz",
+      "integrity": "sha512-729xXL6uoMgtja5J7B2WdWAjFfxb74Pk2QqM3VqkWqY3XNlKWI7+ofvb8S6kI6uFEPGj4ma263uYkEAgsvzBWg==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/watcher": "2.11.0",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/watcher": "2.12.1",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
         "set-cookie-parser": "^2.4.8",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "urlpattern-polyfill": "^4.0.3"
       }
     },
     "@miniflare/d1": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.11.0.tgz",
-      "integrity": "sha512-aDdBVQZ2C0Zs3+Y9ZbRctmuQxozPfpumwJ/6NG6fBadANvune/hW7ddEoxyteIEU9W3IgzVj8s4by4VvasX90A==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.12.1.tgz",
+      "integrity": "sha512-2ldT7xEC7KxoaEJ7nCY9/AB/xwPjbm3mrmpiIspT0b5OgS640Pe9EU4c5bSmzGoUbLvwF+jb+LhLE1QaEbWkBw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1"
       }
     },
     "@miniflare/durable-objects": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.11.0.tgz",
-      "integrity": "sha512-0cKJaMgraTEU1b4kqK8cjD2oTeOjA6QU3Y+lWiZT/k1PMHZULovrSFnjii7qZ8npf4VHSIN6XYPxhyxRyEM65Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.12.1.tgz",
+      "integrity": "sha512-/n9WIxvHavVUgT+Nf280wNOcmJQBG+eZuqOlORWW9RmXXbAzqzS2Mk2lmRDCzbq3xTXAcsndx6cdarQLNRUzBg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/storage-memory": "2.11.0",
-        "undici": "5.9.1"
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "undici": "5.20.0"
       }
     },
     "@miniflare/html-rewriter": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.11.0.tgz",
-      "integrity": "sha512-olTqmuYTHnoTNtiA0vjQ/ixRfbwgPzDrAUbtXDCYW45VFbHfDVJrJGZX3Jg0HpSlxy86Zclle1SUxGbVDzxsBg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.12.1.tgz",
+      "integrity": "sha512-yezYzGRBxy7d/oomAUEftdnL4fq6YIek82LtQlXgzcdcbBDnkYADj8WqGV41tAI+V2+rjrFEc1RuCXx/I1yISw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
         "html-rewriter-wasm": "^0.4.1",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       }
     },
     "@miniflare/http-server": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.11.0.tgz",
-      "integrity": "sha512-sMLcrDFzqqAvnQmAUH0hRTo8sBjW79VZYfnIH5FAGSGcKX6kdAGs9RStdYZ4CftQCBAEQScX0KBsMx5FwJRe9Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.12.1.tgz",
+      "integrity": "sha512-nC6POgDKFHxnyXbKCdR9FGZSsu5frXQUETvSVcoETd5RP+Iws0xZ+XkzVMqiiIZk3ifUC9LzdGUOD0J2PlhHJw==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/web-sockets": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
-        "undici": "5.9.1",
+        "undici": "5.20.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
       }
     },
     "@miniflare/kv": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.11.0.tgz",
-      "integrity": "sha512-3m9dL2HBBN170V1JvwjjucR5zl4G3mlcsV6C1E7A2wLl2Z2TWvIx/tSY9hrhkD96dFnejwJ9qmPMbXMMuynhjg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.12.1.tgz",
+      "integrity": "sha512-8h8wLDMEaWaKAqYTwrckOcNjAz52bzDyLmU4t/lh1/AQOE9eSg/T+H6xQCv0fPGrWPeHmG8iXaFI1JQ+CtkcHw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       }
     },
     "@miniflare/queues": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.11.0.tgz",
-      "integrity": "sha512-fLHjdrNLKhn0LZM/aii/9GsAttFd+lWlGzK8HOg1R0vhfKBwEub4zntjMmOfFbDm1ntc21tdMK7n3ldUphwh5w==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.12.1.tgz",
+      "integrity": "sha512-L/YJkWWvg1RS3sCB5DLZOsf/kAmkwhvshpl+LmGQT7z/PYXlplbBmuhPwVBXaHqZdYE7063XfTzgAIhVPoo72Q==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       }
     },
     "@miniflare/r2": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.11.0.tgz",
-      "integrity": "sha512-MKuyJ/gGNsK3eWbGdygvozqcyaZhM3C6NGHvoaZwH503dwN569j5DpatTWiHGFeDeSu64VqcIsGehz05GDUaag==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.12.1.tgz",
+      "integrity": "sha512-xp8fSSap6o5xSAWp9BtOGgZ4tuf5iHTqrfbAH66LF151j8y69eQtQJ5pxpSvrDJok/F1VOLGc4ihSLmUqxyXhw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0",
-        "undici": "5.9.1"
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0"
       }
     },
     "@miniflare/runner-vm": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.11.0.tgz",
-      "integrity": "sha512-bkVSuvCf5+VylqN8lTiLxIYqYcKFbl+BywZGwGQndPC/3wh42J00mM0jw4hRbvXgwuBhlUyCVpEXtYlftFFT/g==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.12.1.tgz",
+      "integrity": "sha512-pGY/aoQzbvyXOGR6/d3hv5/QsyUXGGbOxAyXdvjlz8h7ZiKOX4dBRS5TUAPS0kb/ofUWCyoYJi8dCVwRGdTYRw==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       }
     },
     "@miniflare/scheduler": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.11.0.tgz",
-      "integrity": "sha512-DPdzINhdWeS99eIicGoluMsD4pLTTAWNQbgCv3CTwgdKA3dxdvMSCkNqZzQLiALzvk9+rSfj46FlH++HE7o7/w==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.12.1.tgz",
+      "integrity": "sha512-AbOP8YpWNqR/t7zMuTmn6q27USCDBQaYaULRVaNNfCsxMTXAUjYfM85iFvnV9mshw+K0HIEU4zR4Xjd2FeJubg==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
         "cron-schedule": "^3.0.4"
       }
     },
     "@miniflare/shared": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.11.0.tgz",
-      "integrity": "sha512-fWMqq3ZkWAg+k7CnyzMV/rZHugwn+/JxvVzCxrtvxzwotTN547THlOxgZe8JAP23U9BiTxOfpTfnLvFEjAmegw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.12.1.tgz",
+      "integrity": "sha512-N8sHNM5vcvjvO+znQ7Mbqf0FChRlWxy/svUpQf1GGpii9aTXzOTWB+WkFvJrJNx44SUReEGxUAzxpdeWnHahmA==",
       "dev": true,
       "requires": {
         "@types/better-sqlite3": "^7.6.0",
         "kleur": "^4.1.4",
-        "npx-import": "^1.1.3",
+        "npx-import": "^1.1.4",
         "picomatch": "^2.3.1"
       }
     },
     "@miniflare/sites": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.11.0.tgz",
-      "integrity": "sha512-qbefKdWZUJgsdLf+kCw03sn3h/92LZgJAbkOpP6bCrfWkXlJ37EQXO4KWdhn4Ghc7A6GwU1s1I/mdB64B3AewQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.12.1.tgz",
+      "integrity": "sha512-LW4r82cfGJvmJFwoBdXfsRcdDggVf8ppjMZGU3zk7xo+u5yD1uHzO2Arf3XbKNiOp7f9WyC/mXxs4zxF605iLA==",
       "dev": true,
       "requires": {
-        "@miniflare/kv": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/storage-file": "2.11.0"
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-file": "2.12.1"
       }
     },
     "@miniflare/storage-file": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.11.0.tgz",
-      "integrity": "sha512-beWF/lTX74x7AiaSB+xQxywPSNdhtEKvqDkRui8eOJ5kqN2o4UaleLKQGgqmCw3WyHRIsckV7If1qpbNiLtWMw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.12.1.tgz",
+      "integrity": "sha512-eq5wzBwxQC5GVxBfji9svb9FRdSOlA8D8DTgzL29DDjuOYtG9j8ydOlo0J7/2MB/Gq0HYFUHYWHhrklzzwdKQQ==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/storage-memory": "2.11.0"
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1"
       }
     },
     "@miniflare/storage-memory": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.11.0.tgz",
-      "integrity": "sha512-s0AhPww7fq/Jz80NbPb+ffhcVRKnfPi7H1dHTRTre2Ud23EVJjAWl2gat42x8NOT/Fu3/o/7A72DWQQJqfO98A==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.12.1.tgz",
+      "integrity": "sha512-E9jbrX0L9N7YIHXj2G4td1EKboVLBdHkwh7RvKEZBwOhxDze5h+jMOou57NIbfC5kLOZPOC1fGXjzpp7xUUE6w==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       }
     },
     "@miniflare/watcher": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.11.0.tgz",
-      "integrity": "sha512-RUfjz2iYcsQXLcGySemJl98CJ2iierbWsPGWZhIVZI+NNhROkEy77g/Q+lvP2ATwexG3/dUSfdJ3P8aH+sI4Ig==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.12.1.tgz",
+      "integrity": "sha512-3IG/6g38id5ppbZHB/gMfEvoIEFYdmTTLRsHaPNyWIk/r3LMhHLluVsMcs+Lr/fphkPk6Diou4cBLD2GeeoP7A==",
       "dev": true,
       "requires": {
-        "@miniflare/shared": "2.11.0"
+        "@miniflare/shared": "2.12.1"
       }
     },
     "@miniflare/web-sockets": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.11.0.tgz",
-      "integrity": "sha512-NC8RKrmxrO0hZmwpzn5g4hPGA2VblnFTIBobmWoxuK95eW49zfs7dtE/PyFs+blsGv3CjTIjHVSQ782K+C6HFA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.12.1.tgz",
+      "integrity": "sha512-Z+zqZqhVdrbmTQf+ETP5H1TPdXC2tUiYPiHRLWTHUks6VVkuwnUtIKxNPBEBXjCjKYYEm8VLclUAt+0yTucLWA==",
       "dev": true,
       "requires": {
-        "@miniflare/core": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "undici": "5.9.1",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0",
         "ws": "^8.2.2"
       }
     },
@@ -43200,9 +43203,9 @@
       }
     },
     "@types/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-RgmaapusqTq6IMAr4McMyAsC6RshYTCjXCnzwVV59WctUxC8bNPyUfT9t5F81lKcU41lLurhjqjoMHfauzfqGg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -53876,32 +53879,32 @@
       "peer": true
     },
     "miniflare": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.11.0.tgz",
-      "integrity": "sha512-QA18I1VQXdCo4nBtPJUcUDxW8c9xbc5ex5F61jwhkGVOISSnYdEheolESmjr8MYk28xwi0XD1ozS4rLaTONd+w==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.12.1.tgz",
+      "integrity": "sha512-pym6gzg8AQZ1NRChRV1hC4K55N49wndoaDEVRMvZPJrFsmGkNnXkWmlvmZ7SB3BN5UkP5MZwKhLqiJ49Ry8tFA==",
       "dev": true,
       "requires": {
-        "@miniflare/cache": "2.11.0",
-        "@miniflare/cli-parser": "2.11.0",
-        "@miniflare/core": "2.11.0",
-        "@miniflare/d1": "2.11.0",
-        "@miniflare/durable-objects": "2.11.0",
-        "@miniflare/html-rewriter": "2.11.0",
-        "@miniflare/http-server": "2.11.0",
-        "@miniflare/kv": "2.11.0",
-        "@miniflare/queues": "2.11.0",
-        "@miniflare/r2": "2.11.0",
-        "@miniflare/runner-vm": "2.11.0",
-        "@miniflare/scheduler": "2.11.0",
-        "@miniflare/shared": "2.11.0",
-        "@miniflare/sites": "2.11.0",
-        "@miniflare/storage-file": "2.11.0",
-        "@miniflare/storage-memory": "2.11.0",
-        "@miniflare/web-sockets": "2.11.0",
+        "@miniflare/cache": "2.12.1",
+        "@miniflare/cli-parser": "2.12.1",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/d1": "2.12.1",
+        "@miniflare/durable-objects": "2.12.1",
+        "@miniflare/html-rewriter": "2.12.1",
+        "@miniflare/http-server": "2.12.1",
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/r2": "2.12.1",
+        "@miniflare/runner-vm": "2.12.1",
+        "@miniflare/scheduler": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/sites": "2.12.1",
+        "@miniflare/storage-file": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
-        "undici": "5.9.1"
+        "undici": "5.20.0"
       }
     },
     "minimalistic-assert": {
@@ -59694,10 +59697,13 @@
       "peer": true
     },
     "undici": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.9.1.tgz",
-      "integrity": "sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==",
-      "dev": true
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -42,7 +42,7 @@
     "edge-runtime": "^2.0.0",
     "esbuild": "^0.15.12",
     "esbuild-register": "^3.3.3",
-    "miniflare": "^2.11.0",
+    "miniflare": "^2.12.1",
     "npm-run-all": "^4.1.5",
     "qunit": "^2.19.3",
     "sinon": "^14.0.1",


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Miniflare is used as a dev dependency to run the tests. If the tests pass, then i believe we are okay to merge this.