### PR TITLE
Improve phone input parsing

### DIFF
--- a/packages/clerk-js/src/core/resources/Environment.ts
+++ b/packages/clerk-js/src/core/resources/Environment.ts
@@ -19,7 +19,7 @@ export class Environment extends BaseResource implements EnvironmentResource {
   displayConfig!: DisplayConfigResource;
   userSettings!: UserSettingsResource;
   organizationSettings!: OrganizationSettingsResource;
-  country!: CountryIso | null;
+  countryIso!: CountryIso | null;
 
   public static getInstance(): Environment {
     if (!Environment.instance) {
@@ -60,8 +60,8 @@ export class Environment extends BaseResource implements EnvironmentResource {
   protected fromJSON(data: EnvironmentJSON | null): this {
     if (data) {
       this.authConfig = new AuthConfig(data.auth_config);
-      const country = data.meta?.responseHeaders?.country;
-      this.country = (country ? country.toLowerCase() : null) as CountryIso | null;
+      const countryIso = data.meta?.responseHeaders?.country;
+      this.countryIso = (countryIso ? countryIso.toLowerCase() : null) as CountryIso | null;
       this.displayConfig = new DisplayConfig(data.display_config);
       this.userSettings = new UserSettings(data.user_settings);
       this.organizationSettings = new OrganizationSettings(data.organization_settings);

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -158,7 +158,7 @@ describe('SignUpStart', () => {
       fixtures.clerk.client.signUp.emailAddress = 'george@clerk.dev';
       fixtures.clerk.client.signUp.firstName = 'George';
       fixtures.clerk.client.signUp.lastName = 'Clerk';
-      fixtures.clerk.client.signUp.phoneNumber = '123456789';
+      fixtures.clerk.client.signUp.phoneNumber = '+1123456789';
 
       const screen = render(<SignUpStart />, { wrapper });
 

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -54,7 +54,12 @@ const PhoneInputBase = (props: PhoneInputProps) => {
   };
 
   const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNumber(e.target.value);
+    const inputValue = e.target.value;
+    if (inputValue.includes('+')) {
+      setNumberAndIso(inputValue);
+    } else {
+      setNumber(inputValue);
+    }
   };
 
   return (
@@ -119,6 +124,9 @@ const PhoneInputBase = (props: PhoneInputProps) => {
         value={formattedNumber}
         onPaste={handlePaste}
         onChange={handlePhoneNumberChange}
+        onInput={e => {
+          console.log('input', e);
+        }}
         maxLength={25}
         type='tel'
         sx={theme => ({

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -1,6 +1,5 @@
 import React, { useLayoutEffect, useState } from 'react';
 
-import { getLongestValidCountryCode } from '../../../ui/utils/phoneUtils';
 import { useEnvironment } from '../../contexts';
 import { Flex, Input, Text } from '../../customizables';
 import { Select, SelectButton, SelectOptionList } from '../../elements';
@@ -21,48 +20,41 @@ const createSelectOption = (country: CountryEntry) => {
 
 const countryOptions = [...IsoToCountryMap.values()].map(createSelectOption);
 
-type PhoneInputProps = PropsOfComponent<typeof Input> & { defaultSelectedIso?: CountryIso };
+type PhoneInputProps = PropsOfComponent<typeof Input> & { locationBasedCountryIso?: CountryIso };
 
 const PhoneInputBase = (props: PhoneInputProps) => {
-  const { onChange: onChangeProp, value, defaultSelectedIso = 'us', ...rest } = props;
+  const { onChange: onChangeProp, value, locationBasedCountryIso, ...rest } = props;
   const phoneInputRef = React.useRef<HTMLInputElement>(null);
-  const { setPhoneNumber, cleanPhoneNumber, formattedPhoneNumber, selectedIso, setSelectedIso } =
-    useFormattedPhoneNumber({
-      defaultPhone: value as string,
-      defaultSelectedIso: defaultSelectedIso.toLowerCase() as CountryIso,
-    });
+  const { setNumber, setIso, setNumberAndIso, numberWithCode, iso, formattedNumber } = useFormattedPhoneNumber({
+    initPhoneWithCode: value as string,
+    locationBasedCountryIso,
+  });
 
   const callOnChangeProp = () => {
     // Quick and dirty way to match this component's public API
     // with every other Input component, so we can use the same helpers
     // without worrying about the underlying implementation details
-    onChangeProp?.({ target: { value: cleanPhoneNumber } } as any);
+    onChangeProp?.({ target: { value: numberWithCode } } as any);
   };
 
   const selectedCountryOption = React.useMemo(() => {
-    return countryOptions.find(o => o.country.iso === selectedIso) || countryOptions[0];
-  }, [selectedIso]);
+    return countryOptions.find(o => o.country.iso === iso) || countryOptions[0];
+  }, [iso]);
 
-  React.useEffect(callOnChangeProp, [cleanPhoneNumber]);
+  React.useEffect(callOnChangeProp, [numberWithCode]);
 
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
     const inputValue = e.clipboardData.getData('text');
-
     if (inputValue.includes('+')) {
-      const { phoneNumberValue, selectedCountry } = getLongestValidCountryCode(inputValue);
-
-      if (selectedCountry) {
-        setSelectedIso(selectedCountry?.iso);
-        setPhoneNumber(phoneNumberValue, selectedCountry?.iso);
-        return;
-      }
+      setNumberAndIso(inputValue);
+    } else {
+      setNumber(inputValue);
     }
-    setPhoneNumber(inputValue);
   };
 
   const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPhoneNumber(e.target.value);
+    setNumber(e.target.value);
   };
 
   return (
@@ -86,7 +78,7 @@ const PhoneInputBase = (props: PhoneInputProps) => {
           />
         )}
         onChange={option => {
-          setSelectedIso(option.country.iso);
+          setIso(option.country.iso);
           phoneInputRef.current?.focus();
         }}
         noResultsMessage='No countries found'
@@ -109,7 +101,7 @@ const PhoneInputBase = (props: PhoneInputProps) => {
               borderTopRightRadius: '0',
             })}
           >
-            <Flag iso={selectedIso} />
+            <Flag iso={iso} />
             <Text
               variant={'smallRegular'}
               sx={{ paddingLeft: '4px' }}
@@ -124,7 +116,7 @@ const PhoneInputBase = (props: PhoneInputProps) => {
         />
       </Select>
       <Input
-        value={formattedPhoneNumber}
+        value={formattedNumber}
         onPaste={handlePaste}
         onChange={handlePhoneNumberChange}
         maxLength={25}
@@ -195,12 +187,12 @@ const Flag = (props: { iso: CountryIso }) => {
 };
 
 export const PhoneInput = (props: Omit<PhoneInputProps, 'dd'>) => {
-  const { country } = useEnvironment();
+  const environment = useEnvironment();
 
   return (
     <PhoneInputBase
       {...props}
-      defaultSelectedIso={(country || 'us') as CountryIso}
+      locationBasedCountryIso={environment.countryIso as CountryIso}
     />
   );
 };

--- a/packages/clerk-js/src/ui/elements/PhoneInput/__tests__/useFormattedPhoneNumber.test.ts
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/__tests__/useFormattedPhoneNumber.test.ts
@@ -1,0 +1,121 @@
+import { renderHook } from '@clerk/shared/testUtils';
+import { waitFor } from '@testing-library/dom';
+
+import { useFormattedPhoneNumber } from '../useFormattedPhoneNumber';
+
+describe('useFormattedPhoneNumber', () => {
+  afterEach(() => {
+    // Empty the localStorage used within the hook
+    window.localStorage.clear();
+  });
+
+  it('should parse and split the init phone value', () => {
+    const { result } = renderHook(() =>
+      useFormattedPhoneNumber({
+        initPhoneWithCode: '+71111111111',
+        locationBasedCountryIso: undefined,
+      }),
+    );
+
+    const { number, iso, formattedNumber, numberWithCode } = result.current;
+    expect(number).toBe('1111111111');
+    expect(iso).toBe('ru');
+    expect(numberWithCode).toBe('+71111111111');
+    expect(formattedNumber).toBe('111 111-11-11');
+  });
+
+  it('should return the correct iso for the number even if location based iso is wrong', () => {
+    const { result } = renderHook(() =>
+      useFormattedPhoneNumber({
+        initPhoneWithCode: '+1 (202) 123 1234',
+        locationBasedCountryIso: 'gr',
+      }),
+    );
+
+    const { number, iso, formattedNumber, numberWithCode } = result.current;
+    expect(number).toBe('2021231234');
+    expect(iso).toBe('us');
+    expect(numberWithCode).toBe('+12021231234');
+    expect(formattedNumber).toBe('(202) 123-1234');
+  });
+
+  it('should correctly handle initialing with an empty value', async () => {
+    const { result } = renderHook(() =>
+      useFormattedPhoneNumber({
+        initPhoneWithCode: '',
+        locationBasedCountryIso: undefined,
+      }),
+    );
+
+    const { number, iso, formattedNumber, numberWithCode } = result.current;
+
+    await waitFor(() => {
+      expect(number).toBe('');
+      expect(iso).toBe('us');
+      expect(numberWithCode).toBe('');
+      expect(formattedNumber).toBe('');
+    });
+  });
+
+  it('should return the correct number and iso when pasting a number containing a country code', async () => {
+    const { result, rerender, unmount } = renderHook(() =>
+      useFormattedPhoneNumber({
+        initPhoneWithCode: '+71111111111',
+        locationBasedCountryIso: undefined,
+      }),
+    );
+
+    expect(result.current.numberWithCode).toBe('+71111111111');
+    expect(result.current.iso).toBe('ru');
+
+    // change number, keep iso
+    await waitFor(() => {
+      result.current.setNumberAndIso('+1 (202) 123 1234');
+      rerender();
+    });
+
+    expect(result.current.number).toBe('2021231234');
+    expect(result.current.iso).toBe('us');
+    expect(result.current.numberWithCode).toBe('+12021231234');
+    expect(result.current.formattedNumber).toBe('(202) 123-1234');
+    unmount();
+  });
+
+  it('should return the correct iso for the number even if location based iso is wrong', async () => {
+    const { result, rerender, unmount } = renderHook(() =>
+      useFormattedPhoneNumber({
+        initPhoneWithCode: '',
+        locationBasedCountryIso: 'gr',
+      }),
+    );
+
+    expect(result.current.number).toBe('');
+    expect(result.current.iso).toBe('gr');
+    expect(result.current.numberWithCode).toBe('');
+    expect(result.current.formattedNumber).toBe('');
+
+    // change number, keep iso
+    await waitFor(() => {
+      result.current.setNumber('6949595959');
+      rerender();
+    });
+
+    expect(result.current.number).toBe('6949595959');
+    expect(result.current.iso).toBe('gr');
+    expect(result.current.numberWithCode).toBe('+306949595959');
+    expect(result.current.formattedNumber).toBe('694 9595959');
+
+    // change iso, keep number
+    await waitFor(() => {
+      result.current.setIso('us');
+      rerender();
+    });
+
+    expect(result.current.number).toBe('6949595959');
+    expect(result.current.iso).toBe('us');
+    expect(result.current.numberWithCode).toBe('+16949595959');
+    expect(result.current.formattedNumber).toBe('(694) 959-5959');
+
+    unmount();
+  });
+});

--- a/packages/clerk-js/src/ui/elements/PhoneInput/countryCodeData.ts
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/countryCodeData.ts
@@ -6,12 +6,12 @@ export type PhonePattern = CountryCodeData[number][3] | '';
 
 const data = [
   ['United States', 'us', '1', '(...) ...-....', 100],
-  ['United Kingdom', 'gb', '44', '.... ......'],
-  ['India', 'in', '91', '.....-.....'],
-  ['Canada', 'ca', '1', '(...) ...-....'],
-  ['Germany', 'de', '49', '... .......'],
-  ['France', 'fr', '33', '. .. .. .. ..'],
-  ['Russia', 'ru', '7', '... ...-..-..'],
+  ['United Kingdom', 'gb', '44', '.... ......', 100],
+  ['India', 'in', '91', '.....-.....', 100],
+  ['Canada', 'ca', '1', '(...) ...-....', 100],
+  ['Germany', 'de', '49', '... .......', 100],
+  ['France', 'fr', '33', '. .. .. .. ..', 100],
+  ['Russia', 'ru', '7', '... ...-..-..', 100],
   ['Afghanistan', 'af', '93'],
   ['Albania', 'al', '355'],
   ['Algeria ', 'dz', '213'],
@@ -563,9 +563,11 @@ export const IsoToCountryMap: IsoToCountryMapType = data.reduce(
   new Map<CountryIso, CountryEntry>(),
 );
 
-export type CodeToCountryIsoMapType = ReadonlyMap<DialingCode, CountryIso>;
+export type CodeToCountryIsoMapType = ReadonlyMap<DialingCode, CountryEntry[]>;
 
-export const CodeToCountryIsoMap: CodeToCountryIsoMapType = data.reduce(
-  (acc, cur) => acc.set(cur[2], cur[1]),
-  new Map<DialingCode, CountryIso>(),
-);
+export const CodeToCountriesMap: CodeToCountryIsoMapType = data.reduce((acc, cur) => {
+  const code = cur[2];
+  const country = createEntry(cur);
+  acc.get(code) ? acc.get(code)!.push(country) : acc.set(code, [country]);
+  return acc;
+}, new Map<DialingCode, CountryEntry[]>());

--- a/packages/clerk-js/src/ui/utils/__tests__/phoneUtils.test.ts
+++ b/packages/clerk-js/src/ui/utils/__tests__/phoneUtils.test.ts
@@ -1,9 +1,9 @@
 import {
   extractDigits,
   formatPhoneNumber,
+  getCountryFromPhoneString,
   getCountryIsoFromFormattedNumber,
   getFlagEmojiFromCountryIso,
-  getLongestValidCountryCode,
 } from '../phoneUtils';
 
 describe('phoneUtils', () => {
@@ -163,7 +163,7 @@ describe('phoneUtils', () => {
     });
   });
 
-  describe('formattedNumberToFlagEmoji(formattedNumber)', () => {
+  describe('getCountryIsoFromFormattedNumber(formattedNumber)', () => {
     it('handles edge cases', () => {
       const res = getCountryIsoFromFormattedNumber(undefined as any);
       expect(res).toBe('us');
@@ -184,9 +184,9 @@ describe('phoneUtils', () => {
       expect(res).toBe('ca');
     });
 
-    it('handles a non-US phone starting with 1 but has a potential non-US code', () => {
+    it('prioritizes US for a non-US phone starting with 1 that has a potential non-US code', () => {
       const res = getCountryIsoFromFormattedNumber('+1242 123123');
-      expect(res).toBe('bs');
+      expect(res).toBe('us');
     });
 
     it('handles a non-US phone starting with code != 1', () => {
@@ -195,30 +195,29 @@ describe('phoneUtils', () => {
     });
 
     it('handles a non-US phone without a format pattern', () => {
-      const res = getCountryIsoFromFormattedNumber('+1758 123123');
-      expect(res).toBe('lc');
+      expect(getCountryIsoFromFormattedNumber('+71111111111')).toBe('ru');
     });
   });
 
   describe('getLongestValidCountryCode(value)', () => {
     it('finds valid country and returns phone number value without country code', () => {
-      const res = getLongestValidCountryCode('+12064563059');
-      expect(res.phoneNumberValue).toBe('2064563059');
-      expect(res.selectedCountry).not.toBe(undefined);
-      expect(res.selectedCountry?.code).toBe('1');
+      const res = getCountryFromPhoneString('+12064563059');
+      expect(res.number).toBe('2064563059');
+      expect(res.country).not.toBe(undefined);
+      expect(res.country.code).toBe('1');
     });
 
     it('finds valid country by applying priority', () => {
-      const res = getLongestValidCountryCode('+1242123123');
-      expect(res.phoneNumberValue).toBe('242123123');
-      expect(res.selectedCountry).not.toBe(undefined);
-      expect(res.selectedCountry?.code).toBe('1');
+      const res = getCountryFromPhoneString('+1242123123');
+      expect(res.number).toBe('242123123');
+      expect(res.country).not.toBe(undefined);
+      expect(res.country.code).toBe('1');
     });
 
-    it('does not find valid country code and returns phone number value as is', () => {
-      const res = getLongestValidCountryCode('+699090909090');
-      expect(res.phoneNumberValue).toBe('699090909090');
-      expect(res.selectedCountry).toBe(undefined);
+    it('falls back to US if a valid country code is not found', () => {
+      const res = getCountryFromPhoneString('+699090909090');
+      expect(res.number).toBe('99090909090');
+      expect(res.country.iso).toBe('us');
     });
   });
 });

--- a/packages/clerk-js/src/ui/utils/formatSafeIdentifier.test.ts
+++ b/packages/clerk-js/src/ui/utils/formatSafeIdentifier.test.ts
@@ -1,0 +1,16 @@
+import { formatSafeIdentifier } from './formatSafeIdentifier';
+
+describe('formatSafeIdentifier', () => {
+  const cases = [
+    ['hello@example.com', 'hello@example.com'],
+    ['h***@***.com', 'h***@***.com'],
+    ['username', 'username'],
+    ['u***e', 'u***e'],
+    ['+71111111111', '+7 111 111-11-11'],
+    ['+791*******1', '+791*******1'],
+  ];
+
+  it.each(cases)('formats the safe identifier', (str, expected) => {
+    expect(formatSafeIdentifier(str)).toBe(expected);
+  });
+});

--- a/packages/clerk-js/src/ui/utils/formatSafeIdentifier.ts
+++ b/packages/clerk-js/src/ui/utils/formatSafeIdentifier.ts
@@ -2,6 +2,11 @@ import { stringToFormattedPhoneString } from './phoneUtils';
 
 export const isMaskedIdentifier = (str: string | undefined | null) => str && str.includes('**');
 
+/**
+ * Formats a string that can contain an email, a username or a phone number.
+ * Depending on the scenario, the string might be obfuscated (parts of the identifier replaced with "*")
+ * Refer to the tests for examples.
+ */
 export const formatSafeIdentifier = (str: string | undefined | null) => {
   if (!str || str.includes('@') || isMaskedIdentifier(str) || str.match(/[a-zA-Z]/)) {
     return str;

--- a/packages/types/src/environment.ts
+++ b/packages/types/src/environment.ts
@@ -13,5 +13,5 @@ export interface EnvironmentResource extends ClerkResource {
   isProduction: () => boolean;
   isDevelopmentOrStaging: () => boolean;
   onWindowLocationHost: () => boolean;
-  country: string | null;
+  countryIso: string | null;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

Refactors the phone utils to make phone parsing more accurate.
This PR also improves PhoneInput component  as it now correctly handles more user input events.

In general, the input now respects this priority order:

- "us" as a default fallback, or
- country iso from the header, or
- country iso from localstorage, or
- country iso from the previous signup.phoneNumber value, or
- country iso from the paste event, or
- country iso after the user explicitly picked a country using the picker (this is persisted locally)


<!-- Description of the Pull Request -->
Fixes JS-276
Fixes JS-275
<!-- Fixes # (issue number) -->
