### PR TITLE
fix(clerk-js): Do not append __clerk_db_jwt if it already exists

### DIFF
--- a/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
@@ -7,6 +7,8 @@ describe('setDevBrowserJWTInURL(url, jwt)', () => {
     ['/foo', 'deadbeef', '/foo#__clerk_db_jwt[deadbeef]'],
     ['#foo', 'deadbeef', '#foo__clerk_db_jwt[deadbeef]'],
     ['/foo?bar=42#qux', 'deadbeef', '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
+    ['/foo#__clerk_db_jwt[deadbeef]', 'deadbeef', '/foo#__clerk_db_jwt[deadbeef]'],
+    ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', '/foo?bar=42#qux__clerk_db_jwt[deadbeef]'],
   ];
 
   test.each(testCases)(

--- a/packages/clerk-js/src/utils/devBrowser.ts
+++ b/packages/clerk-js/src/utils/devBrowser.ts
@@ -1,17 +1,23 @@
 const DEV_BROWSER_JWT_MARKER = '__clerk_db_jwt';
 const DEV_BROWSER_JWT_MARKER_REGEXP = /__clerk_db_jwt\[(.*)\]/;
 
+function extractDevBrowserJWT(url: string): string {
+  const matches = url.match(DEV_BROWSER_JWT_MARKER_REGEXP);
+  return matches ? matches[1] : '';
+}
+
 export function setDevBrowserJWTInURL(url: string, jwt: string): string {
+  const dbJwt = extractDevBrowserJWT(url);
+  if (dbJwt) {
+    url.replace(`${DEV_BROWSER_JWT_MARKER}[${dbJwt}]`, jwt);
+    return url;
+  }
   const hasHash = (url || '').includes('#');
   return `${url}${hasHash ? '' : '#'}${DEV_BROWSER_JWT_MARKER}[${(jwt || '').trim()}]`;
 }
 
 export function getDevBrowserJWTFromURL(url: string): string {
-  const matches = url.match(DEV_BROWSER_JWT_MARKER_REGEXP);
-  if (!matches) {
-    return '';
-  }
-
+  const jwt = extractDevBrowserJWT(url);
   let newUrl = url.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
 
   if (newUrl.endsWith('#')) {
@@ -22,5 +28,5 @@ export function getDevBrowserJWTFromURL(url: string): string {
     globalThis.history.replaceState(null, '', newUrl);
   }
 
-  return matches[1];
+  return jwt;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
That way we will avoid appending it twice for OAuth provider flows were a redirectUrl is passed in but it already includes a db jwt.

In most cases, the redirectUrl will be provided by the user so if a db jwt does not exist, we do need to append it.

However, flows that append a redirectUrl before the mounting of the components (eg, using one of our redirect helpers like RedirectToSignIn) do no need the extra db jwt appended, as the components will already decorate the URL in ClerkUIComponents

Tested with a brand new nextjs + clerk app, using:
```
import '@/styles/globals.css';
import {ClerkProvider, RedirectToSignIn, SignedIn, SignedOut, UserButton} from '@clerk/nextjs';
import type { AppProps } from 'next/app';

export default function App({ Component, pageProps }: AppProps) {
  return (
      <ClerkProvider>
        <SignedIn>
            <UserButton/>
          <Component {...pageProps} />
        </SignedIn>
        <SignedOut>
         <RedirectToSignIn/>
        </SignedOut>
      </ClerkProvider>
  );
}
```

- (no existing user) localhost -> hosted pages -> sign in with google -> redirect to localhost ✅ 
- (w/ existing user + MFA enabled) localhost -> hosted pages -> sign up -> with google -> accounts sign in MFA -> redirect to localhost ✅  

https://user-images.githubusercontent.com/1811063/232997149-6f4569dc-9f0f-4225-a30b-b77e5729160a.mp4

<!-- Fixes # (issue number) -->
