### PR TITLE
fix(clerk-react,shared): Update inClientSide() util to check for document

### DIFF
--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -1,4 +1,4 @@
-import { handleValueOrFn } from '@clerk/shared';
+import { handleValueOrFn, inClientSide } from '@clerk/shared';
 import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
@@ -34,7 +34,7 @@ import type {
   HeadlessBrowserClerkConstrutor,
   IsomorphicClerkOptions,
 } from './types';
-import { inClientSide, isConstructor, loadScript } from './utils';
+import { isConstructor, loadScript } from './utils';
 
 export interface Global {
   Clerk?: HeadlessBrowserClerk | BrowserClerk;

--- a/packages/react/src/utils/inClientSide.ts
+++ b/packages/react/src/utils/inClientSide.ts
@@ -1,3 +1,0 @@
-export const inClientSide = (): boolean => {
-  return typeof window !== 'undefined';
-};

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,6 +1,5 @@
 export * from './childrenUtils';
 export * from './errorThrower';
-export * from './inClientSide';
 export * from './isConstructor';
 export * from './scriptLoader';
 export * from './useMaxAllowedInstancesGuard';

--- a/packages/shared/src/utils/ssr.ts
+++ b/packages/shared/src/utils/ssr.ts
@@ -1,3 +1,3 @@
 export const inClientSide = (): boolean => {
-  return typeof window !== 'undefined';
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
 };


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

This change resolve issues with react Native where `window` is defined but the API is not the same with the Browser resulting in failures when trying to use window.location or any other property.

## Changes

- Drop `inClientSide()` from `react/utils` in favour of `shared` package implementation
- Fix `inClientSide()` in `shared` to check for `document` instead of `window`

issue: https://github.com/clerkinc/javascript/issues/998