### PR TITLE
fix(clerk-js): Only check origin in isAllowedRedirectOrigin

### DIFF
--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -406,13 +406,10 @@ fdescribe('isAllowedRedirectOrigin', () => {
     // glob patterns
     ['https://clerk.com', ['https://*.clerk.com'], false],
     ['https://www.clerk.com', ['https://*.clerk.com'], true],
-    ['https://www.clerk.com/test', ['https://www.clerk.com/*'], true],
-    ['https://www.clerk.com/hello/test', ['https://www.clerk.com/*/test'], true],
-    ['https://www.clerk.com/hello/hello', ['https://www.clerk.com/*/test'], false],
     // trailing slashes
     ['https://www.clerk.com/', ['https://www.clerk.com'], true],
     ['https://www.clerk.com', ['https://www.clerk.com'], true],
-    ['https://www.clerk.com/test', ['https://www.clerk.com'], false],
+    ['https://www.clerk.com/test', ['https://www.clerk.com'], true],
     // multiple origins
     ['https://www.clerk.com', ['https://www.test.dev', 'https://www.clerk.com'], true],
     // relative urls

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -361,7 +361,7 @@ export const isAllowedRedirectOrigin = (_url: string, allowedRedirectOrigins: st
     return true;
   }
 
-  const isAllowed = allowedRedirectOrigins.some(origin => globs.toRegexp(origin).test(trimTrailingSlash(url.href)));
+  const isAllowed = allowedRedirectOrigins.some(origin => globs.toRegexp(origin).test(trimTrailingSlash(url.origin)));
   if (!isAllowed) {
     console.warn(
       `Clerk: Redirect URL ${url} is not on one of the allowedRedirectOrigins, falling back to the default redirect URL.`,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Check the origin in `isAllowedRedirectOrigin`, since we are aiming for origin whitelisting.
<!-- Fixes # (issue number) -->
