### PR TITLE
chore(nextjs): Use redirectToSignIn in app-router auth middleware

### DIFF
--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -7,6 +7,7 @@ import { NextResponse } from 'next/server';
 import { isRedirect, mergeResponses, paths, setHeader } from '../utils';
 import { authenticateRequest, handleInterstitialState, handleUnknownState } from './authenticateRequest';
 import { receivedRequestForIgnoredRoute } from './errors';
+import { redirectToSignIn } from './redirect';
 import type { NextMiddlewareResult, WithAuthOptions } from './types';
 import { decorateRequest } from './utils';
 
@@ -161,10 +162,7 @@ export const createRouteMatcher = (routes: RouteMatcherParam) => {
 const createDefaultAfterAuth = (isPublicRoute: ReturnType<typeof createRouteMatcher>) => {
   return (auth: AuthObject, req: NextRequest) => {
     if (!auth.userId && !isPublicRoute(req)) {
-      // TODO: replace with redirectToSignIn
-      const url = new URL(TMP_SIGN_IN_URL, req.nextUrl.origin);
-      url.searchParams.set('redirect_url', req.url);
-      return NextResponse.redirect(url.toString());
+      return redirectToSignIn({ returnBackUrl: req.url });
     }
     return NextResponse.next();
   };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
