### PR TITLE
fix(clerk-sdk-node): Encode debug headers to avoid Node app crash

### DIFF
--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -52,7 +52,7 @@ export const handleInterstitialCase = (res: ServerResponse, requestState: Reques
 };
 
 export const decorateResponseWithObservabilityHeaders = (res: ServerResponse, requestState: RequestState) => {
-  requestState.message && res.setHeader(constants.Headers.AuthMessage, requestState.message);
-  requestState.reason && res.setHeader(constants.Headers.AuthReason, requestState.reason);
-  requestState.status && res.setHeader(constants.Headers.AuthStatus, requestState.status);
+  requestState.message && res.setHeader(constants.Headers.AuthMessage, encodeURIComponent(requestState.message));
+  requestState.reason && res.setHeader(constants.Headers.AuthReason, encodeURIComponent(requestState.reason));
+  requestState.status && res.setHeader(constants.Headers.AuthStatus, encodeURIComponent(requestState.status));
 };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [-] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Related issue: https://github.com/clerkinc/javascript/issues/953
Related PR: https://github.com/clerkinc/javascript/pull/851