### PR TITLE
fix(clerk-js,types): Deprecate private imageUrl and use logoImageUrl

### DIFF
--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -15,8 +15,8 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   branded!: boolean;
   homeUrl!: string;
   instanceEnvironmentType!: string;
-  logoUrl!: string;
-  faviconUrl!: string;
+  faviconImageUrl!: string;
+  logoImageUrl!: string;
   preferredSignInStrategy!: PreferredSignInStrategy;
   signInUrl!: string;
   signUpUrl!: string;
@@ -45,8 +45,8 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.applicationName = data.application_name;
     this.theme = data.theme;
     this.preferredSignInStrategy = data.preferred_sign_in_strategy;
-    this.logoUrl = data.logo_url;
-    this.faviconUrl = data.favicon_url;
+    this.logoImageUrl = data.logo_image_url || data.logo_url;
+    this.faviconImageUrl = data.favicon_image_url || data.favicon_url;
     this.homeUrl = data.home_url;
     this.signInUrl = data.sign_in_url;
     this.signUpUrl = data.sign_up_url;

--- a/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
+++ b/packages/clerk-js/src/ui/elements/ApplicationLogo.tsx
@@ -29,10 +29,9 @@ type ApplicationLogoProps = PropsOfComponent<typeof Flex>;
 export const ApplicationLogo = (props: ApplicationLogoProps) => {
   const imageRef = React.useRef<HTMLImageElement>(null);
   const [loaded, setLoaded] = React.useState(false);
-  const { logoUrl, applicationName, homeUrl } = useEnvironment().displayConfig;
+  const { logoImageUrl, applicationName, homeUrl } = useEnvironment().displayConfig;
   const { parsedLayout } = useAppearance();
-  // TODO: Should we throw an error if logoImageUrl is not a valid url?
-  const imageSrc = parsedLayout.logoImageUrl || logoUrl;
+  const imageSrc = parsedLayout.logoImageUrl || logoImageUrl;
 
   if (!imageSrc) {
     return null;

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -16,7 +16,11 @@ export interface DisplayConfigJSON {
   home_url: string;
   instance_environment_type: string;
   logo_url: string;
+  /* @deprecated */
   favicon_url: string;
+  /* @deprecated */
+  logo_image_url: string;
+  favicon_image_url: string;
   preferred_sign_in_strategy: PreferredSignInStrategy;
   sign_in_url: string;
   sign_up_url: string;
@@ -43,8 +47,8 @@ export interface DisplayConfigResource extends ClerkResource {
   branded: boolean;
   homeUrl: string;
   instanceEnvironmentType: string;
-  logoUrl: string;
-  faviconUrl: string;
+  logoImageUrl: string;
+  faviconImageUrl: string;
   preferredSignInStrategy: PreferredSignInStrategy;
   signInUrl: string;
   signUpUrl: string;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Instead of going with the per-instance FF approach, we decided to introduce 2 new fields on displayConfig:
```
logoImageUrl
faviconImageUrl
```

They will gradually replace the existing imageUrl and faviconUrl fields

<!-- Fixes # (issue number) -->
