### PR TITLE
fix(clerk-js): Prevent a switch loop when browser autofills again after switching

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -43,6 +43,7 @@ export function _SignInStart(): JSX.Element {
     [userSettings.enabledFirstFactorIdentifiers],
   );
   const [identifierAttribute, setIdentifierAttribute] = useState<SignInStartIdentifier>(identifierAttributes[0] || '');
+  const [hasSwitchedByAutofill, setHasSwitchedByAutofill] = useState(false);
 
   const organizationTicket = getClerkQueryParam('__clerk_ticket') || '';
 
@@ -85,9 +86,13 @@ export function _SignInStart(): JSX.Element {
     if (
       identifierField.value.startsWith('+') &&
       identifierAttributes.includes('phone_number') &&
-      identifierAttribute !== 'phone_number'
+      identifierAttribute !== 'phone_number' &&
+      !hasSwitchedByAutofill
     ) {
       switchToPhoneInput(identifierField.value);
+      // do not switch automatically on subsequent autofills
+      // by the browser to avoid a switch loop
+      setHasSwitchedByAutofill(true);
     }
   }, [identifierField.value, identifierAttributes]);
 


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
It seems that some times (it's inconsistent), the browser will autofill the field in SignInStart after the user has chosen to switch the identifier. If the autofilled value is a phone number, the user will be unable to switch to "email or username", since the component will detect the "+" value and automatically switch to the phone input once again. This commit makes it so the auto-switch can only happen the first time. We might be able to solve this in the future by changing the id of the input depending on the type, but that may cause more problems than it solves.
<!-- Fixes # (issue number) -->
