### PR TITLE
Revert AWS and Railway Apps `x-forwarded-*` headers changes

### DIFF
--- a/packages/backend/src/util/request.test.ts
+++ b/packages/backend/src/util/request.test.ts
@@ -6,19 +6,19 @@ export default (QUnit: QUnit) => {
   const { module, test } = QUnit;
 
   module('check cross-origin-referrer request utility', () => {
-    test('is not CO with IPv6', assert => {
+    test('is not CO with IPv6', async assert => {
       const originURL = new URL('http://[::1]');
       const host = new URL('http://[::1]').host;
       assert.false(checkCrossOrigin({ originURL, host }));
     });
 
-    test('is not CO with set https and 443 port', assert => {
+    test('is not CO with set https and 443 port', async assert => {
       const originURL = new URL('https://localhost:443');
       const host = new URL('https://localhost').host;
       assert.false(checkCrossOrigin({ originURL, host }));
     });
 
-    test('is CO with mixed default security ports', assert => {
+    test('is CO with mixed default security ports', async assert => {
       const originURL = new URL('https://localhost:80');
       const host = new URL('http://localhost:443').host;
       assert.true(checkCrossOrigin({ originURL, host }));
@@ -26,12 +26,12 @@ export default (QUnit: QUnit) => {
 
     // todo(
     //   'we cannot detect if the request is CO when HTTPS to HTTP and no other information is carried over',
-    //   assert => {
+    //   async assert => {
     //     assert.true(true);
     //   },
     // );
 
-    test('is CO when HTTPS to HTTP with present x-forwarded-proto', assert => {
+    test('is CO when HTTPS to HTTP with present x-forwarded-proto', async assert => {
       const originURL = new URL('https://localhost');
       const host = new URL('http://someserver').host;
       const forwardedHost = new URL('http://localhost').host;
@@ -40,7 +40,7 @@ export default (QUnit: QUnit) => {
       assert.true(checkCrossOrigin({ originURL, host, forwardedHost, forwardedProto }));
     });
 
-    test('is CO when HTTPS to HTTP with forwarded port', assert => {
+    test('is CO when HTTPS to HTTP with forwarded port', async assert => {
       const originURL = new URL('https://localhost');
       const host = new URL('http://localhost').host;
       const forwardedPort = '80';
@@ -48,20 +48,20 @@ export default (QUnit: QUnit) => {
       assert.true(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is CO with cross origin auth domain', assert => {
+    test('is CO with cross origin auth domain', async assert => {
       const originURL = new URL('https://accounts.clerk.com');
       const host = new URL('https://localhost').host;
       assert.true(checkCrossOrigin({ originURL, host }));
     });
 
-    test('is CO when forwarded port overrides host derived port', assert => {
+    test('is CO when forwarded port overrides host derived port', async assert => {
       const originURL = new URL('https://localhost:443');
       const host = new URL('https://localhost').host;
       const forwardedPort = '3001';
       assert.true(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is not CO with port included in x-forwarded host', assert => {
+    test('is not CO with port included in x-forwarded host', async assert => {
       /* Example https://www.rfc-editor.org/rfc/rfc7239#section-4 */
       const originURL = new URL('http://localhost:3000');
       const host = '127.0.0.1:3000';
@@ -69,7 +69,7 @@ export default (QUnit: QUnit) => {
       assert.false(checkCrossOrigin({ originURL, host, forwardedHost }));
     });
 
-    test('is CO with port included in x-forwarded host', assert => {
+    test('is CO with port included in x-forwarded host', async assert => {
       /* Example https://www.rfc-editor.org/rfc/rfc7239#section-4 */
       const originURL = new URL('http://localhost:3000');
       const host = '127.0.0.1:3000';
@@ -77,7 +77,7 @@ export default (QUnit: QUnit) => {
       assert.true(checkCrossOrigin({ originURL, host, forwardedHost }));
     });
 
-    test('is not CO when forwarded port and origin does not contain a port - http', assert => {
+    test('is not CO when forwarded port and origin does not contain a port - http', async assert => {
       const originURL = new URL('http://localhost');
       const host = new URL('http://localhost').host;
       const forwardedPort = '80';
@@ -85,43 +85,21 @@ export default (QUnit: QUnit) => {
       assert.false(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is not CO when forwarded port and origin does not contain a port - https', assert => {
+    test('is not CO when forwarded port and origin does not contain a port - https', async assert => {
       const originURL = new URL('https://localhost');
-      const host = originURL.host;
+      const host = new URL('https://localhost').host;
       const forwardedPort = '443';
 
       assert.false(checkCrossOrigin({ originURL, host, forwardedPort }));
     });
 
-    test('is not CO based on referrer with forwarded host & port and referer', assert => {
+    test('is not CO based on referrer with forwarded host & port and referer', async assert => {
       const host = '';
       const forwardedPort = '80';
       const forwardedHost = 'example.com';
       const referrer = 'http://example.com/';
 
       assert.false(checkCrossOrigin({ originURL: new URL(referrer), host, forwardedPort, forwardedHost }));
-    });
-
-    test('is not CO for AWS', assert => {
-      const options = {
-        originURL: new URL('https://main.d38v5rl8fqcx2i.amplifyapp.com'),
-        host: 'prod.eu-central-1.gateway.amplify.aws.dev',
-        forwardedPort: '443,80',
-        forwardedHost: 'main.d38v5rl8fqcx2i.amplifyapp.com',
-        forwardedProto: 'https,http',
-      };
-      assert.false(checkCrossOrigin(options));
-    });
-
-    test('is not CO for Railway App', assert => {
-      const options = {
-        originURL: new URL('https://aws-clerk-nextjs-production.up.railway.app'),
-        host: 'aws-clerk-nextjs-production.up.railway.app',
-        forwardedPort: '80',
-        forwardedHost: 'aws-clerk-nextjs-production.up.railway.app',
-        forwardedProto: 'https,http',
-      };
-      assert.false(checkCrossOrigin(options));
     });
   });
 };

--- a/packages/backend/src/util/request.ts
+++ b/packages/backend/src/util/request.ts
@@ -18,24 +18,14 @@ export function checkCrossOrigin({
   forwardedPort?: string | null;
   forwardedProto?: string | null;
 }) {
-  const fwdProto = getFirstValueFromHeaderValue(forwardedProto);
-  let fwdPort = getFirstValueFromHeaderValue(forwardedPort);
-  // If forwardedPort mismatch with forwardedProto determine forwardedPort
-  // from forwardedProto as fallback (if exists)
-  // This check fixes the Railway App issue
-  if (fwdProto && fwdPort !== getPortFromProtocol(fwdProto)) {
-    fwdPort = getPortFromProtocol(fwdProto);
-  }
-
-  const originProtocol = getProtocolVerb(originURL.protocol);
-  if (fwdProto && fwdProto !== originProtocol) {
+  if (forwardedProto && forwardedProto !== originURL.protocol) {
     return true;
   }
 
-  const protocol = fwdProto || originProtocol;
+  const protocol = forwardedProto || originURL.protocol;
   /* The forwarded host prioritised over host to be checked against the referrer.  */
   const finalURL = convertHostHeaderValueToURL(forwardedHost || host, protocol);
-  finalURL.port = fwdPort || finalURL.port;
+  finalURL.port = forwardedPort || finalURL.port;
 
   if (getPort(finalURL) !== getPort(originURL)) {
     return true;
@@ -47,17 +37,17 @@ export function checkCrossOrigin({
   return false;
 }
 
-export function convertHostHeaderValueToURL(host: string, protocol = 'https'): URL {
+export function convertHostHeaderValueToURL(host: string, protocol = 'https:'): URL {
   /**
    * The protocol is added for the URL constructor to work properly.
    * We do not check for the protocol at any point later on.
    */
-  return new URL(`${protocol}://${host}`);
+  return new URL(`${protocol}//${host}`);
 }
 
 const PROTOCOL_TO_PORT_MAPPING: Record<string, string> = {
-  http: '80',
-  https: '443',
+  'http:': '80',
+  'https:': '443',
 } as const;
 
 function getPort(url: URL) {
@@ -66,12 +56,4 @@ function getPort(url: URL) {
 
 function getPortFromProtocol(protocol: string) {
   return PROTOCOL_TO_PORT_MAPPING[protocol];
-}
-
-function getFirstValueFromHeaderValue(value?: string | null) {
-  return value?.split(',')[0]?.trim() || '';
-}
-
-function getProtocolVerb(protocol: string) {
-  return protocol?.replace(/:$/, '') || '';
 }

--- a/packages/backend/src/util/request.ts
+++ b/packages/backend/src/util/request.ts
@@ -61,7 +61,7 @@ const PROTOCOL_TO_PORT_MAPPING: Record<string, string> = {
 } as const;
 
 function getPort(url: URL) {
-  return url.port || getPortFromProtocol(getProtocolVerb(url.protocol));
+  return url.port || getPortFromProtocol(url.protocol);
 }
 
 function getPortFromProtocol(protocol: string) {

--- a/packages/nextjs/src/server/authenticateRequest.ts
+++ b/packages/nextjs/src/server/authenticateRequest.ts
@@ -33,7 +33,6 @@ export const authenticateRequest = async (req: NextRequest, opts: WithAuthOption
     host: headers.get('host') as string,
     forwardedPort: headers.get('x-forwarded-port') || undefined,
     forwardedHost: headers.get('x-forwarded-host') || undefined,
-    forwardedProto: headers.get('x-forwarded-proto') || undefined,
     referrer: headers.get('referer') || undefined,
     userAgent: headers.get('user-agent') || undefined,
     searchParams: new URL(req.url).searchParams,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
