### PR TITLE
test(clerk-js): Update usage of `act`

### DIFF
--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -1,7 +1,7 @@
+import { render, userEvent, waitFor } from '@clerk/shared/testUtils';
 import type { MembershipRole, OrganizationMembershipResource, OrganizationResource } from '@clerk/types';
 import { describe, it, jest } from '@jest/globals';
 
-import { render, waitFor } from '../../../../testUtils';
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
 import { OrganizationMembers } from '../OrganizationMembers';
 
@@ -48,8 +48,11 @@ describe('OrganizationMembers', () => {
     });
 
     const { getByText } = render(<OrganizationMembers />, { wrapper });
-    expect(getByText('Members')).toBeDefined();
-    expect(getByText('View and manage organization members')).toBeDefined();
+
+    await waitFor(() => {
+      expect(getByText('Members')).toBeDefined();
+      expect(getByText('View and manage organization members')).toBeDefined();
+    });
   });
 
   it('shows an invite button and invited tab if the current user is an admin', async () => {
@@ -59,8 +62,11 @@ describe('OrganizationMembers', () => {
     });
 
     const { getByText, getByRole } = render(<OrganizationMembers />, { wrapper });
-    expect(getByText('Invited')).toBeDefined();
-    expect(getByRole('button', { name: 'Invite' })).toBeDefined();
+
+    await waitFor(() => {
+      expect(getByText('Invited')).toBeDefined();
+      expect(getByRole('button', { name: 'Invite' })).toBeDefined();
+    });
   });
 
   it('does not show an invite button and invited tab if the current user is not an admin', async () => {
@@ -73,8 +79,11 @@ describe('OrganizationMembers', () => {
     });
 
     const { queryByRole, queryByText } = render(<OrganizationMembers />, { wrapper });
-    expect(queryByText('Invited')).toBeNull();
-    expect(queryByRole('button', { name: 'Invite' })).toBeNull();
+
+    await waitFor(() => {
+      expect(queryByText('Invited')).toBeNull();
+      expect(queryByRole('button', { name: 'Invite' })).toBeNull();
+    });
   });
 
   it('navigates to invite screen when user clicks on Invite button', async () => {
@@ -83,9 +92,12 @@ describe('OrganizationMembers', () => {
       f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
 
-    const { getByRole, userEvent } = render(<OrganizationMembers />, { wrapper });
+    const { getByRole } = render(<OrganizationMembers />, { wrapper });
     await userEvent.click(getByRole('button', { name: 'Invite' }));
-    expect(fixtures.router.navigate).toHaveBeenCalledWith('invite-members');
+
+    await waitFor(() => {
+      expect(fixtures.router.navigate).toHaveBeenCalledWith('invite-members');
+    });
   });
 
   it('lists all the members of the Organization', async () => {

--- a/packages/clerk-js/src/ui/router/__tests__/HashRouter.test.tsx
+++ b/packages/clerk-js/src/ui/router/__tests__/HashRouter.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, userEvent } from '@clerk/shared/testUtils';
+import { render, screen, userEvent } from '@clerk/shared/testUtils';
 import React from 'react';
 
 import type Clerk from '../../../core/clerk';
@@ -71,9 +71,10 @@ describe('HashRouter', () => {
       window.location = new URL('https://www.example.com/hash#/foo');
     });
 
-    it('loads that path', async () => {
+    it('loads that path', () => {
       // Wrap this is an await because we need a state update with the path change
       render(<Tester />);
+
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(screen.queryByText('Bar')).toBeInTheDocument();
     });
@@ -87,22 +88,20 @@ describe('HashRouter', () => {
 
     it('preserves the param for internal navigation', async () => {
       render(<Tester />);
-      await act(async () => {
-        const button = screen.getByRole('button', { name: /Internal/i });
-        expect(button).toBeInTheDocument();
-        await userEvent.click(button);
-      });
+
+      const button = screen.getByRole('button', { name: /Internal/i });
+      await userEvent.click(button);
+
       expect(window.location.hash).toBe('#/foo?preserved=1');
       expect(screen.queryByText('Bar')).toBeInTheDocument();
     });
 
     it('removes the param for external navigation', async () => {
       render(<Tester />);
-      await act(async () => {
-        const button = screen.getByRole('button', { name: /External/i });
-        expect(button).toBeInTheDocument();
-        await userEvent.click(button);
-      });
+
+      const button = screen.getByRole('button', { name: /External/i });
+      await userEvent.click(button);
+
       expect(mockNavigate).toHaveBeenNthCalledWith(1, 'https://www.example.com/external');
     });
   });

--- a/packages/clerk-js/src/ui/router/__tests__/PathRouter.test.tsx
+++ b/packages/clerk-js/src/ui/router/__tests__/PathRouter.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, userEvent } from '@clerk/shared/testUtils';
+import { render, screen, userEvent, waitFor } from '@clerk/shared/testUtils';
 import React from 'react';
 
 import type Clerk from '../../../core/clerk';
@@ -71,10 +71,11 @@ describe('PathRouter', () => {
     });
 
     it('adds the hash path to the primary path', async () => {
-      await act(async () => {
-        render(<Tester />);
+      render(<Tester />);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenNthCalledWith(1, '/foo/bar');
       });
-      expect(mockNavigate).toHaveBeenNthCalledWith(1, '/foo/bar');
     });
   });
 
@@ -86,19 +87,19 @@ describe('PathRouter', () => {
 
     it('preserves the param for internal navigation', async () => {
       render(<Tester />);
-      await act(async () => {
-        const button = screen.getByRole('button', { name: /Internal/i });
-        await userEvent.click(button);
-      });
+
+      const button = screen.getByRole('button', { name: /Internal/i });
+      await userEvent.click(button);
+
       expect(mockNavigate).toHaveBeenNthCalledWith(1, '/foo/baz?preserved=1');
     });
 
     it('removes the param for external navigation', async () => {
       render(<Tester />);
-      await act(async () => {
-        const button = screen.getByRole('button', { name: /External/i });
-        await userEvent.click(button);
-      });
+
+      const button = screen.getByRole('button', { name: /External/i });
+      await userEvent.click(button);
+
       expect(mockNavigate).toHaveBeenNthCalledWith(1, 'https://www.example.com/');
     });
   });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

Updates `act` to `waitFor` or removes `act` altogether from the specs.

Fixes multiple similar errors:
```
Warning: An update to ActiveMembersList inside a test was not wrapped in act(...).
@clerk/clerk-js:test:       
@clerk/clerk-js:test:       When testing, code that causes React state updates should be wrapped into act(...):
@clerk/clerk-js:test:       
@clerk/clerk-js:test:       act(() => {
@clerk/clerk-js:test:         /* fire events that update state */
@clerk/clerk-js:test:       });
@clerk/clerk-js:test:       /* assert on the output */
@clerk/clerk-js:test:       
@clerk/clerk-js:test:       This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
```


This, along with #1237 and #1235, removes all errors and extraneous logging from `@clerk/clerk-js`.

<!-- Fixes # (issue number) -->
