### PR TITLE
fix(clerk-sdk-node): Remove @clerk/shared as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36713,7 +36713,6 @@
       "license": "MIT",
       "dependencies": {
         "@clerk/backend": "^0.20.0",
-        "@clerk/shared": "^0.17.0",
         "@clerk/types": "^3.39.0",
         "@types/cookies": "0.7.7",
         "@types/express": "4.17.14",
@@ -40518,7 +40517,6 @@
       "version": "file:packages/sdk-node",
       "requires": {
         "@clerk/backend": "^0.20.0",
-        "@clerk/shared": "^0.17.0",
         "@clerk/types": "^3.39.0",
         "@types/cookie": "^0.5.0",
         "@types/cookies": "0.7.7",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -57,7 +57,6 @@
   },
   "dependencies": {
     "@clerk/backend": "^0.20.0",
-    "@clerk/shared": "^0.17.0",
     "@clerk/types": "^3.39.0",
     "@types/cookies": "0.7.7",
     "@types/express": "4.17.14",

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -1,9 +1,9 @@
 import type { Clerk, RequestState } from '@clerk/backend';
 import { constants } from '@clerk/backend';
-import { handleValueOrFn, isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from '@clerk/shared';
 import cookie from 'cookie';
 import type { IncomingMessage, ServerResponse } from 'http';
 
+import { handleValueOrFn, isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from './shared';
 import type { ClerkMiddlewareOptions } from './types';
 
 const parseCookies = (req: IncomingMessage) => {

--- a/packages/sdk-node/src/shared.ts
+++ b/packages/sdk-node/src/shared.ts
@@ -1,0 +1,58 @@
+/**
+ * These functions originate from @clerk/shared
+ * Maintain these until @clerk/shared does not depend on react
+ */
+export function isValidProxyUrl(key: string | undefined) {
+  if (!key) {
+    return true;
+  }
+
+  return isHttpOrHttps(key) || isProxyUrlRelative(key);
+}
+
+export function isHttpOrHttps(key: string | undefined) {
+  return /^http(s)?:\/\//.test(key || '');
+}
+
+export function isProxyUrlRelative(key: string) {
+  return key.startsWith('/');
+}
+
+export function proxyUrlToAbsoluteURL(url: string | undefined): string {
+  if (!url) {
+    return '';
+  }
+  return isProxyUrlRelative(url) ? new URL(url, window.location.origin).toString() : url;
+}
+
+export function getRequestUrl({ request, relativePath }: { request: Request; relativePath?: string }): URL {
+  const { headers, url: initialUrl } = request;
+  const url = new URL(initialUrl);
+  const host = headers.get('X-Forwarded-Host') ?? headers.get('host') ?? (headers as any)['host'] ?? url.host;
+
+  // X-Forwarded-Proto could be 'https, http'
+  let protocol =
+    (headers.get('X-Forwarded-Proto') ?? (headers as any)['X-Forwarded-Proto'])?.split(',')[0] ?? url.protocol;
+  protocol = protocol.replace(/[:/]/, '');
+
+  return new URL(relativePath || url.pathname, `${protocol}://${host}`);
+}
+
+type VOrFnReturnsV<T> = T | undefined | ((v: URL) => T);
+export function handleValueOrFn<T>(value: VOrFnReturnsV<T>, url: URL): T | undefined;
+export function handleValueOrFn<T>(value: VOrFnReturnsV<T>, url: URL, defaultValue: T): T;
+export function handleValueOrFn<T>(value: VOrFnReturnsV<T>, url: URL, defaultValue?: unknown): unknown {
+  if (typeof value === 'function') {
+    return (value as (v: URL) => T)(url);
+  }
+
+  if (typeof value !== 'undefined') {
+    return value;
+  }
+
+  if (typeof defaultValue !== 'undefined') {
+    return defaultValue;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
@clerk/shared inside @clerk/clerk-sdk-node breaks customers as it requires react to be installed on the project as well.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
