### PR TITLE
fix(clerk-expo): Fix default useOAuth callback

### DIFF
--- a/packages/expo/src/useOAuth.ts
+++ b/packages/expo/src/useOAuth.ts
@@ -52,7 +52,7 @@ export function useOAuth(useOAuthParams: UseOAuthFlowParams) {
       startOAuthFlowParams.redirectUrl ||
       useOAuthParams.redirectUrl ||
       AuthSession.makeRedirectUri({
-        path: '/oauth-native-callback',
+        path: 'oauth-native-callback',
       });
 
     await signIn.create({ strategy, redirectUrl: oauthRedirectUrl });


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The default path parameter shouldn't start with a / otherwise the final URL contains /// when the scheme is concatenated.

<!-- Fixes # (issue number) -->

https://linear.app/clerk/issue/JS-406/expo-useoauth-hook-breaks-production