### PR TITLE
fix(clerk-js): Round hue and lightess to two decimal places when converting

### DIFF
--- a/packages/clerk-js/src/ui/utils/colors.ts
+++ b/packages/clerk-js/src/ui/utils/colors.ts
@@ -243,7 +243,7 @@ const rgbaTupleToHslaColor = (rgb: ColorTuple): HslaColor => {
     s = delta / (2 - max - min);
   }
 
-  return { h: Math.floor(h), s: Math.floor(s * 100), l: Math.floor(l * 100), a };
+  return { h: Math.floor(h * 100) / 100, s: Math.floor(s * 100), l: Math.floor(l * 100 * 100) / 100, a };
 };
 
 const hwbTupleToHslaColor = (hwb: ColorTuple): HslaColor => {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Better color accuracy when converting from rgb to hsl
An example was our purpleish color being converted to the wrong hex value when viewed with an extension.
<!-- Fixes # (issue number) -->
