### PR TITLE
fix(clerk-js): Replace history state when merging fragment into the url

### DIFF
--- a/packages/clerk-js/src/ui/router/PathRouter.tsx
+++ b/packages/clerk-js/src/ui/router/PathRouter.tsx
@@ -38,7 +38,8 @@ export const PathRouter = ({ basePath, preservedParams, children }: PathRouterPr
     const convertHashToPath = async () => {
       if (hasUrlInFragment(window.location.hash)) {
         const url = mergeFragmentIntoUrl(new URL(window.location.href));
-        await internalNavigate(url.href);
+        window.history.replaceState(window.history.state, '', url.href);
+        await internalNavigate(url.href); // make this navigation as well since replaceState is asynchronous
         setStripped(true);
       }
     };


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
When using path routing and clicking on a sign-in/up link, we get rerouted to a hash based url which automatically gets converted to a path based url (that's happening inside PathRouter.tsx). After that, when the back button is pressed, we arrive at the hash-based url that got converted and not at the actual previous page we were on.

Solution: Replace the history state when merging the fragment into the url. Keep the old state data to avoid breaking any custom routers (eg nextjs router).

Before: 

https://github.com/clerkinc/javascript/assets/73396808/436b9029-22b0-47ad-9fb1-d93135eaa8dd


After:

https://github.com/clerkinc/javascript/assets/73396808/818ed562-01f0-4013-80a5-832d9e3dabb2


<!-- Fixes # (issue number) -->
