### PR TITLE
fix(nextjs): Import next/headers dynamically

### DIFF
--- a/packages/nextjs/src/app-router/server/utils.ts
+++ b/packages/nextjs/src/app-router/server/utils.ts
@@ -1,8 +1,11 @@
-import { headers } from 'next/headers';
 import { NextRequest } from 'next/server';
 
 export const buildRequestLike = () => {
   try {
+    // Dynamically import next/headers, otherwise Next12 apps will break
+    // because next/headers was introduced in next@13
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { headers } = require('next/headers');
     return new NextRequest('https://placeholder.com', { headers: headers() });
   } catch (e: any) {
     if (


### PR DESCRIPTION

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
Otherwise Next12 apps will break because next/headers was introduced in next@13

<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
