### PR TITLE
Remove deprecated fields from Sign In, Sing Up, Display Config resources & types

### DIFF
--- a/packages/backend/src/api/resources/Enums.ts
+++ b/packages/backend/src/api/resources/Enums.ts
@@ -21,21 +21,9 @@ export type OrganizationInvitationStatus = 'pending' | 'accepted' | 'revoked';
 
 export type OrganizationMembershipRole = 'basic_member' | 'guest_member' | 'admin';
 
-export type SignInIdentifier = 'username' | 'email_address' | 'phone_number' | 'web3_wallet' | OAuthStrategy;
-
-export type SignInFactorStrategy = 'password' | 'email_link' | 'phone_code' | 'email_code' | OAuthStrategy;
-
 export type SignInStatus = 'needs_identifier' | 'needs_factor_one' | 'needs_factor_two' | 'complete';
 
 export type SignUpStatus = 'missing_requirements' | 'complete' | 'abandoned';
-
-export type SignUpIdentificationRequirements = (
-  | 'email_address'
-  | 'phone_number'
-  | 'web3_wallet'
-  | 'username'
-  | OAuthStrategy
-)[][];
 
 export type SignUpAttributeRequirements = (
   | 'name_title'

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -2,11 +2,8 @@ import type {
   InvitationStatus,
   OrganizationInvitationStatus,
   OrganizationMembershipRole,
-  SignInFactorStrategy,
-  SignInIdentifier,
   SignInStatus,
   SignUpAttributeRequirements,
-  SignUpIdentificationRequirements,
   SignUpStatus,
 } from './Enums';
 
@@ -197,11 +194,7 @@ export interface SessionJSON extends ClerkResourceJSON {
 export interface SignInJSON extends ClerkResourceJSON {
   object: ObjectType.SignInToken;
   status: SignInStatus;
-  allowed_identifier_types: SignInIdentifier[];
   identifier: string;
-  allowed_factor_one_strategies: SignInFactorStrategy[];
-  factor_one_verification: VerificationJSON | null;
-  factor_two_verification: VerificationJSON | null;
   created_session_id: string | null;
 }
 
@@ -217,17 +210,12 @@ export interface SignInTokenJSON extends ClerkResourceJSON {
 export interface SignUpJSON extends ClerkResourceJSON {
   object: ObjectType.SignUpAttempt;
   status: SignUpStatus;
-  identification_requirements: SignUpIdentificationRequirements;
   attribute_requirements: SignUpAttributeRequirements;
   username: string | null;
   email_address: string | null;
-  email_address_verification: VerificationJSON | null;
   phone_number: string | null;
-  phone_number_verification: VerificationJSON | null;
   web3_wallet: string | null;
   web3_wallet_verification: VerificationJSON | null;
-  external_account_strategy: string | null;
-  external_account_verification: VerificationJSON | null;
   external_account: any;
   has_password: boolean;
   name_full: string | null;

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -47,7 +47,6 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.preferredSignInStrategy = data.preferred_sign_in_strategy;
     this.logoUrl = data.logo_url;
     this.faviconUrl = data.favicon_url;
-    this.backendHost = data.backend_host;
     this.homeUrl = data.home_url;
     this.signInUrl = data.sign_in_url;
     this.signUpUrl = data.sign_up_url;

--- a/packages/clerk-js/src/ui/utils/test/fixtures.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtures.ts
@@ -73,7 +73,6 @@ const createBaseDisplayConfig = (): DisplayConfigJSON => {
     after_leave_organization_url: 'https://dashboard.clerk.com',
     after_create_organization_url: 'https://dashboard.clerk.com',
     support_email: null,
-    backend_host: 'dapi.clerk.com',
     branded: true,
     experimental_force_oauth_first: false,
     clerk_js_version: '4',

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -13,7 +13,6 @@ export interface DisplayConfigJSON {
   after_sign_up_url: string;
   after_switch_session_url: string;
   application_name: string;
-  backend_host: string;
   branded: boolean;
   home_url: string;
   instance_environment_type: string;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

We have recently deprecated some fields from the sign, sign up and display config responses as they were part of an older API schema. This commit removes them from the types as well, as it's no longer used to keep them clean.

Display Config
- backend_host

Sign In
- allowed_identifier_types
- allowed_factor_one_strategies
- factor_one_verification
- factor_two_verification

Sign Up
- identification_requirements
- email_address_verification
- phone_number_verification
- external_account_strategy
- external_account_verification

<!-- Fixes # (issue number) -->
