### PR TITLE
COR-269: Avoid overlapping with password manager icons

### DIFF
--- a/packages/clerk-js/src/ui/elements/PasswordInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PasswordInput.tsx
@@ -19,7 +19,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PropsOfComponent<typeo
         {...rest}
         ref={ref}
         type={hidden ? 'password' : 'text'}
-        sx={theme => ({ paddingRight: theme.space.$8 })}
+        sx={theme => ({ paddingRight: theme.space.$10 })}
       />
       <IconButton
         elementDescriptor={descriptors.formFieldInputShowPasswordButton}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Increase right padding of Password inputs to avoid overlapping with the icons or buttons of password manager extensions

### before this PR
![image](https://user-images.githubusercontent.com/19269911/230336971-276d5780-c5fe-4e4c-8160-308c2f01ce51.png)
### after this PR
![image](https://user-images.githubusercontent.com/19269911/230336947-b467234f-dabf-48d6-a17f-18c6b2261b94.png)

<!-- Fixes # (issue number) -->
