### PR TITLE
fix(clerk-js): Use hash based redirect urls for magic links

### DIFF
--- a/packages/clerk-js/src/ui/common/redirects.ts
+++ b/packages/clerk-js/src/ui/common/redirects.ts
@@ -15,7 +15,6 @@ export function buildMagicLinkRedirectUrl(
     authQueryString,
     path,
     endpoint: MAGIC_LINK_VERIFY_PATH_ROUTE,
-    forcePathBased: true,
   });
 }
 
@@ -40,17 +39,9 @@ type BuildRedirectUrlParams = {
   baseUrl: string;
   path: string | undefined;
   endpoint: string;
-  forcePathBased?: boolean;
 };
 
-const buildRedirectUrl = ({
-  routing,
-  authQueryString,
-  baseUrl,
-  path,
-  endpoint,
-  forcePathBased,
-}: BuildRedirectUrlParams): string => {
+const buildRedirectUrl = ({ routing, authQueryString, baseUrl, path, endpoint }: BuildRedirectUrlParams): string => {
   if (!routing || routing === 'hash') {
     return buildHashBasedUrl(authQueryString, endpoint);
   }
@@ -59,7 +50,7 @@ const buildRedirectUrl = ({
     return buildPathBasedUrl(path || '', authQueryString, endpoint);
   }
 
-  return buildVirtualBasedUrl(baseUrl || '', authQueryString, endpoint, forcePathBased);
+  return buildVirtualBasedUrl(baseUrl || '', authQueryString, endpoint);
 };
 
 const buildHashBasedUrl = (authQueryString: AuthQueryString, endpoint: string): string => {
@@ -79,18 +70,7 @@ const buildPathBasedUrl = (path: string, authQueryString: AuthQueryString, endpo
   );
 };
 
-const buildVirtualBasedUrl = (
-  base: string,
-  authQueryString: AuthQueryString,
-  endpoint: string,
-  forcePathBased?: boolean,
-): string => {
-  forcePathBased;
-  if (forcePathBased) {
-    const searchArg = authQueryString ? { search: `?${authQueryString}` } : {};
-    return buildURL({ base: base + endpoint, ...searchArg }, { stringify: true });
-  } else {
-    const hash = endpoint + (authQueryString ? `?${authQueryString}` : '');
-    return buildURL({ base, hash }, { stringify: true });
-  }
+const buildVirtualBasedUrl = (base: string, authQueryString: AuthQueryString, endpoint: string): string => {
+  const hash = endpoint + (authQueryString ? `?${authQueryString}` : '');
+  return buildURL({ base, hash }, { stringify: true });
 };

--- a/packages/clerk-js/src/ui/router/PathRouter.tsx
+++ b/packages/clerk-js/src/ui/router/PathRouter.tsx
@@ -36,8 +36,12 @@ export const PathRouter = ({ basePath, preservedParams, children }: PathRouterPr
   React.useEffect(() => {
     const effect = async () => {
       if (window.location.hash.startsWith('#/')) {
+        const url = new URL(window.location.href);
         const hashToPath = new URL(window.location.pathname + window.location.hash.substr(1), window.location.href);
         hashToPath.pathname = trimTrailingSlash(hashToPath.pathname);
+        for (const [key, value] of url.searchParams) {
+          hashToPath.searchParams.append(key, value);
+        }
         await navigate(stripOrigin(hashToPath));
         setStripped(true);
       }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR also persists the url variables when switching from a hash based url to a path based url, if the component is using path routing.
<!-- Fixes # (issue number) -->
