### PR TITLE
fix(clerk-js): Serve static provider SVGs via new img-service

### DIFF
--- a/packages/clerk-js/src/ui/common/constants.ts
+++ b/packages/clerk-js/src/ui/common/constants.ts
@@ -96,6 +96,19 @@ export function getWeb3ProviderData(name: Web3Provider): Web3ProviderData | unde
   return WEB3_PROVIDERS[name];
 }
 
+/**
+ * Returns the URL for a static SVG image
+ * using the old images.clerk.com service
+ * @deprecated In favor of iconImageUrl
+ */
 export function svgUrl(id: string): string {
   return `https://images.clerk.com/static/${id}.svg`;
+}
+
+/**
+ * Returns the URL for a static SVG image
+ * using the new img.clerk.com service
+ */
+export function iconImageUrl(id: string): string {
+  return `https://img.clerk.com/static/${id}.svg`;
 }

--- a/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
@@ -2,37 +2,60 @@ import type { OAuthProvider, OAuthStrategy, Web3Provider, Web3Strategy } from '@
 // TODO: This import shouldn't be part of @clerk/types
 import { OAUTH_PROVIDERS, WEB3_PROVIDERS } from '@clerk/types/src';
 
-import { svgUrl } from '../common/constants';
+import { iconImageUrl, svgUrl } from '../common/constants';
+import { useOptions } from '../contexts';
 import { useEnvironment } from '../contexts/EnvironmentContext';
 import { fromEntries } from '../utils';
 
 type ThirdPartyStrategyToDataMap = {
-  [k in Web3Strategy | OAuthStrategy]: { id: Web3Provider | OAuthProvider; iconUrl: string; name: string };
+  [k in Web3Strategy | OAuthStrategy]: {
+    id: Web3Provider | OAuthProvider;
+    iconUrl: string;
+    name: string;
+  };
 };
 
 type ThirdPartyProviderToDataMap = {
-  [k in Web3Provider | OAuthProvider]: { strategy: Web3Strategy | OAuthStrategy; iconUrl: string; name: string };
+  [k in Web3Provider | OAuthProvider]: {
+    strategy: Web3Strategy | OAuthStrategy;
+    iconUrl: string;
+    name: string;
+  };
 };
 
 const providerToDisplayData: ThirdPartyProviderToDataMap = fromEntries(
   [...OAUTH_PROVIDERS, ...WEB3_PROVIDERS].map(p => {
-    return [p.provider, { strategy: p.strategy, name: p.name, iconUrl: svgUrl(p.provider) }];
+    return [p.provider, { strategy: p.strategy, name: p.name, iconUrl: iconImageUrl(p.provider) }];
   }),
 ) as ThirdPartyProviderToDataMap;
 
 const strategyToDisplayData: ThirdPartyStrategyToDataMap = fromEntries(
   [...OAUTH_PROVIDERS, ...WEB3_PROVIDERS].map(p => {
-    return [p.strategy, { id: p.provider, name: p.name, iconUrl: svgUrl(p.provider) }];
+    return [p.strategy, { id: p.provider, name: p.name, iconUrl: iconImageUrl(p.provider) }];
   }),
 ) as ThirdPartyStrategyToDataMap;
 
 export const useEnabledThirdPartyProviders = () => {
   const { socialProviderStrategies, web3FirstFactors, authenticatableSocialStrategies } = useEnvironment().userSettings;
+  const { experimental_enableClerkImages } = useOptions();
+
+  // TODO: remove this
+  // We don't care about the mutating the reference here
+  const tempStrategyToDisplayData = strategyToDisplayData;
+  const tempProviderToDisplayData = providerToDisplayData;
+  if (!experimental_enableClerkImages) {
+    Object.values(tempStrategyToDisplayData).forEach(strategy => (strategy.iconUrl = svgUrl(strategy.id)));
+    Object.keys(tempProviderToDisplayData).forEach(
+      // @ts-expect-error
+      provider => (tempProviderToDisplayData[provider].iconUrl = svgUrl(provider)),
+    );
+  }
+
   return {
     strategies: [...socialProviderStrategies, ...web3FirstFactors],
     web3Strategies: [...web3FirstFactors],
     authenticatableOauthStrategies: [...authenticatableSocialStrategies],
-    strategyToDisplayData,
-    providerToDisplayData,
+    strategyToDisplayData: tempStrategyToDisplayData,
+    providerToDisplayData: tempProviderToDisplayData,
   };
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
We need to serve the static files, eg oauth provider icons, through the new img-service worker.

We already have a proxy route in place, however this route requires its payload to be a base64 encoded json. There's no need to do this for static assets clerk-js needs, so we will introduce a /static endpoint:

img.clerk.com/static/google.svg

that will use the proxy route internally. Clerkjs will only be aware of the above route, requiring no changes in logic
<!-- Fixes # (issue number) -->
