### PR TITLE
fix(remix): Enable RootCatchBoundary to be a class component

### DIFF
--- a/packages/remix/src/client/ClerkCatchBoundary.tsx
+++ b/packages/remix/src/client/ClerkCatchBoundary.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { Interstitial } from './Interstitial';
 
-export function ClerkCatchBoundary(RootCatchBoundary?: () => JSX.Element) {
+export function ClerkCatchBoundary(RootCatchBoundary?: React.ComponentType) {
   return () => {
     const { data } = useCatch();
     const { __clerk_ssr_interstitial_html } = data?.clerkState?.__internal_clerk_state || {};


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

While working on the Clerk Remix docs, I noticed that class components were not allowed to be passed as a custom catch boundary, even though there doesn't appear to be any reason for this in the code.

This PR makes an update to the TS typings to fix this issue.

<!-- Fixes # (issue number) -->
