### PR TITLE
chore(clerk-js): Avoid returning defaultChecked as a field prop

### DIFF
--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -45,7 +45,7 @@ type FieldStateProps<Id> = {
   setSuccessful: (message: string) => void;
   successfulText: string;
   isFocused: boolean;
-} & Options;
+} & Omit<Options, 'defaultChecked'>;
 
 export type FormControlState<Id = string> = FieldStateProps<Id> & {
   setError: (error: string | ClerkAPIError | undefined) => void;
@@ -124,6 +124,9 @@ export const useFormControl = <Id extends string>(
     opts.strengthMeter = opts.strengthMeter || false;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { defaultChecked, ...restOpts } = opts;
+
   const props = {
     id,
     name: id,
@@ -138,10 +141,10 @@ export const useFormControl = <Id extends string>(
     onBlur,
     onFocus,
     isFocused,
-    enableErrorAfterBlur: opts.enableErrorAfterBlur || false,
+    enableErrorAfterBlur: restOpts.enableErrorAfterBlur || false,
     setWarning,
     warningText,
-    ...opts,
+    ...restOpts,
   };
 
   return { props, ...props, setError, setValue, setChecked };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
