### PR TITLE
COR-350 fix(clerk-js): Add password bytes exceeded error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37887,7 +37887,7 @@
       "version": "0.16.0-staging.1",
       "license": "ISC",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1"
+        "glob-to-regexp": "0.4.1"
       },
       "devDependencies": {
         "@clerk/types": "^3.37.0-staging.1",
@@ -37895,7 +37895,7 @@
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "13.4.0",
         "@testing-library/user-event": "14.4.3",
-        "@types/glob-to-regexp": "^0.4.1",
+        "@types/glob-to-regexp": "0.4.1",
         "@types/js-cookie": "3.0.2",
         "jest": "*",
         "jest-environment-jsdom": "*",
@@ -42410,9 +42410,9 @@
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "13.4.0",
         "@testing-library/user-event": "14.4.3",
-        "@types/glob-to-regexp": "^0.4.1",
+        "@types/glob-to-regexp": "0.4.1",
         "@types/js-cookie": "3.0.2",
-        "glob-to-regexp": "^0.4.1",
+        "glob-to-regexp": "0.4.1",
         "jest": "*",
         "jest-environment-jsdom": "*",
         "js-cookie": "3.0.1",

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -565,7 +565,7 @@ export const enUS: LocalizationResource = {
   unstable__errors: {
     form_identifier_not_found: '',
     form_password_pwned:
-      'This password has been found as part of a breach and can not be used, please try another password instead',
+      'This password has been found as part of a breach and can not be used, please try another password instead.',
     form_username_invalid_length: '',
     form_param_format_invalid: '',
     form_password_length_too_short: '',
@@ -576,6 +576,8 @@ export const enUS: LocalizationResource = {
     form_identifier_exists: '',
     form_password_validation_failed: 'Incorrect Password',
     form_password_not_strong_enough: 'Your password is not strong enough.',
+    form_password_size_in_bytes_exceeded:
+      'Your password has exceeded the maximum number of bytes allowed, please shorten it or remove some special characters.',
     passwordComplexity: {
       sentencePrefix: 'Your password must contain',
       minimumLength: '{{length}} or more characters',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -611,6 +611,7 @@ type UnstableErrors = WithParamName<{
   not_allowed_access: LocalizationValue;
   form_identifier_exists: LocalizationValue;
   form_password_not_strong_enough: LocalizationValue;
+  form_password_size_in_bytes_exceeded: LocalizationValue;
   passwordComplexity: {
     sentencePrefix: LocalizationValue;
     minimumLength: LocalizationValue;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Add password bytes exceeded error message
<!-- Fixes # (issue number) -->
