### PR TITLE
fix(clerk-react): Memoize useAuth.getToken and useAuth.signOut

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -11,6 +11,6 @@ module.exports = {
     '^.+\\.m?tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json', diagnostics: false }],
   },
 
-  testRegex: ['/ui/.*/__tests__/.*.test.[jt]sx?$', '/(core|utils)/.*.test.[jt]sx?$'],
+  testRegex: ['/ui/.*/__tests__/.*.test.[jt]sx?$', '/(core|utils|hooks)/.*.test.[jt]sx?$'],
   testPathIgnorePatterns: ['/node_modules/'],
 };

--- a/packages/react/src/hooks/useAuth.ts
+++ b/packages/react/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import type { ActJWTClaim, GetToken, MembershipRole, SignOut } from '@clerk/types';
+import { useCallback } from 'react';
 
 import { useAuthContext } from '../contexts/AuthContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
@@ -101,8 +102,8 @@ export const useAuth: UseAuth = () => {
   const { sessionId, userId, actor, orgId, orgRole, orgSlug } = useAuthContext();
   const isomorphicClerk = useIsomorphicClerkContext() as unknown as IsomorphicClerk;
 
-  const getToken: GetToken = createGetToken(isomorphicClerk);
-  const signOut: SignOut = createSignOut(isomorphicClerk);
+  const getToken: GetToken = useCallback(createGetToken(isomorphicClerk), [isomorphicClerk]);
+  const signOut: SignOut = useCallback(createSignOut(isomorphicClerk), [isomorphicClerk]);
 
   if (sessionId === undefined && userId === undefined) {
     return {

--- a/packages/react/src/hooks/utils.ts
+++ b/packages/react/src/hooks/utils.ts
@@ -15,20 +15,22 @@ const clerkLoaded = (isomorphicClerk: IsomorphicClerk) => {
 /**
  * @internal
  */
-export const createGetToken = (isomorphicClerk: IsomorphicClerk) => async (options: any) => {
-  await clerkLoaded(isomorphicClerk);
-  if (!isomorphicClerk.session) {
-    return null;
-  }
-  return isomorphicClerk.session.getToken(options);
+export const createGetToken = (isomorphicClerk: IsomorphicClerk) => {
+  return async (options: any) => {
+    await clerkLoaded(isomorphicClerk);
+    if (!isomorphicClerk.session) {
+      return null;
+    }
+    return isomorphicClerk.session.getToken(options);
+  };
 };
 
 /**
  * @internal
  */
-export const createSignOut =
-  (isomorphicClerk: IsomorphicClerk) =>
-  async (...args: any) => {
+export const createSignOut = (isomorphicClerk: IsomorphicClerk) => {
+  return async (...args: any) => {
     await clerkLoaded(isomorphicClerk);
     return isomorphicClerk.signOut(...args);
   };
+};

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -251,7 +251,6 @@ export default class IsomorphicClerk {
   get session(): ActiveSessionResource | undefined | null {
     if (this.clerkjs) {
       return this.clerkjs.session;
-      // TODO: add ssr condition
     } else {
       return undefined;
     }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Memoize the values of useAuth getToken and signOut

Closes #201
Closes #455
<!-- Fixes # (issue number) -->
