### PR TITLE
fix(clerk-js): Remove leftover .only from MFA tests

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
@@ -1,6 +1,5 @@
 import type { SignInResource } from '@clerk/types';
 import { describe, it } from '@jest/globals';
-import React from 'react';
 
 import { ClerkAPIResponseError } from '../../../../core/resources';
 import { bindCreateFixtures, render, runFakeTimers, screen, waitFor } from '../../../../testUtils';
@@ -36,7 +35,7 @@ describe('SignInFactorTwo', () => {
       expect(inputs.length).toBe(6);
     });
 
-    it.only('sets an active session when user submits second factor successfully', async () => {
+    it('sets an active session when user submits second factor successfully', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.startSignInFactorTwo();
       });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
