### PR TITLE
fix(nextjs): Invalidate cache on before auth state

### DIFF
--- a/packages/nextjs/src/app-router/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/client/ClerkProvider.tsx
@@ -22,17 +22,9 @@ export const ClientClerkProvider = (props: NextClerkProviderProps) => {
 
   useSafeLayoutEffect(() => {
     window.__unstable__onBeforeSetActive = () => {
-      // router.refresh();
-    };
-  }, []);
-
-  useSafeLayoutEffect(() => {
-    window.__unstable__onAfterSetActive = () => {
-      // Re-run the middleware every time there auth state changes.
-      // This enables complete control from a centralised place (NextJS middleware),
-      // as we will invoke it every time the client-side auth state changes, eg: signing-out, switching orgs, etc
       if (__unstable_invokeMiddlewareOnAuthStateChange) {
         router.refresh();
+        router.push(window.location.href);
       }
     };
   }, []);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
