### PR TITLE
fix(clerk-js): Replace the basePath for flowStartPath to work in path routing

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -18,7 +18,10 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
           >
             <ProfileSettingsPage />
           </Route>
-          <Route path='leave'>
+          <Route
+            path='leave'
+            flowStart
+          >
             <LeaveOrganizationPage />
           </Route>
           <Route index>
@@ -28,7 +31,10 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
       </Route>
       <Route>
         <Switch>
-          <Route path='invite-members'>
+          <Route
+            path='invite-members'
+            flowStart
+          >
             <InviteMembersPage />
           </Route>
           <Route index>

--- a/packages/clerk-js/src/ui/elements/NavigateToFlowStartButton.tsx
+++ b/packages/clerk-js/src/ui/elements/NavigateToFlowStartButton.tsx
@@ -7,7 +7,7 @@ type NavigateToFlowStartButtonProps = PropsOfComponent<typeof Button>;
 export const useNavigateToFlowStart = () => {
   const router = useRouter();
   const navigateToFlowStart = async () => {
-    const to = '/' + router.basePath + router.startPath;
+    const to = '/' + router.basePath + router.flowStartPath;
     if (to !== router.currentPath) {
       return router.navigate(to);
     }

--- a/packages/clerk-js/src/ui/router/Route.tsx
+++ b/packages/clerk-js/src/ui/router/Route.tsx
@@ -1,7 +1,6 @@
-import { pathFromFullPath } from '@clerk/shared';
 import React from 'react';
 
-import { trimTrailingSlash } from '../../utils';
+import { pathFromFullPath, trimTrailingSlash } from '../../utils';
 import { newPaths } from './newPaths';
 import { match } from './pathToRegexp';
 import { RouteContext, useRouter } from './RouteContext';
@@ -88,10 +87,9 @@ export function Route(props: RouteProps): JSX.Element | null {
   }
 
   const flowStartPath = props.flowStart
-    ? pathFromFullPath(fullPath)
-        .replace(props.path || '', '')
-        //replace the base path for path routing to work
-        .replace('/' + router.basePath, '') || router.flowStartPath
+    ? //set it as the old full path (the previous step),
+      //replacing the base path for navigateToFlowStart() to work as expected
+      pathFromFullPath(router.fullPath).replace('/' + router.basePath, '')
     : router.flowStartPath;
 
   return (

--- a/packages/clerk-js/src/ui/router/Route.tsx
+++ b/packages/clerk-js/src/ui/router/Route.tsx
@@ -88,7 +88,10 @@ export function Route(props: RouteProps): JSX.Element | null {
   }
 
   const flowStartPath = props.flowStart
-    ? pathFromFullPath(fullPath).replace(props.path || '', '') || router.flowStartPath
+    ? pathFromFullPath(fullPath)
+        .replace(props.path || '', '')
+        //replace the base path for path routing to work
+        .replace('/' + router.basePath, '') || router.flowStartPath
     : router.flowStartPath;
 
   return (

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -358,3 +358,7 @@ export const mergeFragmentIntoUrl = (_url: string | URL): URL => {
 
   return mergedUrl;
 };
+
+export const pathFromFullPath = (fullPath: string) => {
+  return fullPath.replace(/CLERK-ROUTER\/(.*?)\//, '');
+};

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -25,7 +25,3 @@ export function addClerkPrefix(str: string | undefined) {
   const stripped = str.replace(regex, '');
   return `clerk.${stripped}`;
 }
-
-export const pathFromFullPath = (fullPath: string) => {
-  return fullPath.replace(/CLERK-ROUTER\/(.*?)\//, '');
-};


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
We also need to replace the `basePath` when generating the `flowStartPath` since it will be appended by `navigateToFlowStart`. This was an issue for path routing since that's when the `basePath` was actually populated.
<!-- Fixes # (issue number) -->
