### PR TITLE
feat(clerk-js,types,localizations): Show enterprise accounts in user …

### DIFF
--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -37,7 +37,7 @@ export class OrganizationMembership extends BaseResource implements Organization
   }
 
   destroy = async (): Promise<OrganizationMembership> => {
-    // FIXME: Revise the return type of _baseDelete
+    // TODO: Revise the return type of _baseDelete
     const deletedMembership = (await this._baseDelete({
       path: `/organizations/${this.organization.id}/memberships/${this.publicUserData.userId}`,
     })) as unknown as OrganizationMembership;

--- a/packages/clerk-js/src/core/resources/SamlAccount.ts
+++ b/packages/clerk-js/src/core/resources/SamlAccount.ts
@@ -1,4 +1,4 @@
-import type { SamlAccountJSON, SamlAccountResource, VerificationResource } from '@clerk/types';
+import type { SamlAccountJSON, SamlAccountResource, SamlIdpSlug, VerificationResource } from '@clerk/types';
 
 import { BaseResource } from './Base';
 import { Verification } from './Verification';
@@ -8,7 +8,7 @@ import { Verification } from './Verification';
  */
 export class SamlAccount extends BaseResource implements SamlAccountResource {
   id!: string;
-  provider = '';
+  provider: SamlIdpSlug = 'saml_custom';
   emailAddress = '';
   firstName = '';
   lastName = '';

--- a/packages/clerk-js/src/ui/components/UserProfile/EnterpriseAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EnterpriseAccountsSection.tsx
@@ -1,0 +1,78 @@
+import type { SamlAccountResource } from '@clerk/types/src';
+
+import { useRouter } from '../../../ui/router';
+import { useCoreUser } from '../../contexts';
+import { Badge, Col, descriptors, Flex, Image, localizationKeys } from '../../customizables';
+import { ProfileSection, UserPreview } from '../../elements';
+import { useSaml } from '../../hooks';
+import { UserProfileAccordion } from './UserProfileAccordion';
+
+export const EnterpriseAccountsSection = () => {
+  const user = useCoreUser();
+
+  return (
+    <ProfileSection
+      title={localizationKeys('userProfile.start.enterpriseAccountsSection.title')}
+      id='enterpriseAccounts'
+    >
+      {user.samlAccounts.map(account => (
+        <EnterpriseAccountAccordion
+          key={account.id}
+          account={account}
+        />
+      ))}
+    </ProfileSection>
+  );
+};
+
+const EnterpriseAccountAccordion = ({ account }: { account: SamlAccountResource }) => {
+  const router = useRouter();
+  const { getSamlProviderLogoUrl, getSamlProviderName } = useSaml();
+  const error = account.verification?.error?.longMessage;
+  const label = account.emailAddress;
+  const providerName = getSamlProviderName(account.provider);
+  const providerLogoUrl = getSamlProviderLogoUrl(account.provider);
+
+  return (
+    <UserProfileAccordion
+      onCloseCallback={router.urlStateParam?.clearUrlStateParam}
+      icon={
+        <Image
+          elementDescriptor={[descriptors.providerIcon]}
+          elementId={descriptors.enterpriseButtonsProviderIcon.setId(account.provider)}
+          alt={providerName}
+          src={providerLogoUrl}
+          sx={theme => ({ width: theme.sizes.$4 })}
+        />
+      }
+      title={
+        <Flex
+          gap={2}
+          center
+        >
+          {`${providerName} ${label ? `(${label})` : ''}`}
+          {error && (
+            <Badge
+              colorScheme='danger'
+              localizationKey={localizationKeys('badge__requiresAction')}
+            />
+          )}
+        </Flex>
+      }
+    >
+      <Col gap={4}>
+        <UserPreview
+          samlAccount={account}
+          size='lg'
+          icon={
+            <Image
+              alt={providerName}
+              src={providerLogoUrl}
+              sx={theme => ({ width: theme.sizes.$4 })}
+            />
+          }
+        />
+      </Col>
+    </UserProfileAccordion>
+  );
+};

--- a/packages/clerk-js/src/ui/components/UserProfile/RootPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/RootPage.tsx
@@ -1,10 +1,11 @@
-import { useEnvironment } from '../../contexts';
+import { useCoreUser, useEnvironment } from '../../contexts';
 import { Col, descriptors, localizationKeys } from '../../customizables';
 import { CardAlert, Header, useCardState, withCardStateProvider } from '../../elements';
 import { NavbarMenuButtonRow } from '../../elements/Navbar';
 import { ActiveDevicesSection } from './ActiveDevicesSection';
 import { ConnectedAccountsSection } from './ConnectedAccountsSection';
 import { EmailsSection } from './EmailSection';
+import { EnterpriseAccountsSection } from './EnterpriseAccountsSection';
 import { MfaSection } from './MfaSection';
 import { PasswordSection } from './PasswordSection';
 import { PhoneSection } from './PhoneSection';
@@ -14,12 +15,14 @@ import { getSecondFactors } from './utils';
 import { Web3Section } from './Web3Section';
 
 export const RootPage = withCardStateProvider(() => {
-  const { attributes, social, instanceIsPasswordBased } = useEnvironment().userSettings;
+  const { attributes, saml, social, instanceIsPasswordBased } = useEnvironment().userSettings;
   const card = useCardState();
+  const user = useCoreUser();
   const showUsername = attributes.username.enabled;
   const showEmail = attributes.email_address.enabled;
   const showPhone = attributes.phone_number.enabled;
   const showConnectedAccounts = social && Object.values(social).filter(p => p.enabled).length > 0;
+  const showSamlAccounts = saml && saml.enabled && user.samlAccounts.length > 0;
   const showWeb3 = attributes.web3_wallet.enabled;
   const showPassword = instanceIsPasswordBased;
   const showMfa = getSecondFactors(attributes).length > 0;
@@ -49,6 +52,7 @@ export const RootPage = withCardStateProvider(() => {
         {showEmail && <EmailsSection />}
         {showPhone && <PhoneSection />}
         {showConnectedAccounts && <ConnectedAccountsSection />}
+        {showSamlAccounts && <EnterpriseAccountsSection />}
         {showWeb3 && <Web3Section />}
       </Col>
       <Col

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/RootPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/RootPage.test.tsx
@@ -124,6 +124,37 @@ describe('RootPage', () => {
       expect(externalAccountButton.closest('button')).not.toBeNull();
     });
 
+    it('shows the enterprise accounts of the user', async () => {
+      const emailAddress = 'george@jungle.com';
+      const firstName = 'George';
+      const lastName = 'Clerk';
+
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withEmailAddress();
+        f.withSaml();
+        f.withUser({
+          email_addresses: [emailAddress],
+          saml_accounts: [
+            {
+              id: 'samlacc_foo',
+              provider: 'saml_okta',
+              email_address: emailAddress,
+              first_name: firstName,
+              last_name: lastName,
+            },
+          ],
+          first_name: firstName,
+          last_name: lastName,
+        });
+      });
+      fixtures.clerk.user!.getSessions.mockReturnValue(Promise.resolve([]));
+
+      render(<RootPage />, { wrapper });
+      await waitFor(() => expect(fixtures.clerk.user?.getSessions).toHaveBeenCalled());
+      screen.getByText(/Enterprise Accounts/i);
+      screen.getByText(/Okta Workforce/i);
+    });
+
     it('shows the active devices of the user and has appropriate buttons', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withSocialProvider({ provider: 'google' });

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -43,6 +43,8 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'socialButtonsBlockButtonArrow',
   'socialButtonsProviderIcon',
 
+  'enterpriseButtonsProviderIcon',
+
   'alternativeMethods',
   'alternativeMethodsBlockButton',
   'alternativeMethodsBlockButtonText',

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -1,4 +1,4 @@
-import type { ExternalAccountResource, UserPreviewId, UserResource } from '@clerk/types';
+import type { ExternalAccountResource, SamlAccountResource, UserPreviewId, UserResource } from '@clerk/types';
 import React from 'react';
 
 import { getFullName, getIdentifier } from '../../utils/user';
@@ -6,6 +6,11 @@ import type { LocalizationKey } from '../customizables';
 import { descriptors, Flex, Text, useLocalizations } from '../customizables';
 import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { UserAvatar } from './UserAvatar';
+
+// TODO Make this accept an interface with the superset of fields in:
+// - User
+// - ExternalAccountResource
+// - SamlAccountResource
 
 export type UserPreviewProps = Omit<PropsOfComponent<typeof Flex>, 'title' | 'elementId'> & {
   size?: 'lg' | 'md' | 'sm';
@@ -22,10 +27,17 @@ export type UserPreviewProps = Omit<PropsOfComponent<typeof Flex>, 'title' | 'el
     | {
         user?: Partial<UserResource>;
         externalAccount?: null | undefined;
+        samlAccount?: null | undefined;
       }
     | {
         user?: null | undefined;
         externalAccount?: Partial<ExternalAccountResource>;
+        samlAccount?: null | undefined;
+      }
+    | {
+        user?: null | undefined;
+        externalAccount?: null | undefined;
+        samlAccount?: Partial<SamlAccountResource>;
       }
   );
 
@@ -33,6 +45,7 @@ export const UserPreview = (props: UserPreviewProps) => {
   const {
     user,
     externalAccount,
+    samlAccount,
     size = 'md',
     showAvatar = true,
     icon,
@@ -47,8 +60,8 @@ export const UserPreview = (props: UserPreviewProps) => {
     ...rest
   } = props;
   const { t } = useLocalizations();
-  const name = getFullName({ ...user }) || getFullName({ ...externalAccount });
-  const identifier = getIdentifier({ ...user }) || externalAccount?.accountIdentifier?.();
+  const name = getFullName({ ...user }) || getFullName({ ...externalAccount }) || getFullName({ ...samlAccount });
+  const identifier = getIdentifier({ ...user }) || externalAccount?.accountIdentifier?.() || samlAccount?.emailAddress;
   const localizedTitle = t(title);
 
   const imageUrl = imageUrlProp || user?.imageUrl || externalAccount?.imageUrl;
@@ -74,6 +87,7 @@ export const UserPreview = (props: UserPreviewProps) => {
             imageElementDescriptor={descriptors.userPreviewAvatarImage}
             {...user}
             {...externalAccount}
+            {...samlAccount}
             name={name}
             avatarUrl={imageUrl}
             size={t => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size])}

--- a/packages/clerk-js/src/ui/hooks/index.ts
+++ b/packages/clerk-js/src/ui/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useDelayedVisibility';
+export * from './useSaml';
 export * from './useWindowEventListener';
 export * from './useMagicLink';
 export * from './useClipboard';

--- a/packages/clerk-js/src/ui/hooks/useSaml.ts
+++ b/packages/clerk-js/src/ui/hooks/useSaml.ts
@@ -1,0 +1,19 @@
+import type { SamlIdpSlug } from '@clerk/types';
+import { SAML_IDPS } from '@clerk/types';
+
+import { iconImageUrl } from '../common/constants';
+
+function getSamlProviderLogoUrl(provider: SamlIdpSlug = 'saml_custom'): string {
+  return iconImageUrl(SAML_IDPS[provider]?.logo);
+}
+
+function getSamlProviderName(provider: SamlIdpSlug = 'saml_custom'): string {
+  return SAML_IDPS[provider]?.name;
+}
+
+export const useSaml = () => {
+  return {
+    getSamlProviderLogoUrl,
+    getSamlProviderName,
+  };
+};

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -7,6 +7,7 @@ import type {
   OAuthProvider,
   OrganizationJSON,
   PhoneNumberJSON,
+  SamlAccountJSON,
   SessionJSON,
   SignInJSON,
   SignUpJSON,
@@ -40,11 +41,12 @@ const createUserFixtureHelpers = (baseClient: ClientJSON) => {
 
   type WithUserParams = Omit<
     Partial<UserJSON>,
-    'email_addresses' | 'phone_numbers' | 'external_accounts' | 'organization_memberships'
+    'email_addresses' | 'phone_numbers' | 'external_accounts' | 'saml_accounts' | 'organization_memberships'
   > & {
     email_addresses?: Array<string | Partial<EmailAddressJSON>>;
     phone_numbers?: Array<string | Partial<PhoneNumberJSON>>;
     external_accounts?: Array<OAuthProvider | Partial<ExternalAccountJSON>>;
+    saml_accounts?: Array<Partial<SamlAccountJSON>>;
     organization_memberships?: Array<string | OrgParams>;
   };
 
@@ -404,6 +406,10 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     };
   };
 
+  const withSaml = () => {
+    us.saml = { enabled: true };
+  };
+
   // TODO: Add the rest, consult pkg/generate/auth_config.go
 
   return {
@@ -416,5 +422,6 @@ const createUserSettingsFixtureHelpers = (environment: EnvironmentJSON) => {
     withPassword,
     withPasswordComplexity,
     withSocialProvider,
+    withSaml,
   };
 };

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -300,6 +300,9 @@ export const enUS: LocalizationResource = {
         destructiveActionSubtitle: 'Remove this connected account from your account',
         destructiveActionAccordionSubtitle: 'Remove connected account',
       },
+      enterpriseAccountsSection: {
+        title: 'Enterprise accounts',
+      },
       passwordSection: {
         title: 'Password',
         primaryButton__changePassword: 'Change password',

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -1,6 +1,7 @@
 import type * as CSS from 'csstype';
 
 import type { OAuthProvider } from './oauth';
+import type { SamlIdpSlug } from './saml';
 import type { BuiltInColors, TransparentColor } from './theme';
 import type { Web3Provider } from './web3';
 
@@ -9,6 +10,7 @@ type CSSPropertiesWithMultiValues = { [K in keyof CSSProperties]: CSSProperties[
 type CSSPseudos = { [K in CSS.Pseudos as `&${K}`]?: CSSObject };
 
 interface CSSObject extends CSSPropertiesWithMultiValues, CSSPseudos {}
+
 type UserDefinedStyle = string | CSSObject;
 
 type Shade = '50' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
@@ -76,6 +78,7 @@ export type ProfileSectionId =
   | 'emailAddresses'
   | 'phoneNumbers'
   | 'connectedAccounts'
+  | 'enterpriseAccounts'
   | 'web3Wallets'
   | 'password'
   | 'mfa'
@@ -175,6 +178,8 @@ export type ElementsConfig = {
   socialButtonsBlockButtonText: WithOptions<OAuthProvider | Web3Provider, never, never>;
   socialButtonsBlockButtonArrow: WithOptions<OAuthProvider | Web3Provider, never, never>;
   socialButtonsProviderIcon: WithOptions<OAuthProvider | Web3Provider, LoadingState, never>;
+
+  enterpriseButtonsProviderIcon: WithOptions<SamlIdpSlug, LoadingState, never>;
 
   alternativeMethods: WithOptions<never, never, never>;
   alternativeMethodsBlockButton: WithOptions<OAuthProvider | Web3Provider, LoadingState, never>;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -28,6 +28,7 @@ export * from './organizationSettings';
 export * from './phoneNumber';
 export * from './redirects';
 export * from './resource';
+export * from './saml';
 export * from './samlAccount';
 export * from './session';
 export * from './signIn';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -9,6 +9,7 @@ import type { OAuthProvider } from './oauth';
 import type { OrganizationInvitationStatus } from './organizationInvitation';
 import type { MembershipRole } from './organizationMembership';
 import type { OrganizationSettingsJSON } from './organizationSettings';
+import type { SamlIdpSlug } from './saml';
 import type { SessionStatus } from './session';
 import type { SignInFirstFactor, SignInJSON, SignInSecondFactor } from './signIn';
 import type { SignUpField, SignUpIdentificationField, SignUpStatus } from './signUp';
@@ -166,7 +167,7 @@ export interface ExternalAccountJSON extends ClerkResourceJSON {
  */
 export interface SamlAccountJSON extends ClerkResourceJSON {
   object: 'saml_account';
-  provider: string;
+  provider: SamlIdpSlug;
   email_address: string;
   first_name: string;
   last_name: string;

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -333,6 +333,9 @@ type _LocalizationResource = {
         destructiveActionSubtitle: LocalizationValue;
         destructiveActionAccordionSubtitle: LocalizationValue;
       };
+      enterpriseAccountsSection: {
+        title: LocalizationValue;
+      };
       passwordSection: {
         title: LocalizationValue;
         primaryButton__changePassword: LocalizationValue;

--- a/packages/types/src/saml.ts
+++ b/packages/types/src/saml.ts
@@ -1,0 +1,27 @@
+export type SamlIdpSlug = 'saml_okta' | 'saml_google' | 'saml_microsoft' | 'saml_custom';
+
+export type SamlIdp = {
+  name: string;
+  logo: string;
+};
+
+export type SamlIdpMap = Record<SamlIdpSlug, SamlIdp>;
+
+export const SAML_IDPS: SamlIdpMap = {
+  saml_okta: {
+    name: 'Okta Workforce',
+    logo: 'okta',
+  },
+  saml_google: {
+    name: 'Google Workspace',
+    logo: 'google',
+  },
+  saml_microsoft: {
+    name: 'Microsoft Azure AD',
+    logo: 'azure',
+  },
+  saml_custom: {
+    name: 'SAML',
+    logo: 'saml',
+  },
+};

--- a/packages/types/src/samlAccount.ts
+++ b/packages/types/src/samlAccount.ts
@@ -1,11 +1,12 @@
 import type { ClerkResource } from './resource';
+import type { SamlIdpSlug } from './saml';
 import type { VerificationResource } from './verification';
 
 /**
  * @experimental
  */
 export interface SamlAccountResource extends ClerkResource {
-  provider: string;
+  provider: SamlIdpSlug;
   emailAddress: string;
   firstName: string;
   lastName: string;


### PR DESCRIPTION
…profile

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

The current PR shows enterprise accounts on the user profile if SAML is enabled & the use has SAML accounts.

TODOs:

* Tests
* `<UserPreview />` has become a bit messy, it needs a refactor
* Not sure from the mockups if the connection name should be displayed
