### PR TITLE
fix(backend): error parsing POST v1/emails response

### DIFF
--- a/packages/backend/src/api/resources/Deserializer.ts
+++ b/packages/backend/src/api/resources/Deserializer.ts
@@ -35,7 +35,7 @@ type PaginatedResponse = {
 };
 
 function isPaginated(payload: any): payload is PaginatedResponse {
-  return <PaginatedResponse>payload.data !== undefined;
+  return Array.isArray(payload.data) && <PaginatedResponse>payload.data !== undefined;
 }
 
 function getCount(item: { total_count: number }) {

--- a/packages/backend/src/api/resources/Email.ts
+++ b/packages/backend/src/api/resources/Email.ts
@@ -8,7 +8,11 @@ export class Email {
     readonly toEmailAddress?: string,
     readonly subject?: string,
     readonly body?: string,
+    readonly bodyPlain?: string | null,
     readonly status?: string,
+    readonly slug?: string | null,
+    readonly data?: Record<string, any> | null,
+    readonly deliveredByClerk?: boolean,
   ) {}
 
   static fromJSON(data: EmailJSON): Email {
@@ -19,7 +23,11 @@ export class Email {
       data.to_email_address,
       data.subject,
       data.body,
+      data.body_plain,
       data.status,
+      data.slug,
+      data.data,
+      data.delivered_by_clerk,
     );
   }
 }

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -69,7 +69,11 @@ export interface EmailJSON extends ClerkResourceJSON {
   email_address_id: string | null;
   subject?: string;
   body?: string;
+  body_plain?: string | null;
   status?: string;
+  slug?: string | null;
+  data?: Record<string, any> | null;
+  delivered_by_clerk?: boolean;
 }
 
 export interface EmailAddressJSON extends ClerkResourceJSON {
@@ -239,6 +243,7 @@ export interface SMSMessageJSON extends ClerkResourceJSON {
   phone_number_id: string | null;
   message: string;
   status: string;
+  data?: Record<string, any> | null;
 }
 
 export interface UserJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/SMSMessage.ts
+++ b/packages/backend/src/api/resources/SMSMessage.ts
@@ -8,6 +8,7 @@ export class SMSMessage {
     readonly message: string,
     readonly status: string,
     readonly phoneNumberId: string | null,
+    readonly data?: Record<string, any> | null,
   ) {}
 
   static fromJSON(data: SMSMessageJSON): SMSMessage {
@@ -18,6 +19,7 @@ export class SMSMessage {
       data.message,
       data.status,
       data.phone_number_id,
+      data.data,
     );
   }
 }

--- a/packages/backend/src/fixtures/responses/email.json
+++ b/packages/backend/src/fixtures/responses/email.json
@@ -1,0 +1,15 @@
+{
+  "id": "ema_2PHa2N3bS7D6NPPQ5mpHEg0waZQ",
+  "object": "email",
+  "slug": null,
+  "from_email_name": "foobar123",
+  "to_email_address": "test@test.dev",
+  "email_address_id": "idn_2LVNCHPlLJpGE8Ep2wPtsxg7qRt",
+  "user_id": "user_2LVNDmSPQYOhXFeELW9IpLQcvDs",
+  "subject": "this is a test",
+  "body": "this is a test",
+  "body_plain": null,
+  "status": "queued",
+  "data": {},
+  "delivered_by_clerk": true
+}

--- a/playground/nextjs/pages/api/sendEmail.ts
+++ b/playground/nextjs/pages/api/sendEmail.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAuth, clerkClient } from '@clerk/nextjs/server';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { userId } = await getAuth(req);
+  if (!userId) return res.status(401);
+
+  const user = await clerkClient.users.getUser(userId);
+  const email = user.primaryEmailAddressId;
+
+  if (!email) return res.status(422).json({ error: 'primaryEmailAddress is required!' });
+
+  const params = {
+    fromEmailName: 'foobar123',
+    emailAddressId: email,
+    body: 'this is a test',
+    subject: 'this is a test',
+  };
+  const response = await clerkClient.emails.createEmail(params);
+  console.log(response);
+  return res.status(200).json({ name: 'John Doe' });
+}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Update `Email` & `SmsMessage` resources types and fix isPaginated condition to check that `data` contained in the resource response should be array.
I have also added a test with the actual response of BAPI call to `POST v1/emails` to verify the fix.
