### PR TITLE
fix(clerk-js): Ignore imageUrl in UserAvatar and OrganizationAvatar

### DIFF
--- a/packages/clerk-js/src/ui/elements/OrganizationAvatar.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationAvatar.tsx
@@ -7,7 +7,8 @@ type OrganizationAvatarProps = PropsOfComponent<typeof Avatar> &
   Partial<Pick<OrganizationResource, 'name' | 'logoUrl'>>;
 
 export const OrganizationAvatar = (props: OrganizationAvatarProps) => {
-  const { name = '', logoUrl, ...rest } = props;
+  //TODO: replace logoUrl with imageUrl
+  const { name = '', logoUrl, imageUrl, ...rest } = props;
 
   return (
     <Avatar

--- a/packages/clerk-js/src/ui/elements/UserAvatar.tsx
+++ b/packages/clerk-js/src/ui/elements/UserAvatar.tsx
@@ -10,7 +10,8 @@ type UserAvatarProps = PropsOfComponent<typeof Avatar> &
   };
 
 export const UserAvatar = (props: UserAvatarProps) => {
-  const { name, firstName, lastName, profileImageUrl, ...rest } = props;
+  //TODO: replace profileImageUrl with imageUrl
+  const { name, firstName, lastName, profileImageUrl, imageUrl, ...rest } = props;
   const generatedName = getFullName({ name, firstName, lastName });
   const initials = getInitials({ name, firstName, lastName });
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
