### PR TITLE
fix(clerk-js): Form errors not displayed when form submitted with enter

### DIFF
--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -1,6 +1,6 @@
 import { createContextAndHook } from '@clerk/shared';
 import type { FieldId } from '@clerk/types';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Button, descriptors, Flex, Form as FormPrim, localizationKeys } from '../customizables';
 import { useLoadingStatus } from '../hooks';
@@ -8,13 +8,18 @@ import type { PropsOfComponent } from '../styledSystem';
 import { useCardState } from './contexts';
 import { FormControl } from './FormControl';
 
-const [FormState, useFormState] = createContextAndHook<{ isLoading: boolean; isDisabled: boolean }>('FormState');
+const [FormState, useFormState] = createContextAndHook<{
+  isLoading: boolean;
+  isDisabled: boolean;
+  submittedWithEnter: boolean;
+}>('FormState');
 
 type FormProps = PropsOfComponent<typeof FormPrim>;
 
 const FormRoot = (props: FormProps): JSX.Element => {
   const card = useCardState();
   const status = useLoadingStatus();
+  const [submittedWithEnter, setSubmittedWithEnter] = useState(false);
 
   const onSubmit: React.FormEventHandler<HTMLFormElement> = async e => {
     e.preventDefault();
@@ -25,6 +30,7 @@ const FormRoot = (props: FormProps): JSX.Element => {
     try {
       card.setLoading();
       status.setLoading();
+      setSubmittedWithEnter(true);
       await props.onSubmit(e);
     } finally {
       card.setIdle();
@@ -33,8 +39,10 @@ const FormRoot = (props: FormProps): JSX.Element => {
   };
 
   const value = React.useMemo(() => {
-    return { value: { isLoading: status.isLoading, isDisabled: card.isLoading || status.isLoading } };
-  }, [card.isLoading, status.isLoading]);
+    return {
+      value: { isLoading: status.isLoading, isDisabled: card.isLoading || status.isLoading, submittedWithEnter },
+    };
+  }, [card.isLoading, status.isLoading, submittedWithEnter]);
 
   return (
     <FormState.Provider value={value}>
@@ -52,6 +60,7 @@ const FormRoot = (props: FormProps): JSX.Element => {
         */}
         <button
           type='submit'
+          onClick={() => console.log('firing')}
           aria-hidden
           // Avoid using display:none because safari will ignore the button
           style={{ visibility: 'hidden', position: 'absolute' }}
@@ -117,3 +126,5 @@ export const Form = {
   SubmitButton: FormSubmit,
   ResetButton: FormReset,
 };
+
+export { useFormState };

--- a/packages/clerk-js/src/ui/elements/FormControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FormControl.tsx
@@ -1,6 +1,6 @@
 import type { FieldId } from '@clerk/types';
 import type { ClerkAPIError } from '@clerk/types';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 
 import type { LocalizationKey } from '../customizables';
 import {
@@ -18,6 +18,7 @@ import {
 } from '../customizables';
 import type { PropsOfComponent } from '../styledSystem';
 import { useCardState } from './contexts';
+import { useFormState } from './Form';
 import { PasswordInput } from './PasswordInput';
 import { PhoneInput } from './PhoneInput';
 
@@ -55,6 +56,7 @@ const getInputElementForType = (type: FormControlProps['type']) => {
 export const FormControl = forwardRef<HTMLInputElement, FormControlProps>((props, ref) => {
   const { t } = useLocalizations();
   const card = useCardState();
+  const { submittedWithEnter } = useFormState();
   const {
     id,
     errorText,
@@ -78,6 +80,16 @@ export const FormControl = forwardRef<HTMLInputElement, FormControlProps>((props
 
   const InputElement = getInputElementForType(props.type);
   const isCheckbox = props.type === 'checkbox';
+
+  const shouldDisplayError = useMemo(() => {
+    if (enableErrorAfterBlur) {
+      if (submittedWithEnter) {
+        return true;
+      }
+      return hasLostFocus;
+    }
+    return true;
+  }, [enableErrorAfterBlur, hasLostFocus, submittedWithEnter]);
 
   return (
     <FormControlPrim
@@ -182,7 +194,7 @@ export const FormControl = forwardRef<HTMLInputElement, FormControlProps>((props
         elementDescriptor={descriptors.formFieldErrorText}
         elementId={descriptors.formFieldErrorText.setId(id)}
       >
-        {enableErrorAfterBlur ? hasLostFocus && errorText : errorText}
+        {shouldDisplayError && errorText}
       </FormErrorText>
     </FormControlPrim>
   );


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This is introduced due to enableErrorAfterBlur option from useFormControl that will delay an error message from being displayed until user moves clicks away from the field at least once.

This was a necessary change I had to make, in order to support displaying error messages while typing a password, but for better UX to delay giving users feedback for the errors until they move away (only the first time).

In order to fix this, I introduced a flag that keeps track of whether the form was submitted  by pressing enter inside the field. If that's the case then I bypass that the logic above and directly display the error message.

<!-- Fixes # (issue number) -->
