### PR TITLE
fix(backend): Fixes issue with the forwarded headers

### DIFF
--- a/packages/backend/src/util/request.test.ts
+++ b/packages/backend/src/util/request.test.ts
@@ -87,7 +87,7 @@ export default (QUnit: QUnit) => {
 
     test('is not CO when forwarded port and origin does not contain a port - https', assert => {
       const originURL = new URL('https://localhost');
-      const host = new URL('https://localhost').host;
+      const host = originURL.host;
       const forwardedPort = '443';
 
       assert.false(checkCrossOrigin({ originURL, host, forwardedPort }));
@@ -100,6 +100,17 @@ export default (QUnit: QUnit) => {
       const referrer = 'http://example.com/';
 
       assert.false(checkCrossOrigin({ originURL: new URL(referrer), host, forwardedPort, forwardedHost }));
+    });
+
+    test('is not CO for AWS', assert => {
+      const options = {
+        originURL: new URL('https://main.d38v5rl8fqcx2i.amplifyapp.com'),
+        host: 'prod.eu-central-1.gateway.amplify.aws.dev',
+        forwardedPort: '443,80',
+        forwardedHost: 'main.d38v5rl8fqcx2i.amplifyapp.com',
+        forwardedProto: 'https,http',
+      };
+      assert.false(checkCrossOrigin(options));
     });
   });
 };

--- a/packages/backend/src/util/request.test.ts
+++ b/packages/backend/src/util/request.test.ts
@@ -112,5 +112,16 @@ export default (QUnit: QUnit) => {
       };
       assert.false(checkCrossOrigin(options));
     });
+
+    test('is not CO for Railway App', assert => {
+      const options = {
+        originURL: new URL('https://aws-clerk-nextjs-production.up.railway.app'),
+        host: 'aws-clerk-nextjs-production.up.railway.app',
+        forwardedPort: '80',
+        forwardedHost: 'aws-clerk-nextjs-production.up.railway.app',
+        forwardedProto: 'https,http',
+      };
+      assert.false(checkCrossOrigin(options));
+    });
   });
 };

--- a/packages/backend/src/util/request.test.ts
+++ b/packages/backend/src/util/request.test.ts
@@ -6,19 +6,19 @@ export default (QUnit: QUnit) => {
   const { module, test } = QUnit;
 
   module('check cross-origin-referrer request utility', () => {
-    test('is not CO with IPv6', async assert => {
+    test('is not CO with IPv6', assert => {
       const originURL = new URL('http://[::1]');
       const host = new URL('http://[::1]').host;
       assert.false(checkCrossOrigin({ originURL, host }));
     });
 
-    test('is not CO with set https and 443 port', async assert => {
+    test('is not CO with set https and 443 port', assert => {
       const originURL = new URL('https://localhost:443');
       const host = new URL('https://localhost').host;
       assert.false(checkCrossOrigin({ originURL, host }));
     });
 
-    test('is CO with mixed default security ports', async assert => {
+    test('is CO with mixed default security ports', assert => {
       const originURL = new URL('https://localhost:80');
       const host = new URL('http://localhost:443').host;
       assert.true(checkCrossOrigin({ originURL, host }));
@@ -26,12 +26,12 @@ export default (QUnit: QUnit) => {
 
     // todo(
     //   'we cannot detect if the request is CO when HTTPS to HTTP and no other information is carried over',
-    //   async assert => {
+    //   assert => {
     //     assert.true(true);
     //   },
     // );
 
-    test('is CO when HTTPS to HTTP with present x-forwarded-proto', async assert => {
+    test('is CO when HTTPS to HTTP with present x-forwarded-proto', assert => {
       const originURL = new URL('https://localhost');
       const host = new URL('http://someserver').host;
       const forwardedHost = new URL('http://localhost').host;
@@ -40,7 +40,7 @@ export default (QUnit: QUnit) => {
       assert.true(checkCrossOrigin({ originURL, host, forwardedHost, forwardedProto }));
     });
 
-    test('is CO when HTTPS to HTTP with forwarded port', async assert => {
+    test('is CO when HTTPS to HTTP with forwarded port', assert => {
       const originURL = new URL('https://localhost');
       const host = new URL('http://localhost').host;
       const forwardedPort = '80';
@@ -48,20 +48,20 @@ export default (QUnit: QUnit) => {
       assert.true(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is CO with cross origin auth domain', async assert => {
+    test('is CO with cross origin auth domain', assert => {
       const originURL = new URL('https://accounts.clerk.com');
       const host = new URL('https://localhost').host;
       assert.true(checkCrossOrigin({ originURL, host }));
     });
 
-    test('is CO when forwarded port overrides host derived port', async assert => {
+    test('is CO when forwarded port overrides host derived port', assert => {
       const originURL = new URL('https://localhost:443');
       const host = new URL('https://localhost').host;
       const forwardedPort = '3001';
       assert.true(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is not CO with port included in x-forwarded host', async assert => {
+    test('is not CO with port included in x-forwarded host', assert => {
       /* Example https://www.rfc-editor.org/rfc/rfc7239#section-4 */
       const originURL = new URL('http://localhost:3000');
       const host = '127.0.0.1:3000';
@@ -69,7 +69,7 @@ export default (QUnit: QUnit) => {
       assert.false(checkCrossOrigin({ originURL, host, forwardedHost }));
     });
 
-    test('is CO with port included in x-forwarded host', async assert => {
+    test('is CO with port included in x-forwarded host', assert => {
       /* Example https://www.rfc-editor.org/rfc/rfc7239#section-4 */
       const originURL = new URL('http://localhost:3000');
       const host = '127.0.0.1:3000';
@@ -77,7 +77,7 @@ export default (QUnit: QUnit) => {
       assert.true(checkCrossOrigin({ originURL, host, forwardedHost }));
     });
 
-    test('is not CO when forwarded port and origin does not contain a port - http', async assert => {
+    test('is not CO when forwarded port and origin does not contain a port - http', assert => {
       const originURL = new URL('http://localhost');
       const host = new URL('http://localhost').host;
       const forwardedPort = '80';
@@ -85,7 +85,7 @@ export default (QUnit: QUnit) => {
       assert.false(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is not CO when forwarded port and origin does not contain a port - https', async assert => {
+    test('is not CO when forwarded port and origin does not contain a port - https', assert => {
       const originURL = new URL('https://localhost');
       const host = new URL('https://localhost').host;
       const forwardedPort = '443';
@@ -93,7 +93,7 @@ export default (QUnit: QUnit) => {
       assert.false(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is not CO based on referrer with forwarded host & port and referer', async assert => {
+    test('is not CO based on referrer with forwarded host & port and referer', assert => {
       const host = '';
       const forwardedPort = '80';
       const forwardedHost = 'example.com';

--- a/packages/backend/src/util/request.ts
+++ b/packages/backend/src/util/request.ts
@@ -18,14 +18,19 @@ export function checkCrossOrigin({
   forwardedPort?: string | null;
   forwardedProto?: string | null;
 }) {
-  if (forwardedProto && forwardedProto !== originURL.protocol) {
+  const proto = getFirstValueFromHeaderValue(forwardedProto);
+  const port = getFirstValueFromHeaderValue(forwardedPort);
+
+  const originProtocol = getProtocolVerb(originURL.protocol);
+
+  if (proto && proto !== originProtocol) {
     return true;
   }
 
-  const protocol = forwardedProto || originURL.protocol;
+  const protocol = proto || originProtocol;
   /* The forwarded host prioritised over host to be checked against the referrer.  */
   const finalURL = convertHostHeaderValueToURL(forwardedHost || host, protocol);
-  finalURL.port = forwardedPort || finalURL.port;
+  finalURL.port = port || finalURL.port;
 
   if (getPort(finalURL) !== getPort(originURL)) {
     return true;
@@ -37,17 +42,17 @@ export function checkCrossOrigin({
   return false;
 }
 
-export function convertHostHeaderValueToURL(host: string, protocol = 'https:'): URL {
+export function convertHostHeaderValueToURL(host: string, protocol = 'https'): URL {
   /**
    * The protocol is added for the URL constructor to work properly.
    * We do not check for the protocol at any point later on.
    */
-  return new URL(`${protocol}//${host}`);
+  return new URL(`${protocol}://${host}`);
 }
 
 const PROTOCOL_TO_PORT_MAPPING: Record<string, string> = {
-  'http:': '80',
-  'https:': '443',
+  http: '80',
+  https: '443',
 } as const;
 
 function getPort(url: URL) {
@@ -56,4 +61,12 @@ function getPort(url: URL) {
 
 function getPortFromProtocol(protocol: string) {
   return PROTOCOL_TO_PORT_MAPPING[protocol];
+}
+
+function getFirstValueFromHeaderValue(value?: string | null) {
+  return value?.split(',')[0]?.trim() || '';
+}
+
+function getProtocolVerb(protocol: string) {
+  return protocol?.replace(/:$/, '') || '';
 }

--- a/packages/nextjs/src/server/authenticateRequest.ts
+++ b/packages/nextjs/src/server/authenticateRequest.ts
@@ -33,6 +33,7 @@ export const authenticateRequest = async (req: NextRequest, opts: WithAuthOption
     host: headers.get('host') as string,
     forwardedPort: headers.get('x-forwarded-port') || undefined,
     forwardedHost: headers.get('x-forwarded-host') || undefined,
+    forwardedProto: headers.get('x-forwarded-proto') || undefined,
     referrer: headers.get('referer') || undefined,
     userAgent: headers.get('user-agent') || undefined,
     searchParams: new URL(req.url).searchParams,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Changes:
- Use the first value in `x-forwarded-proto`, `x-forwarded-port` when multiple values passed in headers
- Pass `x-forwarded-proto` header from `@clerk/nextjs` to `@clerk/backend`
- Use `x-forwarded-proto` as fallback when `x-forwarded-proto` and `x-forwarded-port` mismatch (fixes Railway App issue with headers)
- Drop `async` from requests test

### Review it per commit