### PR TITLE
chore(nextjs): Deprecate withClerkMiddleware

### DIFF
--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -42,7 +42,8 @@ export const decorateResponseWithObservabilityHeaders = (res: NextResponse, requ
 };
 
 /**
- * @deprecated Use authMiddleware instead https://clerk.com/docs/nextjs/middleware
+ * @deprecated withClerkMiddleware has been deprecated in favor of `authMiddleware`.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
  */
 export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => {
   const noop = () => undefined;

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -41,6 +41,9 @@ export const decorateResponseWithObservabilityHeaders = (res: NextResponse, requ
   requestState.status && res.headers.set(constants.Headers.AuthStatus, encodeURIComponent(requestState.status));
 };
 
+/**
+ * @deprecated Use authMiddleware instead https://clerk.com/docs/nextjs/middleware
+ */
 export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => {
   const noop = () => undefined;
   const [handler = noop, opts = {}] = args as [NextMiddleware, WithAuthOptions] | [];


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Deprecate `withClerkMiddleware` in favour of the new `authMiddleware`.
<!-- Fixes # (issue number) -->
