### PR TITLE
fix(clerk-js): Load chunks using __PKG_VERSION__ defined during build time

### DIFF
--- a/packages/clerk-js/src/index.browser.ts
+++ b/packages/clerk-js/src/index.browser.ts
@@ -1,3 +1,8 @@
+// It's crucial this is the first import,
+// otherwise chunk loading will not work
+// eslint-disable-next-line
+import './utils/setWebpackChunkPublicPath';
+
 import 'regenerator-runtime/runtime';
 
 import Clerk from './core/clerk';

--- a/packages/clerk-js/src/index.ts
+++ b/packages/clerk-js/src/index.ts
@@ -1,3 +1,7 @@
+// It's crucial this is the first import,
+// otherwise chunk loading will not work
+// eslint-disable-next-line
+import './utils/setWebpackChunkPublicPath';
 import 'regenerator-runtime/runtime';
 
 import Clerk from './core/clerk';

--- a/packages/clerk-js/src/utils/setWebpackChunkPublicPath.ts
+++ b/packages/clerk-js/src/utils/setWebpackChunkPublicPath.ts
@@ -1,0 +1,42 @@
+/**
+ * A combination of settings a fixed __PKG_VERSION__ during build time
+ * and the runtime __webpack_public_path__ config option (https://webpack.js.org/guides/public-path/).
+ * We explicitly set the public path in order to account for all chunk caching scenarios.
+ * A specific version of clerk.browser.js file should always try to load its corresponding chunk versions,
+ * otherwise we risk hitting caching issues.
+ *
+ * Scenario:
+ * 1. We release clerk-js@1.0.0 containing: clerk.browser.js, chunkA-1.0.0.js, chunkB-1.0.0.js
+ * 2. A user opens an app using Clerk
+ * 3. The browser downloads and caches `/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`
+ * 4. chunkA is needed so the browser downloads and caches `/npm/@clerk/clerk-js@latest/dist/chunkA-1.0.0.js`
+ * 5. Meanwhile, we release clerk-js@1.2.0 containing: clerk.browser.js, chunkA-1.2.0.js, chunkB-1.2.0.js
+ *    On our CDN, @clerk/clerk-js@latest now points to the new version
+ * 6. A user opens the app again
+ * 7. The browser loads `/npm/@clerk/clerk-js@latest/dist/clerk.browser.js` FROM CACHE (v1.0.0 file)
+ * 8. chunkA is needed so the browser loads `/npm/@clerk/clerk-js@latest/dist/chunkA-1.0.0.js` FROM CACHE (v1.0.0 file)
+ * 9. chunkB is needed for the first time. The cached v1.0.0 clerk.browser.js will try to load (request)
+ *    `/npm/@clerk/clerk-js@latest/dist/chunkA-1.0.0.js` but because clerk-js@latest now resolves to v1.2.0,
+ *    the v1.0.0 file will not be found and the app will crash
+ *
+ *  Solution:
+ *  A given clerk.browser.js file will only load its corresponding chunks using a fixed version. Example:
+ *  - clerk.browser.js loads from https://pk.accounts.dev/npm/@clerk/clerk-js@staging/dist/clerk.browser.js
+ *  - all other chunks need to be loaded from https://pk.accounts.dev/npm/@clerk/clerk-js@__PKG_VERSION__/dist/
+ */
+export const setWebpackChunkPublicPath = () => {
+  const VERSION_REGEX = /@clerk\/clerk-js@(.+?)\//;
+  try {
+    // @ts-expect-error
+    const scriptUrl = new URL(document.currentScript.src);
+    const hrefWithoutFilename = new URL(scriptUrl.href.split('/').slice(0, -1).join('/')).href;
+    const matches = hrefWithoutFilename.match(VERSION_REGEX) || [];
+    const tag = matches[1];
+    __webpack_public_path__ = tag ? hrefWithoutFilename.replace(tag, __PKG_VERSION__) : hrefWithoutFilename;
+    console.log(__webpack_public_path__);
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+setWebpackChunkPublicPath();

--- a/packages/clerk-js/src/utils/setWebpackChunkPublicPath.ts
+++ b/packages/clerk-js/src/utils/setWebpackChunkPublicPath.ts
@@ -33,9 +33,8 @@ export const setWebpackChunkPublicPath = () => {
     const matches = hrefWithoutFilename.match(VERSION_REGEX) || [];
     const tag = matches[1];
     __webpack_public_path__ = tag ? hrefWithoutFilename.replace(tag, __PKG_VERSION__) : hrefWithoutFilename;
-    console.log(__webpack_public_path__);
   } catch (e) {
-    console.log(e);
+    //
   }
 };
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
A combination of setting a fixed __PKG_VERSION__ during build time and the runtime __webpack_public_path__ config option (https://webpack.js.org/guides/public-path/). We explicitly set the public path in order to account for all chunk caching scenarios. A specific version of clerk.browser.js file should always try to load its corresponding chunk versions, otherwise we risk hitting caching issues.

Scenario:
1. We release clerk-js@1.0.0 containing: clerk.browser.js, chunkA-1.0.0.js, chunkB-1.0.0.js
2. A user opens an app using Clerk
3. The browser downloads and caches `/npm/@clerk/clerk-js@latest/dist/clerk.browser.js`
4. chunkA is needed so the browser downloads and caches `/npm/@clerk/clerk-js@latest/dist/chunkA-1.0.0.js`
5. Meanwhile, we release clerk-js@1.2.0 containing: clerk.browser.js, chunkA-1.2.0.js, chunkB-1.2.0.js On our CDN, @clerk/clerk-js@latest now points to the new version
6. A user opens the app again
7. The browser loads `/npm/@clerk/clerk-js@latest/dist/clerk.browser.js` FROM CACHE (v1.0.0 file)
8. chunkA is needed so the browser loads `/npm/@clerk/clerk-js@latest/dist/chunkA-1.0.0.js` FROM CACHE (v1.0.0 file)
9. chunkB is needed for the first time. The cached v1.0.0 clerk.browser.js will try to load (request) `/npm/@clerk/clerk-js@latest/dist/chunkA-1.0.0.js` but because clerk-js@latest now resolves to v1.2.0, the v1.0.0 file will not be found and the app will crash

 Solution:
 A given clerk.browser.js file will only load its corresponding chunks using a fixed version. Example:
 - clerk.browser.js loads from https://pk.accounts.dev/npm/@clerk/clerk-js@staging/dist/clerk.browser.js
 - all other chunks need to be loaded from https://pk.accounts.dev/npm/@clerk/clerk-js@__PKG_VERSION__/dist/

<!-- Fixes # (issue number) -->
