### PR TITLE
fix(nextjs): Export SignOutButton

### DIFF
--- a/packages/nextjs/src/client-boundary/uiComponents.tsx
+++ b/packages/nextjs/src/client-boundary/uiComponents.tsx
@@ -14,6 +14,7 @@ export {
   CreateOrganization,
   SignInButton,
   SignUpButton,
+  SignOutButton,
 } from '@clerk/clerk-react';
 
 export const SignIn = (props: SignInProps) => {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -28,6 +28,7 @@ export {
   OrganizationProfile,
   CreateOrganization,
   SignInButton,
+  SignOutButton,
 } from './client-boundary/uiComponents';
 
 /**

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -1,7 +1,15 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 
-import { ClerkProvider, OrganizationSwitcher, SignInButton, UserButton } from '@clerk/nextjs';
+import {
+  ClerkProvider,
+  OrganizationSwitcher,
+  SignedIn,
+  SignedOut,
+  SignInButton,
+  SignOutButton,
+  UserButton,
+} from '@clerk/nextjs';
 import { dark, neobrutalism, shadesOfPurple } from '@clerk/themes';
 import Link from 'next/link';
 import React, { useState } from 'react';
@@ -76,7 +84,14 @@ const AppBar = (props: AppBarProps) => {
       </select>
       <button onClick={props.onToggleDark}>toggle dark mode</button>
       <UserButton />
-      <SignInButton mode={'modal'} />
+
+      <SignedIn>
+        <SignOutButton />
+      </SignedIn>
+
+      <SignedOut>
+        <SignInButton mode={'modal'} />
+      </SignedOut>
     </div>
   );
 };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

`SignOutButton` wasn't exported from `@clerk/nextjs`. This PR simply re-exports it from `@clerk/clerk-react`.

I also added `SignOutButton` into the NextJS playground for a simple "gut check."

Fixes #1213 
