### PR TITLE
fix(clerk-js): Partially revert commit d53432e

### DIFF
--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -1,7 +1,6 @@
-import type { BuildUrlWithAuthParams } from '@clerk/types';
 import React from 'react';
 
-import { buildAuthQueryString, buildURL, isRedirectForFAPIInitiatedFlow, pickRedirectionProp } from '../../utils';
+import { buildAuthQueryString, buildURL, pickRedirectionProp } from '../../utils';
 import { useCoreClerk, useEnvironment, useOptions } from '../contexts';
 import { useNavigate } from '../hooks';
 import type { ParsedQs } from '../router';
@@ -118,26 +117,14 @@ export const useSignInContext = (): SignInContextType => {
     }),
   );
 
-  const extractedAfterSignInUrl = pickRedirectionProp('afterSignInUrl', {
-    queryParams,
-    ctx,
-    options,
-    displayConfig,
-  });
-
-  const buildUrlWithAuthParams: BuildUrlWithAuthParams = {};
-  if (
-    clerk.instanceType !== 'production' &&
-    isRedirectForFAPIInitiatedFlow(clerk.frontendApi, extractedAfterSignInUrl)
-  ) {
-    buildUrlWithAuthParams.useQueryParam = true;
-
-    if (clerk.session) {
-      navigate(clerk.buildUrlWithAuth(extractedAfterSignInUrl, buildUrlWithAuthParams));
-    }
-  }
-
-  const afterSignInUrl = clerk.buildUrlWithAuth(extractedAfterSignInUrl, buildUrlWithAuthParams);
+  const afterSignInUrl = clerk.buildUrlWithAuth(
+    pickRedirectionProp('afterSignInUrl', {
+      queryParams,
+      ctx,
+      options,
+      displayConfig,
+    }),
+  );
 
   const navigateAfterSignIn = () => navigate(afterSignInUrl);
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Reasons for partially reverting commit d53432e:
- navigation inside SignInContext does not make any sense
- after navigating it should stop the execution flow since control passes to the navigated route

We will revert that change and come back to fix this after the release of `app-router` changes!