### PR TITLE
Throw error when domain is set as function for non-…

### DIFF
--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -31,3 +31,6 @@ export function isMagicLinkError(err: any): err is MagicLinkError {
 
 export const invalidStateError =
   'Invalid state. Feel free to submit a bug or reach out to support here: https://clerk.com/support';
+
+export const domainAsFunctionError =
+  'The usage of a function as domain is not supported in non-browser environments. Please contact support@clerk.com';

--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -32,5 +32,5 @@ export function isMagicLinkError(err: any): err is MagicLinkError {
 export const invalidStateError =
   'Invalid state. Feel free to submit a bug or reach out to support here: https://clerk.com/support';
 
-export const domainAsFunctionError =
-  'The usage of a function as domain is not supported in non-browser environments. Please contact support@clerk.com';
+export const unsupportedNonBrowserDomainFunction =
+  'Unsupported usage of domain. The usage of domain as function is not supported in non-browser environments.';

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -3,7 +3,6 @@ import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
   Clerk,
-  Clerk as ClerkInterface,
   ClientResource,
   CreateOrganizationParams,
   CreateOrganizationProps,
@@ -26,6 +25,7 @@ import type {
 } from '@clerk/types';
 import type { OrganizationProfileProps, OrganizationSwitcherProps } from '@clerk/types/src';
 
+import { domainAsFunctionError } from './errors';
 import type {
   BrowserClerk,
   BrowserClerkConstructor,
@@ -92,6 +92,16 @@ export default class IsomorphicClerk {
   }
 
   get domain(): string {
+    /**
+     * This getter can run in environments where window is not available.
+     * In those cases we should expect and use domain as a string
+     */
+    if (!inClientSide()) {
+      if (typeof this.#domain === 'function') {
+        throw new Error(domainAsFunctionError);
+      }
+      return this.#domain || '';
+    }
     return handleValueOrFn(this.#domain, new URL(window.location.href), '');
   }
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -25,7 +25,7 @@ import type {
 } from '@clerk/types';
 import type { OrganizationProfileProps, OrganizationSwitcherProps } from '@clerk/types/src';
 
-import { domainAsFunctionError } from './errors';
+import { unsupportedNonBrowserDomainFunction } from './errors';
 import type {
   BrowserClerk,
   BrowserClerkConstructor,
@@ -92,13 +92,11 @@ export default class IsomorphicClerk {
   }
 
   get domain(): string {
-    /**
-     * This getter can run in environments where window is not available.
-     * In those cases we should expect and use domain as a string
-     */
+    // This getter can run in environments where window is not available.
+    // In those cases we should expect and use domain as a string
     if (!inClientSide()) {
       if (typeof this.#domain === 'function') {
-        throw new Error(domainAsFunctionError);
+        throw new Error(unsupportedNonBrowserDomainFunction);
       }
       return this.#domain || '';
     }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Accessing this.domain inside Isomorphic clerk will result to runtime error when the window is undefined. 

For non-browser environments, prohibit the usage of a function for now. 

<!-- Fixes # (issue number) -->
