### PR TITLE
fix(nextjs): Pass value of NEXT_PUBLIC_CLERK_SIGN_IN_URL in CSR

### DIFF
--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -41,6 +41,7 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
     proxyUrl,
     domain,
     isSatellite,
+    signInUrl,
     // @ts-expect-error
     __clerk_ssr_state,
     clerkJSUrl,
@@ -72,6 +73,7 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
       proxyUrl={proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || ''}
       domain={domain || process.env.NEXT_PUBLIC_CLERK_DOMAIN || ''}
       isSatellite={isSatellite || process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true'}
+      signInUrl={signInUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || ''}
       navigate={to => push(to)}
       // withServerSideAuth automatically injects __clerk_ssr_state
       // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
