### PR TITLE
Forgot password link displays new screen before reset password code

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/ForgotPasswordAlternativeMethods.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/ForgotPasswordAlternativeMethods.tsx
@@ -1,0 +1,96 @@
+import { descriptors, Flex, Flow, localizationKeys, Text } from '../../customizables';
+import { ArrowBlockButton, Card, CardAlert, Footer, Header } from '../../elements';
+import { useCardState } from '../../elements/contexts';
+import { useAlternativeStrategies } from '../../hooks/useAlternativeStrategies';
+import type { AlternativeMethodListProps, AlternativeMethodsProps } from './AlternativeMethods';
+import { getButtonLabel } from './AlternativeMethods';
+import { SignInSocialButtons } from './SignInSocialButtons';
+import { useResetPasswordFactor } from './useResetPasswordFactor';
+import { withHavingTrouble } from './withHavingTrouble';
+
+export const ForgotPasswordAlternativeMethods = (props: AlternativeMethodsProps) => {
+  return withHavingTrouble(ForgotPasswordAlternativeMethodsList, {
+    ...props,
+  });
+};
+
+const ForgotPasswordAlternativeMethodsList = (props: AlternativeMethodListProps) => {
+  const { onBackLinkClick, onHavingTroubleClick, onFactorSelected } = props;
+  const card = useCardState();
+
+  const resetPasswordFactor = useResetPasswordFactor();
+
+  const { firstPartyFactors, hasAnyStrategy } = useAlternativeStrategies({
+    filterOutFactor: props.currentFactor,
+  });
+
+  if (!resetPasswordFactor) {
+    // Make TS happy, we are handling this logic further up in the tree already,
+    // so we will never return null here.
+    return null;
+  }
+
+  return (
+    <Flow.Part part='alternativeMethods'>
+      <Card>
+        <CardAlert>{card.error}</CardAlert>
+        <Header.Root>
+          {onBackLinkClick && <Header.BackLink onClick={onBackLinkClick} />}
+          <Header.Title localizationKey={localizationKeys('signIn.forgotPasswordAlternativeMethods.title')} />
+        </Header.Root>
+
+        <Flex
+          direction='col'
+          elementDescriptor={descriptors.main}
+          gap={6}
+        >
+          <ArrowBlockButton
+            textLocalizationKey={getButtonLabel(resetPasswordFactor)}
+            elementDescriptor={descriptors.alternativeMethodsBlockButton}
+            textElementDescriptor={descriptors.alternativeMethodsBlockButtonText}
+            arrowElementDescriptor={descriptors.alternativeMethodsBlockButtonArrow}
+            isDisabled={card.isLoading}
+            onClick={() => onFactorSelected(resetPasswordFactor)}
+          />
+          {hasAnyStrategy && (
+            <>
+              <Text
+                localizationKey={localizationKeys('signIn.forgotPasswordAlternativeMethods.label__alternativeMethods')}
+              />
+              <Flex
+                elementDescriptor={descriptors.alternativeMethods}
+                direction='col'
+                gap={2}
+              >
+                <SignInSocialButtons
+                  enableWeb3Providers
+                  enableOAuthProviders
+                />
+                {firstPartyFactors.map((factor, i) => (
+                  <ArrowBlockButton
+                    textLocalizationKey={getButtonLabel(factor)}
+                    elementDescriptor={descriptors.alternativeMethodsBlockButton}
+                    textElementDescriptor={descriptors.alternativeMethodsBlockButtonText}
+                    arrowElementDescriptor={descriptors.alternativeMethodsBlockButtonArrow}
+                    key={i}
+                    isDisabled={card.isLoading}
+                    onClick={() => onFactorSelected(factor)}
+                  />
+                ))}
+              </Flex>
+            </>
+          )}
+        </Flex>
+        <Footer.Root>
+          <Footer.Action elementId='havingTrouble'>
+            <Footer.ActionLink
+              localizationKey={localizationKeys('signIn.alternativeMethods.actionLink')}
+              onClick={onHavingTroubleClick}
+            />
+          </Footer.Action>
+          <Footer.Links />
+        </Footer.Root>
+      </Card>
+    </Flow.Part>
+  );
+};

--- a/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInFactorOnePasswordCard.tsx
@@ -9,32 +9,22 @@ import { useSupportEmail } from '../../hooks/useSupportEmail';
 import { useRouter } from '../../router/RouteContext';
 import { handleError, useFormControl } from '../../utils';
 import { HavingTrouble } from './HavingTrouble';
-import { isResetPasswordStrategy } from './utils';
+import { useResetPasswordFactor } from './useResetPasswordFactor';
 
 type SignInFactorOnePasswordProps = {
+  onForgotPasswordMethodClick: React.MouseEventHandler | undefined;
   onShowAlternativeMethodsClick: React.MouseEventHandler | undefined;
   onFactorPrepare: (f: ResetPasswordCodeFactor) => void;
 };
 
 const usePasswordControl = (props: SignInFactorOnePasswordProps) => {
-  const { onShowAlternativeMethodsClick, onFactorPrepare } = props;
-  const signIn = useCoreSignIn();
+  const { onForgotPasswordMethodClick, onShowAlternativeMethodsClick } = props;
+  const resetPasswordFactor = useResetPasswordFactor();
 
   const passwordControl = useFormControl('password', '', {
     type: 'password',
     label: localizationKeys('formFieldLabel__password'),
   });
-
-  const resetPasswordFactor = signIn.supportedFirstFactors.find(({ strategy }) => isResetPasswordStrategy(strategy)) as
-    | ResetPasswordCodeFactor
-    | undefined;
-
-  const goToForgotPassword = () => {
-    resetPasswordFactor &&
-      onFactorPrepare({
-        ...resetPasswordFactor,
-      });
-  };
 
   return {
     ...passwordControl,
@@ -42,8 +32,8 @@ const usePasswordControl = (props: SignInFactorOnePasswordProps) => {
       ...passwordControl.props,
       actionLabel:
         resetPasswordFactor || onShowAlternativeMethodsClick ? localizationKeys('formFieldAction__forgotPassword') : '',
-      onActionClicked: resetPasswordFactor
-        ? goToForgotPassword
+      onActionClicked: onForgotPasswordMethodClick
+        ? onForgotPasswordMethodClick
         : onShowAlternativeMethodsClick
         ? onShowAlternativeMethodsClick
         : () => null,

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -136,13 +136,13 @@ describe('SignInFactorOne', () => {
           });
         });
         const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.click(screen.getByText('Forgot password'));
+        await userEvent.click(screen.getByText(/Forgot password/i));
         screen.getByText('Use another method');
         screen.getByText(`Send code to ${email}`);
         expect(screen.queryByText('Sign in with your password')).not.toBeInTheDocument();
       });
 
-      it('should render the Forgot Password component when clicking on "Forgot password" (email)', async () => {
+      it('should render the Forgot Password alternative methods component when clicking on "Forgot password" (email)', async () => {
         const { wrapper, fixtures } = await createFixtures(f => {
           f.withEmailAddress();
           f.withPassword();
@@ -156,7 +156,9 @@ describe('SignInFactorOne', () => {
         const { userEvent } = render(<SignInFactorOne />, { wrapper });
 
         fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
-        await userEvent.click(screen.getByText('Forgot password'));
+        await userEvent.click(screen.getByText(/Forgot password/i));
+        screen.getByText('Forgot Password?');
+        await userEvent.click(screen.getByText('Reset your password'));
         screen.getByText('Check your email');
         screen.getByText('to reset your password');
       });
@@ -202,8 +204,10 @@ describe('SignInFactorOne', () => {
         });
         fixtures.signIn.prepareFirstFactor.mockReturnValueOnce(Promise.resolve({} as SignInResource));
         const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.click(screen.getByText('Forgot password'));
+        await userEvent.click(screen.getByText(/Forgot password/i));
+        screen.getByText('Forgot Password?');
 
+        await userEvent.click(screen.getByText('Reset your password'));
         screen.getByText('Check your phone');
         screen.getByText('Reset password code');
       });
@@ -224,7 +228,8 @@ describe('SignInFactorOne', () => {
           Promise.resolve({ status: 'needs_new_password' } as SignInResource),
         );
         const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.click(screen.getByText('Forgot password'));
+        await userEvent.click(screen.getByText(/Forgot password/i));
+        await userEvent.click(screen.getByText('Reset your password'));
         await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
         expect(fixtures.signIn.attemptFirstFactor).toHaveBeenCalledWith({
           strategy: 'reset_password_email_code',
@@ -250,7 +255,8 @@ describe('SignInFactorOne', () => {
           Promise.resolve({ status: 'needs_new_password' } as SignInResource),
         );
         const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.click(screen.getByText('Forgot password'));
+        await userEvent.click(screen.getByText(/Forgot password/i));
+        await userEvent.click(screen.getByText('Reset your password'));
         await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
         expect(fixtures.signIn.attemptFirstFactor).toHaveBeenCalledWith({
           strategy: 'reset_password_phone_code',

--- a/packages/clerk-js/src/ui/components/SignIn/useResetPasswordFactor.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/useResetPasswordFactor.tsx
@@ -1,0 +1,12 @@
+import type { ResetPasswordCodeFactor } from '@clerk/types';
+
+import { useCoreSignIn } from '../../contexts';
+import { isResetPasswordStrategy } from './utils';
+
+export function useResetPasswordFactor() {
+  const signIn = useCoreSignIn();
+
+  return signIn.supportedFirstFactors.find(({ strategy }) => isResetPasswordStrategy(strategy)) as
+    | ResetPasswordCodeFactor
+    | undefined;
+}

--- a/packages/clerk-js/src/ui/components/SignIn/withHavingTrouble.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/withHavingTrouble.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import type { AlternativeMethodsProps } from './AlternativeMethods';
+import { HavingTrouble } from './HavingTrouble';
+
+export const withHavingTrouble = <P extends AlternativeMethodsProps>(
+  Component: React.ComponentType<P>,
+  props: AlternativeMethodsProps,
+) => {
+  const [showHavingTrouble, setShowHavingTrouble] = React.useState(false);
+  const toggleHavingTrouble = React.useCallback(() => setShowHavingTrouble(s => !s), [setShowHavingTrouble]);
+
+  if (showHavingTrouble) {
+    return <HavingTrouble onBackLinkClick={toggleHavingTrouble} />;
+  }
+
+  return (
+    <Component
+      {...(props as unknown as P)}
+      onHavingTroubleClick={toggleHavingTrouble}
+    />
+  );
+};

--- a/packages/clerk-js/src/ui/hooks/useAlternativeStrategies.ts
+++ b/packages/clerk-js/src/ui/hooks/useAlternativeStrategies.ts
@@ -1,0 +1,29 @@
+import type { SignInFactor } from '@clerk/types';
+
+import { factorHasLocalStrategy, isResetPasswordStrategy } from '../components/SignIn/utils';
+import { useCoreSignIn } from '../contexts';
+import { allStrategiesButtonsComparator } from '../utils';
+import { useEnabledThirdPartyProviders } from './useEnabledThirdPartyProviders';
+
+export function useAlternativeStrategies({ filterOutFactor }: { filterOutFactor: SignInFactor | null | undefined }) {
+  const { supportedFirstFactors } = useCoreSignIn();
+
+  const { strategies: OAuthStrategies } = useEnabledThirdPartyProviders();
+
+  const firstFactors = supportedFirstFactors.filter(
+    f => f.strategy !== filterOutFactor?.strategy && !isResetPasswordStrategy(f.strategy),
+  );
+
+  const shouldAllowForAlternativeStrategies = firstFactors.length + OAuthStrategies.length > 0;
+
+  const firstPartyFactors = supportedFirstFactors
+    .filter(f => !f.strategy.startsWith('oauth_') && !(f.strategy === filterOutFactor?.strategy))
+    .filter(factor => factorHasLocalStrategy(factor))
+    .sort(allStrategiesButtonsComparator);
+
+  return {
+    hasAnyStrategy: shouldAllowForAlternativeStrategies,
+    hasFirstParty: !!firstPartyFactors,
+    firstPartyFactors,
+  };
+}

--- a/packages/localizations/src/da-DK.ts
+++ b/packages/localizations/src/da-DK.ts
@@ -50,7 +50,7 @@ export const daDK: LocalizationResource = {
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
   formFieldInputPlaceholder__organizationSlug: '',
-  formFieldAction__forgotPassword: 'Glemt adgangskode',
+  formFieldAction__forgotPassword: 'Glemt adgangskode?',
   formFieldHintText__optional: 'Valgfri',
   formButtonPrimary: 'Fortsæt',
   signInEnterPasswordTitle: 'Indtast din adgangskode',

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -36,7 +36,7 @@ export const deDE: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
-  formFieldAction__forgotPassword: 'Passwort vergessen',
+  formFieldAction__forgotPassword: 'Passwort vergessen?',
   formFieldHintText__optional: 'Optional',
   formButtonPrimary: 'Fortsetzen',
   signInEnterPasswordTitle: 'Geben Sie Ihr Passwort ein',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -52,7 +52,7 @@ export const enUS: LocalizationResource = {
   formFieldInputPlaceholder__organizationSlug: '',
   formFieldError__notMatchingPasswords: `Passwords don't match.`,
   formFieldError__matchingPasswords: 'Passwords match.',
-  formFieldAction__forgotPassword: 'Forgot password',
+  formFieldAction__forgotPassword: 'Forgot password?',
   formFieldHintText__optional: 'Optional',
   formButtonPrimary: 'Continue',
   signInEnterPasswordTitle: 'Enter your password',
@@ -137,6 +137,11 @@ export const enUS: LocalizationResource = {
       title: 'Enter your password',
       subtitle: 'to continue to {{applicationName}}',
       actionLink: 'Use another method',
+    },
+    forgotPasswordAlternativeMethods: {
+      title: 'Forgot Password?',
+      label__alternativeMethods: 'Or, sign in with another method.',
+      blockButton__resetPassword: 'Reset your password',
     },
     forgotPassword: {
       title_email: 'Check your email',

--- a/packages/localizations/src/es-ES.ts
+++ b/packages/localizations/src/es-ES.ts
@@ -48,7 +48,7 @@ export const esES: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
-  formFieldAction__forgotPassword: 'Has olvidado tu contraseña',
+  formFieldAction__forgotPassword: 'Has olvidado tu contraseña?',
   formFieldHintText__optional: 'Opcional',
   formButtonPrimary: 'Continuar',
   signInEnterPasswordTitle: 'Ingresa tu contraseña',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -36,7 +36,7 @@ export const frFR: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
-  formFieldAction__forgotPassword: 'Mot de passe oublié',
+  formFieldAction__forgotPassword: 'Mot de passe oublié?',
   formFieldHintText__optional: 'Optionnel',
   formButtonPrimary: 'Continuer',
   signInEnterPasswordTitle: 'Tapez votre mot de passe',

--- a/packages/localizations/src/it-IT.ts
+++ b/packages/localizations/src/it-IT.ts
@@ -48,7 +48,7 @@ export const itIT: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
-  formFieldAction__forgotPassword: 'Password dimenticata',
+  formFieldAction__forgotPassword: 'Password dimenticata?',
   formFieldHintText__optional: 'Opzionale',
   formButtonPrimary: 'Continua',
   signInEnterPasswordTitle: 'Inserisci la tua password',

--- a/packages/localizations/src/nl-NL.ts
+++ b/packages/localizations/src/nl-NL.ts
@@ -46,7 +46,7 @@ export const nlNL: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
-  formFieldAction__forgotPassword: 'Wachtwoord vergeten',
+  formFieldAction__forgotPassword: 'Wachtwoord vergeten?',
   formFieldHintText__optional: 'Optioneel',
   formButtonPrimary: 'Doorgaan',
   signInEnterPasswordTitle: 'Vul je wachtwoord in',

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -47,7 +47,7 @@ export const ptBR: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
-  formFieldAction__forgotPassword: 'Esqueceu a senha',
+  formFieldAction__forgotPassword: 'Esqueceu a senha?',
   formFieldHintText__optional: 'Opcional',
   formButtonPrimary: 'Continuar',
   signInEnterPasswordTitle: 'Insira sua senha',

--- a/packages/localizations/src/sv-SE.ts
+++ b/packages/localizations/src/sv-SE.ts
@@ -48,7 +48,7 @@ export const svSE: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
-  formFieldAction__forgotPassword: 'Glömt lösenord',
+  formFieldAction__forgotPassword: 'Glömt lösenord?',
   formFieldHintText__optional: 'Valfritt',
   formButtonPrimary: 'Fortsätt',
   signInEnterPasswordTitle: 'Ange ditt lösenord',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -156,6 +156,11 @@ type _LocalizationResource = {
       subtitle: LocalizationValue;
       actionLink: LocalizationValue;
     };
+    forgotPasswordAlternativeMethods: {
+      title: LocalizationValue;
+      label__alternativeMethods: LocalizationValue;
+      blockButton__resetPassword: LocalizationValue;
+    };
     forgotPassword: {
       title_email: LocalizationValue;
       title_phone: LocalizationValue;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR has the following changes
- Change text from 'Forgot Password' to 'Forgot Password?' in <SignIn />
- When user clicks on the link show a screen with the following options:
  - Add Reset Password Option
  - Social Connection and Web3 Options
  - If other authentication factors are turned on
     - Email Code
     - Email Link
     - SMS Code

https://github.com/clerkinc/javascript/assets/19269911/a9d55752-150a-4127-b305-46858067a844


<!-- Fixes # (issue number) -->
