### PR TITLE
fix(clerk-js,types): Update isDefaultProfileImage util

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileSettingsPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileSettingsPage.tsx
@@ -91,8 +91,8 @@ export const ProfileSettingsPage = withCardStateProvider(() => {
             onAvatarRemove={
               experimental_enableClerkImages
                 ? isDefaultImage(organization.experimental_imageUrl)
-                  ? onAvatarRemove
-                  : null
+                  ? null
+                  : onAvatarRemove
                 : organization.logoUrl
                 ? onAvatarRemove
                 : null

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileSettingsPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ProfileSettingsPage.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+import { isDefaultImage } from '../../../utils';
 import { useWizard, Wizard } from '../../common';
-import { useCoreOrganization } from '../../contexts';
+import { useCoreOrganization, useOptions } from '../../contexts';
 import { localizationKeys } from '../../customizables';
 import { ContentPage, Form, FormButtons, SuccessPage, useCardState, withCardStateProvider } from '../../elements';
 import { handleError, useFormControl } from '../../utils';
@@ -14,6 +15,7 @@ export const ProfileSettingsPage = withCardStateProvider(() => {
   const subtitle = localizationKeys('organizationProfile.profilePage.subtitle');
   const card = useCardState();
   const [avatarChanged, setAvatarChanged] = React.useState(false);
+  const { experimental_enableClerkImages } = useOptions();
   const { organization } = useCoreOrganization();
 
   const wizard = useWizard({ onNextStep: () => card.setError(undefined) });
@@ -86,7 +88,15 @@ export const ProfileSettingsPage = withCardStateProvider(() => {
           <OrganizationProfileAvatarUploader
             organization={organization}
             onAvatarChange={uploadAvatar}
-            onAvatarRemove={organization.logoUrl ? onAvatarRemove : null}
+            onAvatarRemove={
+              experimental_enableClerkImages
+                ? isDefaultImage(organization.experimental_imageUrl)
+                  ? onAvatarRemove
+                  : null
+                : organization.logoUrl
+                ? onAvatarRemove
+                : null
+            }
           />
           <Form.ControlRow elementId={nameField.id}>
             <Form.Control

--- a/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { isDefaultProfileImage } from '../../../utils/user';
+import { isDefaultImage } from '../../../utils';
 import { useWizard, Wizard } from '../../common';
 import { useCoreUser, useEnvironment, useOptions } from '../../contexts';
 import { localizationKeys } from '../../customizables';
@@ -89,7 +89,7 @@ export const ProfilePage = withCardStateProvider(() => {
             user={user}
             onAvatarChange={uploadAvatar}
             onAvatarRemove={
-              !isDefaultProfileImage(experimental_enableClerkImages ? user.experimental_imageUrl : user.profileImageUrl)
+              !isDefaultImage(experimental_enableClerkImages ? user.experimental_imageUrl : user.profileImageUrl)
                 ? onAvatarRemove
                 : null
             }

--- a/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ProfilePage.tsx
@@ -89,9 +89,9 @@ export const ProfilePage = withCardStateProvider(() => {
             user={user}
             onAvatarChange={uploadAvatar}
             onAvatarRemove={
-              !isDefaultImage(experimental_enableClerkImages ? user.experimental_imageUrl : user.profileImageUrl)
-                ? onAvatarRemove
-                : null
+              isDefaultImage(experimental_enableClerkImages ? user.experimental_imageUrl : user.profileImageUrl)
+                ? null
+                : onAvatarRemove
             }
           />
           {showFirstName && (

--- a/packages/clerk-js/src/utils/image.ts
+++ b/packages/clerk-js/src/utils/image.ts
@@ -1,8 +1,18 @@
 import { isomorphicAtob } from '@clerk/shared';
-import type { EncodedImageData } from '@clerk/types';
+
+/**
+ * @private
+ */
+interface EncodedImageData {
+  type: 'default' | 'proxy';
+  iid?: string;
+  rid?: string;
+  src?: string;
+  initials?: string;
+}
 
 export const isDefaultImage = (url: string) => {
-  // Remove this check when renaming experimental_imageUrl to imageUrl
+  // TODO: Remove this check when renaming experimental_imageUrl to imageUrl
   if ((url || '').includes('gravatar')) {
     return true;
   }

--- a/packages/clerk-js/src/utils/image.ts
+++ b/packages/clerk-js/src/utils/image.ts
@@ -1,0 +1,18 @@
+import { isomorphicAtob } from '@clerk/shared';
+import type { EncodedImageData } from '@clerk/types';
+
+export const isDefaultImage = (url: string) => {
+  // Remove this check when renaming experimental_imageUrl to imageUrl
+  if ((url || '').includes('gravatar')) {
+    return true;
+  }
+
+  try {
+    const encoded = new URL(url).pathname.replace('/', '');
+    const decoded = isomorphicAtob(encoded);
+    const obj = JSON.parse(decoded) as EncodedImageData;
+    return obj.type === 'default';
+  } catch {
+    return false;
+  }
+};

--- a/packages/clerk-js/src/utils/index.ts
+++ b/packages/clerk-js/src/utils/index.ts
@@ -28,3 +28,4 @@ export * from './componentGuards';
 export * from './queryStateParams';
 export * from './decodeBase16';
 export * from './authPropHelpers';
+export * from './image';

--- a/packages/clerk-js/src/utils/user.ts
+++ b/packages/clerk-js/src/utils/user.ts
@@ -10,9 +10,8 @@ export const getFullName = ({ firstName, lastName, name }: NameHelperParams) =>
 export const getInitials = ({ firstName, lastName, name }: NameHelperParams) =>
   [(firstName || '')[0], (lastName || '')[0]].join('').trim() || (name || '')[0];
 
-import type { UserResource } from '@clerk/types';
-
-import { decodeBase16 } from '../utils';
+import { isomorphicAtob } from '@clerk/shared';
+import type { EncodedImageData, UserResource } from '@clerk/types';
 
 export const getIdentifier = (user: Partial<UserResource>): string => {
   if (user.username) {
@@ -42,8 +41,9 @@ export const isDefaultProfileImage = (url: string) => {
 
   try {
     const encoded = new URL(url).pathname.replace('/', '');
-    const decoded = decodeBase16(encoded);
-    return decoded.includes('default');
+    const decoded = isomorphicAtob(encoded);
+    const obj = JSON.parse(decoded) as EncodedImageData;
+    return obj.type === 'default';
   } catch {
     return false;
   }

--- a/packages/clerk-js/src/utils/user.ts
+++ b/packages/clerk-js/src/utils/user.ts
@@ -10,8 +10,7 @@ export const getFullName = ({ firstName, lastName, name }: NameHelperParams) =>
 export const getInitials = ({ firstName, lastName, name }: NameHelperParams) =>
   [(firstName || '')[0], (lastName || '')[0]].join('').trim() || (name || '')[0];
 
-import { isomorphicAtob } from '@clerk/shared';
-import type { EncodedImageData, UserResource } from '@clerk/types';
+import type { UserResource } from '@clerk/types';
 
 export const getIdentifier = (user: Partial<UserResource>): string => {
   if (user.username) {
@@ -31,20 +30,4 @@ export const getIdentifier = (user: Partial<UserResource>): string => {
   }
 
   return '';
-};
-
-export const isDefaultProfileImage = (url: string) => {
-  // Remove this check when renaming experimental_imageUrl to imageUrl
-  if ((url || '').includes('gravatar')) {
-    return true;
-  }
-
-  try {
-    const encoded = new URL(url).pathname.replace('/', '');
-    const decoded = isomorphicAtob(encoded);
-    const obj = JSON.parse(decoded) as EncodedImageData;
-    return obj.type === 'default';
-  } catch {
-    return false;
-  }
 };

--- a/packages/types/src/image.ts
+++ b/packages/types/src/image.ts
@@ -5,11 +5,3 @@ export interface ImageResource extends ClerkResource {
   name: string | null;
   publicUrl: string | null;
 }
-
-export interface EncodedImageData {
-  type: 'default' | 'proxy';
-  iid?: string;
-  rid?: string;
-  src?: string;
-  initials?: string;
-}

--- a/packages/types/src/image.ts
+++ b/packages/types/src/image.ts
@@ -5,3 +5,11 @@ export interface ImageResource extends ClerkResource {
   name: string | null;
   publicUrl: string | null;
 }
+
+export interface EncodedImageData {
+  type: 'default' | 'proxy';
+  iid?: string;
+  rid?: string;
+  src?: string;
+  initials?: string;
+}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Also fixed the issue of not checking for org image removal ability correctly.
I'd consider adding this as a method on the user/org objects as well.
<!-- Fixes # (issue number) -->
