### PR TITLE
Cor 213

### DIFF
--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -6,6 +6,7 @@ export const DEV_BROWSER_SSO_JWT_HTTP_HEADER = 'Clerk-Cookie';
 
 export const CLERK_MODAL_STATE = '__clerk_modal_state';
 export const CLERK_SYNCED = '__clerk_synced';
+export const CLERK_SYNCING = '__clerk_syncing';
 
 export const ERROR_CODES = {
   FORM_IDENTIFIER_NOT_FOUND: 'form_identifier_not_found',

--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -97,3 +97,7 @@ export function clerkMissingProxyUrlAndDomain(): never {
     `${errorPrefix} Missing domain and proxyUrl. A satellite application needs to specify a domain or a proxyUrl`,
   );
 }
+
+export function clerkMissingSignInUrlAsSatellite(): never {
+  throw new Error(`${errorPrefix} Missing signInUrl. Pass a signInUrl for dev instances if an app is satellite`);
+}

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -1,4 +1,4 @@
-import { CLERK_SYNCED } from '../core/constants';
+import { CLERK_SYNCED, CLERK_SYNCING } from '../core/constants';
 
 const ClerkQueryParams = [
   '__clerk_status',
@@ -7,6 +7,7 @@ const ClerkQueryParams = [
   '__clerk_ticket',
   '__clerk_modal_state',
   CLERK_SYNCED,
+  CLERK_SYNCING,
 ] as const;
 
 type ClerkQueryParam = typeof ClerkQueryParams[number];
@@ -18,6 +19,7 @@ type ClerkQueryParamsToValuesMap = {
   __clerk_ticket: string;
   __clerk_modal_state: string;
   __clerk_synced: string;
+  __clerk_syncing: string;
 };
 
 export type VerificationStatus = 'expired' | 'failed' | 'loading' | 'verified' | 'verified_switch_tab';

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -472,6 +472,7 @@ export interface ClerkOptions {
    * @experimental
    */
   isSatellite?: boolean | ((url: URL) => boolean);
+  signInUrl?: string;
 }
 
 export interface Resources {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR is the first of a many that will add support for the multi-domain feature for development instances
### adds support for the following `signInUrl` prop
```jsx
<ClerkProvider isSatellite signInUrl="https://primary.com/sign-in" >
```

### Redirects a satellite app to primary
By using the value set in `signInUrl` we perform a redirect with a query string appended `?__clerk_syncing=true&redirect_url={window.location.href}`


### Primary app redirects back to satellite app
- Use the `redirect_url` from the query string that was set from the step above
- Redirect back to satellite app :
  - Append the query string param ?__clerk_synced=true to the value of `redirect_url`.  This will prevent the satellite app from request syncing again from primary (causing an infinite loop of redirects)
  - Use `redirectWithAuth()` to go back to satellite. That will allow for the `dev_session` hash to be appended and later retrieved form the satellite app

### Back to satelllite
At this point we have completed the syncing process and we either have an app with a dev_session if one existed in primary or we don't because there was none to retrieve.
The existing `__clerk_synced=true` query param in the url will prevent the satellite from syncing again.



<!-- Fixes # (issue number) -->
