### PR TITLE
fix(backend): Not cross-origin when explicit default host port matches implicit default origin port

### DIFF
--- a/packages/backend/src/util/request.test.ts
+++ b/packages/backend/src/util/request.test.ts
@@ -76,5 +76,21 @@ export default (QUnit: QUnit) => {
       const forwardedHost = 'localhost:4000';
       assert.true(checkCrossOrigin({ originURL, host, forwardedHost }));
     });
+
+    test('is not CO when forwarded port is default - http', async assert => {
+      const originURL = new URL('http://localhost');
+      const host = new URL('http://localhost').host;
+      const forwardedPort = '80';
+
+      assert.false(checkCrossOrigin({ originURL, host, forwardedPort }));
+    });
+
+    test('is not CO when forwarded port is default - https', async assert => {
+      const originURL = new URL('https://localhost');
+      const host = new URL('https://localhost').host;
+      const forwardedPort = '443';
+
+      assert.false(checkCrossOrigin({ originURL, host, forwardedPort }));
+    });
   });
 };

--- a/packages/backend/src/util/request.ts
+++ b/packages/backend/src/util/request.ts
@@ -22,12 +22,14 @@ export function checkCrossOrigin({
     return true;
   }
 
+  const defaultHostProtocol = originURL.protocol;
+
   /* The forwarded host prioritised over host to be checked against the referrer.  */
-  const finalURL = convertHostHeaderValueToURL(forwardedHost || host);
+  const finalURL = convertHostHeaderValueToURL(forwardedHost || host, defaultHostProtocol);
 
-  finalURL.port = forwardedPort || finalURL.port;
+  const finalURLPort = (forwardedPort || finalURL.port || getDefaultPort(forwardedProto || defaultHostProtocol)) ?? '';
 
-  if (finalURL.port !== originURL.port) {
+  if (finalURLPort !== (originURL.port || getDefaultPort(originURL.protocol))) {
     return true;
   }
   if (finalURL.hostname !== originURL.hostname) {
@@ -37,10 +39,17 @@ export function checkCrossOrigin({
   return false;
 }
 
-export function convertHostHeaderValueToURL(host: string): URL {
+export function convertHostHeaderValueToURL(host: string, protocol: string): URL {
   /**
    * The protocol is added for the URL constructor to work properly.
    * We do not check for the protocol at any point later on.
    */
-  return new URL(`https://${host}`);
+  return new URL(`${protocol}//${host}`);
+}
+
+export function getDefaultPort(protocol: string): string | undefined {
+  return {
+    'http:': '80',
+    'https:': '443',
+  }[protocol];
 }


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Refer to added test cases.

Support setting `x-forwarded-port` to the default port (80 for http) without triggering cross-origin.

This is required because AWS's load balancer sets that header to the default.

### Fixes
Currently the cross-origin check incorrectly flags when comparing the host port of '80' to the origin port of '', here: https://github.com/clerkinc/javascript/blob/edc33b2daf64152eabb187080e7c64df4468fc58/packages/backend/src/util/request.ts#LL30C42-L30C42.

Bug report: https://discordapp.com/channels/856971667393609759/1110775689898111006/1110775689898111006
