### PR TITLE
fix(clerk-js): Support RegExp for allowedRedirectOrigins

### DIFF
--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -399,7 +399,7 @@ describe('getETLDPlusOneFromFrontendApi(frontendAp: string)', () => {
 });
 
 fdescribe('isAllowedRedirectOrigin', () => {
-  const cases: [string, string[] | undefined, boolean][] = [
+  const cases: [string, Array<string | RegExp> | undefined, boolean][] = [
     // base cases
     ['https://clerk.com', ['https://www.clerk.com'], false],
     ['https://www.clerk.com', ['https://www.clerk.com'], true],
@@ -410,6 +410,7 @@ fdescribe('isAllowedRedirectOrigin', () => {
     ['https://www.clerk.com/', ['https://www.clerk.com'], true],
     ['https://www.clerk.com', ['https://www.clerk.com'], true],
     ['https://www.clerk.com/test', ['https://www.clerk.com'], true],
+    ['https://www.clerk.com/test', ['https://www.clerk.com/'], true],
     // multiple origins
     ['https://www.clerk.com', ['https://www.test.dev', 'https://www.clerk.com'], true],
     // relative urls
@@ -422,6 +423,12 @@ fdescribe('isAllowedRedirectOrigin', () => {
     ['https://www.clerk.com/', [], false],
     //undefined origins
     ['https://www.clerk.com/', undefined, true],
+    // query params
+    ['https://www.clerk.com/foo?hello=1', ['https://www.clerk.com'], true],
+    ['https://www.clerk.com/foo?hello=1', ['https://www.clerk.com/'], true],
+    // regexp
+    ['https://www.clerk.com/foo?hello=1', [/https:\/\/www\.clerk\.com/], true],
+    ['https://test.clerk.com/foo?hello=1', [/https:\/\/www\.clerk\.com/], false],
   ];
 
   test.each(cases)('isAllowedRedirectOrigin("%s","%s") === %s', (url, allowedOrigins, expected) => {

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -350,7 +350,7 @@ export function isRedirectForFAPIInitiatedFlow(frontendApi: string, redirectUrl:
   return frontendApi === url.host && frontendApiRedirectPaths.includes(path);
 }
 
-export const isAllowedRedirectOrigin = (_url: string, allowedRedirectOrigins: string[] | undefined) => {
+export const isAllowedRedirectOrigin = (_url: string, allowedRedirectOrigins: Array<string | RegExp> | undefined) => {
   if (!allowedRedirectOrigins) {
     return true;
   }
@@ -361,7 +361,10 @@ export const isAllowedRedirectOrigin = (_url: string, allowedRedirectOrigins: st
     return true;
   }
 
-  const isAllowed = allowedRedirectOrigins.some(origin => globs.toRegexp(origin).test(trimTrailingSlash(url.origin)));
+  const isAllowed = allowedRedirectOrigins
+    .map(origin => (typeof origin === 'string' ? globs.toRegexp(trimTrailingSlash(origin)) : origin))
+    .some(origin => origin.test(trimTrailingSlash(url.origin)));
+
   if (!isAllowed) {
     console.warn(
       `Clerk: Redirect URL ${url} is not on one of the allowedRedirectOrigins, falling back to the default redirect URL.`,

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -486,7 +486,7 @@ export interface ClerkOptions {
   signUpUrl?: string;
   afterSignInUrl?: string;
   afterSignUpUrl?: string;
-  allowedRedirectOrigins?: string[];
+  allowedRedirectOrigins?: Array<string | RegExp>;
   /**
    * @experimental
    */


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- Add regex support
- Trim trailing slashes from origins to improve DX for glob matching
-
<!-- Fixes # (issue number) -->
