### PR TITLE
fix(clerk-js): Use redirectWithAuth after multi session signOut

### DIFF
--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -182,6 +182,7 @@ export const useUserProfileContext = (): UserProfileContextType => {
 export const useUserButtonContext = () => {
   const { componentName, ...ctx } = (React.useContext(ComponentContext) || {}) as UserButtonCtx;
   const { navigate } = useNavigate();
+  const Clerk = useCoreClerk();
   const { displayConfig } = useEnvironment();
   const options = useOptions();
 
@@ -193,7 +194,7 @@ export const useUserButtonContext = () => {
   const userProfileUrl = ctx.userProfileUrl || displayConfig.userProfileUrl;
 
   const afterMultiSessionSingleSignOutUrl = ctx.afterMultiSessionSingleSignOutUrl || displayConfig.afterSignOutOneUrl;
-  const navigateAfterMultiSessionSingleSignOut = () => navigate(afterMultiSessionSingleSignOutUrl);
+  const navigateAfterMultiSessionSingleSignOut = () => Clerk.redirectWithAuth(afterMultiSessionSingleSignOutUrl);
 
   const afterSignOutUrl = ctx.afterSignOutUrl;
   const navigateAfterSignOut = () => navigate(afterSignOutUrl);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR persists the session when the user is being redirected from the app to the accounts page. 
Uses `redirectWithAuth` in order to inject the session JWT into the URL and the accounts app to pick it up.

### Before

https://user-images.githubusercontent.com/19269911/235620593-7fb7521c-87e1-478a-9e04-ed1df96f313b.mov


### After 

https://user-images.githubusercontent.com/19269911/235620504-ffde5c08-b484-46f9-aee4-313274f9c4b9.mov




<!-- Fixes # (issue number) -->
