### PR TITLE
fix: add missing organization query param types

### DIFF
--- a/packages/backend/src/api/endpoints/OrganizationApi.ts
+++ b/packages/backend/src/api/endpoints/OrganizationApi.ts
@@ -13,6 +13,8 @@ type MetadataParams<TPublic = OrganizationPublicMetadata> = {
 type GetOrganizationListParams = {
   limit?: number;
   offset?: number;
+  includeMembersCount?: boolean;
+  query?: string;
 };
 
 type CreateParams = {
@@ -27,6 +29,7 @@ type GetOrganizationParams = { organizationId: string } | { slug: string };
 
 type UpdateParams = {
   name?: string;
+  slug?: string;
   maxAllowedMemberships?: number;
 } & MetadataParams;
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

Adds missing API types.

<!-- Fixes # (issue number) -->

Fixes #1023
