### PR TITLE
fix(clerk-js): Enable clerk images

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -127,6 +127,7 @@ const defaultOptions: ClerkOptions = {
   afterSignInUrl: undefined,
   afterSignUpUrl: undefined,
   isInterstitial: false,
+  experimental_enableClerkImages: true,
 };
 
 export default class Clerk implements ClerkInterface {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Separate release to enable clerk images so we can rollback easily in case anything breaks. Not removing the FF also allows us to individually rollback dashboard or accounts by explicitly settings the ff to false. 

This is the final release before we remove the experimental prefix tomorrow.
 
<!-- Fixes # (issue number) -->
