### PR TITLE
fix(clerk-react): Catch handleRedirectCallback error that occurs in strict mode

### DIFF
--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -600,7 +600,15 @@ export default class IsomorphicClerk {
   handleRedirectCallback = (params: HandleOAuthCallbackParams): void => {
     const callback = () => this.clerkjs?.handleRedirectCallback(params);
     if (this.clerkjs && this.#loaded) {
-      void callback();
+      void callback()?.catch(() => {
+        // This error is caused when the host app is using React18
+        // and strictMode is enabled. This useEffects runs twice because
+        // the clerk-react ui components mounts, unmounts and mounts again
+        // so the clerk-js component loses its state because of the custom
+        // unmount callback we're using.
+        // This needs to be solved by tweaking the logic in uiComponents.tsx
+        // or by making handleRedirectCallback idempotent
+      });
     } else {
       this.premountMethodCalls.set('handleRedirectCallback', callback);
     }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
When using strict mode in React 18, the component will mount twice and so, `handleRedirectCallback` will also run two time, resulting in an error the second time. This is handled in the same manner in clerk-js, but it was not handled in this case here.
<!-- Fixes # (issue number) -->
