### PR TITLE
fix(clerk-js): Slug icon breaks layout spacing due to its margin

### DIFF
--- a/packages/clerk-js/src/ui/elements/FormControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FormControl.tsx
@@ -78,7 +78,10 @@ export const FormControl = forwardRef<HTMLInputElement, FormControlProps>((props
         </FormLabel>
         {icon && (
           // TODO: This is a temporary fix. Replace this when the tooltip component is introduced
-          <p title='A slug is a human-readable ID that must be unique.  It’s often used in URLs.'>
+          <Flex
+            as={'span'}
+            title='A slug is a human-readable ID that must be unique.  It’s often used in URLs.'
+          >
             <Icon
               icon={icon}
               sx={theme => ({
@@ -88,7 +91,7 @@ export const FormControl = forwardRef<HTMLInputElement, FormControlProps>((props
                 height: theme.sizes.$4,
               })}
             />
-          </p>
+          </Flex>
         )}
         {isOptional && !actionLabel && (
           <Text


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
### before
![image](https://user-images.githubusercontent.com/19269911/230343151-90851e38-a237-4fdf-80b8-e0b631c2a7bf.png)
### after
![image](https://user-images.githubusercontent.com/19269911/230343208-080c12d4-181d-4259-a578-5b6b3e26f361.png)


<!-- Fixes # (issue number) -->
