### PR TITLE
Allow `__client_uat` to be set when visiting from external site

### DIFF
--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -38,9 +38,9 @@ export const createCookieHandler = () => {
     return parseInt(clientUatCookie.get() || '0', 10);
   };
 
-  const setClientUatCookie = (client: ClientResource | undefined) => {
+  const setClientUatCookie = (client: ClientResource | undefined, options?: { sameSite: 'Lax' | 'Strict' }) => {
+    const sameSite = options?.sameSite || 'Strict';
     const expires = addYears(Date.now(), 1);
-    const sameSite = 'Strict';
     const secure = false;
 
     // '0' indicates the user is signed out


### PR DESCRIPTION

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

### Background
So far for development instances, the sync/link flow boils down to:
- Visit the satellite app.
- Satellite redirects to `signInUrl`
- Primary (with clerk loaded) is accessed, redirects back to satellite
- Satellite receives a request with `__clerk_synced=true` and sets the `client_uat` cookie
- Satellite reloads in order to read the `client_uat` cookie

###  The problem
All the above work perfectly fine when both apps are on localhost. But, let's say that we add an nginx configuration and we now have [primary.dev](http://primary.dev/) and [satellite.dev](http://satellite.dev/) as the domains with self-signed certificates. 

Let's repeat the above steps.
- Visit `https://satellite.dev/`
- Satellite redirects to `https://primary.dev/whatever`
- Primary is accessed, redirects back to `https://satellite.dev?__clerk_synced=true`
- Satellite sets the client_uat cookie.

In this final step, the `client_uat` cookie cannot be set. The `client_uat` cookie's SameSite policy is "Strict". The request is considered cross-origin by the browser, because the referrer is `primary.dev`, so the "Strict" policy will block the cookie.
As a result, when satellite reloads in step (5), the client_uat cookie isn't there and the satellite tries to sync again. Visits https://primary.dev/whatever and we get stuck in an infinite loop of redirects.

### The solution of this PR
If we change the `client_uat` cookie's SameSite policy to "Lax" everything works as expected.


<!-- Fixes # (issue number) -->
