### PR TITLE
feat(clerk-js): Add back button to VerificationCodeCard

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOneCodeForm.tsx
@@ -11,7 +11,10 @@ import { useSupportEmail } from '../../hooks/useSupportEmail';
 import { useRouter } from '../../router';
 import { handleError } from '../../utils';
 
-export type SignInFactorOneCodeCard = Pick<VerificationCodeCardProps, 'onShowAlternativeMethodsClicked'> & {
+export type SignInFactorOneCodeCard = Pick<
+  VerificationCodeCardProps,
+  'onShowAlternativeMethodsClicked' | 'showAlternativeMethods' | 'onBackLinkClicked'
+> & {
   factor: EmailCodeFactor | PhoneCodeFactor;
   factorAlreadyPrepared: boolean;
   onFactorPrepare: () => void;
@@ -80,7 +83,9 @@ export const SignInFactorOneCodeForm = (props: SignInFactorOneCodeFormProps) => 
       safeIdentifier={props.factor.safeIdentifier}
       profileImageUrl={signIn.userData.imageUrl}
       onShowAlternativeMethodsClicked={props.onShowAlternativeMethodsClicked}
+      showAlternativeMethods={props.showAlternativeMethods}
       onIdentityPreviewEditClicked={goBack}
+      onBackLinkClicked={props.onBackLinkClicked}
     />
   );
 };

--- a/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
+++ b/packages/clerk-js/src/ui/elements/VerificationCodeCard.tsx
@@ -27,11 +27,14 @@ export type VerificationCodeCardProps = {
     reject: (err: unknown) => Promise<void>,
   ) => void;
   onResendCodeClicked?: React.MouseEventHandler;
+  showAlternativeMethods?: boolean;
   onShowAlternativeMethodsClicked?: React.MouseEventHandler;
   onIdentityPreviewEditClicked?: React.MouseEventHandler;
+  onBackLinkClicked?: React.MouseEventHandler;
 };
 
 export const VerificationCodeCard = (props: VerificationCodeCardProps) => {
+  const { showAlternativeMethods = true } = props;
   const [success, setSuccess] = React.useState(false);
   const status = useLoadingStatus();
   const codeControlState = useFormControl('code', '');
@@ -67,13 +70,14 @@ export const VerificationCodeCard = (props: VerificationCodeCardProps) => {
     <Card>
       <CardAlert>{card.error}</CardAlert>
       <Header.Root>
+        {props.onBackLinkClicked && <Header.BackLink onClick={props.onBackLinkClicked} />}
         <Header.Title localizationKey={props.cardTitle} />
         <Header.Subtitle localizationKey={props.cardSubtitle} />
       </Header.Root>
       <IdentityPreview
         identifier={props.safeIdentifier}
         avatarUrl={props.profileImageUrl}
-        onClick={props.onIdentityPreviewEditClicked}
+        onClick={!props.onBackLinkClicked ? props.onIdentityPreviewEditClicked : undefined}
       />
       <Col
         elementDescriptor={descriptors.main}
@@ -89,17 +93,18 @@ export const VerificationCodeCard = (props: VerificationCodeCardProps) => {
           onResendCodeClicked={handleResend}
         />
       </Col>
-      <Footer.Root>
-        <Footer.Action elementId='alternativeMethods'>
-          {props.onShowAlternativeMethodsClicked && (
+
+      {showAlternativeMethods && props.onShowAlternativeMethodsClicked && (
+        <Footer.Root>
+          <Footer.Action elementId='alternativeMethods'>
             <Footer.ActionLink
               localizationKey={localizationKeys('footerActionLink__useAnotherMethod')}
               onClick={props.onShowAlternativeMethodsClicked}
             />
-          )}
-        </Footer.Action>
-        <Footer.Links />
-      </Footer.Root>
+          </Footer.Action>
+          <Footer.Links />
+        </Footer.Root>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
+ Conditionally displaying alternative methods. We continue to display them by default

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

### Before this PR
![image](https://user-images.githubusercontent.com/19269911/230896139-04edb123-3bd5-4142-b907-1b3d91a535e3.png)

### After this PR
![image](https://user-images.githubusercontent.com/19269911/230896068-368b3966-5ae0-4aa7-a4ea-83d6307cb061.png)

NOTE: This PR does not remove the previous UI, it only expands the customisation of `<VerificationCodeCard />`



<!-- Fixes # (issue number) -->
