### PR TITLE
deDe should be deDE instead

### DIFF
--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -1,6 +1,6 @@
 import type { LocalizationResource } from '@clerk/types';
 
-export const deDe: LocalizationResource = {
+export const deDE: LocalizationResource = {
   socialButtonsBlockButton: 'Weiter mit {{provider|titleize}}',
   dividerText: 'oder',
   formFieldLabel__emailAddress: 'E-Mail-Adresse',
@@ -556,6 +556,5 @@ export const deDe: LocalizationResource = {
 } as const;
 
 
-export const deDE = deDe;
 
 

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -554,3 +554,8 @@ export const deDe: LocalizationResource = {
     numeric: "{{ date | numeric('de-DE') }}",
   },
 } as const;
+
+
+export const deDE = deDe;
+
+

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -554,7 +554,3 @@ export const deDE: LocalizationResource = {
     numeric: "{{ date | numeric('de-DE') }}",
   },
 } as const;
-
-
-
-

--- a/packages/localizations/src/index.ts
+++ b/packages/localizations/src/index.ts
@@ -1,6 +1,6 @@
 export { enUS } from './en-US';
 export { frFR } from './fr-FR';
-export { deDe } from './de-DE';
+export { deDE } from './de-DE';
 export { itIT } from './it-IT';
 export { ptBR } from './pt-BR';
 export { esES } from './es-ES';

--- a/packages/localizations/src/index.ts
+++ b/packages/localizations/src/index.ts
@@ -3,7 +3,7 @@ export { frFR } from './fr-FR';
 /**
  * @deprecated Use `deDE` instead
 */
-export { deDe } from './de-DE'; 
+export { deDE as deDe } from './de-DE'; 
 export { deDE } from './de-DE';
 export { itIT } from './it-IT';
 export { ptBR } from './pt-BR';

--- a/packages/localizations/src/index.ts
+++ b/packages/localizations/src/index.ts
@@ -1,5 +1,9 @@
 export { enUS } from './en-US';
 export { frFR } from './fr-FR';
+/**
+ * @deprecated Use `deDE` instead
+*/
+export { deDe } from './de-DE'; 
 export { deDE } from './de-DE';
 export { itIT } from './it-IT';
 export { ptBR } from './pt-BR';


### PR DESCRIPTION
Seems like deDe is wrong, it should be deDE to stay consistent with all the other keys.

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [X] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
