### PR TITLE
fix(clerk-js): Correct china phone number hyphen positions

### DIFF
--- a/packages/clerk-js/src/ui/elements/PhoneInput/countryCodeData.ts
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/countryCodeData.ts
@@ -54,7 +54,7 @@ const data = [
   ['Central African Republic', 'cf', '236'],
   ['Chad', 'td', '235'],
   ['Chile', 'cl', '56'],
-  ['China', 'cn', '86', '..-........'],
+  ['China', 'cn', '86', '...-....-....'],
   ['Colombia', 'co', '57'],
   ['Comoros', 'km', '269'],
   ['Congo', 'cd', '243'],


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Before:
<img width="398" alt="Screenshot 2023-05-29 at 14 30 09" 
src="https://github.com/clerkinc/javascript/assets/73396808/f6170948-572d-49dc-9c91-e4d3af4a6905">

After:
<img width="378" alt="Screenshot 2023-05-29 at 14 30 42" src="https://github.com/clerkinc/javascript/assets/73396808/d5723d93-fc57-41f1-983e-5e8c2c9552de">

<!-- Fixes # (issue number) -->
