### PR TITLE
fix(clerk-js): Only close modals when pressing on their overlay

### DIFF
--- a/packages/clerk-js/src/ui/elements/Modal.tsx
+++ b/packages/clerk-js/src/ui/elements/Modal.tsx
@@ -1,5 +1,5 @@
 import { createContextAndHook, useSafeLayoutEffect } from '@clerk/shared';
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { descriptors, Flex } from '../customizables';
 import { usePopover, useScrollLock } from '../hooks';
@@ -19,11 +19,13 @@ type ModalProps = React.PropsWithChildren<{
 
 export const Modal = withFloatingTree((props: ModalProps) => {
   const { handleClose, handleOpen, contentSx, containerSx } = props;
+  const { disableScroll, enableScroll } = useScrollLock(document.body);
+  const overlayRef = useRef<HTMLDivElement>(null);
   const { floating, isOpen, context, nodeId, toggle } = usePopover({
     defaultOpen: true,
     autoUpdate: false,
+    outsidePress: e => e.target === overlayRef.current,
   });
-  const { disableScroll, enableScroll } = useScrollLock(document.body);
 
   React.useEffect(() => {
     if (!isOpen) {
@@ -50,6 +52,7 @@ export const Modal = withFloatingTree((props: ModalProps) => {
       <ModalContext.Provider value={modalCtx}>
         <Flex
           aria-hidden
+          ref={overlayRef}
           elementDescriptor={descriptors.modalBackdrop}
           sx={[
             t => ({

--- a/packages/clerk-js/src/ui/hooks/usePopover.ts
+++ b/packages/clerk-js/src/ui/hooks/usePopover.ts
@@ -7,6 +7,7 @@ type UsePopoverProps = {
   placement?: UseFloatingProps['placement'];
   offset?: Parameters<typeof offset>[0];
   autoUpdate?: boolean;
+  outsidePress?: boolean | ((event: MouseEvent) => boolean);
   bubbles?:
     | boolean
     | {
@@ -18,7 +19,7 @@ type UsePopoverProps = {
 export type UsePopoverReturn = ReturnType<typeof usePopover>;
 
 export const usePopover = (props: UsePopoverProps = {}) => {
-  const { bubbles = true } = props;
+  const { bubbles = true, outsidePress } = props;
   const [isOpen, setIsOpen] = React.useState(props.defaultOpen || false);
   const nodeId = useFloatingNodeId();
   const { update, reference, floating, strategy, x, y, context } = useFloating({
@@ -30,7 +31,10 @@ export const usePopover = (props: UsePopoverProps = {}) => {
     middleware: [offset(props.offset || 6), flip(), shift()],
   });
 
-  useDismiss(context, { bubbles });
+  useDismiss(context, {
+    bubbles,
+    outsidePress,
+  });
 
   useEffect(() => {
     if (props.defaultOpen) {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This fixes the issue with the 1Password button where the modal would close when that was pressed. It also fixes the issue where having two modals open and clicking the latest one would close the first one.

<!-- Fixes # (issue number) -->
