### PR TITLE
fix(chrome-extension): Build before publish & add some other scripts

### DIFF
--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -9,8 +9,12 @@
   ],
   "scripts": {
     "build": "tsup --env.NODE_ENV production",
+    "clean": "rimraf ./dist",
     "dev": "tsup --watch",
-    "test": "jest"
+    "lint": "eslint .",
+    "test": "jest",
+    "test:coverage": "jest --collectCoverage && open coverage/lcov-report/index.html",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@clerk/clerk-js": "^4.35.0-staging.1",


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [x] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
