### PR TITLE
Append `__domain` query param to FAPI requests for satellite apps with dev instances

### DIFF
--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -6,6 +6,7 @@ import { API_VERSION } from '../constants';
 import runtime from '../runtime';
 import { callWithRetry } from '../util/callWithRetry';
 import { isStaging } from '../util/instance';
+import { isDevOrStagingUrl } from '../util/isDevOrStagingUrl';
 import { parsePublishableKey } from '../util/parsePublishableKey';
 import { joinPaths } from '../util/path';
 import { TokenVerificationError, TokenVerificationErrorAction, TokenVerificationErrorReason } from './errors';
@@ -40,6 +41,7 @@ export function addClerkPrefix(str: string | undefined) {
 
 export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions, 'apiUrl'>) {
   options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
+  const domainOnlyInProd = !isDevOrStagingUrl(options.frontendApi) ? addClerkPrefix(options.domain) : '';
   const { debugData, frontendApi, pkgVersion, publishableKey, proxyUrl, isSatellite = false, domain } = options;
   return `
     <head>
@@ -100,7 +102,7 @@ export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions,
                 ${domain ? `script.setAttribute('data-clerk-domain', '${domain}');` : ''}
                 ${proxyUrl ? `script.setAttribute('data-clerk-proxy-url', '${proxyUrl}')` : ''};
                 script.async = true;
-                script.src = '${getScriptUrl(proxyUrl || addClerkPrefix(domain) || frontendApi, pkgVersion)}';
+                script.src = '${getScriptUrl(proxyUrl || domainOnlyInProd || frontendApi, pkgVersion)}';
                 script.crossOrigin = 'anonymous';
                 script.addEventListener('load', startClerk);
                 document.body.appendChild(script);

--- a/packages/backend/src/util/isDevOrStagingUrl.ts
+++ b/packages/backend/src/util/isDevOrStagingUrl.ts
@@ -1,0 +1,34 @@
+// TODO: use the same function from @clerk/shared once treeshakable
+function createDevOrStagingUrlCache() {
+  const DEV_OR_STAGING_SUFFIXES = [
+    '.lcl.dev',
+    '.stg.dev',
+    '.lclstage.dev',
+    '.stgstage.dev',
+    '.dev.lclclerk.com',
+    '.stg.lclclerk.com',
+    '.accounts.lclclerk.com',
+    'accountsstage.dev',
+    'accounts.dev',
+  ];
+
+  const devOrStagingUrlCache = new Map<string, boolean>();
+
+  return {
+    isDevOrStagingUrl: (url: string | URL): boolean => {
+      if (!url) {
+        return false;
+      }
+
+      const hostname = typeof url === 'string' ? url : url.hostname;
+      let res = devOrStagingUrlCache.get(hostname);
+      if (res === undefined) {
+        res = DEV_OR_STAGING_SUFFIXES.some(s => hostname.endsWith(s));
+        devOrStagingUrlCache.set(hostname, res);
+      }
+      return res;
+    },
+  };
+}
+const { isDevOrStagingUrl } = createDevOrStagingUrlCache();
+export { isDevOrStagingUrl };

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1045,8 +1045,6 @@ export default class Clerk implements ClerkInterface {
       primarySyncUrl = new URL(`${proxy.pathname}/v1/client/sync`, proxy.origin);
     } else if (this.domain) {
       primarySyncUrl = new URL(`/v1/client/sync`, `https://${this.domain}`);
-    } else {
-      clerkMissingProxyUrlAndDomain();
     }
 
     primarySyncUrl?.searchParams.append('redirect_url', window.location.href);

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -160,7 +160,15 @@ export default class Clerk implements ClerkInterface {
   }
 
   get domain(): string {
-    return addClerkPrefix(stripScheme(handleValueOrFn(this.#domain, new URL(window.location.href))));
+    const strippedDomainString = stripScheme(handleValueOrFn(this.#domain, new URL(window.location.href)));
+    if (this.#instanceType === 'production') {
+      return addClerkPrefix(strippedDomainString);
+    }
+    return strippedDomainString;
+  }
+
+  get instanceType() {
+    return this.#instanceType;
   }
 
   public constructor(key: string, options?: DomainOrProxyUrl) {

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -132,7 +132,7 @@ export default class Clerk implements ClerkInterface {
   public readonly publishableKey?: string;
   public readonly proxyUrl?: ClerkInterface['proxyUrl'];
 
-  #domain?: ClerkInterface['domain'];
+  #domain: DomainOrProxyUrl['domain'];
   #authService: SessionCookieService | null = null;
   #broadcastChannel: LocalStorageBroadcastChannel<ClerkCoreBroadcastChannelEvent> | null = null;
   #componentControls?: ReturnType<MountComponentRenderer> | null;

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -9,7 +9,6 @@ import {
   hasExternalAccountSignUpError,
   isAccountsHostedPages,
   isDataUri,
-  isDevOrStagingUrl,
   isValidUrl,
   removeSearchParameterFromHash,
   setSearchParameterInHash,
@@ -32,31 +31,6 @@ describe('isAccountsHostedPages(url)', () => {
   test.each(goodUrls)('.isAccountsHostedPages(%s)', (a, expected) => {
     // @ts-ignore
     expect(isAccountsHostedPages(a)).toBe(expected);
-  });
-});
-
-describe('isDevOrStagingUrl(url)', () => {
-  const goodUrls: Array<[string | URL, boolean]> = [
-    ['https://www.google.com', false],
-    ['https://www.clerk.com', false],
-    ['https://www.lclclerk.com', false],
-    ['clerk.prod.lclclerk.com', false],
-    ['something.dev.lclclerk.com', true],
-    ['something.lcl.dev', true],
-    ['https://www.something.stg.lclclerk.com', true],
-    [new URL('https://www.lclclerk.com'), false],
-    [new URL('https://www.something.stg.lclclerk.com'), true],
-    [new URL('https://www.something.stg.lclclerk.com:4000'), true],
-  ];
-
-  const badUrls: Array<[string | null, boolean]> = [
-    ['', false],
-    [null, false],
-  ];
-
-  test.each([...goodUrls, ...badUrls])('.isDevOrStagingUrl(%s)', (a, expected) => {
-    // @ts-ignore
-    expect(isDevOrStagingUrl(a)).toBe(expected);
   });
 });
 

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -1,4 +1,4 @@
-import { camelToSnake, isIPV4Address } from '@clerk/shared';
+import { camelToSnake, createDevOrStagingUrlCache, isIPV4Address } from '@clerk/shared';
 import type { SignUpResource } from '@clerk/types';
 
 import { loadScript } from '../utils';
@@ -36,22 +36,9 @@ export const DEV_OR_STAGING_SUFFIXES = [
 
 const BANNED_URI_PROTOCOLS = ['javascript:'] as const;
 
-const devOrStagingUrlCache = new Map<string, boolean>();
+const { isDevOrStagingUrl } = createDevOrStagingUrlCache();
+export { isDevOrStagingUrl };
 const accountsCache = new Map<string, boolean>();
-
-export function isDevOrStagingUrl(url: string | URL): boolean {
-  if (!url) {
-    return false;
-  }
-
-  const hostname = typeof url === 'string' ? url : url.hostname;
-  let res = devOrStagingUrlCache.get(hostname);
-  if (res === undefined) {
-    res = DEV_OR_STAGING_SUFFIXES.some(s => hostname.endsWith(s));
-    devOrStagingUrlCache.set(hostname, res);
-  }
-  return res;
-}
 
 export function isAccountsHostedPages(url: string | URL = window.location.hostname): boolean {
   if (!url) {

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -55,6 +55,10 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
     const isSatellite = handleValueOrFn(opts.isSatellite, new URL(req.url), IS_SATELLITE);
     const domain = handleValueOrFn(opts.domain, new URL(req.url), DOMAIN);
 
+    if (isSatellite && !proxyUrl && !domain) {
+      throw new Error(`Missing domain and proxyUrl. A satellite application needs to specify a domain or a proxyUrl`);
+    }
+
     // get auth state, check if we need to return an interstitial
     const cookieToken = getCookie(req, constants.Cookies.Session);
     const headerToken = headers.get('authorization')?.replace('Bearer ', '');

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -7,6 +7,7 @@ import type {
   ClientResource,
   CreateOrganizationParams,
   CreateOrganizationProps,
+  DomainOrProxyUrl,
   HandleMagicLinkVerificationParams,
   HandleOAuthCallbackParams,
   OrganizationMembershipResource,
@@ -72,7 +73,7 @@ export default class IsomorphicClerk {
   private loadedListeners: Array<() => void> = [];
 
   #loaded = false;
-  #domain?: ClerkInterface['domain'];
+  #domain: DomainOrProxyUrl['domain'];
 
   get loaded(): boolean {
     return this.#loaded;

--- a/packages/react/src/utils/isDevOrStageUrl.tsx
+++ b/packages/react/src/utils/isDevOrStageUrl.tsx
@@ -1,0 +1,3 @@
+import { createDevOrStagingUrlCache } from '@clerk/shared';
+const { isDevOrStagingUrl } = createDevOrStagingUrlCache();
+export { isDevOrStagingUrl };

--- a/packages/react/src/utils/scriptLoader.ts
+++ b/packages/react/src/utils/scriptLoader.ts
@@ -3,6 +3,7 @@ import { addClerkPrefix, isValidProxyUrl, parsePublishableKey, proxyUrlToAbsolut
 import { LIB_VERSION } from '../info';
 import type { BrowserClerk } from '../types';
 import { errorThrower } from './errorThrower';
+import { isDevOrStagingUrl } from './isDevOrStageUrl';
 
 export interface Global {
   Clerk?: BrowserClerk;
@@ -48,7 +49,7 @@ function getScriptSrc({
   let scriptHost = '';
   if (!!proxyUrl && isValidProxyUrl(proxyUrl)) {
     scriptHost = proxyUrlToAbsoluteURL(proxyUrl).replace(/http(s)?:\/\//, '');
-  } else if (domain) {
+  } else if (domain && !isDevOrStagingUrl(parsePublishableKey(publishableKey)?.frontendApi || frontendApi || '')) {
     scriptHost = addClerkPrefix(domain);
   } else {
     scriptHost = parsePublishableKey(publishableKey)?.frontendApi || frontendApi || '';

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -78,3 +78,7 @@ Otherwise, you can pass a secretKey parameter to rootAuthLoader or getAuth.
 export const noRelativeProxyInSSR = createErrorMessage(
   `Only a absolute URL that starts with https is allowed to be used in SSR`,
 );
+
+export const satelliteAndMissingProxyUrlAndDomain = createErrorMessage(
+  `Missing domain and proxyUrl. A satellite application needs to specify a domain or a proxyUrl`,
+);

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -2,7 +2,7 @@ import type { RequestState } from '@clerk/backend';
 import { Clerk } from '@clerk/backend';
 import { handleValueOrFn, isHttpOrHttps } from '@clerk/shared';
 
-import { noRelativeProxyInSSR, noSecretKeyOrApiKeyError } from '../errors';
+import { noRelativeProxyInSSR, noSecretKeyOrApiKeyError, satelliteAndMissingProxyUrlAndDomain } from '../errors';
 import { getEnvVariable } from '../utils';
 import type { LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
 import { parseCookies } from './utils';
@@ -51,6 +51,10 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
 
   if (!!proxyUrl && !isHttpOrHttps(proxyUrl)) {
     throw new Error(noRelativeProxyInSSR);
+  }
+
+  if (isSatellite && !proxyUrl && !domain) {
+    throw new Error(satelliteAndMissingProxyUrlAndDomain);
   }
 
   const { headers } = request;

--- a/packages/shared/src/utils/keys.test.ts
+++ b/packages/shared/src/utils/keys.test.ts
@@ -1,4 +1,10 @@
-import { buildPublishableKey, isLegacyFrontendApiKey, isPublishableKey, parsePublishableKey } from './keys';
+import {
+  buildPublishableKey,
+  createDevOrStagingUrlCache,
+  isLegacyFrontendApiKey,
+  isPublishableKey,
+  parsePublishableKey,
+} from './keys';
 
 describe('buildPublishableKey(key)', () => {
   const cases = [
@@ -53,5 +59,32 @@ describe('isLegacyFrontendApiKey(key)', () => {
   });
   it('returns true if the key is not a valid legacy frontend Api key', () => {
     expect(isLegacyFrontendApiKey('pk_live_Y2xlcmsuY2xlcmsuZGV2JA==')).toBe(false);
+  });
+});
+
+describe('isDevOrStagingUrl(url)', () => {
+  const { isDevOrStagingUrl } = createDevOrStagingUrlCache();
+
+  const goodUrls: Array<[string | URL, boolean]> = [
+    ['https://www.google.com', false],
+    ['https://www.clerk.dev', false],
+    ['https://www.lclclerk.com', false],
+    ['clerk.prod.lclclerk.com', false],
+    ['something.dev.lclclerk.com', true],
+    ['something.lcl.dev', true],
+    ['https://www.something.stg.lclclerk.com', true],
+    [new URL('https://www.lclclerk.com'), false],
+    [new URL('https://www.something.stg.lclclerk.com'), true],
+    [new URL('https://www.something.stg.lclclerk.com:4000'), true],
+  ];
+
+  const badUrls: Array<[string | null, boolean]> = [
+    ['', false],
+    [null, false],
+  ];
+
+  test.each([...goodUrls, ...badUrls])('.isDevOrStagingUrl(%s)', (a, expected) => {
+    // @ts-ignore
+    expect(isDevOrStagingUrl(a)).toBe(expected);
   });
 });

--- a/packages/shared/src/utils/keys.ts
+++ b/packages/shared/src/utils/keys.ts
@@ -53,3 +53,35 @@ export function isLegacyFrontendApiKey(key: string) {
 
   return key.startsWith('clerk.');
 }
+
+export function createDevOrStagingUrlCache() {
+  const DEV_OR_STAGING_SUFFIXES = [
+    '.lcl.dev',
+    '.stg.dev',
+    '.lclstage.dev',
+    '.stgstage.dev',
+    '.dev.lclclerk.com',
+    '.stg.lclclerk.com',
+    '.accounts.lclclerk.com',
+    'accountsstage.dev',
+    'accounts.dev',
+  ];
+
+  const devOrStagingUrlCache = new Map<string, boolean>();
+
+  return {
+    isDevOrStagingUrl: (url: string | URL): boolean => {
+      if (!url) {
+        return false;
+      }
+
+      const hostname = typeof url === 'string' ? url : url.hostname;
+      let res = devOrStagingUrlCache.get(hostname);
+      if (res === undefined) {
+        res = DEV_OR_STAGING_SUFFIXES.some(s => hostname.endsWith(s));
+        devOrStagingUrlCache.set(hostname, res);
+      }
+      return res;
+    },
+  };
+}

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -75,6 +75,9 @@ export interface Clerk {
    */
   domain?: string | ((url: URL) => string);
 
+  /** Clerk Flag for satellite apps. */
+  isSatellite: boolean;
+
   instanceType?: InstanceType;
 
   /** Client handling most Clerk operations. */

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -69,11 +69,8 @@ export interface Clerk {
   /** Clerk Proxy url string. */
   proxyUrl?: string;
 
-  /**
-   * @experimental
-   * Clerk Satellite Frontend API string.
-   */
-  domain?: string | ((url: URL) => string);
+  /** Clerk Satellite Frontend API string. */
+  domain: string;
 
   /** Clerk Flag for satellite apps. */
   isSatellite: boolean;

--- a/packages/types/src/multiDomain.ts
+++ b/packages/types/src/multiDomain.ts
@@ -1,4 +1,6 @@
-import type { Clerk as ClerkInterface, ClerkOptions } from './clerk';
+import type { ClerkOptions } from './clerk';
+
+type DOMAIN = string | ((url: URL) => string);
 
 /**
  * DomainOrProxyUrl supports the following cases
@@ -16,7 +18,7 @@ export type MultiDomainAndOrProxy =
   | {
       isSatellite: Exclude<ClerkOptions['isSatellite'], undefined>;
       proxyUrl?: never;
-      domain: Exclude<ClerkInterface['domain'], undefined>;
+      domain: DOMAIN;
     }
   | {
       isSatellite: Exclude<ClerkOptions['isSatellite'], undefined>;
@@ -44,7 +46,7 @@ export type MultiDomainAndOrProxyPrimitives =
 export type DomainOrProxyUrl =
   | {
       proxyUrl?: never;
-      domain?: ClerkInterface['domain'];
+      domain?: DOMAIN;
     }
   | {
       proxyUrl?: string;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR tackles:

- changes to fapiClient when domain is used in dev instances
- constructing clerk.js script url when domain is used in dev instances (affects the react package and interstitial)
- Clerk.js throws an error if isSatellite is set without proxyUrl or domain. (for both prod and dev instances)
- withClerkMiddleware and rootAuthLoader  throw the same error mentioned in the previous line

In order to complete the above items some refactor was needed:
- `isDevOrStagingUrl` utility function  was moved from `clerk-js` to `shared`
- fixed types for Clerk.js Singleton (domain, isSatellite)

<!-- Fixes # (issue number) -->
