### PR TITLE
fix(clerk-js,types): Remove after_sign_out_url as it not returned by FAPI

### DIFF
--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -53,7 +53,6 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.userProfileUrl = data.user_profile_url;
     this.afterSignInUrl = data.after_sign_in_url;
     this.afterSignUpUrl = data.after_sign_up_url;
-    this.afterSignOutUrl = data.after_sign_out_url;
     this.afterSignOutOneUrl = data.after_sign_out_one_url;
     this.afterSignOutAllUrl = data.after_sign_out_all_url;
     this.afterSwitchSessionUrl = data.after_switch_session_url;

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -9,7 +9,6 @@ export interface DisplayConfigJSON {
   after_sign_in_url: string;
   after_sign_out_all_url: string;
   after_sign_out_one_url: string;
-  after_sign_out_url: string;
   after_sign_up_url: string;
   after_switch_session_url: string;
   application_name: string;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
