### PR TITLE
chore(clerk-js): Mock `console.warn` in `url.test.ts`

### DIFF
--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -438,15 +438,6 @@ describe('isAllowedRedirectOrigin', () => {
 
   test.each(cases)('isAllowedRedirectOrigin("%s","%s") === %s', (url, allowedOrigins, expected) => {
     expect(isAllowedRedirectOrigin(url, allowedOrigins)).toEqual(expected);
-
-    if (!expected) {
-      const output = warnMock.mock.calls[0][0];
-
-      expect(warnMock).toHaveBeenCalledTimes(1);
-      expect(output.includes(new URL(url))).toBe(true);
-      expect(output).toMatch(/allowedRedirectOrigins/);
-    } else {
-      expect(warnMock).not.toHaveBeenCalled();
-    }
+    expect(warnMock).toHaveBeenCalledTimes(Number(expected)); // Number(boolean) evaluates to 0 or 1
   });
 });

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -398,7 +398,7 @@ describe('getETLDPlusOneFromFrontendApi(frontendAp: string)', () => {
   });
 });
 
-fdescribe('isAllowedRedirectOrigin', () => {
+describe('isAllowedRedirectOrigin', () => {
   const cases: [string, Array<string | RegExp> | undefined, boolean][] = [
     // base cases
     ['https://clerk.com', ['https://www.clerk.com'], false],
@@ -431,7 +431,22 @@ fdescribe('isAllowedRedirectOrigin', () => {
     ['https://test.clerk.com/foo?hello=1', [/https:\/\/www\.clerk\.com/], false],
   ];
 
+  const warnMock = jest.spyOn(global.console, 'warn').mockImplementation();
+
+  beforeEach(() => warnMock.mockClear());
+  afterAll(() => warnMock.mockRestore());
+
   test.each(cases)('isAllowedRedirectOrigin("%s","%s") === %s', (url, allowedOrigins, expected) => {
     expect(isAllowedRedirectOrigin(url, allowedOrigins)).toEqual(expected);
+
+    if (!expected) {
+      const output = warnMock.mock.calls[0][0];
+
+      expect(warnMock).toHaveBeenCalledTimes(1);
+      expect(output.includes(new URL(url))).toBe(true);
+      expect(output).toMatch(/allowedRedirectOrigins/);
+    } else {
+      expect(warnMock).not.toHaveBeenCalled();
+    }
   });
 });

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -438,6 +438,6 @@ describe('isAllowedRedirectOrigin', () => {
 
   test.each(cases)('isAllowedRedirectOrigin("%s","%s") === %s', (url, allowedOrigins, expected) => {
     expect(isAllowedRedirectOrigin(url, allowedOrigins)).toEqual(expected);
-    expect(warnMock).toHaveBeenCalledTimes(Number(expected)); // Number(boolean) evaluates to 0 or 1
+    expect(warnMock).toHaveBeenCalledTimes(Number(!expected)); // Number(boolean) evaluates to 0 or 1
   });
 });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Mocks `console.warn` in `url.test.ts` to ensure clean Jest log output. Added minimal checks to ensure the correct message is being sent.

### Note:
I discovered that the `isAllowedRedirectOrigin` test was being run using `fdescribe` meaning that only that test in the current file was being run. I updated it to `describe`.

<!-- Fixes # (issue number) -->
