### PR TITLE
chore(nextjs): Use req.cookies instead of getCookie

### DIFF
--- a/packages/nextjs/src/server/authMiddleware.test.ts
+++ b/packages/nextjs/src/server/authMiddleware.test.ts
@@ -54,7 +54,9 @@ const mockRequest = (url: string, appendDevBrowserCookie = false) => {
   return {
     url: new URL(url, 'https://www.clerk.com').toString(),
     nextUrl: new URL(url, 'https://www.clerk.com'),
-    cookies: (appendDevBrowserCookie ? { __clerk_db_jwt: 'test_jwt' } : {}) as any,
+    cookies: {
+      get: () => (appendDevBrowserCookie ? { name: '__clerk_db_jwt', value: 'test_jwt' } : {}) as any,
+    },
     headers: new Headers(),
   } as NextRequest;
 };

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -11,7 +11,7 @@ import { DEV_BROWSER_JWT_MARKER, setDevBrowserJWTInURL } from './devBrowser';
 import { receivedRequestForIgnoredRoute } from './errors';
 import { isDevOrStagingUrl, redirectToSignIn } from './redirect';
 import type { NextMiddlewareResult, WithAuthOptions } from './types';
-import { decorateRequest, getCookie, setRequestHeadersOnNextResponse } from './utils';
+import { decorateRequest, setRequestHeadersOnNextResponse } from './utils';
 
 type WithPathPatternWildcard<T> = `${T & string}(.*)`;
 type NextTypedRoute<T = Parameters<typeof Link>['0']['href']> = T extends string ? T : never;
@@ -217,7 +217,7 @@ const withDefaultPublicRoutes = (publicRoutes: RouteMatcherParam | undefined) =>
 const appendDevBrowserOnDevOrStaging = (req: NextRequest, res: Response) => {
   const location = res.headers.get('location');
   if (!!location && isDevOrStagingUrl(location)) {
-    const dbJwt = getCookie(req, DEV_BROWSER_JWT_MARKER);
+    const dbJwt = req.cookies.get(DEV_BROWSER_JWT_MARKER)?.value;
     const urlWithDevBrowser = setDevBrowserJWTInURL(location, dbJwt);
     return NextResponse.redirect(urlWithDevBrowser, res);
   }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
