### PR TITLE
Support Reset password for custom flows

### DIFF
--- a/packages/types/src/factors.ts
+++ b/packages/types/src/factors.ts
@@ -139,9 +139,11 @@ export type BackupCodeAttempt = {
 export type ResetPasswordPhoneCodeAttempt = {
   strategy: ResetPasswordPhoneCodeStrategy;
   code: string;
+  password?: string;
 };
 
 export type ResetPasswordEmailCodeAttempt = {
   strategy: ResetPasswordEmailCodeStrategy;
   code: string;
+  password?: string;
 };

--- a/packages/types/src/signIn.ts
+++ b/packages/types/src/signIn.ts
@@ -169,7 +169,12 @@ export type SignInCreateParams = (
       identifier: string;
     }
   | {
-      strategy: PhoneCodeStrategy | EmailCodeStrategy | Web3Strategy;
+      strategy:
+        | PhoneCodeStrategy
+        | EmailCodeStrategy
+        | Web3Strategy
+        | ResetPasswordEmailCodeStrategy
+        | ResetPasswordPhoneCodeStrategy;
       identifier: string;
     }
   | {

--- a/playground/nextjs/middleware.ts
+++ b/playground/nextjs/middleware.ts
@@ -2,7 +2,7 @@ import { redirectToSignIn, getAuth, withClerkMiddleware } from '@clerk/nextjs/se
 import { NextResponse } from 'next/server';
 
 // Set the paths that don't require the user to be signed in
-const publicPaths = ['/', '/sign-in*', '/sign-up*', '/app-dir*'];
+const publicPaths = ['/', '/sign-in*', '/sign-up*', '/app-dir*', '/custom*'];
 
 const isPublic = (path: string) => {
   return publicPaths.find(x => path.match(new RegExp(`^${x}$`.replace('*$', '($|/)'))));

--- a/playground/nextjs/pages/custom/forgotPassword.tsx
+++ b/playground/nextjs/pages/custom/forgotPassword.tsx
@@ -1,0 +1,110 @@
+import React, { SyntheticEvent, useState } from 'react';
+import { useSignIn } from '@clerk/nextjs';
+import type { NextPage } from 'next';
+
+const SignInPage: NextPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [code, setCode] = useState('');
+  const [successfulCreation, setSuccessfulCreation] = useState(false);
+  const [complete, setComplete] = useState(false);
+  const [secondFactor, setSecondFactor] = useState(false);
+
+  const { isLoaded, signIn, setActive } = useSignIn();
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  async function create(e: SyntheticEvent) {
+    e.preventDefault();
+    await signIn
+      ?.create({
+        strategy: 'reset_password_email_code',
+        identifier: email,
+      })
+      .then(_ => {
+        setSuccessfulCreation(true);
+      })
+      .catch(err => console.error('error', err.errors[0].longMessage));
+  }
+
+  async function reset(e: SyntheticEvent) {
+    e.preventDefault();
+    await signIn
+      ?.attemptFirstFactor({
+        strategy: 'reset_password_email_code',
+        code,
+        password,
+      })
+      .then(result => {
+        if (result.status === 'needs_second_factor') {
+          setSecondFactor(true);
+        } else if (result.status === 'complete') {
+          setActive({ session: result.createdSessionId });
+          setComplete(true);
+        } else {
+          console.log(result);
+        }
+      })
+      .catch(err => console.error('error', err.errors[0].longMessage));
+  }
+
+  return (
+    <div
+      style={{
+        margin: 'auto',
+        maxWidth: '500px',
+      }}
+    >
+      <h1>Forgot Password ?</h1>
+      <form
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1em',
+        }}
+        onSubmit={!successfulCreation ? create : reset}
+      >
+        {!successfulCreation && !complete && (
+          <>
+            <label htmlFor='email'>Please provide identifier</label>
+            <input
+              type='email'
+              placeholder='e.g john@doe.com'
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+            />
+
+            <button>Sign in</button>
+          </>
+        )}
+
+        {successfulCreation && !complete && (
+          <>
+            <label htmlFor='password'>New password</label>
+            <input
+              type='password'
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+            />
+
+            <label htmlFor='password'>Reset password code</label>
+            <input
+              type='text'
+              value={code}
+              onChange={e => setCode(e.target.value)}
+            />
+
+            <button>Reset</button>
+          </>
+        )}
+
+        {complete && 'You successfully changed you password'}
+        {secondFactor && '2FA is required, this UI does not handle that'}
+      </form>
+    </div>
+  );
+};
+
+export default SignInPage;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [x] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR 
- Updates types for `signIn.create` and `signIn. attemptFirstFactor` to properly allow the reset password params
- Adds an example usage in a playground app

<!-- Fixes # (issue number) -->
