### PR TITLE
chore(clerk-js): Remove unnecessary runtime error

### DIFF
--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -68,12 +68,6 @@ export function clerkVerifyEmailAddressCalledBeforeCreate(type: 'SignIn' | 'Sign
   throw new Error(`${errorPrefix} You need to start a ${type} flow by calling ${type}.create() first.`);
 }
 
-export function clerkResetPasswordMissingEmailOrPhone(): never {
-  throw new Error(
-    `${errorPrefix} You need to provide either phoneNumberId or an emailAddressId when calling prepareFirstFactor with 'reset_password_code' as strategy`,
-  );
-}
-
 export function clerkInvalidStrategy(functionaName: string, strategy: string): never {
   throw new Error(`${errorPrefix} Strategy "${strategy}" is not a valid strategy for ${functionaName}.`);
 }

--- a/packages/clerk-js/src/core/resources/SignIn.ts
+++ b/packages/clerk-js/src/core/resources/SignIn.ts
@@ -32,7 +32,6 @@ import {
   clerkInvalidFAPIResponse,
   clerkInvalidStrategy,
   clerkMissingOptionError,
-  clerkResetPasswordMissingEmailOrPhone,
   clerkVerifyEmailAddressCalledBeforeCreate,
   clerkVerifyWeb3WalletCalledBeforeCreate,
 } from '../errors';
@@ -97,8 +96,6 @@ export class SignIn extends BaseResource implements SignInResource {
           config = { emailAddressId: factor?.emailAddressId } as ResetPasswordCodeFactorConfig;
         } else if (factor.phoneNumberId) {
           config = { phoneNumberId: factor?.phoneNumberId } as ResetPasswordCodeFactorConfig;
-        } else {
-          clerkResetPasswordMissingEmailOrPhone();
         }
         break;
       default:


### PR DESCRIPTION
FAPI will throw a similar error if the request fails

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
