### PR TITLE
fix(clerk-react): Fallback to Clerk.isReady if Clerk.loaded is not available

### DIFF
--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -3,6 +3,7 @@ import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
   Clerk,
+  Clerk as ClerkInterface,
   ClientResource,
   CreateOrganizationParams,
   CreateOrganizationProps,
@@ -22,7 +23,6 @@ import type {
   UserProfileProps,
   UserResource,
 } from '@clerk/types';
-import type { Clerk as ClerkInterface } from '@clerk/types';
 import type { OrganizationProfileProps, OrganizationSwitcherProps } from '@clerk/types/src';
 
 import type {
@@ -166,7 +166,10 @@ export default class IsomorphicClerk {
         await global.Clerk.load(this.options);
       }
 
-      return global.Clerk?.loaded ? this.hydrateClerkJS(global.Clerk) : undefined;
+      if (global.Clerk?.loaded || global.Clerk?.isReady()) {
+        return this.hydrateClerkJS(global.Clerk);
+      }
+      return;
     } catch (err) {
       const error = err as Error;
       // In Next.js we can throw a full screen error in development mode.


### PR DESCRIPTION

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This change makes clerk/clerk-react compatible with both clerk-js@3 and clerk-js@4 in regards to loading in standards browser. This allows the accounts project to load any of these 2 versions on a per-request basis, even if the latest clerk/clerk-react package is installed

<!-- Fixes # (issue number) -->
