### PR TITLE
chore(clerk-js): Remove AuthV1 related code

### DIFF
--- a/packages/clerk-js/src/core/services/authentication/SessionCookieService.ts
+++ b/packages/clerk-js/src/core/services/authentication/SessionCookieService.ts
@@ -25,7 +25,6 @@ export class SessionCookieService {
 
   public setEnvironment(environment: EnvironmentResource) {
     this.environment = environment;
-    this.clearLegacyAuthV1Cookies();
     this.setClientUatCookieForDevelopmentInstances();
   }
 
@@ -94,12 +93,6 @@ export class SessionCookieService {
   private inCustomDevelopmentDomain() {
     const domain = this.clerk.frontendApi.replace('clerk.', '');
     return !window.location.host.endsWith(domain);
-  }
-
-  private clearLegacyAuthV1Cookies() {
-    if (this.environment?.isProduction() && this.environment?.onWindowLocationHost()) {
-      void this.cookies.clearLegacyAuthV1SessionCookie();
-    }
   }
 
   private handleGetTokenError(e: any) {

--- a/packages/clerk-js/src/utils/cookies/client_uat.ts
+++ b/packages/clerk-js/src/utils/cookies/client_uat.ts
@@ -4,7 +4,7 @@ const CLIENT_UAT_COOKIE_NAME = '__client_uat';
 
 /**
  *
- * This is a long-lived JS cookie used in AuthV2 development instances, to
+ * This is a long-lived JS cookie used in development instances, to
  * signal to the customer's backend (SDK) when the Client was last updated and
  * therefore when the SDK should re-concile the state with FAPI.
  *

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -1,7 +1,7 @@
 import { addYears } from '@clerk/shared';
 import type { ClientResource } from '@clerk/types';
 
-import { buildURL, getAllETLDs } from '../url';
+import { getAllETLDs } from '../url';
 import { clientCookie } from './client';
 import { clientUatCookie } from './client_uat';
 import { inittedCookie } from './initted';
@@ -67,38 +67,6 @@ export const createCookieHandler = () => {
     getAllETLDs().forEach(domain => ssoCookie.remove({ domain, path: COOKIE_PATH }));
   };
 
-  const clearLegacyAuthV1SessionCookie = async () => {
-    if (!checkIfHttpOnlyAuthV1SessionCookieExists()) {
-      return;
-    }
-
-    const clearSessionCookieUrl = buildURL(
-      {
-        base: `https://clerk.${window.location.host}`,
-        pathname: 'v1/clear-session-cookie',
-      },
-      { stringify: false },
-    );
-
-    await fetch(clearSessionCookieUrl.toString(), {
-      credentials: 'include',
-    });
-  };
-
-  const checkIfHttpOnlyAuthV1SessionCookieExists = (): boolean => {
-    if (document.cookie.indexOf('__session=') !== -1) {
-      return false;
-    }
-
-    const d = new Date();
-    d.setTime(d.getTime() + 1000);
-
-    document.cookie = `__session=check;path=/;domain=${window.location.host};expires=${d.toUTCString()}`;
-    const cookieExists = document.cookie.indexOf('__session=') === -1;
-    document.cookie = `__session=;path=/;domain=${window.location.host};max-age=-1`;
-    return cookieExists;
-  };
-
   return {
     getDevBrowserInittedCookie,
     setDevBrowserInittedCookie,
@@ -107,6 +75,5 @@ export const createCookieHandler = () => {
     setClientUatCookie,
     removeSessionCookie,
     removeAllDevBrowserCookies,
-    clearLegacyAuthV1SessionCookie,
   };
 };


### PR DESCRIPTION
As AuthV1, the old way of authenticating with Clerk, has now been officially deprecated, we are removing the related code from clerk.js as well

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

As AuthV1, the old way of authenticating with Clerk, has now been officially deprecated, we are removing the related code from clerk.js as well

<!-- Fixes # (issue number) -->
