### PR TITLE
fix(backend): Add exports test to validate package API

### DIFF
--- a/packages/backend/src/exports.test.ts
+++ b/packages/backend/src/exports.test.ts
@@ -1,0 +1,53 @@
+import type QUnit from 'qunit';
+
+import * as publicExports from './index';
+
+export default (QUnit: QUnit) => {
+  const { module, test } = QUnit;
+
+  module('public exports', () => {
+    test('should not include a breaking change', assert => {
+      const exportedApiKeys = [
+        'AllowlistIdentifier',
+        'AuthStatus',
+        'Clerk',
+        'Client',
+        'DeletedObject',
+        'Email',
+        'EmailAddress',
+        'ExternalAccount',
+        'IdentificationLink',
+        'Invitation',
+        'OauthAccessToken',
+        'ObjectType',
+        'Organization',
+        'OrganizationInvitation',
+        'OrganizationMembership',
+        'OrganizationMembershipPublicUserData',
+        'PhoneNumber',
+        'RedirectUrl',
+        'SMSMessage',
+        'Session',
+        'SignInToken',
+        'Token',
+        'User',
+        'Verification',
+        'constants',
+        'createAuthenticateRequest',
+        'debugRequestState',
+        'decodeJwt',
+        'deserialize',
+        'hasValidSignature',
+        'loadInterstitialFromLocal',
+        'makeAuthObjectSerializable',
+        'prunePrivateMetadata',
+        'sanitizeAuthObject',
+        'signedInAuthObject',
+        'signedOutAuthObject',
+        'verifyJwt',
+        'verifyToken',
+      ];
+      assert.deepEqual(Object.keys(publicExports).sort(), exportedApiKeys);
+    });
+  });
+};

--- a/packages/backend/tests/suites.ts
+++ b/packages/backend/tests/suites.ts
@@ -10,7 +10,19 @@ import jwtTest from './dist/tokens/jwt.test.js';
 import utilRequestTest from './dist/util/request.test.js';
 import factoryTest from './dist/api/factory.test.js';
 
+import exportsTest from './dist/exports.test.js';
+
 // Add them to the suite array
-const suites = [apiTest, requestTest, utilRequestTest, keysTest, verifyTest, pathTest, jwtTest, factoryTest];
+const suites = [
+  apiTest,
+  exportsTest,
+  requestTest,
+  utilRequestTest,
+  keysTest,
+  verifyTest,
+  pathTest,
+  jwtTest,
+  factoryTest,
+];
 
 export default suites;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
