### PR TITLE
chore(repo): Support debug for playground/nextjs12 in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "playground/nextjs12: debug server",
+        "type": "node-terminal",
+        "request": "launch",
+        "command": "npm run dev",
+        "cwd": "${workspaceFolder}/playground/nextjs12"
+      }
+    ]
+  }

--- a/playground/nextjs/README.md
+++ b/playground/nextjs/README.md
@@ -1,14 +1,35 @@
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
-## Getting Started
+## Setup
 
-First, run the development server:
+At repository level:
+
+```bash
+npm run build
+npm run yalc:all
+```
+
+At current directory level:
+
+```bash
+npm run yalc:add
+npm i
+```
+
+## Run development server
 
 ```bash
 npm run dev
 # or
 yarn dev
 ```
+
+This starts your app in development mode, rebuilding assets on file changes.
+
+To get the latest unpublished changes from the `packages` (if they are not auto updated) use `npm run yalc:all` in repository level or `yalc push --replace` from the updated package
+after an `npm run build` is being executed.
+
+## Getting Started
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -6,10 +6,16 @@
     "dev": "rm -rf .next && next dev --port 4011",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "yalc:add": "yalc add -- @clerk/shared @clerk/types @clerk/backend @clerk/clerk-react @clerk/clerk-sdk-node @clerk/nextjs"
   },
   "dependencies": {
-    "@clerk/nextjs": "*",
+    "@clerk/backend": "file:.yalc/@clerk/backend",
+    "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
+    "@clerk/clerk-sdk-node": "file:.yalc/@clerk/clerk-sdk-node",
+    "@clerk/nextjs": "file:.yalc/@clerk/nextjs",
+    "@clerk/shared": "file:.yalc/@clerk/shared",
+    "@clerk/types": "file:.yalc/@clerk/types",
     "next": "^13.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/playground/nextjs12/README.md
+++ b/playground/nextjs12/README.md
@@ -1,14 +1,35 @@
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
-## Getting Started
+## Setup
 
-First, run the development server:
+At repository level:
+
+```bash
+npm run build
+npm run yalc:all
+```
+
+At current directory level:
+
+```bash
+npm run yalc:add
+npm i
+```
+
+## Run development server
 
 ```bash
 npm run dev
 # or
 yarn dev
 ```
+
+This starts your app in development mode, rebuilding assets on file changes.
+
+To get the latest unpublished changes from the `packages` (if they are not auto updated) use `npm run yalc:all` in repository level or `yalc push --replace` from the updated package
+after an `npm run build` is being executed.
+
+## Getting Started
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/playground/nextjs12/package.json
+++ b/playground/nextjs12/package.json
@@ -6,10 +6,16 @@
     "dev": "rm -rf .next && next dev --port 4011",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "yalc:add": "yalc add -- @clerk/shared @clerk/types @clerk/backend @clerk/clerk-react @clerk/clerk-sdk-node @clerk/nextjs"
   },
   "dependencies": {
-    "@clerk/nextjs": "*",
+    "@clerk/backend": "file:.yalc/@clerk/backend",
+    "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
+    "@clerk/clerk-sdk-node": "file:.yalc/@clerk/clerk-sdk-node",
+    "@clerk/nextjs": "file:.yalc/@clerk/nextjs",
+    "@clerk/shared": "file:.yalc/@clerk/shared",
+    "@clerk/types": "file:.yalc/@clerk/types",
     "next": "^12.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/playground/remix-node/README.md
+++ b/playground/remix-node/README.md
@@ -2,15 +2,32 @@
 
 - [Remix Docs](https://remix.run/docs)
 
-## Development
+## Setup
 
-From your terminal:
+At repository level:
 
-```sh
+```bash
+npm run build
+npm run yalc:all
+```
+
+At current directory level:
+
+```bash
+npm run yalc:add
+npm i
+```
+
+## Run development server
+
+```bash
 npm run dev
 ```
 
 This starts your app in development mode, rebuilding assets on file changes.
+
+To get the latest unpublished changes from the `packages` (if they are not auto updated) use `npm run yalc:all` in repository level or `yalc push --replace` from the updated package
+after an `npm run build` is being executed.
 
 ## Deployment
 

--- a/playground/remix-node/package.json
+++ b/playground/remix-node/package.json
@@ -5,13 +5,14 @@
     "build": "remix build",
     "dev": "remix dev",
     "start": "remix-serve build",
-    "yalc:add": "yalc add @clerk/types && yalc add @clerk/remix && yalc add @clerk/backend"
+    "yalc:add": "yalc add -- @clerk/types @clerk/shared @clerk/backend @clerk/remix @clerk/clerk-react"
   },
   "dependencies": {
-    "@clerk/backend": "*",
-    "@clerk/clerk-react": "*",
-    "@clerk/remix": "*",
-    "@clerk/types": "*",
+    "@clerk/backend": "file:.yalc/@clerk/backend",
+    "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
+    "@clerk/remix": "file:.yalc/@clerk/remix",
+    "@clerk/shared": "file:.yalc/@clerk/shared",
+    "@clerk/types": "file:.yalc/@clerk/types",
     "@remix-run/node": "^1.12.0",
     "@remix-run/react": "^1.12.0",
     "@remix-run/serve": "^1.12.0",


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [x] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Introduce debug command for VSCode for the `playground/nextjs12` application.
