### PR TITLE
Fix flaky UI error tests

### DIFF
--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
@@ -1,7 +1,7 @@
 import type { SignInResource } from '@clerk/types';
 import { describe, it } from '@jest/globals';
 
-import { bindCreateFixtures, fireEvent, render, screen, waitFor } from '../../../../testUtils';
+import { bindCreateFixtures, fireEvent, render, runFakeTimers, screen, waitFor } from '../../../../testUtils';
 import { ResetPassword } from '../ResetPassword';
 
 const { createFixtures } = bindCreateFixtures('SignIn');
@@ -30,13 +30,15 @@ describe('ResetPassword', () => {
       }),
     );
 
-    render(<ResetPassword />, { wrapper });
-    screen.getByRole('heading', { name: /Reset password/i });
+    await runFakeTimers(async () => {
+      render(<ResetPassword />, { wrapper });
+      screen.getByRole('heading', { name: /Reset password/i });
 
-    const passwordField = screen.getByLabelText(/New password/i);
-    fireEvent.focus(passwordField);
-    await waitFor(() => {
-      screen.getByText(/Your password must contain 8 or more characters/i);
+      const passwordField = screen.getByLabelText(/New password/i);
+      fireEvent.focus(passwordField);
+      await waitFor(() => {
+        screen.getByText(/Your password must contain 8 or more characters/i);
+      });
     });
   });
 
@@ -99,19 +101,21 @@ describe('ResetPassword', () => {
     it('results in error if the passwords do not match and persists', async () => {
       const { wrapper } = await createFixtures();
 
-      const { userEvent } = render(<ResetPassword />, { wrapper });
+      await runFakeTimers(async () => {
+        const { userEvent } = render(<ResetPassword />, { wrapper });
 
-      await userEvent.type(screen.getByLabelText(/new password/i), 'testewrewr');
-      const confirmField = screen.getByLabelText(/confirm password/i);
-      await userEvent.type(confirmField, 'testrwerrwqrwe');
-      fireEvent.blur(confirmField);
-      await waitFor(() => {
-        screen.getByText(`Passwords don't match.`);
-      });
+        await userEvent.type(screen.getByLabelText(/new password/i), 'testewrewr');
+        const confirmField = screen.getByLabelText(/confirm password/i);
+        await userEvent.type(confirmField, 'testrwerrwqrwe');
+        fireEvent.blur(confirmField);
+        await waitFor(() => {
+          screen.getByText(`Passwords don't match.`);
+        });
 
-      await userEvent.clear(confirmField);
-      await waitFor(() => {
-        screen.getByText(`Passwords don't match.`);
+        await userEvent.clear(confirmField);
+        await waitFor(() => {
+          screen.getByText(`Passwords don't match.`);
+        });
       });
     }, 10000);
 

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -186,10 +186,12 @@ describe('SignInFactorOne', () => {
             status: 422,
           }),
         );
-        const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.type(screen.getByLabelText('Password'), '123456');
-        await userEvent.click(screen.getByText('Continue'));
-        await waitFor(() => expect(screen.getByText('Incorrect Password')).toBeDefined());
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorOne />, { wrapper });
+          await userEvent.type(screen.getByLabelText('Password'), '123456');
+          await userEvent.click(screen.getByText('Continue'));
+          await waitFor(() => expect(screen.getByText('Incorrect Password')).toBeDefined());
+        });
       });
     });
 
@@ -397,9 +399,11 @@ describe('SignInFactorOne', () => {
             status: 422,
           }),
         );
-        const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
-        await waitFor(() => expect(screen.getByText('Incorrect code')).toBeDefined());
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorOne />, { wrapper });
+          await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
+          await waitFor(() => expect(screen.getByText('Incorrect code')).toBeDefined());
+        });
       });
     });
 
@@ -474,9 +478,11 @@ describe('SignInFactorOne', () => {
             status: 422,
           }),
         );
-        const { userEvent } = render(<SignInFactorOne />, { wrapper });
-        await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
-        await waitFor(() => expect(screen.getByText('Incorrect phone code')).toBeDefined());
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorOne />, { wrapper });
+          await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
+          await waitFor(() => expect(screen.getByText('Incorrect phone code')).toBeDefined());
+        });
       });
     });
   });

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorTwo.test.tsx
@@ -194,9 +194,11 @@ describe('SignInFactorTwo', () => {
             status: 422,
           }),
         );
-        const { userEvent } = render(<SignInFactorTwo />, { wrapper });
-        await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
-        await waitFor(() => expect(screen.getByText('Incorrect phone code')).toBeDefined());
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorTwo />, { wrapper });
+          await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
+          await waitFor(() => expect(screen.getByText('Incorrect phone code')).toBeDefined());
+        });
       }, 10000);
     });
 
@@ -250,9 +252,11 @@ describe('SignInFactorTwo', () => {
             status: 422,
           }),
         );
-        const { userEvent } = render(<SignInFactorTwo />, { wrapper });
-        await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
-        await waitFor(() => expect(screen.getByText('Incorrect authenticator code')).toBeDefined());
+        await runFakeTimers(async () => {
+          const { userEvent } = render(<SignInFactorTwo />, { wrapper });
+          await userEvent.type(screen.getByLabelText(/Enter verification code/i), '123456');
+          await waitFor(() => expect(screen.getByText('Incorrect authenticator code')).toBeDefined());
+        });
       }, 10000);
     });
 
@@ -338,10 +342,12 @@ describe('SignInFactorTwo', () => {
             status: 422,
           }),
         );
-        const { userEvent, getByLabelText, getByText } = render(<SignInFactorTwo />, { wrapper });
-        await userEvent.type(getByLabelText('Backup code'), '123456');
-        await userEvent.click(getByText('Continue'));
-        await waitFor(() => expect(screen.getByText('Incorrect backup code')).toBeDefined());
+        await runFakeTimers(async () => {
+          const { userEvent, getByLabelText, getByText } = render(<SignInFactorTwo />, { wrapper });
+          await userEvent.type(getByLabelText('Backup code'), '123456');
+          await userEvent.click(getByText('Continue'));
+          await waitFor(() => expect(screen.getByText('Incorrect backup code')).toBeDefined());
+        });
       }, 10000);
     });
   });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
@@ -1,7 +1,7 @@
 import type { UserResource } from '@clerk/types';
 import { describe, it } from '@jest/globals';
 
-import { bindCreateFixtures, fireEvent, render, screen, waitFor } from '../../../../testUtils';
+import { bindCreateFixtures, fireEvent, render, runFakeTimers, screen, waitFor } from '../../../../testUtils';
 import { PasswordPage } from '../PasswordPage';
 
 const { createFixtures } = bindCreateFixtures('UserProfile');
@@ -79,59 +79,65 @@ xdescribe('PasswordPage', () => {
     it('results in error if the password is too small', async () => {
       const { wrapper } = await createFixtures(initConfig);
 
-      const { userEvent } = render(<PasswordPage />, { wrapper });
+      await runFakeTimers(async () => {
+        const { userEvent } = render(<PasswordPage />, { wrapper });
 
-      await userEvent.type(screen.getByLabelText(/new password/i), 'test');
-      const confirmField = screen.getByLabelText(/confirm password/i);
-      await userEvent.type(confirmField, 'test');
-      fireEvent.blur(confirmField);
-      await waitFor(() => {
-        screen.getByText(/or more/i);
+        await userEvent.type(screen.getByLabelText(/new password/i), 'test');
+        const confirmField = screen.getByLabelText(/confirm password/i);
+        await userEvent.type(confirmField, 'test');
+        fireEvent.blur(confirmField);
+        await waitFor(() => {
+          screen.getByText(/or more/i);
+        });
       });
     });
 
     it('results in error if the passwords do not match and persists', async () => {
       const { wrapper } = await createFixtures(initConfig);
 
-      const { userEvent } = render(<PasswordPage />, { wrapper });
+      await runFakeTimers(async () => {
+        const { userEvent } = render(<PasswordPage />, { wrapper });
 
-      await userEvent.type(screen.getByLabelText(/new password/i), 'testewrewr');
-      const confirmField = screen.getByLabelText(/confirm password/i);
-      await userEvent.type(confirmField, 'testrwerrwqrwe');
-      fireEvent.blur(confirmField);
-      await waitFor(() => {
-        screen.getByText(`Passwords don't match.`);
-      });
+        await userEvent.type(screen.getByLabelText(/new password/i), 'testewrewr');
+        const confirmField = screen.getByLabelText(/confirm password/i);
+        await userEvent.type(confirmField, 'testrwerrwqrwe');
+        fireEvent.blur(confirmField);
+        await waitFor(() => {
+          screen.getByText(`Passwords don't match.`);
+        });
 
-      await userEvent.clear(confirmField);
-      await waitFor(() => {
-        screen.getByText(`Passwords don't match.`);
+        await userEvent.clear(confirmField);
+        await waitFor(() => {
+          screen.getByText(`Passwords don't match.`);
+        });
       });
     }, 10000);
 
     it(`Displays "Password match" when password match and removes it if they stop`, async () => {
       const { wrapper } = await createFixtures(initConfig);
+      await runFakeTimers(async () => {
+        const { userEvent } = render(<PasswordPage />, { wrapper });
+        const passwordField = screen.getByLabelText(/new password/i);
 
-      const { userEvent } = render(<PasswordPage />, { wrapper });
-
-      const passwordField = screen.getByLabelText(/new password/i);
-      await userEvent.type(passwordField, 'testewrewr');
-      const confirmField = screen.getByLabelText(/confirm password/i);
-      expect(screen.queryByText(`Passwords match.`)).not.toBeInTheDocument();
-      await userEvent.type(confirmField, 'testewrewr');
-      await waitFor(() => {
-        screen.getByText(`Passwords match.`);
-      });
-
-      await userEvent.type(confirmField, 'testrwerrwqrwe');
-      await waitFor(() => {
+        await userEvent.type(passwordField, 'testewrewr');
+        const confirmField = screen.getByLabelText(/confirm password/i);
         expect(screen.queryByText(`Passwords match.`)).not.toBeInTheDocument();
-      });
 
-      await userEvent.type(passwordField, 'testrwerrwqrwe');
-      fireEvent.blur(confirmField);
-      await waitFor(() => {
-        screen.getByText(`Passwords match.`);
+        await userEvent.type(confirmField, 'testewrewr');
+        await waitFor(() => {
+          screen.getByText(`Passwords match.`);
+        });
+
+        await userEvent.type(confirmField, 'testrwerrwqrwe');
+        await waitFor(() => {
+          expect(screen.queryByText(`Passwords match.`)).not.toBeInTheDocument();
+        });
+
+        await userEvent.type(passwordField, 'testrwerrwqrwe');
+        fireEvent.blur(confirmField);
+        await waitFor(() => {
+          screen.getByText(`Passwords match.`);
+        });
       });
     }, 10000);
 

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
@@ -14,7 +14,7 @@ const changePasswordConfig = createFixtures.config(f => {
   f.withUser({ password_enabled: true });
 });
 
-xdescribe('PasswordPage', () => {
+describe('PasswordPage', () => {
   it('renders the component', async () => {
     const { wrapper } = await createFixtures(initConfig);
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR wraps parts of code in our tests that depend on real time to elapse (usage of `setTimeout`). Wrapping those part with `runFakeTimers` prevents the code from being delayed while executing setTimeout inside tests.

This results to test taking less time to run and there is much less change for a test to fail due to timeouts

<!-- Fixes # (issue number) -->
