### PR TITLE
feat(clerk-js,types): Add Select, Menu and Invite member button appearance keys

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -126,6 +126,7 @@ const MemberRow = (props: {
                 isDisabled: isCurrentUser,
               },
             ]}
+            elementId={'member'}
           />
         )}
       </Td>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -129,6 +129,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
             <Text localizationKey={localizationKeys('formFieldLabel__role')} />
             {/*// @ts-expect-error */}
             <Select
+              elementId='role'
               {...roleField.props}
               onChange={option => roleField.setValue(option.value)}
             >

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
@@ -85,6 +85,7 @@ const InvitationRow = (props: { invitation: OrganizationInvitationResource; onRe
               onClick: onRevoke,
             },
           ]}
+          elementId={'invitation'}
         />
       </Td>
     </RowContainer>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -130,6 +130,7 @@ export const RoleSelect = (props: { value: MembershipRole; onChange: any; isDisa
 
   return (
     <Select
+      elementId='role'
       options={roles}
       value={value}
       onChange={role => onChange(role.value)}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -52,6 +52,7 @@ export const OrganizationMembers = withCardStateProvider(() => {
           </Header.Root>
           {isAdmin && (
             <IconButton
+              elementDescriptor={descriptors.membersPageInviteButton}
               aria-label='Invite'
               onClick={() => navigate('invite-members')}
               icon={

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -143,6 +143,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'organizationPreviewMainIdentifier',
   'organizationPreviewSecondaryIdentifier',
 
+  'membersPageInviteButton',
   'organizationProfilePage',
 
   'identityPreview',
@@ -166,8 +167,14 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'tabListContainer',
 
   'selectButton',
+  'selectSearchInput',
   'selectButtonIcon',
   'selectOptionsContainer',
+  'selectOption',
+
+  'menuButton',
+  'menuList',
+  'menuItem',
 
   'loader',
   'loaderIcon',

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -77,6 +77,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps>((props, ref
       })}
     >
       <Select
+        elementId='countryCode'
         value={selectedCountryOption.value}
         options={countryOptions}
         optionBuilder={(option, _index, isFocused) => (

--- a/packages/clerk-js/src/ui/elements/ThreeDotsMenu.tsx
+++ b/packages/clerk-js/src/ui/elements/ThreeDotsMenu.tsx
@@ -1,3 +1,5 @@
+import type { MenuId } from '@clerk/types';
+
 import type { LocalizationKey } from '../customizables';
 import { Button, Icon } from '../customizables';
 import { ThreeDots } from '../icons';
@@ -12,12 +14,13 @@ type Action = {
 
 type ThreeDotsMenuProps = {
   actions: Action[];
+  elementId?: MenuId;
 };
 
 export const ThreeDotsMenu = (props: ThreeDotsMenuProps) => {
-  const { actions } = props;
+  const { actions, elementId } = props;
   return (
-    <Menu>
+    <Menu elementId={elementId}>
       <MenuTrigger>
         <Button
           size='xs'

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -91,6 +91,9 @@ export type OrganizationPreviewId = 'organizationSwitcher';
 
 export type FooterActionId = 'havingTrouble' | 'alternativeMethods' | 'signUp' | 'signIn';
 
+export type MenuId = 'invitation' | 'member';
+export type SelectId = 'countryCode' | 'role';
+
 /**
  * A type that describes the states and the ids that we will combine
  * in order to create all theming combinations
@@ -284,7 +287,9 @@ export type ElementsConfig = {
   organizationPreviewMainIdentifier: WithOptions<OrganizationPreviewId, never, never>;
   organizationPreviewSecondaryIdentifier: WithOptions<OrganizationPreviewId, never, never>;
 
+  membersPageInviteButton: WithOptions<never, never, never>;
   organizationProfilePage: WithOptions<never, never, never>;
+
   identityPreview: WithOptions<never, never, never>;
   identityPreviewAvatarBox: WithOptions<never, never, never>;
   identityPreviewAvatarImage: WithOptions<never, never, never>;
@@ -305,9 +310,15 @@ export type ElementsConfig = {
   tabButton: WithOptions<never, never, never>;
   tabListContainer: WithOptions<never, never, never>;
 
-  selectButton: WithOptions<never, never, never>;
-  selectButtonIcon: WithOptions<never, never, never>;
-  selectOptionsContainer: WithOptions<never, never, never>;
+  selectButton: WithOptions<SelectId, never, never>;
+  selectSearchInput: WithOptions<SelectId, never, never>;
+  selectButtonIcon: WithOptions<SelectId, never, never>;
+  selectOptionsContainer: WithOptions<SelectId, never, never>;
+  selectOption: WithOptions<SelectId, never, never>;
+
+  menuButton: WithOptions<MenuId, never, never>;
+  menuList: WithOptions<MenuId, never, never>;
+  menuItem: WithOptions<MenuId, never, never>;
 
   loader: WithOptions<never, never, never>;
   loaderIcon: WithOptions<never, ErrorState, never>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Add some missing appearance keys to the `Select` and `Menu` elements, and the invite member button inside the organization profile.
<!-- Fixes # (issue number) -->
