### PR TITLE
fix(remix): Use location to verify navigation completion

### DIFF
--- a/packages/remix/src/client/useAwaitableNavigate.tsx
+++ b/packages/remix/src/client/useAwaitableNavigate.tsx
@@ -1,24 +1,22 @@
-import { useNavigate, useTransition } from '@remix-run/react';
+import { useLocation, useNavigate } from '@remix-run/react';
 import React from 'react';
 
 type Resolve = (value?: unknown) => void;
 
 export const useAwaitableNavigate = () => {
   const navigate = useNavigate();
-  const transition = useTransition();
+  const location = useLocation();
   const resolveFunctionsRef = React.useRef<Resolve[]>([]);
-
   const resolveAll = () => {
-    if (transition.state !== 'idle') {
-      return;
-    }
     resolveFunctionsRef.current.forEach(resolve => resolve());
     resolveFunctionsRef.current.splice(0, resolveFunctionsRef.current.length);
   };
 
+  // location.key will change even when navigating to the same url,
+  // so we will successfully resolve in that case as well
   React.useEffect(() => {
     resolveAll();
-  }, [transition.state]);
+  }, [location]);
 
   return (to: string) => {
     return new Promise(res => {


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
When using a catchall route (`$.tsx`) in remix, the transition state `useTransition().state` remains idle during the navigation, so we are never able to resolve the promise we create in our `awaitableNavigate`.

I've replaced that with the `useLocation` hook, which is exported straight from the `react-router` package. This will rerender the component even if we navigate to the same url (in that case `location.key` will be different).

<!-- Fixes # (issue number) -->
