### PR TITLE
COR-378 fix(clerk-js): Make sign-out from all sessions option to be true by d…

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/ResetPassword.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/ResetPassword.tsx
@@ -38,6 +38,7 @@ export const _ResetPassword = () => {
   const sessionsField = useFormControl('signOutOfOtherSessions', '', {
     type: 'checkbox',
     label: localizationKeys('formFieldLabel__signOutOfOtherSessions'),
+    defaultChecked: true,
   });
 
   const { displayConfirmPasswordFeedback, isPasswordMatch } = useConfirmPassword({

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
@@ -54,14 +54,14 @@ describe('ResetPassword', () => {
       await userEvent.click(screen.getByRole('button', { name: /Reset Password/i }));
       expect(fixtures.signIn.resetPassword).toHaveBeenCalledWith({
         password: 'testtest',
-        signOutOfOtherSessions: false,
+        signOutOfOtherSessions: true,
       });
       expect(fixtures.router.navigate).toHaveBeenCalledWith(
         '../reset-password-success?createdSessionId=1234_session_id',
       );
     });
 
-    it('resets the password, does not require MFA and signs out of sessions', async () => {
+    it('resets the password, does not require MFA and leaves sessions intact', async () => {
       const { wrapper, fixtures } = await createFixtures();
       fixtures.signIn.resetPassword.mockResolvedValue({
         status: 'complete',
@@ -75,7 +75,7 @@ describe('ResetPassword', () => {
       await userEvent.click(screen.getByRole('button', { name: /Reset Password/i }));
       expect(fixtures.signIn.resetPassword).toHaveBeenCalledWith({
         password: 'testtest',
-        signOutOfOtherSessions: true,
+        signOutOfOtherSessions: false,
       });
       expect(fixtures.router.navigate).toHaveBeenCalledWith(
         '../reset-password-success?createdSessionId=1234_session_id',

--- a/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
@@ -67,6 +67,7 @@ export const PasswordPage = withCardStateProvider(() => {
   const sessionsField = useFormControl('signOutOfOtherSessions', '', {
     type: 'checkbox',
     label: localizationKeys('formFieldLabel__signOutOfOtherSessions'),
+    defaultChecked: true,
   });
 
   const { displayConfirmPasswordFeedback, isPasswordMatch } = useConfirmPassword({

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
@@ -51,15 +51,16 @@ describe('PasswordPage', () => {
       await userEvent.click(screen.getByRole('button', { name: /continue/i }));
       expect(fixtures.clerk.user?.updatePassword).toHaveBeenCalledWith({
         newPassword: 'testtest',
-        signOutOfOtherSessions: false,
+        signOutOfOtherSessions: true,
       });
 
       expect(await screen.findByText(/has been set/i));
+      expect(await screen.findByText(/signed out/i));
       await userEvent.click(screen.getByRole('button', { name: /finish/i }));
       expect(fixtures.router.navigate).toHaveBeenCalledWith('/');
     });
 
-    it('updates passwords and signs out of other sessions', async () => {
+    it('updates passwords and leave other sessions intact', async () => {
       const { wrapper, fixtures } = await createFixtures(initConfig);
 
       fixtures.clerk.user?.update.mockResolvedValue({} as UserResource);
@@ -71,10 +72,8 @@ describe('PasswordPage', () => {
       await userEvent.click(screen.getByRole('button', { name: /continue/i }));
       expect(fixtures.clerk.user?.updatePassword).toHaveBeenCalledWith({
         newPassword: 'testtest',
-        signOutOfOtherSessions: true,
+        signOutOfOtherSessions: false,
       });
-
-      expect(await screen.findByText(/signed out/i));
     });
 
     it('results in error if the password is too small', async () => {

--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -13,7 +13,7 @@ type Options = {
   label: string | LocalizationKey;
   placeholder?: string | LocalizationKey;
   options?: SelectOption[];
-  checked?: boolean;
+  defaultChecked?: boolean;
   enableErrorAfterBlur?: boolean;
   informationText?: string;
 } & (
@@ -33,6 +33,7 @@ type FieldStateProps<Id> = {
   id: Id;
   name: Id;
   value: string;
+  checked?: boolean;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   onBlur: React.FocusEventHandler<HTMLInputElement>;
   onFocus: React.FocusEventHandler<HTMLInputElement>;
@@ -67,11 +68,12 @@ export const useFormControl = <Id extends string>(
     options: [],
     enableErrorAfterBlur: false,
     informationText: '',
+    defaultChecked: false,
   };
 
   const { translateError } = useLocalizations();
   const [value, setValueInternal] = React.useState<string>(initialState);
-  const [checked, setCheckedInternal] = React.useState<boolean>(opts?.checked || false);
+  const [checked, setCheckedInternal] = React.useState<boolean>(opts?.defaultChecked || false);
   const [errorText, setErrorText] = React.useState<string | undefined>(undefined);
   const [warningText, setWarningText] = React.useState('');
   const [successfulText, setSuccessfulText] = React.useState('');


### PR DESCRIPTION
…efault

fix(clerk-js): Make sign-out from all sessions option to be true by default

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Make 'Sign out of All Devices' checked by Default
<!-- Fixes # (issue number) -->
