### PR TITLE
fix(gatsby-plugin-clerk): Pass the plugin options as ClerkProvider props

### DIFF
--- a/packages/gatsby-plugin-clerk/src/gatsby-browser.tsx
+++ b/packages/gatsby-plugin-clerk/src/gatsby-browser.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ClerkProvider } from './GatsbyClerkProvider';
 
-export const wrapPageElement: GatsbyBrowser['wrapPageElement'] = ({ element, props }) => {
+export const wrapPageElement: GatsbyBrowser['wrapPageElement'] = ({ element, props }, pluginOptions) => {
   let clerkSsrState: any;
   if ((props.serverData as any)?.clerkState) {
     clerkSsrState = (props.serverData as any).clerkState;
@@ -18,6 +18,7 @@ export const wrapPageElement: GatsbyBrowser['wrapPageElement'] = ({ element, pro
       clerkJSUrl={process.env.GATSBY_CLERK_JS}
       proxyUrl={process.env.GATSBY_CLERK_PROXY_URL}
       clerkState={clerkSsrState || {}}
+      {...pluginOptions}
     >
       {element}
     </ClerkProvider>

--- a/packages/gatsby-plugin-clerk/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-clerk/src/gatsby-ssr.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ClerkProvider } from './GatsbyClerkProvider';
 
-export const wrapPageElement: GatsbySSR['wrapPageElement'] = ({ element, props }) => {
+export const wrapPageElement: GatsbySSR['wrapPageElement'] = ({ element, props }, pluginOptions) => {
   let clerkSsrState: any;
   if ((props.serverData as any)?.clerkState) {
     clerkSsrState = (props.serverData as any).clerkState;
@@ -18,6 +18,7 @@ export const wrapPageElement: GatsbySSR['wrapPageElement'] = ({ element, props }
       clerkJSUrl={process.env.GATSBY_CLERK_JS}
       proxyUrl={process.env.GATSBY_CLERK_PROXY_URL}
       clerkState={clerkSsrState || {}}
+      {...pluginOptions}
     >
       {element}
     </ClerkProvider>


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [x] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR propagates the Gatsby plugin options to ClerkProvider as props.

Example using localization:
```ts
import type { GatsbyConfig } from "gatsby"
import type { ClerkProviderProps } from "gatsby-plugin-clerk"
import { frFR } from "@clerk/localizations"

const config: GatsbyConfig = {
  ...
  plugins: [
    {
      resolve: `gatsby-plugin-clerk`,
      options: {
        localization: frFR,
      } as ClerkProviderProps
    },
  ],
}

export default config
```
<!-- Fixes # (issue number) -->
