### PR TITLE
feat(clerk-js): Use path-based routing as default when repo-level paths exist

### DIFF
--- a/packages/nextjs/src/client/NextProviderContext.tsx
+++ b/packages/nextjs/src/client/NextProviderContext.tsx
@@ -1,0 +1,21 @@
+import type { ClerkProviderProps } from '@clerk/clerk-react';
+import React from 'react';
+
+type ClerkNextContextValue = Omit<ClerkProviderProps, 'children'>;
+
+const ClerkNextContext = React.createContext<{ value: ClerkNextContextValue } | undefined>(undefined);
+ClerkNextContext.displayName = 'ClerkNextContext';
+
+const useClerkNextContext = () => {
+  const ctx = React.useContext(ClerkNextContext);
+  return (ctx as any).value as ClerkNextContextValue;
+};
+
+const ClerkNextProvider = (props: ClerkProviderProps) => {
+  const { children, ...restProps } = props;
+  const ctxValue = { value: restProps };
+
+  return <ClerkNextContext.Provider value={ctxValue}>{children}</ClerkNextContext.Provider>;
+};
+
+export { ClerkNextProvider, useClerkNextContext };

--- a/packages/nextjs/src/client/index.tsx
+++ b/packages/nextjs/src/client/index.tsx
@@ -1,10 +1,16 @@
-import { __internal__setErrorThrowerOptions, ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';
+import {
+  __internal__setErrorThrowerOptions,
+  ClerkProvider as ReactClerkProvider,
+  SignIn as BaseSignIn,
+  SignUp as BaseSignUp,
+} from '@clerk/clerk-react';
 import type { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
-import type { MultiDomainAndOrProxy, PublishableKeyOrFrontendApi } from '@clerk/types';
+import type { MultiDomainAndOrProxy, PublishableKeyOrFrontendApi, SignInProps, SignUpProps } from '@clerk/types';
 import { useRouter } from 'next/router';
 import React from 'react';
 
 import { invalidateNextRouterCache } from './invalidateNextRouterCache';
+import { ClerkNextProvider, useClerkNextContext } from './NextProviderContext';
 
 // TODO: Import from shared once [JS-118] is done
 const useSafeLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
@@ -14,6 +20,34 @@ __internal__setErrorThrowerOptions({
 });
 
 export * from '@clerk/clerk-react';
+
+export const SignIn = (props: SignInProps) => {
+  const { signInUrl } = useClerkNextContext();
+  if (signInUrl) {
+    return (
+      <BaseSignIn
+        routing='path'
+        path={signInUrl}
+        {...props}
+      />
+    );
+  }
+  return <BaseSignIn {...props} />;
+};
+
+export const SignUp = (props: SignUpProps) => {
+  const { signUpUrl } = useClerkNextContext();
+  if (signUpUrl) {
+    return (
+      <BaseSignUp
+        routing='path'
+        path={signUpUrl}
+        {...props}
+      />
+    );
+  }
+  return <BaseSignUp {...props} />;
+};
 
 type NextClerkProviderProps = {
   children: React.ReactNode;
@@ -67,26 +101,29 @@ export function ClerkProvider({ children, ...rest }: NextClerkProviderProps): JS
     };
   }, []);
 
+  const nextProps = {
+    frontendApi: frontendApi || process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '',
+    publishableKey: publishableKey || process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '',
+    clerkJSUrl: clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS,
+    proxyUrl: proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '',
+    domain: domain || process.env.NEXT_PUBLIC_CLERK_DOMAIN || '',
+    isSatellite: isSatellite || process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true',
+    signInUrl: signInUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '',
+    signUpUrl: signUpUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '',
+    afterSignInUrl: afterSignInUrl || process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL || '',
+    afterSignUpUrl: afterSignUpUrl || process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL || '',
+    navigate: (to: string) => push(to),
+    // withServerSideAuth automatically injects __clerk_ssr_state
+    // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state
+    initialState: authServerSideProps?.__clerk_ssr_state || __clerk_ssr_state,
+    ...restProps,
+  };
+
   return (
     // @ts-expect-error
-    <ReactClerkProvider
-      frontendApi={frontendApi || process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || ''}
-      publishableKey={publishableKey || process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || ''}
-      clerkJSUrl={clerkJSUrl || process.env.NEXT_PUBLIC_CLERK_JS}
-      proxyUrl={proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || ''}
-      domain={domain || process.env.NEXT_PUBLIC_CLERK_DOMAIN || ''}
-      isSatellite={isSatellite || process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true'}
-      signInUrl={signInUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || ''}
-      signUpUrl={signUpUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || ''}
-      afterSignInUrl={afterSignInUrl || process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL || ''}
-      afterSignUpUrl={afterSignUpUrl || process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL || ''}
-      navigate={to => push(to)}
-      // withServerSideAuth automatically injects __clerk_ssr_state
-      // getAuth returns a user-facing authServerSideProps that hides __clerk_ssr_state
-      initialState={authServerSideProps?.__clerk_ssr_state || __clerk_ssr_state}
-      {...restProps}
-    >
-      {children}
-    </ReactClerkProvider>
+    <ClerkNextProvider {...nextProps}>
+      {/*@ts-expect-error*/}
+      <ReactClerkProvider {...nextProps}>{children}</ReactClerkProvider>
+    </ClerkNextProvider>
   );
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
If `signInUrl` or `signUpUrl` are set in the repo-level, we can default to path-based routing for the SignIn or SignUp components respectively.

This PR depends on #1098
<!-- Fixes # (issue number) -->
