### PR TITLE
fix(clerk-js): Avoid merging twice in mergeFragmentUrl

### DIFF
--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -355,6 +355,7 @@ describe('mergeFragmentIntoUrl(url | string)', () => {
     ['https://test.test#data', new URL('https://test.test#data')],
     ['https://test.test/foo?a=a&b=b#/bar?c=c', new URL('https://test.test/foo/bar?a=a&b=b&c=c')],
     ['https://test.test?a=a#/?a=b', new URL('https://test.test?a=b')],
+    ['https://test.test/en-US/sign-in#/?a=b', new URL('https://test.test/en-US/sign-in?a=b')],
   ];
 
   test.each(testCases)('url=(%s), expected value=(%s)', (url, expectedParamValue) => {

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -346,7 +346,7 @@ export const mergeFragmentIntoUrl = (_url: string | URL): URL => {
     .filter(Boolean)
     .join('/');
 
-  const mergedUrl = new URL(mergedPathname, url);
+  const mergedUrl = new URL(mergedPathname, url.origin);
 
   url.searchParams.forEach((val, key) => {
     mergedUrl.searchParams.set(key, val);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
Fixes #1058 