### PR TITLE
chore(clerk-js): Enable SVGO in Webpack through SVGR

### DIFF
--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -66,13 +66,25 @@ const common = ({ mode }) => {
   };
 };
 
+/** @type { () => (import('webpack').RuleSetRule) }  */
 const svgLoader = () => {
   return {
     test: /\.svg$/,
-    use: ['@svgr/webpack'],
+    use: {
+      loader: '@svgr/webpack',
+      options: {
+        svgo: true,
+        svgoConfig: {
+          floatPrecision: 3,
+          transformPrecision: 1,
+          plugins: ['preset-default', 'removeDimensions', 'removeStyleElement'],
+        },
+      },
+    },
   };
 };
 
+/** @type { () => (import('webpack').RuleSetRule) } */
 const typescriptLoaderProd = () => {
   return {
     test: /\.(ts|js)x?$/,
@@ -86,6 +98,7 @@ const typescriptLoaderProd = () => {
   };
 };
 
+/** @type { () => (import('webpack').RuleSetRule) } */
 const typescriptLoaderDev = () => {
   return {
     test: /\.(ts|js)x?$/,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Optimizes SVGs automatically via Webpack. 

It contains all of the settings I used via SVGOMG in #1222 with the exception of `floatPrecision` and `transformPrecision` so as to not cause undue rendering issues.

### Note: 

While this is a good step, it's largely a catch-all. `floatPrecision` being set to `3` is a safe and will catch any errant SVGs, but is unlikely to get you the true optimization you're looking for.

I would still suggest manually optimizing new SVGs with [SVGOMG](https://jakearchibald.github.io/svgomg/) as you're able. It'll allow you to fine-tune the `floatPrecision` and, if need be, `transformPrecision` and seeing if, and how, the SVG is affected. Make sure to enable "Prefer viewBox to width/height" when using SVGOMG.

### Note 2:

As with #1222, I did my best to check the output "in the wild" and things seemed 👍 . Please do a quick once-over to ensure I didn't miss anything.

Thanks!