### PR TITLE
fix(clerk-js): Add a dummy base when constructing the url in isRedirectForFAPIInitiatedFlow

### DIFF
--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -126,7 +126,10 @@ export const useSignInContext = (): SignInContextType => {
   });
 
   const buildUrlWithAuthParams: BuildUrlWithAuthParams = {};
-  if (clerk.instanceType !== 'production' && isRedirectForFAPIInitiatedFlow(clerk, extractedAfterSignInUrl)) {
+  if (
+    clerk.instanceType !== 'production' &&
+    isRedirectForFAPIInitiatedFlow(clerk.frontendApi, extractedAfterSignInUrl)
+  ) {
     buildUrlWithAuthParams.useQueryParam = true;
 
     if (clerk.session) {

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -1,6 +1,7 @@
 import type { BuildUrlWithAuthParams } from '@clerk/types';
 import React from 'react';
-import { buildAuthQueryString, buildURL, pickRedirectionProp } from '../../utils';
+
+import { buildAuthQueryString, buildURL, isRedirectForFAPIInitiatedFlow, pickRedirectionProp } from '../../utils';
 import { useCoreClerk, useEnvironment, useOptions } from '../contexts';
 import { useNavigate } from '../hooks';
 import type { ParsedQs } from '../router';
@@ -15,7 +16,6 @@ import type {
   UserButtonCtx,
   UserProfileCtx,
 } from '../types';
-import { isRedirectForFAPIInitiatedFlow } from './utils';
 
 export const ComponentContext = React.createContext<AvailableComponentCtx | null>(null);
 

--- a/packages/clerk-js/src/ui/contexts/utils.ts
+++ b/packages/clerk-js/src/ui/contexts/utils.ts
@@ -13,16 +13,3 @@ export function assertContextExists(contextVal: unknown, providerName: string): 
     clerkCoreErrorContextProviderNotFound(providerName);
   }
 }
-
-export function isRedirectForFAPIInitiatedFlow(clerk: Clerk, redirectUrl: string): boolean {
-  const url = new URL(redirectUrl);
-  const path = url.pathname;
-
-  return clerk.frontendApi === url.host && frontendApiRedirectPaths.includes(path);
-}
-
-const frontendApiRedirectPaths: string[] = [
-  '/oauth/authorize', // OAuth2 identify provider flow
-  '/v1/verify', // magic links
-  '/v1/tickets/accept', // ticket flow
-];

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -9,6 +9,7 @@ import {
   hasExternalAccountSignUpError,
   isAccountsHostedPages,
   isDataUri,
+  isRedirectForFAPIInitiatedFlow,
   isValidUrl,
   mergeFragmentIntoUrl,
   trimTrailingSlash,
@@ -362,4 +363,23 @@ describe('mergeFragmentIntoUrl(url | string)', () => {
     expect(mergeFragmentIntoUrl(new URL(url)).href).toEqual(expectedParamValue.href);
     expect(mergeFragmentIntoUrl(url).href).toEqual(expectedParamValue.href);
   });
+});
+
+describe('isRedirectForFAPIInitiatedFlow(frontendAp: string, redirectUrl: string)', () => {
+  const testCases: Array<[string, string, boolean]> = [
+    ['clerk.foo.bar-53.lcl.dev', 'foo', false],
+    ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/deadbeef.', false],
+    ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/oauth/authorize', true],
+    ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/v1/verify', true],
+    ['clerk.foo.bar-53.lcl.dev', 'https://clerk.foo.bar-53.lcl.dev/v1/tickets/accept', true],
+    ['clerk.foo.bar-53.lcl.dev', 'https://google.com', false],
+    ['clerk.foo.bar-53.lcl.dev', 'https://google.com/v1/verify', false],
+  ];
+
+  test.each(testCases)(
+    'frontendApi=(%s), redirectUrl=(%s), expected value=(%s)',
+    (frontendApi, redirectUrl, expectedValue) => {
+      expect(isRedirectForFAPIInitiatedFlow(frontendApi, redirectUrl)).toEqual(expectedValue);
+    },
+  );
 });

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -1,5 +1,5 @@
 import { camelToSnake, createDevOrStagingUrlCache, isIPV4Address } from '@clerk/shared';
-import type { SignUpResource } from '@clerk/types';
+import type { Clerk, SignUpResource } from '@clerk/types';
 
 import { loadScript } from '../utils';
 import { joinPaths } from './path';
@@ -362,3 +362,16 @@ export const mergeFragmentIntoUrl = (_url: string | URL): URL => {
 export const pathFromFullPath = (fullPath: string) => {
   return fullPath.replace(/CLERK-ROUTER\/(.*?)\//, '');
 };
+
+const frontendApiRedirectPaths: string[] = [
+  '/oauth/authorize', // OAuth2 identify provider flow
+  '/v1/verify', // magic links
+  '/v1/tickets/accept', // ticket flow
+];
+
+export function isRedirectForFAPIInitiatedFlow(clerk: Clerk, redirectUrl: string): boolean {
+  const url = new URL(redirectUrl, DUMMY_URL_BASE);
+  const path = url.pathname;
+
+  return clerk.frontendApi === url.host && frontendApiRedirectPaths.includes(path);
+}

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -1,5 +1,5 @@
 import { camelToSnake, createDevOrStagingUrlCache, isIPV4Address } from '@clerk/shared';
-import type { Clerk, SignUpResource } from '@clerk/types';
+import type { SignUpResource } from '@clerk/types';
 
 import { loadScript } from '../utils';
 import { joinPaths } from './path';
@@ -369,9 +369,9 @@ const frontendApiRedirectPaths: string[] = [
   '/v1/tickets/accept', // ticket flow
 ];
 
-export function isRedirectForFAPIInitiatedFlow(clerk: Clerk, redirectUrl: string): boolean {
+export function isRedirectForFAPIInitiatedFlow(frontendApi: string, redirectUrl: string): boolean {
   const url = new URL(redirectUrl, DUMMY_URL_BASE);
   const path = url.pathname;
 
-  return clerk.frontendApi === url.host && frontendApiRedirectPaths.includes(path);
+  return frontendApi === url.host && frontendApiRedirectPaths.includes(path);
 }


### PR DESCRIPTION


## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
