### PR TITLE
fix(nextjs): Enable authMiddleware testing for sign-in/sign-up urls from env

### DIFF
--- a/packages/nextjs/src/server/authMiddleware.test.ts
+++ b/packages/nextjs/src/server/authMiddleware.test.ts
@@ -224,19 +224,33 @@ describe('authMiddleware(params)', () => {
       expect(resp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/public');
     });
 
-    // TODO: @dimikl
-    xit('renders sign-in/sing-up routes', async () => {
-      const signInResp = await authMiddleware({
-        publicRoutes: '/public',
-      })(mockRequest('/sign-in'), {} as NextFetchEvent);
-      expect(signInResp?.status).toEqual(200);
-      expect(signInResp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/sign-in');
+    describe('when sign-in/sign-up routes are defined in env', () => {
+      const currentSignInUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL;
+      const currentSignUpUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL;
 
-      const signUpResp = await authMiddleware({
-        publicRoutes: '/public',
-      })(mockRequest('/sign-up'), {} as NextFetchEvent);
-      expect(signUpResp?.status).toEqual(200);
-      expect(signUpResp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/sign-up');
+      beforeEach(() => {
+        process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL = '/custom-sign-in';
+        process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL = '/custom-sign-up';
+      });
+
+      afterEach(() => {
+        process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL = currentSignInUrl;
+        process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL = currentSignUpUrl;
+      });
+
+      it('renders sign-in/sign-up routes', async () => {
+        const signInResp = await authMiddleware({
+          publicRoutes: '/public',
+        })(mockRequest('/custom-sign-in'), {} as NextFetchEvent);
+        expect(signInResp?.status).toEqual(200);
+        expect(signInResp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/custom-sign-in');
+
+        const signUpResp = await authMiddleware({
+          publicRoutes: '/public',
+        })(mockRequest('/custom-sign-up'), {} as NextFetchEvent);
+        expect(signUpResp?.status).toEqual(200);
+        expect(signUpResp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/custom-sign-up');
+      });
     });
 
     it('redirects to sign-in for protected route', async () => {

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -7,7 +7,6 @@ import { NextResponse } from 'next/server';
 import { isRedirect, mergeResponses, paths, setHeader, stringifyHeaders } from '../utils';
 import { withLogger } from '../utils/debugLogger';
 import { authenticateRequest, handleInterstitialState, handleUnknownState } from './authenticateRequest';
-import { SIGN_IN_URL, SIGN_UP_URL } from './clerkClient';
 import { receivedRequestForIgnoredRoute } from './errors';
 import { redirectToSignIn } from './redirect';
 import type { NextMiddlewareResult, WithAuthOptions } from './types';
@@ -194,12 +193,19 @@ const withDefaultPublicRoutes = (publicRoutes: RouteMatcherParam | undefined) =>
   if (typeof publicRoutes === 'function') {
     return publicRoutes;
   }
+
   const routes = [publicRoutes || ''].flat().filter(Boolean);
-  if (SIGN_IN_URL) {
-    routes.push(matchRoutesStartingWith(SIGN_IN_URL));
+  // TODO: refactor it to use common config file eg SIGN_IN_URL from ./clerkClient
+  // we use process.env for now to support testing
+  const signInUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '';
+  if (signInUrl) {
+    routes.push(matchRoutesStartingWith(signInUrl));
   }
-  if (SIGN_UP_URL) {
-    routes.push(matchRoutesStartingWith(SIGN_UP_URL));
+  // TODO: refactor it to use common config file eg SIGN_UP_URL from ./clerkClient
+  // we use process.env for now to support testing
+  const signUpUrl = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '';
+  if (signUpUrl) {
+    routes.push(matchRoutesStartingWith(signUpUrl));
   }
   return routes;
 };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Add skipped failing test for supporting sign-in and sign-up urls from env and update the code to retrieve the envs each time the middleware tun to support support the testing.