### PR TITLE
Add identifier for password managers where password changes

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/ResetPassword.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/ResetPassword.tsx
@@ -95,6 +95,15 @@ export const _ResetPassword = () => {
           onSubmit={resetPassword}
           onBlur={validateForm}
         >
+          {/* For password managers */}
+          <input
+            readOnly
+            data-testid='hidden-identifier'
+            id='identifier-field'
+            name='identifier'
+            value={signIn.identifier || ''}
+            style={{ display: 'none' }}
+          />
           <Form.ControlRow elementId={passwordField.id}>
             <Form.Control
               {...passwordField.props}

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
@@ -42,6 +42,17 @@ describe('ResetPassword', () => {
     });
   });
 
+  it('renders a hidden identifier field', async () => {
+    const identifier = 'test@clerk.dev';
+    const { wrapper } = await createFixtures(f => {
+      f.startSignInWithEmailAddress({ identifier });
+    });
+    render(<ResetPassword />, { wrapper });
+
+    const identifierField: HTMLInputElement = screen.getByTestId('hidden-identifier');
+    expect(identifierField.value).toBe(identifier);
+  });
+
   describe('Actions', () => {
     it('resets the password and does not require MFA', async () => {
       const { wrapper, fixtures } = await createFixtures();

--- a/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PasswordPage.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 
 import { useWizard, Wizard } from '../../common';
-import { useCoreUser, useEnvironment } from '../../contexts';
+import { useCoreSession, useCoreUser, useEnvironment } from '../../contexts';
 import { localizationKeys } from '../../customizables';
 import { ContentPage, Form, FormButtons, SuccessPage, useCardState, withCardStateProvider } from '../../elements';
 import { useConfirmPassword, usePasswordComplexity } from '../../hooks';
@@ -26,6 +26,7 @@ const generateSuccessPageText = (userHasPassword: boolean, sessionSignOut: boole
 
 export const PasswordPage = withCardStateProvider(() => {
   const user = useCoreUser();
+  const session = useCoreSession();
   const title = user.passwordEnabled
     ? localizationKeys('userProfile.passwordPage.changePasswordTitle')
     : localizationKeys('userProfile.passwordPage.title');
@@ -116,6 +117,14 @@ export const PasswordPage = withCardStateProvider(() => {
           onSubmit={updatePassword}
           onBlur={validateForm}
         >
+          {/* For password managers */}
+          <input
+            readOnly
+            id='identifier-field'
+            name='identifier'
+            value={session.publicUserData.identifier || ''}
+            style={{ display: 'none' }}
+          />
           {user.passwordEnabled && (
             <Form.ControlRow elementId={currentPasswordField.id}>
               <Form.Control

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
@@ -2,6 +2,7 @@ import type { UserResource } from '@clerk/types';
 import { describe, it } from '@jest/globals';
 
 import { bindCreateFixtures, fireEvent, render, runFakeTimers, screen, waitFor } from '../../../../testUtils';
+import { ResetPassword } from '../../SignIn/ResetPassword';
 import { PasswordPage } from '../PasswordPage';
 
 const { createFixtures } = bindCreateFixtures('UserProfile');
@@ -37,6 +38,17 @@ describe('PasswordPage', () => {
 
     screen.getByRole('heading', { name: /change password/i });
     screen.getByLabelText(/current password/i);
+  });
+
+  it('renders a hidden identifier field', async () => {
+    const identifier = 'test@clerk.dev';
+    const { wrapper } = await createFixtures(f => {
+      f.startSignInWithEmailAddress({ identifier });
+    });
+    render(<ResetPassword />, { wrapper });
+
+    const identifierField: HTMLInputElement = screen.getByTestId('hidden-identifier');
+    expect(identifierField.value).toBe(identifier);
   });
 
   describe('Actions', () => {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
