### PR TITLE
fix(clerk-js): Use FormFeedback abstraction instead of FormErrorText

### DIFF
--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -81,6 +81,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'formFieldErrorText',
   'formFieldWarningText',
   'formFieldSuccessText',
+  'formFieldInfoText',
   'formFieldDirectionsText',
   'formFieldHintText',
   'formButtonRow',

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -203,7 +203,12 @@ export const CodeControl = React.forwardRef<{ reset: any }, CodeControlProps>((p
           />
         )}
       </Flex>
-      <FormFeedback errorText={errorText} />
+      <FormFeedback
+        errorText={errorText}
+        elementDescriptors={{
+          error: descriptors.otpCodeFieldErrorText,
+        }}
+      />
     </Flex>
   );
 });

--- a/packages/clerk-js/src/ui/elements/CodeControl.tsx
+++ b/packages/clerk-js/src/ui/elements/CodeControl.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { descriptors, Flex, FormErrorText, Input, Spinner } from '../customizables';
+import { descriptors, Flex, Input, Spinner } from '../customizables';
 import type { PropsOfComponent } from '../styledSystem';
 import { common } from '../styledSystem';
 import type { FormControlState } from '../utils';
+import { FormFeedback } from './FormControl';
 
 type UseCodeInputOptions = {
   length?: number;
@@ -202,7 +203,7 @@ export const CodeControl = React.forwardRef<{ reset: any }, CodeControlProps>((p
           />
         )}
       </Flex>
-      <FormErrorText elementDescriptor={descriptors.otpCodeFieldErrorText}>{errorText}</FormErrorText>
+      <FormFeedback errorText={errorText} />
     </Flex>
   );
 });

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -214,6 +214,7 @@ export type ElementsConfig = {
   formFieldErrorText: WithOptions<FieldId, ControlState, never>;
   formFieldWarningText: WithOptions<FieldId, ControlState, never>;
   formFieldSuccessText: WithOptions<FieldId, ControlState, never>;
+  formFieldInfoText: WithOptions<FieldId, ControlState, never>;
   formFieldDirectionsText: WithOptions<FieldId, ControlState, never>;
   formFieldHintText: WithOptions<FieldId, ControlState, never>;
   formButtonRow: WithOptions<never, ControlState | LoadingState, never>;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
## Before 
![image](https://github.com/clerkinc/javascript/assets/19269911/84e4f648-4d59-4083-928d-88e736e4e45e)

## After 
![Screenshot 2023-05-23 at 2 20 37 PM](https://github.com/clerkinc/javascript/assets/19269911/5cacea07-65c7-4041-807d-e4696e6b3ae0)


<!-- Fixes # (issue number) -->
