### PR TITLE
fix(clerk-js): Replace useRef with useState

### DIFF
--- a/packages/clerk-js/src/ui/hooks/useClerkModalStateParams.tsx
+++ b/packages/clerk-js/src/ui/hooks/useClerkModalStateParams.tsx
@@ -4,23 +4,23 @@ import { CLERK_MODAL_STATE } from '../../core/constants';
 import { readStateParam, removeClerkQueryParam } from '../../utils';
 
 export const useClerkModalStateParams = () => {
-  const contentRef = React.useRef({ startPath: '', path: '', componentName: '', socialProvider: '' });
+  const [state, setState] = React.useState({ startPath: '', path: '', componentName: '', socialProvider: '' });
   const decodedRedirectParams = readStateParam();
 
   React.useLayoutEffect(() => {
     if (decodedRedirectParams) {
-      contentRef.current = decodedRedirectParams;
+      setState(decodedRedirectParams);
     }
   }, []);
 
   const clearUrlStateParam = () => {
-    contentRef.current = { startPath: '', path: '', componentName: '', socialProvider: '' };
+    setState({ startPath: '', path: '', componentName: '', socialProvider: '' });
   };
 
   const removeQueryParam = () => removeClerkQueryParam(CLERK_MODAL_STATE);
 
   return {
-    urlStateParam: { ...contentRef.current, clearUrlStateParam },
+    urlStateParam: { ...state, clearUrlStateParam },
     decodedRedirectParams,
     clearUrlStateParam,
     removeQueryParam,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
It seems that `useRef` was causing issues with the `urlStateParams` so it was replaced with `useState` which resolves the problem
<!-- Fixes # (issue number) -->
