### PR TITLE
fix(clerk-js): Do not replaceState if a db JWT is not found in the url

### DIFF
--- a/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/devbrowser.test.ts
@@ -39,6 +39,11 @@ describe('getDevBrowserJWTFromURL(url,)', () => {
     replaceStateMock.mockReset();
   });
 
+  it('does not replaceState if the url does not contain a dev browser JWT', () => {
+    expect(getDevBrowserJWTFromURL('/foo')).toEqual('');
+    expect(replaceStateMock).not.toHaveBeenCalled();
+  });
+
   const testCases: Array<[string, string, null | string]> = [
     ['', '', null],
     ['foo', '', null],
@@ -48,8 +53,13 @@ describe('getDevBrowserJWTFromURL(url,)', () => {
     ['#foo__clerk_db_jwt[deadbeef]', 'deadbeef', '#foo'],
     ['/foo?bar=42#qux__clerk_db_jwt[deadbeef]', 'deadbeef', '/foo?bar=42#qux'],
   ];
+
   test.each(testCases)('returns the dev browser JWT from a url. Params: url=(%s), jwt=(%s)', (url, jwt, calledWith) => {
     expect(getDevBrowserJWTFromURL(url)).toEqual(jwt);
-    calledWith && expect(replaceStateMock).toHaveBeenCalledWith(null, '', calledWith);
+    if (calledWith === null) {
+      expect(replaceStateMock).not.toHaveBeenCalled();
+    } else {
+      expect(replaceStateMock).toHaveBeenCalledWith(null, '', calledWith);
+    }
   });
 });

--- a/packages/clerk-js/src/utils/devBrowser.ts
+++ b/packages/clerk-js/src/utils/devBrowser.ts
@@ -18,6 +18,10 @@ export function setDevBrowserJWTInURL(url: string, jwt: string): string {
 
 export function getDevBrowserJWTFromURL(url: string): string {
   const jwt = extractDevBrowserJWT(url);
+  if (!jwt) {
+    return '';
+  }
+
   let newUrl = url.replace(DEV_BROWSER_JWT_MARKER_REGEXP, '');
 
   if (newUrl.endsWith('#')) {


### PR DESCRIPTION

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Replacing state on every navigation during local development breaks routers that depend on the history API.

<!-- Fixes # (issue number) -->
