### PR TITLE
feat(clerk-js,types): add option to not render the signup for private login forms

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -11,7 +11,7 @@ import {
   withRedirectToHomeSingleSessionGuard,
 } from '../../common';
 import { useCoreClerk, useCoreSignIn, useEnvironment, useSignInContext } from '../../contexts';
-import { Col, descriptors, Flow, localizationKeys } from '../../customizables';
+import { Col, descriptors, Flow, localizationKeys, useAppearance } from '../../customizables';
 import {
   Card,
   CardAlert,
@@ -38,6 +38,7 @@ export function _SignInStart(): JSX.Element {
   const { navigate } = useNavigate();
   const { navigateAfterSignIn, signUpUrl } = useSignInContext();
   const supportEmail = useSupportEmail();
+  const { showSignUpLink } = useAppearance().parsedLayout;
   const identifierAttributes = useMemo<SignInStartIdentifier[]>(
     () => groupIdentifiers(userSettings.enabledFirstFactorIdentifiers),
     [userSettings.enabledFirstFactorIdentifiers],
@@ -255,20 +256,22 @@ export function _SignInStart(): JSX.Element {
             ) : null}
           </SocialButtonsReversibleContainerWithDivider>
         </Col>
-        <Footer.Root>
-          <Footer.Action elementId='signIn'>
-            <Footer.ActionText localizationKey={localizationKeys('signIn.start.actionText')}>
-              No account?
-            </Footer.ActionText>
-            <Footer.ActionLink
-              localizationKey={localizationKeys('signIn.start.actionLink')}
-              to={signUpUrl}
-            >
-              Sign up
-            </Footer.ActionLink>
-          </Footer.Action>
-          <Footer.Links />
-        </Footer.Root>
+        {showSignUpLink ? (
+          <Footer.Root>
+            <Footer.Action elementId='signIn'>
+              <Footer.ActionText localizationKey={localizationKeys('signIn.start.actionText')}>
+                No account?
+              </Footer.ActionText>
+              <Footer.ActionLink
+                localizationKey={localizationKeys('signIn.start.actionLink')}
+                to={signUpUrl}
+              >
+                Sign up
+              </Footer.ActionLink>
+            </Footer.Action>
+            <Footer.Links />
+          </Footer.Root> 
+        ): null}
       </Card>
     </Flow.Part>
   );

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { bindCreateFixtures, fireEvent, render, screen } from '../../../../testUtils';
 import { SignInStart } from '../SignInStart';
+import { AppearanceProvider } from '../../../customizables';
 
 const { createFixtures } = bindCreateFixtures('SignIn');
 
@@ -198,6 +199,37 @@ describe('SignInStart', () => {
       render(<SignInStart />, { wrapper });
 
       expect(screen.getByRole('textbox', { name: /phone number/i })).toHaveAttribute('type', 'tel');
+    });
+  });
+
+  describe('Remove signup element', () => {
+    it('shows a link to the signup page', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withSupportEmail();
+      });
+      render(
+        <AppearanceProvider appearanceKey='signIn'>
+          <SignInStart />
+        </AppearanceProvider>,
+        { wrapper },
+      );
+
+      expect(screen.queryByText('No account?')).toBeDefined();
+    });
+
+    it('does not show a link to the signup page', async () => {
+      const { wrapper } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withSupportEmail();
+      });
+      render(
+        <AppearanceProvider appearanceKey='signIn' appearance={{ layout: { showSignUpLink: false } }}>
+          <SignInStart />
+        </AppearanceProvider>,
+        { wrapper },
+      );
+      expect(screen.queryByText('No account?')).toBeNull();
     });
   });
 });

--- a/packages/clerk-js/src/ui/customizables/__tests__/parseAppearance.test.tsx
+++ b/packages/clerk-js/src/ui/customizables/__tests__/parseAppearance.test.tsx
@@ -269,6 +269,7 @@ describe('AppearanceProvider layout flows', () => {
             termsPageUrl: 'test2',
             logoPlacement: 'outside',
             showOptionalFields: true,
+            showSignUpLink: true,
             socialButtonsPlacement: 'top',
             socialButtonsVariant: 'blockButton',
           },
@@ -285,6 +286,7 @@ describe('AppearanceProvider layout flows', () => {
     expect(result.current.parsedLayout.termsPageUrl).toBe('test2');
     expect(result.current.parsedLayout.logoPlacement).toBe('outside');
     expect(result.current.parsedLayout.showOptionalFields).toBe(true);
+    expect(result.current.parsedLayout.showSignUpLink).toBe(true);
     expect(result.current.parsedLayout.socialButtonsPlacement).toBe('top');
     expect(result.current.parsedLayout.socialButtonsVariant).toBe('blockButton');
   });
@@ -301,6 +303,7 @@ describe('AppearanceProvider layout flows', () => {
             termsPageUrl: 'test',
             logoPlacement: 'inside',
             showOptionalFields: false,
+            showSignUpLink: false,
             socialButtonsPlacement: 'bottom',
             socialButtonsVariant: 'iconButton',
           },
@@ -313,6 +316,7 @@ describe('AppearanceProvider layout flows', () => {
             termsPageUrl: 'test2',
             logoPlacement: 'outside',
             showOptionalFields: true,
+            showSignUpLink: true,
             socialButtonsPlacement: 'top',
             socialButtonsVariant: 'blockButton',
           },
@@ -329,6 +333,7 @@ describe('AppearanceProvider layout flows', () => {
     expect(result.current.parsedLayout.termsPageUrl).toBe('test2');
     expect(result.current.parsedLayout.logoPlacement).toBe('outside');
     expect(result.current.parsedLayout.showOptionalFields).toBe(true);
+    expect(result.current.parsedLayout.showSignUpLink).toBe(true);
     expect(result.current.parsedLayout.socialButtonsPlacement).toBe('top');
     expect(result.current.parsedLayout.socialButtonsVariant).toBe('blockButton');
   });

--- a/packages/clerk-js/src/ui/customizables/parseAppearance.ts
+++ b/packages/clerk-js/src/ui/customizables/parseAppearance.ts
@@ -37,6 +37,7 @@ const defaultLayout: ParsedLayout = {
   socialButtonsVariant: 'auto',
   logoImageUrl: '',
   showOptionalFields: true,
+  showSignUpLink: true,
   helpPageUrl: '',
   privacyPageUrl: '',
   termsPageUrl: '',

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -549,6 +549,11 @@ export type Layout = {
    */
   showOptionalFields?: boolean;
   /**
+   * Controls whether the SignIn will show a link to navigate to the SignUp page.
+   * @default true
+   */
+  showSignUpLink?: boolean;
+  /**
    * This options enables the "Terms" link which is, by default, displayed on the bottom-right corner of the
    * prebuilt components. Clicking the link will open the passed URL in a new tab
    */


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [X] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.

This pull request adds a new option to the SignIn component to disable rendering the "No account? Signup" link, allowing exclusive login functionality. The feature is implemented through a new configuration parameter in the appearance settings. Users can choose to hide the signup button by setting the parameter to "false".

**Usage**
```typescript
<SignIn
    path="/sign-in"
    appearance={{ layout: { showSignUpLink: false } }}
/>
```

Maybe it's better to put the option somewhere else? But this way we might be able to set this configuration from the Clerk Options online.

Feedback and suggestions are welcome. Thank you for considering this enhancement.
