### PR TITLE
Support for simple feature flags

### DIFF
--- a/packages/clerk-js/.env
+++ b/packages/clerk-js/.env
@@ -1,0 +1,2 @@
+STAGING=false
+CLERK_FF_ENABLE_IMAGES=false

--- a/packages/clerk-js/scripts/feature-flags.js
+++ b/packages/clerk-js/scripts/feature-flags.js
@@ -1,0 +1,54 @@
+const path = require('path');
+const fs = require('fs');
+const dotenv = require('dotenv');
+
+const files = {
+  '.env.local': path.resolve(__dirname, './../.env.local'),
+  '.env.prod': path.resolve(__dirname, './../.env.prod'),
+};
+
+const getFlagsFromFile = file => {
+  try {
+    return dotenv.parse(fs.readFileSync(file));
+  } catch (e) {
+    return {};
+  }
+};
+
+const parseFlags = flags => {
+  return Object.fromEntries(
+    Object.entries(flags).map(([key, value]) => {
+      return [key, value === 'true' ? true : value === 'false' ? false : value];
+    }),
+  );
+};
+
+const prefixFlagNames = flags => {
+  return Object.fromEntries(Object.entries(flags).map(([key, value]) => [`__${key}__`, value]));
+};
+
+const allFlagsWithUndefinedValue = (...flags) => {
+  return Object.fromEntries(
+    flags
+      .map(f => Object.keys(f))
+      .flat()
+      .map(f => [f, undefined]),
+  );
+};
+
+const getFeatureFlags = () => {
+  const localFlags = prefixFlagNames(parseFlags(getFlagsFromFile(files['.env.local'])));
+  const prodFlags = prefixFlagNames(parseFlags(getFlagsFromFile(files['.env.prod'])));
+
+  // always define all flags from all envs as undefined to avoid build errors
+  const allFlagsAsUndefined = allFlagsWithUndefinedValue(localFlags, prodFlags);
+
+  return {
+    local: { ...allFlagsAsUndefined, ...localFlags },
+    prod: { ...allFlagsAsUndefined, ...prodFlags },
+  };
+};
+
+module.exports = {
+  getFeatureFlags,
+};

--- a/packages/clerk-js/setupJest.ts
+++ b/packages/clerk-js/setupJest.ts
@@ -1,5 +1,7 @@
 import { jest } from '@jest/globals';
 
+const { getFeatureFlags } = require('./scripts/feature-flags.js');
+
 window.ResizeObserver =
   window.ResizeObserver ||
   jest.fn().mockImplementation(() => ({
@@ -22,8 +24,16 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+// @ts-ignore
 global.__PKG_NAME__ = '';
+// @ts-ignore
 global.__PKG_VERSION__ = '';
+
+// @ts-ignore
+Object.entries(getFeatureFlags().local).forEach(([key, value]) => {
+  // @ts-ignore
+  global[key] = value;
+});
 
 //@ts-expect-error
 global.IntersectionObserver = class IntersectionObserver {

--- a/packages/clerk-js/src/globals.d.ts
+++ b/packages/clerk-js/src/globals.d.ts
@@ -1,7 +1,10 @@
 declare global {
   const __DEV__: boolean;
+  const __STAGING__: boolean;
   const __PKG_NAME__: string;
   const __PKG_VERSION__: string;
+
+  const __FF__ENABLE_IMAGES__: boolean;
 
   interface Window {
     __unstable__onBeforeSetActive: () => void;

--- a/packages/clerk-js/src/globals.d.ts
+++ b/packages/clerk-js/src/globals.d.ts
@@ -4,7 +4,7 @@ declare global {
   const __PKG_NAME__: string;
   const __PKG_VERSION__: string;
 
-  const __FF__ENABLE_IMAGES__: boolean;
+  const __CLERK_FF_ENABLE_IMAGES__: boolean;
 
   interface Window {
     __unstable__onBeforeSetActive: () => void;

--- a/packages/clerk-js/src/ui/elements/UserAvatar.tsx
+++ b/packages/clerk-js/src/ui/elements/UserAvatar.tsx
@@ -19,8 +19,8 @@ export const UserAvatar = (props: UserAvatarProps) => {
     <Avatar
       title={generatedName}
       initials={initials}
-      {...rest}
       imageUrl={__CLERK_FF_ENABLE_IMAGES__ ? imageUrl : profileImageUrl}
+      {...rest}
     />
   );
 };

--- a/packages/clerk-js/src/ui/elements/UserAvatar.tsx
+++ b/packages/clerk-js/src/ui/elements/UserAvatar.tsx
@@ -19,8 +19,8 @@ export const UserAvatar = (props: UserAvatarProps) => {
     <Avatar
       title={generatedName}
       initials={initials}
-      imageUrl={profileImageUrl}
       {...rest}
+      imageUrl={__FF__ENABLE_IMAGES__ ? imageUrl : profileImageUrl}
     />
   );
 };

--- a/packages/clerk-js/src/ui/elements/UserAvatar.tsx
+++ b/packages/clerk-js/src/ui/elements/UserAvatar.tsx
@@ -20,7 +20,7 @@ export const UserAvatar = (props: UserAvatarProps) => {
       title={generatedName}
       initials={initials}
       {...rest}
-      imageUrl={__FF__ENABLE_IMAGES__ ? imageUrl : profileImageUrl}
+      imageUrl={__CLERK_FF_ENABLE_IMAGES__ ? imageUrl : profileImageUrl}
     />
   );
 };

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -7,6 +7,11 @@ const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin'
 const ReactRefreshTypeScript = require('react-refresh-typescript');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
+require('dotenv').config();
+require('dotenv').config({ path: path.resolve(__dirname, '.env.local') });
+
+const env = { ...process.env };
+
 const isProduction = mode => mode === 'production';
 const isDevelopment = mode => !isProduction(mode);
 
@@ -26,17 +31,24 @@ const variantToSourceFile = {
 
 /** @type { () => import('webpack').Configuration } */
 const common = ({ mode }) => {
+  const envVariables = {
+    __PKG_VERSION__: JSON.stringify(packageJSON.version),
+    __PKG_NAME__: JSON.stringify(packageJSON.name),
+    __DEV__: isDevelopment(mode),
+    __STAGING__: env.CLERK_STAGING === 'true',
+    // TODO: Improve feature flag infrastructure
+    __FF__ENABLE_IMAGES__: env.CLERK_FF_ENABLE_IMAGES === 'true',
+  };
+
+  console.log('Building clerk-js with env: ', envVariables);
+
   return {
     mode,
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
     plugins: [
-      new webpack.DefinePlugin({
-        __DEV__: isDevelopment(mode),
-        __PKG_VERSION__: JSON.stringify(packageJSON.version),
-        __PKG_NAME__: JSON.stringify(packageJSON.name),
-      }),
+      new webpack.DefinePlugin(envVariables),
       new webpack.EnvironmentPlugin({
         CLERK_ENV: mode,
         NODE_ENV: mode,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

This is an extremely early-stage mechanism for clerk-js FF. More improvements and a repo-level FF mechanism will follow.
Setup: 
- create a .env.local file in packages/clerk-js: 
```
STAGING=true
CLERK_FF_ENABLE_IMAGES=true
```

Usage:
All feature flags from .env will be defined. Their values can be overriden using `.env.local`.
Variables found in `process.env` will only be used if they are defined in `.env`, otherwise they will be ignored. 


So for the above file, you'd have 2 new vars: 
```
__STAGING__
__CLERK_FF_ENABLE_IMAGES__
```

See the 2nd commit. 

The .env.local variables will be picked up during `npm run dev` by default. For `npm run build` you need to use the `.env` file or redefined the .env variables in `process.env`. 

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
