### PR TITLE
fix(clerk-js): Removed unsupported props when inviting org members

### DIFF
--- a/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationInvitation.ts
@@ -22,13 +22,13 @@ export class OrganizationInvitation extends BaseResource implements Organization
 
   static async create(
     organizationId: string,
-    { emailAddress, role, redirectUrl }: CreateOrganizationInvitationParams,
+    { emailAddress, role }: CreateOrganizationInvitationParams,
   ): Promise<OrganizationInvitationResource> {
     const json = (
       await BaseResource._fetch<OrganizationInvitationJSON>({
         path: `/organizations/${organizationId}/invitations`,
         method: 'POST',
-        body: { email_address: emailAddress, role, redirect_url: redirectUrl } as any,
+        body: { email_address: emailAddress, role } as any,
       })
     )?.response as unknown as OrganizationInvitationJSON;
     const newInvitation = new OrganizationInvitation(json);
@@ -40,12 +40,12 @@ export class OrganizationInvitation extends BaseResource implements Organization
     organizationId: string,
     params: CreateBulkOrganizationInvitationParams,
   ): Promise<OrganizationInvitationResource[]> {
-    const { emailAddresses, redirectUrl, role } = params;
+    const { emailAddresses, role } = params;
     const json = (
       await BaseResource._fetch<OrganizationInvitationJSON>({
         path: `/organizations/${organizationId}/invitations/bulk`,
         method: 'POST',
-        body: { email_address: emailAddresses, role, redirect_url: redirectUrl } as any,
+        body: { email_address: emailAddresses, role } as any,
       })
     )?.response as unknown as OrganizationInvitationJSON[];
     // const newInvitation = new OrganizationInvitation(json);

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -774,13 +774,11 @@ export interface HandleMagicLinkVerificationParams {
 export type CreateOrganizationInvitationParams = {
   emailAddress: string;
   role: MembershipRole;
-  redirectUrl?: string;
 };
 
 export type CreateBulkOrganizationInvitationParams = {
   emailAddresses: string[];
   role: MembershipRole;
-  redirectUrl?: string;
 };
 
 export interface CreateOrganizationParams {

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -48,13 +48,11 @@ export interface AddMemberParams {
 export interface InviteMemberParams {
   emailAddress: string;
   role: MembershipRole;
-  redirectUrl?: string;
 }
 
 export interface InviteMembersParams {
   emailAddresses: string[];
   role: MembershipRole;
-  redirectUrl?: string;
 }
 
 export interface UpdateMembershipParams {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This commit removes removes the unused `redirectUrl` property from the organization member invitation.

This property is supported when creating organization invitations from BAPI, but not from FAPI.
Unfortunately, they were accidentally added in our FE types and should be removed because they cause confusion, given that the FAPI will return an error if someone tries to use them.

<!-- Fixes # (issue number) -->
