### PR TITLE
feat(backend): Propagate audience option to verifyToken

### DIFF
--- a/packages/backend/src/tokens/jwt.ts
+++ b/packages/backend/src/tokens/jwt.ts
@@ -149,7 +149,7 @@ export async function verifyJwt(
 
   // Verify audience claim (aud)
   if (typeof aud === 'string') {
-    if (aud !== audience) {
+    if (audience && aud !== audience) {
       throw new TokenVerificationError({
         action: TokenVerificationErrorAction.EnsureClerkJWT,
         reason: TokenVerificationErrorReason.TokenVerificationFailed,
@@ -157,7 +157,7 @@ export async function verifyJwt(
       });
     }
   } else if (Array.isArray(aud) && aud.length > 0 && aud.every(a => typeof a === 'string')) {
-    if (!aud.includes(audience)) {
+    if (audience && !aud.includes(audience)) {
       throw new TokenVerificationError({
         action: TokenVerificationErrorAction.EnsureClerkJWT,
         reason: TokenVerificationErrorReason.TokenVerificationFailed,

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -33,7 +33,13 @@ export type RequiredVerifyTokenOptions = Required<
 export type OptionalVerifyTokenOptions = Partial<
   Pick<
     VerifyTokenOptions,
-    'authorizedParties' | 'clockSkewInSeconds' | 'jwksCacheTtlInMs' | 'skipJwksCache' | 'jwtKey' | 'proxyUrl'
+    | 'audience'
+    | 'authorizedParties'
+    | 'clockSkewInSeconds'
+    | 'jwksCacheTtlInMs'
+    | 'skipJwksCache'
+    | 'jwtKey'
+    | 'proxyUrl'
   >
 >;
 

--- a/packages/backend/src/tokens/verify.ts
+++ b/packages/backend/src/tokens/verify.ts
@@ -23,6 +23,7 @@ export async function verifyToken(token: string, options: VerifyTokenOptions): P
     secretKey,
     apiUrl,
     apiVersion,
+    audience,
     authorizedParties,
     clockSkewInSeconds,
     issuer,
@@ -53,6 +54,7 @@ export async function verifyToken(token: string, options: VerifyTokenOptions): P
   }
 
   return await verifyJwt(token, {
+    audience,
     authorizedParties,
     clockSkewInSeconds,
     key,

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -12,7 +12,7 @@ import { parseCookies } from './utils';
  */
 export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoaderOptions = {}): Promise<RequestState> {
   const { request, context } = args;
-  const { loadSession, loadUser, loadOrganization, authorizedParties } = opts;
+  const { loadSession, loadUser, loadOrganization, audience, authorizedParties } = opts;
 
   // Fetch environment variables across Remix runtimes.
   // 1. First try from process.env if exists (Node).
@@ -77,6 +77,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     forwardedHost: headers.get('x-forwarded-host') as string,
     referrer: headers.get('referer') || '',
     userAgent: headers.get('user-agent') as string,
+    audience,
     authorizedParties,
     proxyUrl,
     isSatellite,

--- a/packages/remix/src/ssr/types.ts
+++ b/packages/remix/src/ssr/types.ts
@@ -1,4 +1,4 @@
-import type { AuthObject, Organization, Session, User } from '@clerk/backend';
+import type { AuthObject, OptionalVerifyTokenOptions, Organization, Session, User } from '@clerk/backend';
 import type { MultiDomainAndOrProxy } from '@clerk/types';
 import type { DataFunctionArgs, LoaderFunction } from '@remix-run/server-runtime';
 
@@ -19,8 +19,8 @@ export type RootAuthLoaderOptions = {
   loadUser?: boolean;
   loadSession?: boolean;
   loadOrganization?: boolean;
-  authorizedParties?: [];
-} & MultiDomainAndOrProxy;
+} & Pick<OptionalVerifyTokenOptions, 'audience' | 'authorizedParties'> &
+  MultiDomainAndOrProxy;
 
 export type RootAuthLoaderCallback<Options extends RootAuthLoaderOptions> = (
   args: LoaderFunctionArgsWithAuth<Options>,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

In rare circumstances, one may want to specify the `audience` to validate the token against since the `aud` claim may be specified in the session customization settings. Also, if the `audience` is not specified for verification, then the presence of the `aud` claim should not result in a failure.
