### PR TITLE
feat(clerk-js,types): Support sign in with SAML strategy

### DIFF
--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -195,6 +195,7 @@ export class SignUp extends BaseResource implements SignUpResource {
   }: AuthenticateWithRedirectParams & { unsafeMetadata?: SignUpUnsafeMetadata }): Promise<void> => {
     const authenticateFn = (args: SignUpCreateParams | SignUpUpdateParams) =>
       continueSignUp && this.id ? this.update(args) : this.create(args);
+
     const { verifications } = await authenticateFn({
       strategy,
       redirectUrl: SignUp.clerk.buildUrlWithAuth(redirectUrl),
@@ -202,6 +203,7 @@ export class SignUp extends BaseResource implements SignUpResource {
       unsafeMetadata,
       emailAddress,
     });
+
     const { externalAccount } = verifications;
     const { status, externalVerificationRedirectURL } = externalAccount;
 

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -127,15 +127,20 @@ describe('SignInStart', () => {
         f.withEmailAddress();
       });
       fixtures.signIn.create.mockReturnValueOnce(
-        Promise.resolve({ status: 'needs_identifier', supportedFirstFactors: ['saml'] } as unknown as SignInResource),
+        Promise.resolve({
+          status: 'needs_identifier',
+          supportedFirstFactors: [{ strategy: 'saml' }],
+        } as unknown as SignInResource),
       );
       const { userEvent } = render(<SignInStart />, { wrapper });
       await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.dev');
       await userEvent.click(screen.getByText('Continue'));
       expect(fixtures.signIn.create).toHaveBeenCalled();
-
-      // FIXME this should pass
-      //expect(fixtures.signIn.authenticateWithRedirect).toHaveBeenCalled();
+      expect(fixtures.signIn.authenticateWithRedirect).toHaveBeenCalledWith({
+        strategy: 'saml',
+        redirectUrl: 'http://localhost/#/sso-callback',
+        redirectUrlComplete: 'https://dashboard.clerk.com',
+      });
     });
   });
 

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -121,6 +121,24 @@ describe('SignInStart', () => {
     });
   });
 
+  describe('SAML', () => {
+    it('initiates a SAML flow if saml is listed as a supported first factor', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      fixtures.signIn.create.mockReturnValueOnce(
+        Promise.resolve({ status: 'needs_identifier', supportedFirstFactors: ['saml'] } as unknown as SignInResource),
+      );
+      const { userEvent } = render(<SignInStart />, { wrapper });
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.dev');
+      await userEvent.click(screen.getByText('Continue'));
+      expect(fixtures.signIn.create).toHaveBeenCalled();
+
+      // FIXME this should pass
+      //expect(fixtures.signIn.authenticateWithRedirect).toHaveBeenCalled();
+    });
+  });
+
   describe('Identifier switching', () => {
     it('shows the email label', async () => {
       const { wrapper } = await createFixtures(f => {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { ERROR_CODES } from '../../../core/constants';
 import { getClerkQueryParam } from '../../../utils/getClerkQueryParam';
-import { withRedirectToHomeSingleSessionGuard } from '../../common';
+import { buildSSOCallbackURL, withRedirectToHomeSingleSessionGuard } from '../../common';
 import { useCoreClerk, useCoreSignUp, useEnvironment, useSignUpContext } from '../../contexts';
 import { descriptors, Flex, Flow, localizationKeys, useAppearance } from '../../customizables';
 import {
@@ -33,7 +33,8 @@ function _SignUpStart(): JSX.Element {
   const { navigate } = useNavigate();
   const { attributes } = userSettings;
   const { setActive } = useCoreClerk();
-  const { navigateAfterSignUp, signInUrl } = useSignUpContext();
+  const ctx = useSignUpContext();
+  const { navigateAfterSignUp, signInUrl } = ctx;
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
     getInitialActiveIdentifier(attributes, userSettings.signUp.progressive),
   );
@@ -192,6 +193,10 @@ function _SignUpStart(): JSX.Element {
 
     card.setLoading();
     card.setError(undefined);
+
+    const redirectUrl = buildSSOCallbackURL(ctx, displayConfig.signUpUrl);
+    const redirectUrlComplete = ctx.afterSignInUrl || displayConfig.afterSignUpUrl;
+
     return signUp
       .create(buildRequest(fieldsToSubmit))
       .then(res =>
@@ -201,6 +206,8 @@ function _SignUpStart(): JSX.Element {
           verifyPhonePath: 'verify-phone-number',
           handleComplete: () => setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignUp }),
           navigate,
+          redirectUrl,
+          redirectUrlComplete,
         }),
       )
       .catch(err => handleError(err, fieldsToSubmit, card.setError))

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -1,5 +1,4 @@
 import { OAUTH_PROVIDERS } from '@clerk/types';
-import React from 'react';
 
 import { bindCreateFixtures, render, screen } from '../../../../testUtils';
 import { SignUpStart } from '../SignUpStart';

--- a/packages/clerk-js/src/ui/components/SignUp/util.ts
+++ b/packages/clerk-js/src/ui/components/SignUp/util.ts
@@ -6,6 +6,8 @@ type CompleteSignUpFlowProps = {
   verifyPhonePath?: string;
   navigate: (to: string) => Promise<void>;
   handleComplete?: () => Promise<void>;
+  redirectUrl?: string;
+  redirectUrlComplete?: string;
 };
 
 export const completeSignUpFlow = ({
@@ -14,10 +16,21 @@ export const completeSignUpFlow = ({
   verifyPhonePath,
   navigate,
   handleComplete,
+  redirectUrl = '',
+  redirectUrlComplete = '',
 }: CompleteSignUpFlowProps): Promise<void> | undefined => {
   if (signUp.status === 'complete') {
     return handleComplete && handleComplete();
   } else if (signUp.status === 'missing_requirements') {
+    if (signUp.missingFields.some(mf => mf === 'saml')) {
+      return signUp.authenticateWithRedirect({
+        strategy: 'saml',
+        redirectUrl,
+        redirectUrlComplete,
+        continueSignUp: true,
+      });
+    }
+
     if (signUp.unverifiedFields?.includes('email_address') && verifyEmailPath) {
       return navigate(verifyEmailPath);
     }

--- a/packages/types/src/redirects.ts
+++ b/packages/types/src/redirects.ts
@@ -2,14 +2,14 @@ import type { OAuthStrategy, SamlStrategy } from './strategies';
 
 export type AuthenticateWithRedirectParams = {
   /**
-   * Full URL or path to the route that will complete the OAuth flow.
+   * Full URL or path to the route that will complete the OAuth or SAML flow.
    * Typically, this will be a simple `/sso-callback` route that calls `Clerk.handleRedirectCallback`
    * or mounts the <AuthenticateWithRedirectCallback /> component.
    */
   redirectUrl: string;
 
   /**
-   * Full URL or path to navigate after the OAuth flow completes.
+   * Full URL or path to navigate after the OAuth or SAML flow completes.
    */
   redirectUrlComplete: string;
 

--- a/packages/types/src/signUp.ts
+++ b/packages/types/src/signUp.ts
@@ -152,7 +152,7 @@ export type SignUpVerifiableField =
   | Web3WalletIdentifier;
 
 // TODO: Does it make sense that the identification *field* holds a *strategy*?
-export type SignUpIdentificationField = SignUpVerifiableField | OAuthStrategy;
+export type SignUpIdentificationField = SignUpVerifiableField | OAuthStrategy | SamlStrategy;
 
 // TODO: Replace with discriminated union type
 export type SignUpCreateParams = Partial<


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Note: Draft PR

First commit addresses signing in with SAML.

~~If the sign-up created contains `saml` in the supported_first_factors, then we navigate to the `/sign-in/factor-one` route, where the actual redirection is initiated.~~

~~Note: debating whether I should keep the handling in `SignInStart.tsx` instead.~~

Redirection is handled in `SignUpStart.tsx` for sign-up & `SignInStart.tsx` for`sign-in`, respectively.