### PR TITLE
fix(clerk-js): Password settings maximum allowed length

### DIFF
--- a/packages/clerk-js/src/core/resources/UserSettings.test.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.test.ts
@@ -56,7 +56,7 @@ describe('UserSettings', () => {
     expect(sut.instanceIsPasswordBased).toEqual(false);
   });
 
-  it('respects default values for min and max length', function () {
+  it('respects default values for min and max password length', function () {
     let sut = new UserSettings({
       attributes: {
         password: {
@@ -72,7 +72,7 @@ describe('UserSettings', () => {
 
     expect(sut.passwordSettings).toMatchObject({
       min_length: 8,
-      max_length: 100,
+      max_length: 72,
     });
 
     sut = new UserSettings({
@@ -91,6 +91,24 @@ describe('UserSettings', () => {
     expect(sut.passwordSettings).toMatchObject({
       min_length: 10,
       max_length: 50,
+    });
+
+    sut = new UserSettings({
+      attributes: {
+        password: {
+          enabled: true,
+          required: false,
+        },
+      },
+      password_settings: {
+        min_length: 10,
+        max_length: 100,
+      },
+    } as any as UserSettingsJSON);
+
+    expect(sut.passwordSettings).toMatchObject({
+      min_length: 10,
+      max_length: 72,
     });
   });
 

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -13,6 +13,9 @@ import type {
 
 import { BaseResource } from './internal';
 
+const defaultMaxPasswordLength = 72;
+const defaultMinPasswordLength = 8;
+
 /**
  * @internal
  */
@@ -66,8 +69,11 @@ export class UserSettings extends BaseResource implements UserSettingsResource {
     this.signUp = data.sign_up;
     this.passwordSettings = {
       ...data.password_settings,
-      min_length: Math.max(data?.password_settings?.min_length, 8),
-      max_length: data?.password_settings?.max_length === 0 ? 100 : data?.password_settings?.max_length,
+      min_length: Math.max(data?.password_settings?.min_length, defaultMinPasswordLength),
+      max_length:
+        data?.password_settings?.max_length === 0
+          ? defaultMaxPasswordLength
+          : Math.min(data?.password_settings?.max_length, defaultMaxPasswordLength),
     };
     this.socialProviderStrategies = this.getSocialProviderStrategies(data.social);
     this.authenticatableSocialStrategies = this.getAuthenticatableSocialStrategies(data.social);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

The setting for password maximum allowed length is 72.

<!-- Fixes # (issue number) -->
