### PR TITLE
chore(remix): List @clerk/shared as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33489,6 +33489,7 @@
       "dependencies": {
         "@clerk/backend": "^0.14.0-staging.1",
         "@clerk/clerk-react": "^4.13.0-staging.10",
+        "@clerk/shared": "^0.14.0-staging.6",
         "@clerk/types": "^3.31.0-staging.6",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
@@ -39088,6 +39089,7 @@
       "requires": {
         "@clerk/backend": "^0.14.0-staging.1",
         "@clerk/clerk-react": "^4.13.0-staging.10",
+        "@clerk/shared": "^0.14.0-staging.6",
         "@clerk/types": "^3.31.0-staging.6",
         "@types/cookie": "^0.5.0",
         "@types/node": "^16.11.55",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@clerk/backend": "^0.14.0-staging.1",
     "@clerk/clerk-react": "^4.13.0-staging.10",
+    "@clerk/shared": "^0.14.0-staging.6",
     "@clerk/types": "^3.31.0-staging.6",
     "cookie": "0.5.0",
     "tslib": "2.4.1"


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Locally, the package exists in the root node_modules dir
When installed, the package gets installed as a dependency of clerk/clerk-react. However, it should be listed explicitly as a dependency

<!-- Fixes # (issue number) -->
