### PR TITLE
Fix flaky test regarding UI errors in forms

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
@@ -113,7 +113,7 @@ describe('ResetPassword', () => {
       await waitFor(() => {
         screen.getByText(`Passwords don't match.`);
       });
-    });
+    }, 10000);
 
     it('navigates to the root page upon pressing the back link', async () => {
       const { wrapper, fixtures } = await createFixtures();

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
@@ -197,7 +197,7 @@ describe('SignInFactorTwo', () => {
         const { userEvent } = render(<SignInFactorTwo />, { wrapper });
         await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
         await waitFor(() => expect(screen.getByText('Incorrect phone code')).toBeDefined());
-      });
+      }, 10000);
     });
 
     describe('Authenticator app', () => {
@@ -253,7 +253,7 @@ describe('SignInFactorTwo', () => {
         const { userEvent } = render(<SignInFactorTwo />, { wrapper });
         await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
         await waitFor(() => expect(screen.getByText('Incorrect authenticator code')).toBeDefined());
-      });
+      }, 10000);
     });
 
     describe('Backup code', () => {
@@ -342,7 +342,7 @@ describe('SignInFactorTwo', () => {
         await userEvent.type(getByLabelText('Backup code'), '123456');
         await userEvent.click(getByText('Continue'));
         await waitFor(() => expect(screen.getByText('Incorrect backup code')).toBeDefined());
-      });
+      }, 10000);
     });
   });
 

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
@@ -107,7 +107,7 @@ describe('PasswordPage', () => {
       await waitFor(() => {
         screen.getByText(`Passwords don't match.`);
       });
-    });
+    }, 10000);
 
     it(`Displays "Password match" when password match and removes it if they stop`, async () => {
       const { wrapper } = await createFixtures(initConfig);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Due to the delayed mount and unmount of the animated field errors some tests fail in an inconsistent pattern. Increasing the timeout for this test fixes the problem

<!-- Fixes # (issue number) -->
