### PR TITLE
chore(nextjs): Use tsup to bundle and minify package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35455,6 +35455,7 @@
         "jest": "*",
         "node-fetch-native": "^0.1.8",
         "ts-jest": "*",
+        "tsup": "*",
         "typescript": "*"
       },
       "engines": {
@@ -41434,6 +41435,7 @@
         "node-fetch-native": "^0.1.8",
         "ts-jest": "*",
         "tslib": "2.4.1",
+        "tsup": "*",
         "typescript": "*"
       },
       "dependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -31,8 +31,8 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "dev": "tsup --watch",
-    "build": "tsup --env.NODE_ENV production",
-    "build:analyze": "tsup --metafile --env.NODE_ENV production",
+    "build": "tsup",
+    "build:analyze": "tsup --metafile",
     "clean": "rimraf ./dist",
     "lint": "eslint .",
     "test": "jest"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -30,11 +30,12 @@
   ],
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsup --watch",
+    "build": "tsup --env.NODE_ENV production",
+    "build:analyze": "tsup --metafile --env.NODE_ENV production",
     "clean": "rimraf ./dist",
     "lint": "eslint .",
-    "test": "jest",
-    "dev": "tsc -p tsconfig.build.json --watch"
+    "test": "jest"
   },
   "dependencies": {
     "@clerk/backend": "^0.16.2-staging.1",
@@ -50,6 +51,7 @@
     "jest": "*",
     "node-fetch-native": "^0.1.8",
     "ts-jest": "*",
+    "tsup": "*",
     "typescript": "*"
   },
   "peerDependencies": {

--- a/packages/nextjs/src/middleware/utils/serializeProps.ts
+++ b/packages/nextjs/src/middleware/utils/serializeProps.ts
@@ -15,7 +15,7 @@ export function injectSSRStateIntoProps(callbackResult: any, authData: AuthData)
 
 export const injectSSRStateIntoObject = (obj: any, authData: AuthData) => {
   // Serializing the state on dev env is a temp workaround for the following issue:
-  // https://github.com/vercel/next.js/discussions/11209|Next.js
+  // https://github.com/vercel/next.js/discussions/11209
   const __clerk_ssr_state =
     process.env.NODE_ENV !== 'production' ? JSON.parse(JSON.stringify({ ...authData })) : { ...authData };
   return { ...obj, __clerk_ssr_state };

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -136,7 +136,7 @@ export const nextJsVersionCanOverrideRequestHeaders = () => {
 
 export const injectSSRStateIntoObject = <O, T>(obj: O, authObject: T) => {
   // Serializing the state on dev env is a temp workaround for the following issue:
-  // https://github.com/vercel/next.js/discussions/11209|Next.js
+  // https://github.com/vercel/next.js/discussions/11209
   const __clerk_ssr_state = (
     process.env.NODE_ENV !== 'production' ? JSON.parse(JSON.stringify({ ...authObject })) : { ...authObject }
   ) as T;

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "incremental": true
-  }
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__"]
 }

--- a/packages/nextjs/tsup.config.ts
+++ b/packages/nextjs/tsup.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'tsup';
+
+import { name, version } from './package.json';
+
+export default defineConfig(overrideOptions => {
+  const isProd = overrideOptions.env?.NODE_ENV === 'production';
+
+  return {
+    entry: [
+      'src/index.ts',
+      'src/ssr/index.ts',
+      'src/server/index.ts',
+      'src/api/index.ts',
+      'src/middleware/index.ts',
+      'src/app-beta/index.ts',
+      'src/client/index.ts',
+      'src/constants.ts',
+    ],
+    onSuccess: 'tsc --emitDeclarationOnly --declaration',
+    minify: isProd,
+    sourcemap: true,
+    format: ['cjs', 'esm'],
+    define: {
+      PACKAGE_NAME: `"${name}"`,
+      PACKAGE_VERSION: `"${version}"`,
+      __DEV__: `${!isProd}`,
+    },
+    legacyOutput: true,
+  };
+});

--- a/packages/nextjs/tsup.config.ts
+++ b/packages/nextjs/tsup.config.ts
@@ -6,14 +6,14 @@ export default defineConfig(overrideOptions => {
   const isProd = overrideOptions.env?.NODE_ENV === 'production';
 
   return {
+    clean: true,
     entry: [
       'src/index.ts',
       'src/ssr/index.ts',
       'src/server/index.ts',
       'src/api/index.ts',
-      'src/middleware/index.ts',
+      'src/edge-middleware/index.ts',
       'src/app-beta/index.ts',
-      'src/client/index.ts',
       'src/constants.ts',
     ],
     onSuccess: 'tsc --emitDeclarationOnly --declaration',

--- a/packages/nextjs/tsup.config.ts
+++ b/packages/nextjs/tsup.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from 'tsup';
 
-import { name, version } from './package.json';
-
-export default defineConfig(overrideOptions => {
-  const isProd = overrideOptions.env?.NODE_ENV === 'production';
-
+export default defineConfig(options => {
   return {
     clean: true,
     entry: [
@@ -17,14 +13,9 @@ export default defineConfig(overrideOptions => {
       'src/constants.ts',
     ],
     onSuccess: 'tsc --emitDeclarationOnly --declaration',
-    minify: isProd,
+    minify: !options.watch,
     sourcemap: true,
     format: ['cjs', 'esm'],
-    define: {
-      PACKAGE_NAME: `"${name}"`,
-      PACKAGE_VERSION: `"${version}"`,
-      __DEV__: `${!isProd}`,
-    },
     legacyOutput: true,
   };
 });

--- a/playground/nextjs12/app/app-dir/page.tsx
+++ b/playground/nextjs12/app/app-dir/page.tsx
@@ -9,7 +9,7 @@ import {
   SignedOut,
   SignIn,
   UserButton,
-} from '@clerk/nextjs/dist/app-beta';
+} from '@clerk/nextjs/app-beta';
 
 export default async function Page() {
   const { userId } = auth();


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] Tested that `clerk-nextjs-starter` is functional with the tsup bundled NextJS (using yalc)

Changes of this PR:
- Re-apply the 4 reverted commits of PR: https://github.com/clerkinc/javascript/pull/946
- Update some GH issues referenced links in comments (see 2nd commit from the end)
- Update tsup config for nextjs package to fix the issue (see last commit) 
