### PR TITLE
fix(backend): Remove semicolon from url.protocol when trying to trans…

### DIFF
--- a/packages/backend/src/util/request.ts
+++ b/packages/backend/src/util/request.ts
@@ -61,7 +61,7 @@ const PROTOCOL_TO_PORT_MAPPING: Record<string, string> = {
 } as const;
 
 function getPort(url: URL) {
-  return url.port || getPortFromProtocol(url.protocol);
+  return url.port || getPortFromProtocol(getProtocolVerb(url.protocol));
 }
 
 function getPortFromProtocol(protocol: string) {


### PR DESCRIPTION
…form it to port

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Resolves invalid comparison of ports between origin and final url.