### PR TITLE
Support passing a function as proxyUrl

### DIFF
--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -33,10 +33,7 @@ export type RequiredVerifyTokenOptions = Required<
 >;
 
 export type OptionalVerifyTokenOptions = Partial<
-  Pick<
-    VerifyTokenOptions,
-    'authorizedParties' | 'clockSkewInSeconds' | 'jwksCacheTtlInMs' | 'skipJwksCache' | 'jwtKey' | 'proxyUrl'
-  >
+  Pick<VerifyTokenOptions, 'authorizedParties' | 'clockSkewInSeconds' | 'jwksCacheTtlInMs' | 'skipJwksCache' | 'jwtKey'>
 >;
 
 export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
@@ -74,6 +71,10 @@ export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
      * @experimental
      */
     isSatellite?: boolean;
+    /**
+     * @experimental
+     */
+    proxyUrl?: string;
     /**
      * @experimental
      */

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -174,14 +174,14 @@ export function isDevelopmentFromApiKey(apiKey: string): boolean {
   return apiKey.startsWith('test_') || apiKey.startsWith('sk_test_');
 }
 // TODO: use @clerk/shared once it is tree-shakeable
-export function createProxyUrl({ request, relativePath }: { request: Request; relativePath: string }): string {
+export function createProxyUrl({ request, relativePath }: { request: Request; relativePath?: string }): string {
   const { headers, url: initialUrl } = request;
   const url = new URL(initialUrl);
   const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? url.host;
 
   // X-Forwarded-Proto could be 'https, http'
   const protocol = headers.get('X-Forwarded-Proto')?.split(',')[0] ?? url.protocol;
-  return new URL(relativePath, `${protocol}://${host}`).toString();
+  return new URL(relativePath || url.pathname, `${protocol}://${host}`).toString();
 }
 
 // Auth result will be set as both a query param & header when applicable

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -173,15 +173,17 @@ export function isHttpOrHttps(key: string | undefined) {
 export function isDevelopmentFromApiKey(apiKey: string): boolean {
   return apiKey.startsWith('test_') || apiKey.startsWith('sk_test_');
 }
+
 // TODO: use @clerk/shared once it is tree-shakeable
-export function createProxyUrl({ request, relativePath }: { request: Request; relativePath?: string }): string {
+export function getRequestUrl({ request, relativePath }: { request: Request; relativePath?: string }): URL {
   const { headers, url: initialUrl } = request;
   const url = new URL(initialUrl);
-  const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? url.host;
+  const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? (headers as any)['host'] ?? url.host;
 
   // X-Forwarded-Proto could be 'https, http'
-  const protocol = headers.get('X-Forwarded-Proto')?.split(',')[0] ?? url.protocol;
-  return new URL(relativePath || url.pathname, `${protocol}://${host}`).toString();
+  const protocol =
+    (headers.get('X-Forwarded-Proto') ?? (headers as any)['X-Forwarded-Proto'])?.split(',')[0] ?? url.protocol;
+  return new URL(relativePath || url.pathname, `${protocol}://${host}`);
 }
 
 // Auth result will be set as both a query param & header when applicable

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -48,7 +48,11 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
   return async (req: NextRequest, event: NextFetchEvent) => {
     const { headers } = req;
 
-    const relativeOrAbsoluteProxyUrl = opts?.proxyUrl || PROXY_URL;
+    const requestURL = createProxyUrl({
+      request: req,
+    });
+
+    const relativeOrAbsoluteProxyUrl = handleValueOrFn(opts?.proxyUrl, new URL(requestURL), PROXY_URL);
 
     let proxyUrl;
     if (!!relativeOrAbsoluteProxyUrl && !isHttpOrHttps(relativeOrAbsoluteProxyUrl)) {

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -20,9 +20,9 @@ import {
 import { missingDomainAndProxy, missingSignInUrlInDev } from './errors';
 import type { WithAuthOptions } from './types';
 import {
-  createProxyUrl,
   decorateRequest,
   getCookie,
+  getRequestUrl,
   handleValueOrFn,
   isDevelopmentFromApiKey,
   isHttpOrHttps,
@@ -48,18 +48,13 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
   return async (req: NextRequest, event: NextFetchEvent) => {
     const { headers } = req;
 
-    const requestURL = createProxyUrl({
+    const requestURL = getRequestUrl({
       request: req,
     });
-
-    const relativeOrAbsoluteProxyUrl = handleValueOrFn(opts?.proxyUrl, new URL(requestURL), PROXY_URL);
-
+    const relativeOrAbsoluteProxyUrl = handleValueOrFn(opts?.proxyUrl, requestURL, PROXY_URL);
     let proxyUrl;
     if (!!relativeOrAbsoluteProxyUrl && !isHttpOrHttps(relativeOrAbsoluteProxyUrl)) {
-      proxyUrl = createProxyUrl({
-        request: req,
-        relativePath: relativeOrAbsoluteProxyUrl,
-      });
+      proxyUrl = new URL(relativeOrAbsoluteProxyUrl, requestURL).toString();
     } else {
       proxyUrl = relativeOrAbsoluteProxyUrl;
     }

--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -32,5 +32,5 @@ export function isMagicLinkError(err: any): err is MagicLinkError {
 export const invalidStateError =
   'Invalid state. Feel free to submit a bug or reach out to support here: https://clerk.com/support';
 
-export const unsupportedNonBrowserDomainFunction =
-  'Unsupported usage of domain. The usage of domain as function is not supported in non-browser environments.';
+export const unsupportedNonBrowserDomainOrProxyUrlFunction =
+  'Unsupported usage of domain or proxyUrl. The usage of domain or proxyUrl as function is not supported in non-browser environments.';

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -26,7 +26,7 @@ import type {
 import type { BeforeEmitCallback } from '@clerk/types';
 import type { OrganizationProfileProps, OrganizationSwitcherProps } from '@clerk/types/src';
 
-import { unsupportedNonBrowserDomainFunction } from './errors';
+import { unsupportedNonBrowserDomainOrProxyUrlFunction } from './errors';
 import type {
   BrowserClerk,
   BrowserClerkConstructor,
@@ -55,7 +55,6 @@ export default class IsomorphicClerk {
   private readonly mode: 'browser' | 'server';
   private readonly frontendApi?: string;
   private readonly publishableKey?: string;
-  private readonly proxyUrl?: Clerk['proxyUrl'];
   private readonly options: IsomorphicClerkOptions;
   private readonly Clerk: ClerkProp;
   private clerkjs: BrowserClerk | HeadlessBrowserClerk | null = null;
@@ -75,6 +74,7 @@ export default class IsomorphicClerk {
 
   #loaded = false;
   #domain: DomainOrProxyUrl['domain'];
+  #proxyUrl: DomainOrProxyUrl['proxyUrl'];
 
   get loaded(): boolean {
     return this.#loaded;
@@ -99,16 +99,28 @@ export default class IsomorphicClerk {
       return handleValueOrFn(this.#domain, new URL(window.location.href), '');
     }
     if (typeof this.#domain === 'function') {
-      throw new Error(unsupportedNonBrowserDomainFunction);
+      throw new Error(unsupportedNonBrowserDomainOrProxyUrlFunction);
     }
     return this.#domain || '';
+  }
+
+  get proxyUrl(): string {
+    // This getter can run in environments where window is not available.
+    // In those cases we should expect and use domain as a string
+    if (typeof window !== 'undefined' && window.location) {
+      return handleValueOrFn(this.#proxyUrl, new URL(window.location.href), '');
+    }
+    if (typeof this.#proxyUrl === 'function') {
+      throw new Error(unsupportedNonBrowserDomainOrProxyUrlFunction);
+    }
+    return this.#proxyUrl || '';
   }
 
   constructor(options: IsomorphicClerkOptions) {
     const { Clerk = null, frontendApi, publishableKey } = options || {};
     this.frontendApi = frontendApi;
     this.publishableKey = publishableKey;
-    this.proxyUrl = options?.proxyUrl;
+    this.#proxyUrl = options?.proxyUrl;
     this.#domain = options?.domain;
     this.options = options;
     this.Clerk = Clerk;

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -106,7 +106,7 @@ export default class IsomorphicClerk {
 
   get proxyUrl(): string {
     // This getter can run in environments where window is not available.
-    // In those cases we should expect and use domain as a string
+    // In those cases we should expect and use proxy as a string
     if (typeof window !== 'undefined' && window.location) {
       return handleValueOrFn(this.#proxyUrl, new URL(window.location.href), '');
     }

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -55,8 +55,15 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     handleValueOrFn(opts.isSatellite, new URL(request.url)) ||
     false;
 
-  const relativeOrAbsoluteProxyUrl =
-    getEnvVariable('CLERK_PROXY_URL') || (context?.CLERK_PROXY_URL as string) || opts.proxyUrl || '';
+  const requestURL = createProxyUrl({
+    request,
+  });
+
+  const relativeOrAbsoluteProxyUrl = handleValueOrFn(
+    opts?.proxyUrl,
+    new URL(requestURL),
+    getEnvVariable('CLERK_PROXY_URL') || (context?.CLERK_PROXY_URL as string),
+  );
 
   let proxyUrl;
   if (!!relativeOrAbsoluteProxyUrl && !isHttpOrHttps(relativeOrAbsoluteProxyUrl)) {

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -1,6 +1,6 @@
 import type { RequestState } from '@clerk/backend';
 import { Clerk } from '@clerk/backend';
-import { createProxyUrl, handleValueOrFn, isHttpOrHttps } from '@clerk/shared';
+import { getRequestUrl, handleValueOrFn, isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from '@clerk/shared';
 
 import {
   noSecretKeyOrApiKeyError,
@@ -55,7 +55,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     handleValueOrFn(opts.isSatellite, new URL(request.url)) ||
     false;
 
-  const requestURL = createProxyUrl({
+  const requestURL = getRequestUrl({
     request,
   });
 
@@ -66,11 +66,8 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
   );
 
   let proxyUrl;
-  if (!!relativeOrAbsoluteProxyUrl && !isHttpOrHttps(relativeOrAbsoluteProxyUrl)) {
-    proxyUrl = createProxyUrl({
-      request,
-      relativePath: relativeOrAbsoluteProxyUrl,
-    });
+  if (isValidProxyUrl(relativeOrAbsoluteProxyUrl) && isProxyUrlRelative(relativeOrAbsoluteProxyUrl)) {
+    proxyUrl = new URL(relativeOrAbsoluteProxyUrl, requestURL).toString();
   } else {
     proxyUrl = relativeOrAbsoluteProxyUrl;
   }

--- a/packages/shared/src/utils/proxy.ts
+++ b/packages/shared/src/utils/proxy.ts
@@ -21,12 +21,12 @@ export function proxyUrlToAbsoluteURL(url: string | undefined): string {
   return isProxyUrlRelative(url) ? new URL(url, window.location.origin).toString() : url;
 }
 
-export function createProxyUrl({ request, relativePath }: { request: Request; relativePath: string }): string {
+export function createProxyUrl({ request, relativePath }: { request: Request; relativePath?: string }): string {
   const { headers, url: initialUrl } = request;
   const url = new URL(initialUrl);
   const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? url.host;
 
   // X-Forwarded-Proto could be 'https, http'
   const protocol = headers.get('X-Forwarded-Proto')?.split(',')[0] ?? url.protocol;
-  return new URL(relativePath, `${protocol}://${host}`).toString();
+  return new URL(relativePath || url.pathname, `${protocol}://${host}`).toString();
 }

--- a/packages/shared/src/utils/proxy.ts
+++ b/packages/shared/src/utils/proxy.ts
@@ -21,12 +21,13 @@ export function proxyUrlToAbsoluteURL(url: string | undefined): string {
   return isProxyUrlRelative(url) ? new URL(url, window.location.origin).toString() : url;
 }
 
-export function createProxyUrl({ request, relativePath }: { request: Request; relativePath?: string }): string {
+export function getRequestUrl({ request, relativePath }: { request: Request; relativePath?: string }): URL {
   const { headers, url: initialUrl } = request;
   const url = new URL(initialUrl);
-  const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? url.host;
+  const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? (headers as any)['host'] ?? url.host;
 
   // X-Forwarded-Proto could be 'https, http'
-  const protocol = headers.get('X-Forwarded-Proto')?.split(',')[0] ?? url.protocol;
-  return new URL(relativePath || url.pathname, `${protocol}://${host}`).toString();
+  const protocol =
+    (headers.get('X-Forwarded-Proto') ?? (headers as any)['X-Forwarded-Proto'])?.split(',')[0] ?? url.protocol;
+  return new URL(relativePath || url.pathname, `${protocol}://${host}`);
 }

--- a/packages/types/src/multiDomain.ts
+++ b/packages/types/src/multiDomain.ts
@@ -1,7 +1,6 @@
 import type { ClerkOptions } from './clerk';
 
-type DOMAIN = string | ((url: URL) => string);
-type PROXY_URL = string | ((url: URL) => string);
+type StringOrURLFnToString = string | ((url: URL) => string);
 
 /**
  * DomainOrProxyUrl supports the following cases
@@ -13,17 +12,17 @@ type PROXY_URL = string | ((url: URL) => string);
 export type MultiDomainAndOrProxy =
   | {
       isSatellite?: never;
-      proxyUrl?: never | PROXY_URL;
+      proxyUrl?: never | StringOrURLFnToString;
       domain?: never;
     }
   | {
       isSatellite: Exclude<ClerkOptions['isSatellite'], undefined>;
       proxyUrl?: never;
-      domain: DOMAIN;
+      domain: StringOrURLFnToString;
     }
   | {
       isSatellite: Exclude<ClerkOptions['isSatellite'], undefined>;
-      proxyUrl: PROXY_URL;
+      proxyUrl: StringOrURLFnToString;
       domain?: never;
     };
 
@@ -47,9 +46,9 @@ export type MultiDomainAndOrProxyPrimitives =
 export type DomainOrProxyUrl =
   | {
       proxyUrl?: never;
-      domain?: DOMAIN;
+      domain?: StringOrURLFnToString;
     }
   | {
-      proxyUrl?: PROXY_URL;
+      proxyUrl?: StringOrURLFnToString;
       domain?: never;
     };

--- a/packages/types/src/multiDomain.ts
+++ b/packages/types/src/multiDomain.ts
@@ -1,6 +1,7 @@
 import type { ClerkOptions } from './clerk';
 
 type DOMAIN = string | ((url: URL) => string);
+type PROXY_URL = string | ((url: URL) => string);
 
 /**
  * DomainOrProxyUrl supports the following cases
@@ -12,7 +13,7 @@ type DOMAIN = string | ((url: URL) => string);
 export type MultiDomainAndOrProxy =
   | {
       isSatellite?: never;
-      proxyUrl?: never | string;
+      proxyUrl?: never | PROXY_URL;
       domain?: never;
     }
   | {
@@ -22,7 +23,7 @@ export type MultiDomainAndOrProxy =
     }
   | {
       isSatellite: Exclude<ClerkOptions['isSatellite'], undefined>;
-      proxyUrl: string;
+      proxyUrl: PROXY_URL;
       domain?: never;
     };
 
@@ -49,6 +50,6 @@ export type DomainOrProxyUrl =
       domain?: DOMAIN;
     }
   | {
-      proxyUrl?: string;
+      proxyUrl?: PROXY_URL;
       domain?: never;
     };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

### Before (react)

```jsx
<ClerkProvider proxyUrl={'/__clerk'}>
 {...}
</ClerkProvider>
```

### After (react)

```jsx
<ClerkProvider proxyUrl={'/__clerk'}>
 {...}
</ClerkProvider>

{/* or*/}

<ClerkProvider 
    proxyUrl={(url) => {
       /* Do something with the url */
       return new Url('/__clerk',url).toString(); // or simply return  '/__clerk'
    }}
>
 {...}
</ClerkProvider>

```

This PR adds support for proxyUrl function in react, nextjs(middleware), remix(rootLoader)

<!-- Fixes # (issue number) -->
