### PR TITLE
fix(clerk-js): Eagerly include the dynamic chunks for the clerk.js entry

### DIFF
--- a/packages/clerk-js/src/index.ts
+++ b/packages/clerk-js/src/index.ts
@@ -1,7 +1,3 @@
-// It's crucial this is the first import,
-// otherwise chunk loading will not work
-// eslint-disable-next-line
-import './utils/setWebpackChunkPublicPath';
 import 'regenerator-runtime/runtime';
 
 import Clerk from './core/clerk';

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -151,13 +151,26 @@ const prodConfig = ({ mode, env }) => {
     // prettier-ignore
     [variants.clerk]: merge(
       entryForVariant(variants.clerk),
-      common({ mode }),
+      common({mode}),
       commonForProd(),
+      {
+        // Include the lazy chunks in the bundle as well
+        // so that the final bundle can be imported and bundled again
+        // by a different bundler, eg the webpack instance used by react-scripts
+        // This is very similar to using new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
+        module: {
+          parser: {
+            javascript: {
+              dynamicImportMode: 'eager'
+            }
+          }
+        }
+      }
     ),
     // prettier-ignore
     [variants.clerkBrowser]: merge(
       entryForVariant(variants.clerkBrowser),
-      common({ mode }),
+      common({mode}),
       commonForProd(),
     ),
     [variants.clerkHeadless]: merge(
@@ -222,13 +235,13 @@ const devConfig = ({ mode, env }) => {
     // prettier-ignore
     [variants.clerk]: merge(
       entryForVariant(variants.clerk),
-      common({ mode }),
+      common({mode}),
       commonForDev(),
     ),
     // prettier-ignore
     [variants.clerkBrowser]: merge(
       entryForVariant(variants.clerkBrowser),
-      common({ mode }),
+      common({mode}),
       commonForDev(),
     ),
     [variants.clerkHeadless]: merge(


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Lazily-loading chunks is mostly inteded to be used in a browser environment from the host app OR used with a true UMD bundle that will be loaded and executed as a standalone lib in the browser's global namespace.

 We've found that in most webpack configurations, a chunked bundle cannot go through another bundling process again unless the host bundler config accounts for that use case explicitly. For example, importing Clerk from `@clerk/clerk-js` within a React app generated using CRA will fail as the default CRA webpack config cannot parse and bundle the lazy chunks and the app will fail during runtime with a ChunkLoadError.

 This PR adjust our webpack config accordingly to account for the above issues. The clerk.js bundle includes all the dependencies, while clerk.browser.js is split between an entry module and lazy chunks loaded from a CDN
<!-- Fixes # (issue number) -->
