### PR TITLE
fix(clerk-js): Treat displaying errors onBlur as opt-in option

### DIFF
--- a/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
@@ -46,6 +46,7 @@ export const PasswordPage = withCardStateProvider(() => {
     type: 'password',
     label: localizationKeys('formFieldLabel__newPassword'),
     isRequired: true,
+    enableErrorAfterBlur: true,
   });
   const confirmField = useFormControl('confirmPassword', '', {
     type: 'password',

--- a/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
@@ -59,9 +59,10 @@ export const PasswordPage = withCardStateProvider(() => {
     label: localizationKeys('formFieldLabel__signOutOfOtherSessions'),
   });
 
-  const isPasswordMatch =
-    passwordField.value && passwordField.value === confirmField.value && passwordField.value.length > 7;
-  const canSubmit = user.passwordEnabled ? currentPasswordField.value && isPasswordMatch : isPasswordMatch;
+  const isPasswordMatch = passwordField.value === confirmField.value;
+  const hasErrors = !!passwordField.errorText || !!confirmField.errorText;
+  const canSubmit =
+    (user.passwordEnabled ? currentPasswordField.value && isPasswordMatch : isPasswordMatch) && !hasErrors;
 
   const validateForm = () => {
     if (passwordField.value && confirmField.value && passwordField.value !== confirmField.value) {

--- a/packages/clerk-js/src/ui/elements/FormControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FormControl.tsx
@@ -36,6 +36,7 @@ type FormControlProps = Omit<PropsOfComponent<typeof Input>, 'label' | 'placehol
   setSuccessful: (isSuccess: boolean) => void;
   isSuccessful: boolean;
   hasLostFocus: boolean;
+  enableErrorAfterBlur?: boolean;
   complexity?: boolean;
 };
 
@@ -71,6 +72,7 @@ export const FormControl = forwardRef<HTMLInputElement, FormControlProps>((props
     setSuccessful,
     complexity,
     hasLostFocus,
+    enableErrorAfterBlur,
     ...rest
   } = props;
   const hasError = !!errorText && hasLostFocus;
@@ -183,7 +185,7 @@ export const FormControl = forwardRef<HTMLInputElement, FormControlProps>((props
         elementDescriptor={descriptors.formFieldErrorText}
         elementId={descriptors.formFieldErrorText.setId(id)}
       >
-        {hasLostFocus && errorText}
+        {enableErrorAfterBlur ? hasLostFocus && errorText : errorText}
       </FormErrorText>
     </FormControlPrim>
   );

--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -14,6 +14,7 @@ type Options = {
   type?: HTMLInputTypeAttribute;
   options?: SelectOption[];
   checked?: boolean;
+  enableErrorAfterBlur?: boolean;
 };
 
 type FieldStateProps<Id> = {
@@ -42,7 +43,14 @@ export const useFormControl = <Id extends string>(
   initialState: string,
   opts?: Options,
 ): FormControlState<Id> => {
-  opts = opts || { type: 'text', label: '', isRequired: false, placeholder: '', options: [] };
+  opts = opts || {
+    type: 'text',
+    label: '',
+    isRequired: false,
+    placeholder: '',
+    options: [],
+    enableErrorAfterBlur: false,
+  };
   const { translateError } = useLocalizations();
   const [value, setValueInternal] = React.useState<string>(initialState);
   const [checked, setCheckedInternal] = React.useState<boolean>(opts?.checked || false);
@@ -86,6 +94,7 @@ export const useFormControl = <Id extends string>(
     setError,
     onChange,
     onBlur,
+    enableErrorAfterBlur: opts.enableErrorAfterBlur || false,
     ...opts,
   };
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

### Before
https://user-images.githubusercontent.com/19269911/231273142-ab6abed3-4f56-480d-aa34-a604078e7b3b.mov
### After
https://user-images.githubusercontent.com/19269911/231272976-7579a731-b483-4eae-8f15-eba8c57a1e91.mov

This ensures that we don't break other input fields that where using the previous behaviour

<!-- Fixes # (issue number) -->
