### PR TITLE
fix(clerk-js): Change update user password URL

### DIFF
--- a/packages/clerk-js/src/core/resources/User.test.ts
+++ b/packages/clerk-js/src/core/resources/User.test.ts
@@ -267,4 +267,28 @@ describe('User', () => {
       expect(user.fullName).toBe(fullName);
     });
   });
+
+  it('.updatePassword triggers a request to change password', async () => {
+    // @ts-ignore
+    BaseResource._fetch = jest.fn().mockReturnValue(Promise.resolve({ response: {} }));
+
+    const user = new User({
+      email_addresses: [],
+      phone_numbers: [],
+      web3_wallets: [],
+      external_accounts: [],
+    } as unknown as UserJSON);
+    const params = {
+      currentPassword: 'current-password',
+      newPassword: 'new-password',
+    };
+    await user.updatePassword(params);
+
+    // @ts-ignore
+    expect(BaseResource._fetch).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/me/password/change',
+      body: params,
+    });
+  });
 });

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -201,9 +201,9 @@ export class User extends BaseResource implements UserResource {
   };
 
   updatePassword = (params: UpdateUserPasswordParams): Promise<UserResource> => {
-    return this._basePatch({
+    return this._basePost({
       body: params,
-      path: `${this.path()}/password`,
+      path: `${this.path()}/password/change`,
     });
   };
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

The updated endpoint for changing a user's password is `POST /v1/me/password/change`.

<!-- Fixes # (issue number) -->
