### PR TITLE
Update signUp.ts - missing expired status 

### DIFF
--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -92,7 +92,7 @@ export interface SignUpResource extends ClerkResource {
   authenticateWithMetamask: (params?: SignUpAuthenticateWithMetamaskParams) => Promise<SignUpResource>;
 }
 
-export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';
+export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned' | 'expired';
 
 export type SignUpField = SignUpAttributeField | SignUpIdentificationField;
 


### PR DESCRIPTION
Expired is missing from the types as seen in response and in docs.

## Type of change

- [x ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
