### PR TITLE
fix(clerk-js): Handle SSO flows in dev instances with URL based session syncing

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -16,6 +16,7 @@ import type {
   ActiveSessionResource,
   AuthenticateWithMetamaskParams,
   BeforeEmitCallback,
+  BuildUrlWithAuthParams,
   Clerk as ClerkInterface,
   ClerkOptions,
   ClientResource,
@@ -604,7 +605,7 @@ export default class Clerk implements ClerkInterface {
     return await customNavigate(stripOrigin(toURL));
   };
 
-  public buildUrlWithAuth(to: string): string {
+  public buildUrlWithAuth(to: string, options?: BuildUrlWithAuthParams): string {
     if (this.#instanceType === 'production' || !this.#devBrowserHandler?.usesUrlBasedSessionSync()) {
       return to;
     }
@@ -620,7 +621,12 @@ export default class Clerk implements ClerkInterface {
       return clerkMissingDevBrowserJwt();
     }
 
-    return setDevBrowserJWTInURL(toURL.href, devBrowserJwt);
+    let asQueryParam = false;
+    if (options && options.useQueryParam) {
+      asQueryParam = options.useQueryParam;
+    }
+
+    return setDevBrowserJWTInURL(toURL.href, devBrowserJwt, asQueryParam);
   }
 
   public buildSignInUrl(options?: RedirectOptions): string {

--- a/packages/clerk-js/src/ui/contexts/utils.ts
+++ b/packages/clerk-js/src/ui/contexts/utils.ts
@@ -13,3 +13,16 @@ export function assertContextExists(contextVal: unknown, providerName: string): 
     clerkCoreErrorContextProviderNotFound(providerName);
   }
 }
+
+export function isRedirectForFAPIInitiatedFlow(clerk: Clerk, redirectUrl: string): boolean {
+  const url = new URL(redirectUrl);
+  const path = url.pathname;
+
+  return clerk.frontendApi === url.host && frontendApiRedirectPaths.includes(path);
+}
+
+const frontendApiRedirectPaths: string[] = [
+  '/oauth/authorize', // OAuth2 identify provider flow
+  '/v1/verify', // magic links
+  '/v1/tickets/accept', // ticket flow
+];

--- a/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
@@ -1,20 +1,22 @@
 import { getDevBrowserJWTFromURL, setDevBrowserJWTInURL } from '../devBrowser';
 
 describe('setDevBrowserJWTInURL(url, jwt)', () => {
-  const testCases: Array<[string, string, string]> = [
-    ['', 'deadbeef', '#__clerk_db_jwt[deadbeef]'],
-    ['foo', 'deadbeef', 'foo#__clerk_db_jwt[deadbeef]'],
-    ['/foo', 'deadbeef', '/foo#__clerk_db_jwt[deadbeef]'],
-    ['#foo', 'deadbeef', '#foo__clerk_db_jwt[deadbeef]'],
-    ['/foo?bar=42#qux', 'deadbeef', '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
-    ['/foo#__clerk_db_jwt[deadbeef]', 'deadbeef', '/foo#__clerk_db_jwt[deadbeef]'],
-    ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
+  const testCases: Array<[string, string, boolean, string]> = [
+    ['', 'deadbeef', false, '#__clerk_db_jwt[deadbeef]'],
+    ['foo', 'deadbeef', false, 'foo#__clerk_db_jwt[deadbeef]'],
+    ['/foo', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
+    ['#foo', 'deadbeef', false, '#foo__clerk_db_jwt[deadbeef]'],
+    ['/foo?bar=42#qux', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
+    ['/foo#__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo#__clerk_db_jwt[deadbeef]'],
+    ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', false, '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
+    ['/foo', 'deadbeef', true, '/foo?__dev_session=deadbeef'],
+    ['/foo?bar=42', 'deadbeef', true, '/foo?bar=42&__dev_session=deadbeef'],
   ];
 
   test.each(testCases)(
     'sets the dev browser JWT at the end of the provided url. Params: url=(%s), jwt=(%s), expected url=(%s)',
-    (hash, paramName, expectedUrl) => {
-      expect(setDevBrowserJWTInURL(hash, paramName)).toEqual(expectedUrl);
+    (hash, paramName, asQueryParam, expectedUrl) => {
+      expect(setDevBrowserJWTInURL(hash, paramName, asQueryParam)).toEqual(expectedUrl);
     },
   );
 });

--- a/packages/clerk-js/src/utils/devBrowser.ts
+++ b/packages/clerk-js/src/utils/devBrowser.ts
@@ -1,3 +1,5 @@
+import { DEV_BROWSER_SSO_JWT_PARAMETER } from '../core/constants';
+
 const DEV_BROWSER_JWT_MARKER = '__clerk_db_jwt';
 const DEV_BROWSER_JWT_MARKER_REGEXP = /__clerk_db_jwt\[(.*)\]/;
 
@@ -6,7 +8,12 @@ function extractDevBrowserJWT(url: string): string {
   return matches ? matches[1] : '';
 }
 
-export function setDevBrowserJWTInURL(url: string, jwt: string): string {
+export function setDevBrowserJWTInURL(url: string, jwt: string, asQueryParam: boolean): string {
+  if (asQueryParam) {
+    const hasQueryParam = (url || '').includes('?');
+    return `${url}${hasQueryParam ? '&' : '?'}${DEV_BROWSER_SSO_JWT_PARAMETER}=${(jwt || '').trim()}`;
+  }
+
   const dbJwt = extractDevBrowserJWT(url);
   if (dbJwt) {
     url.replace(`${DEV_BROWSER_JWT_MARKER}[${dbJwt}]`, jwt);

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -293,8 +293,9 @@ export interface Clerk {
    * Decorates the provided url with the auth token for development instances.
    *
    * @param {string} to
+   * @param opts A {@link BuildUrlWithAuthParams} object
    */
-  buildUrlWithAuth(to: string): string;
+  buildUrlWithAuth(to: string, opts?: BuildUrlWithAuthParams): string;
 
   /**
    * Returns the configured url where <SignIn/> is mounted or a custom sign-in page is rendered.
@@ -456,6 +457,13 @@ export type HandleOAuthCallbackParams = {
  * @experimental
  */
 export type HandleSamlCallbackParams = HandleOAuthCallbackParams;
+
+export type BuildUrlWithAuthParams = {
+  /**
+   * Controls if dev browser JWT is added as a query param
+   */
+  useQueryParam?: boolean | null;
+};
 
 // TODO: Make sure Isomorphic Clerk navigate can work with the correct type:
 // (to: string) => Promise<unknown>


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
URL based session synced dev instances don't set a cookie on FAPI. For OAuth2 IDP and future SSO flows, we get around this by appending the dev browser JWT as a query parameter instead of hash. This way, FAPI can retrieve the dev browser jwt from the url and complete the sso flow.

<!-- Fixes # (issue number) -->
