### PR TITLE
fix(clerk-js): Focus on the first digit the first time user clicks on Phone code input

### DIFF
--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -53,6 +53,7 @@ type CodeControlProps = UseCodeControlReturn['otpInputProps'] & {
 export const CodeControl = React.forwardRef<{ reset: any }, CodeControlProps>((props, ref) => {
   const [disabled, setDisabled] = React.useState(false);
   const refs = React.useRef<Array<HTMLInputElement | null>>([]);
+  const firstClickRef = React.useRef(false);
   const { values, setValues, isDisabled, errorText, isSuccessfullyFilled, isLoading, length } = props;
 
   React.useImperativeHandle(ref, () => ({
@@ -90,6 +91,14 @@ export const CodeControl = React.forwardRef<{ reset: any }, CodeControlProps>((p
 
   const handleOnClick = (index: number) => (e: React.MouseEvent<HTMLInputElement>) => {
     e.preventDefault();
+    // Focus on the first digit, when the first click happens.
+    // This is helpful especially for mobile (iOS) devices that cannot autofocus
+    // and user needs to manually tap the input area
+    if (!firstClickRef.current) {
+      focusInputAt(0);
+      firstClickRef.current = true;
+      return;
+    }
     focusInputAt(index);
   };
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This change fixes a UX issue.

The issue is that Safari on iOS won't let you programmatically focus an input field if no user interaction has happened first. So the user has to focus on the input area by tapping, and the bad part is that they have to aim for the first digit, or else the autofill from the messages starts filling from the digit they focused on.

With this change, we focus on the first digit the first time the user clicks/taps on any of the digit inputs. This way, the autofill works smoothly, and even if they don't use the autofill, they will start typing from the first digit.
<!-- Fixes # (issue number) -->
