### PR TITLE
fix(clerk-js): Don't take into account auth instance settings in SignUpContinue form

### DIFF
--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -22,7 +22,6 @@ import {
   emailOrPhone,
   getInitialActiveIdentifier,
   minimizeFieldsForExistingSignup,
-  showFormFields,
 } from './signUpFormHelpers';
 import { SignUpSocialButtons } from './SignUpSocialButtons';
 import { completeSignUpFlow } from './util';
@@ -173,15 +172,13 @@ function _SignUpContinue() {
                 enableWeb3Providers={showWeb3Providers}
               />
             )}
-            {showFormFields(userSettings) && (
-              <SignUpForm
-                handleSubmit={handleSubmit}
-                fields={fields}
-                formState={formState}
-                canToggleEmailPhone={canToggleEmailPhone}
-                handleEmailPhoneToggle={handleChangeActive}
-              />
-            )}
+            <SignUpForm
+              handleSubmit={handleSubmit}
+              fields={fields}
+              formState={formState}
+              canToggleEmailPhone={canToggleEmailPhone}
+              handleEmailPhoneToggle={handleChangeActive}
+            />
           </SocialButtonsReversibleContainerWithDivider>
         </Flex>
         <Footer.Root>


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Clerk offers a progressive sign up flow, which means that using an OAuth provider to sign up, users will be able to fill any required and missing fields, such as name, username, in order to complete the flow. There was a bug in our components, where an instance had only Social Connection enabled as first factor, method to sign in, and required other fields (first/last name) which are not used for sign in of course. If a user tried to sign up with an OAuth provider, which doesn't provide these info (first/last name), the sign up wasn't completed but a user end up in blank screen without a chance to fill the missing fields. This was because we were rendering the form conditionally, based in the instance auth factor settings, which were not applicable in this case

### Before

https://user-images.githubusercontent.com/22435234/227915251-988f12af-486d-49b7-bca7-c6cddd775e44.mov

### After

https://user-images.githubusercontent.com/22435234/227915241-6dc21ac4-ca12-485e-acfa-9b50ef103759.mov