### PR TITLE
chore(chrome-extension): Add more instructions for FAPI URL on the README

### DIFF
--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -125,8 +125,8 @@ Examples of a chrome extension using the `@clerk/chrome-extension` package for a
 can be found in our `clerk-chrome-extension-starter` github repository.
 The 2 supported cases (links to different branches of the same repository):
 
-- [Standalone](https://github.com/clerkinc/clerk-chrome-extension-starter): The extension is using its own authentication
-- [WebSSO](https://github.com/clerkinc/clerk-chrome-extension-starter): The extensions shares authentication with a website in the same browser
+- [Standalone](https://github.com/clerkinc/clerk-chrome-extension-starter/tree/main): The extension is using its own authentication
+- [WebSSO](https://github.com/clerkinc/clerk-chrome-extension-starter/tree/webapp_sso): The extensions shares authentication with a website in the same browser
 
 ## WebSSO required settings
 
@@ -137,13 +137,15 @@ The 2 supported cases (links to different branches of the same repository):
 
 ### Host permissions (in manifest.json)
 
+You will need your Frontend API URL, which can be found in your `Dashboard > API Keys > Advanced > Clerk API URLs`.
+
 ```
 "host_permissions": ["*://YOUR_CLERK_FRONTEND_API_GOES_HERE/"],
 ```
 
 ### Clerk settings
 
-Add your chrome extension origin to your instance allowed_origins using BAPI:
+Add your Chrome extension origin to your instance allowed_origins using BAPI:
 
 ```bash
 curl  -X PATCH https://api.clerk.com/v1/instance \


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [x] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
