### PR TITLE
feat(nextjs): Return 401 Response on protected API routes

### DIFF
--- a/.changeset/seven-mayflies-push.md
+++ b/.changeset/seven-mayflies-push.md
@@ -1,0 +1,9 @@
+---
+'@clerk/nextjs': minor
+---
+We tweaked the default `authMiddleware` behavior for protected API routes. An unauthenticated request for a protected API route will no longer return a `307 Redirect` - a `401 Unauthorized` response will be returned instead. An API route is considered a request for which the following rules apply:
+- The request url matches the following patterns; `['/api/(.*)', '/trpc/(.*)']`
+- Or, the request has `Content-Type: application/json`
+- Or, the request method is not one of: `GET`, `OPTIONS` ,` HEAD`
+  A new `apiRoutes` param has been introduced on `authMiddleware`. It can accept an array of path patterns, `RegexExp` or strings. If `apiRoutes` is passed in explicitly, then it overrides the behavior described above and only the requests matching `apiRoutes` will be considered as API routes requests.
+  For more technical details, refer to the PR's description.

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -86,7 +86,7 @@
     "@types/react-dom": "*",
     "expect-type": "^0.15.0",
     "jest": "*",
-    "node-fetch-native": "^0.1.8",
+    "node-fetch-native": "1.1.1",
     "ts-jest": "*",
     "typescript": "*"
   },

--- a/packages/nextjs/src/server/authMiddleware.test.ts
+++ b/packages/nextjs/src/server/authMiddleware.test.ts
@@ -50,14 +50,27 @@ jest.mock('./clerkClient', () => {
   };
 });
 
-const mockRequest = (url: string, appendDevBrowserCookie = false) => {
+type MockRequestParams = {
+  url: string;
+  appendDevBrowserCookie?: boolean;
+  method?: string;
+  headers?: any;
+};
+
+const mockRequest = ({
+  url,
+  appendDevBrowserCookie = false,
+  method = 'GET',
+  headers = new Headers(),
+}: MockRequestParams) => {
   return {
     url: new URL(url, 'https://www.clerk.com').toString(),
     nextUrl: new URL(url, 'https://www.clerk.com'),
     cookies: {
       get: () => (appendDevBrowserCookie ? { name: '__clerk_db_jwt', value: 'test_jwt' } : {}) as any,
     },
-    headers: new Headers(),
+    method,
+    headers,
   } as NextRequest;
 };
 
@@ -65,44 +78,44 @@ describe('isPublicRoute', () => {
   describe('should work with path patterns', function () {
     it('matches path and all sub paths using *', () => {
       const isPublicRoute = createRouteMatcher(['/hello(.*)']);
-      expect(isPublicRoute(mockRequest('/hello'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/hello/'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/hello/test/a'))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello/test/a' }))).toBe(true);
     });
 
     it('matches filenames with specific extensions', () => {
       const isPublicRoute = createRouteMatcher(['/(.*).ts', '/(.*).js']);
-      expect(isPublicRoute(mockRequest('/hello.js'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/test/hello.js'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/test/hello.ts'))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello.js' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/test/hello.js' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/test/hello.ts' }))).toBe(true);
     });
 
     it('works with single values (non array)', () => {
       const isPublicRoute = createRouteMatcher('/test/hello.ts');
-      expect(isPublicRoute(mockRequest('/hello.js'))).not.toBe(true);
-      expect(isPublicRoute(mockRequest('/test/hello.js'))).not.toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello.js' }))).not.toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/test/hello.js' }))).not.toBe(true);
     });
   });
 
   describe('should work with regex patterns', function () {
     it('matches path and all sub paths using *', () => {
       const isPublicRoute = createRouteMatcher([/^\/hello.*$/]);
-      expect(isPublicRoute(mockRequest('/hello'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/hello/'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/hello/test/a'))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello/' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello/test/a' }))).toBe(true);
     });
 
     it('matches filenames with specific extensions', () => {
       const isPublicRoute = createRouteMatcher([/^.*\.(ts|js)$/]);
-      expect(isPublicRoute(mockRequest('/hello.js'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/test/hello.js'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/test/hello.ts'))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello.js' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/test/hello.js' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/test/hello.ts' }))).toBe(true);
     });
 
     it('works with single values (non array)', () => {
       const isPublicRoute = createRouteMatcher(/hello/g);
-      expect(isPublicRoute(mockRequest('/hello.js'))).toBe(true);
-      expect(isPublicRoute(mockRequest('/test/hello.js'))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/hello.js' }))).toBe(true);
+      expect(isPublicRoute(mockRequest({ url: '/test/hello.js' }))).toBe(true);
     });
   });
 });
@@ -131,14 +144,14 @@ describe('default config matcher', () => {
   describe('does not match any static files or next internals', function () {
     it.each(invalidRoutes)(`does not match %s`, path => {
       const matcher = createRouteMatcher(DEFAULT_CONFIG_MATCHER);
-      expect(matcher(mockRequest(path))).toBe(false);
+      expect(matcher(mockRequest({ url: path }))).toBe(false);
     });
   });
 
   describe('matches /api or known framework routes', function () {
     it.each(validRoutes)(`matches %s`, path => {
       const matcher = createRouteMatcher(DEFAULT_CONFIG_MATCHER);
-      expect(matcher(mockRequest(path))).toBe(true);
+      expect(matcher(mockRequest({ url: path }))).toBe(true);
     });
   });
 });
@@ -153,14 +166,14 @@ describe('default ignored routes matcher', () => {
   describe('matches all static files or next internals', function () {
     it.each(invalidRoutes)(`matches %s`, path => {
       const matcher = createRouteMatcher(DEFAULT_IGNORED_ROUTES);
-      expect(matcher(mockRequest(path))).toBe(true);
+      expect(matcher(mockRequest({ url: path }))).toBe(true);
     });
   });
 
   describe('does not match /api or known framework routes', function () {
     it.each(validRoutes)(`does not match %s`, path => {
       const matcher = createRouteMatcher(DEFAULT_IGNORED_ROUTES);
-      expect(matcher(mockRequest(path))).toBe(false);
+      expect(matcher(mockRequest({ url: path }))).toBe(false);
     });
   });
 });
@@ -175,7 +188,7 @@ describe('authMiddleware(params)', () => {
 
   describe('without params', function () {
     it('redirects to sign-in for protected route', async () => {
-      const resp = await authMiddleware()(mockRequest('/protected'), {} as NextFetchEvent);
+      const resp = await authMiddleware()(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);
       expect(resp?.headers.get('location')).toEqual(
@@ -185,14 +198,14 @@ describe('authMiddleware(params)', () => {
 
     it('renders public route', async () => {
       const signInResp = await authMiddleware({ publicRoutes: '/sign-in' })(
-        mockRequest('/sign-in'),
+        mockRequest({ url: '/sign-in' }),
         {} as NextFetchEvent,
       );
       expect(signInResp?.status).toEqual(200);
       expect(signInResp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/sign-in');
 
       const signUpResp = await authMiddleware({ publicRoutes: ['/sign-up'] })(
-        mockRequest('/sign-up'),
+        mockRequest({ url: '/sign-up' }),
         {} as NextFetchEvent,
       );
       expect(signUpResp?.status).toEqual(200);
@@ -208,7 +221,7 @@ describe('authMiddleware(params)', () => {
         ignoredRoutes: '/ignored',
         beforeAuth: beforeAuthSpy,
         afterAuth: afterAuthSpy,
-      })(mockRequest('/ignored'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/ignored' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(200);
       expect(authenticateRequest).not.toBeCalled();
@@ -223,7 +236,7 @@ describe('authMiddleware(params)', () => {
         ignoredRoutes: '/ignored',
         beforeAuth: beforeAuthSpy,
         afterAuth: afterAuthSpy,
-      })(mockRequest('/protected'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(200);
       expect(authenticateRequest).toBeCalled();
@@ -236,7 +249,7 @@ describe('authMiddleware(params)', () => {
     it('renders public route', async () => {
       const resp = await authMiddleware({
         publicRoutes: '/public',
-      })(mockRequest('/public'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/public' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(200);
       expect(resp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/public');
@@ -259,13 +272,13 @@ describe('authMiddleware(params)', () => {
       it('renders sign-in/sign-up routes', async () => {
         const signInResp = await authMiddleware({
           publicRoutes: '/public',
-        })(mockRequest('/custom-sign-in'), {} as NextFetchEvent);
+        })(mockRequest({ url: '/custom-sign-in' }), {} as NextFetchEvent);
         expect(signInResp?.status).toEqual(200);
         expect(signInResp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/custom-sign-in');
 
         const signUpResp = await authMiddleware({
           publicRoutes: '/public',
-        })(mockRequest('/custom-sign-up'), {} as NextFetchEvent);
+        })(mockRequest({ url: '/custom-sign-up' }), {} as NextFetchEvent);
         expect(signUpResp?.status).toEqual(200);
         expect(signUpResp?.headers.get('x-middleware-rewrite')).toEqual('https://www.clerk.com/custom-sign-up');
       });
@@ -274,7 +287,7 @@ describe('authMiddleware(params)', () => {
     it('redirects to sign-in for protected route', async () => {
       const resp = await authMiddleware({
         publicRoutes: '/public',
-      })(mockRequest('/protected'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);
       expect(resp?.headers.get('location')).toEqual(
@@ -289,7 +302,7 @@ describe('authMiddleware(params)', () => {
       const resp = await authMiddleware({
         beforeAuth: () => false,
         afterAuth: afterAuthSpy,
-      })(mockRequest('/protected'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(200);
       expect(resp?.headers.get('x-clerk-auth-reason')).toEqual('skip');
@@ -302,7 +315,7 @@ describe('authMiddleware(params)', () => {
       const resp = await authMiddleware({
         beforeAuth: () => undefined,
         afterAuth: afterAuthSpy,
-      })(mockRequest('/protected'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(200);
       expect(authenticateRequest).toBeCalled();
@@ -314,7 +327,7 @@ describe('authMiddleware(params)', () => {
       const resp = await authMiddleware({
         beforeAuth: () => NextResponse.redirect('https://www.clerk.com/custom-redirect'),
         afterAuth: afterAuthSpy,
-      })(mockRequest('/protected'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);
       expect(resp?.headers.get('location')).toEqual('https://www.clerk.com/custom-redirect');
@@ -337,7 +350,7 @@ describe('authMiddleware(params)', () => {
               'x-after-auth-header': 'after',
             },
           }),
-      })(mockRequest('/protected'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(200);
       expect(resp?.headers.get('x-before-auth-header')).toEqual('before');
@@ -350,7 +363,7 @@ describe('authMiddleware(params)', () => {
     it('redirects to sign-in for protected route and sets redirect as auth reason header', async () => {
       const resp = await authMiddleware({
         beforeAuth: () => NextResponse.next(),
-      })(mockRequest('/protected'), {} as NextFetchEvent);
+      })(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(307);
       expect(resp?.headers.get('location')).toEqual(
@@ -361,7 +374,7 @@ describe('authMiddleware(params)', () => {
     });
 
     it('uses authenticateRequest result as auth', async () => {
-      const req = mockRequest('/protected');
+      const req = mockRequest({ url: '/protected' });
       const event = {} as NextFetchEvent;
       // @ts-ignore
       authenticateRequest.mockResolvedValueOnce({ toAuth: () => ({ userId: null }) });
@@ -385,7 +398,7 @@ describe('authMiddleware(params)', () => {
     it('returns 401 with local interstitial for interstitial requestState', async () => {
       // @ts-ignore
       authenticateRequest.mockResolvedValueOnce({ isInterstitial: true });
-      const resp = await authMiddleware()(mockRequest('/protected'), {} as NextFetchEvent);
+      const resp = await authMiddleware()(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(401);
       expect(resp?.headers.get('content-type')).toEqual('text/html');
@@ -395,11 +408,23 @@ describe('authMiddleware(params)', () => {
     it('returns 401 for unknown requestState', async () => {
       // @ts-ignore
       authenticateRequest.mockResolvedValueOnce({ isUnknown: true });
-      const resp = await authMiddleware()(mockRequest('/protected'), {} as NextFetchEvent);
+      const resp = await authMiddleware()(mockRequest({ url: '/protected' }), {} as NextFetchEvent);
 
       expect(resp?.status).toEqual(401);
-      expect(resp?.body).toBeNull();
-      expect(resp?.headers.get('content-type')).toEqual('text/html');
+      expect(resp?.headers.get('content-type')).toEqual('application/json');
+      expect(clerkClient.localInterstitial).not.toBeCalled();
+    });
+
+    it('returns 401 for interstitial requestState in an API route', async () => {
+      // @ts-ignore
+      authenticateRequest.mockResolvedValueOnce({ isInterstitial: true });
+      const resp = await authMiddleware({ apiRoutes: ['/api/items'] })(
+        mockRequest({ url: '/api/items' }),
+        {} as NextFetchEvent,
+      );
+
+      expect(resp?.status).toEqual(401);
+      expect(resp?.headers.get('content-type')).toEqual('application/json');
       expect(clerkClient.localInterstitial).not.toBeCalled();
     });
   });
@@ -409,7 +434,7 @@ describe('Dev Browser JWT when redirecting to Clerk Hosted Pages', function () {
   it('does NOT append the Dev Browser JWT when cookie is missing', async () => {
     const resp = await authMiddleware({
       beforeAuth: () => NextResponse.next(),
-    })(mockRequest('/protected', false), {} as NextFetchEvent);
+    })(mockRequest({ url: '/protected', appendDevBrowserCookie: false }), {} as NextFetchEvent);
 
     expect(resp?.status).toEqual(307);
     expect(resp?.headers.get('location')).toEqual(
@@ -422,7 +447,7 @@ describe('Dev Browser JWT when redirecting to Clerk Hosted Pages', function () {
   it('appends the Dev Browser JWT on the URL when cookie __clerk_db_jwt exists', async () => {
     const resp = await authMiddleware({
       beforeAuth: () => NextResponse.next(),
-    })(mockRequest('/protected', true), {} as NextFetchEvent);
+    })(mockRequest({ url: '/protected', appendDevBrowserCookie: true }), {} as NextFetchEvent);
 
     expect(resp?.status).toEqual(307);
     expect(resp?.headers.get('location')).toEqual(
@@ -440,7 +465,7 @@ describe('Dev Browser JWT when redirecting to Clerk Hosted Pages', function () {
     );
     const resp = await authMiddleware({
       beforeAuth: () => NextResponse.next(),
-    })(mockRequest('/protected', true), {} as NextFetchEvent);
+    })(mockRequest({ url: '/protected', appendDevBrowserCookie: true }), {} as NextFetchEvent);
 
     expect(resp?.status).toEqual(307);
     expect(resp?.headers.get('location')).toEqual(
@@ -448,5 +473,105 @@ describe('Dev Browser JWT when redirecting to Clerk Hosted Pages', function () {
     );
     expect(resp?.headers.get('x-clerk-auth-reason')).toEqual('redirect');
     expect(authenticateRequest).toBeCalled();
+  });
+});
+
+describe('isApiRoute', function () {
+  it('treats route as API route if apiRoutes match the route path', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+      apiRoutes: ['/api/(.*)'],
+    })(mockRequest({ url: '/api/items' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(401);
+    expect(resp?.headers.get('content-type')).toEqual('application/json');
+  });
+
+  it('treats route as Page route if apiRoutes do not match the route path', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+      apiRoutes: ['/api/(.*)'],
+    })(mockRequest({ url: '/page' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(307);
+  });
+
+  it('treats route as API route if apiRoutes prop is missing and route path matches the default matcher (/api/(.*))', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+    })(mockRequest({ url: '/api/items' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(401);
+    expect(resp?.headers.get('content-type')).toEqual('application/json');
+  });
+
+  it('treats route as API route if apiRoutes prop is missing and route path matches the default matcher (/trpc/(.*))', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+    })(mockRequest({ url: '/trpc/items' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(401);
+    expect(resp?.headers.get('content-type')).toEqual('application/json');
+  });
+
+  it('treats route as API route if apiRoutes prop is missing and Request method is not-GET,OPTIONS,HEAD', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+    })(mockRequest({ url: '/products/items', method: 'POST' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(401);
+    expect(resp?.headers.get('content-type')).toEqual('application/json');
+  });
+
+  it('treats route as API route if apiRoutes prop is missing and Request headers Content-Type is application/json', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+    })(
+      mockRequest({ url: '/products/items', headers: new Headers({ 'content-type': 'application/json' }) }),
+      {} as NextFetchEvent,
+    );
+
+    expect(resp?.status).toEqual(401);
+    expect(resp?.headers.get('content-type')).toEqual('application/json');
+  });
+});
+
+describe('401 Response on Api Routes', function () {
+  it('returns 401 when route is not public and route matches API routes', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+      apiRoutes: ['/products/(.*)'],
+    })(mockRequest({ url: '/products/items' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(401);
+    expect(resp?.headers.get('content-type')).toEqual('application/json');
+  });
+
+  it('returns 307 when route is not public and route does not match API routes', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+      apiRoutes: ['/products/(.*)'],
+    })(mockRequest({ url: '/api/items' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(307);
+    expect(resp?.headers.get('content-type')).not.toEqual('application/json');
+  });
+
+  it('returns 200 when API route is public', async () => {
+    const resp = await authMiddleware({
+      beforeAuth: () => NextResponse.next(),
+      publicRoutes: ['/public'],
+      apiRoutes: ['/public'],
+    })(mockRequest({ url: '/public' }), {} as NextFetchEvent);
+
+    expect(resp?.status).toEqual(200);
   });
 });

--- a/packages/nextjs/src/server/authMiddleware.test.ts
+++ b/packages/nextjs/src/server/authMiddleware.test.ts
@@ -387,6 +387,7 @@ describe('authMiddleware(params)', () => {
         {
           userId: null,
           isPublicRoute: false,
+          isApiRoute: false,
         },
         req,
         event,

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -11,7 +11,7 @@ import { DEV_BROWSER_JWT_MARKER, setDevBrowserJWTInURL } from './devBrowser';
 import { receivedRequestForIgnoredRoute } from './errors';
 import { isDevOrStagingUrl, redirectToSignIn } from './redirect';
 import type { NextMiddlewareResult, WithAuthOptions } from './types';
-import { decorateRequest, setRequestHeadersOnNextResponse } from './utils';
+import { apiEndpointUnauthorizedNextResponse, decorateRequest, setRequestHeadersOnNextResponse } from './utils';
 
 type WithPathPatternWildcard<T> = `${T & string}(.*)`;
 type NextTypedRoute<T = Parameters<typeof Link>['0']['href']> = T extends string ? T : never;
@@ -38,6 +38,10 @@ export const DEFAULT_CONFIG_MATCHER = ['/((?!.*\\..*|_next).*)', '/', '/(api|trp
  * This is the inverted version of DEFAULT_CONFIG_MATCHER.
  */
 export const DEFAULT_IGNORED_ROUTES = ['/((?!api|trpc))(_next|.+\\..+)(.*)'];
+/**
+ * Any routes matching this path will be treated as API endpoints by the middleware.
+ */
+export const DEFAULT_API_ROUTES = ['/api/(.*)', '/trpc/(.*)'];
 
 type RouteMatcherParam =
   | Array<RegExp | RouteMatcherWithNextTypedRoutes>
@@ -46,6 +50,7 @@ type RouteMatcherParam =
   | ((req: NextRequest) => boolean);
 
 type IgnoredRoutesParam = Array<RegExp | string> | RegExp | string | ((req: NextRequest) => boolean);
+type ApiRoutesParam = Array<RegExp | string> | RegExp | string | ((req: NextRequest) => boolean);
 
 type BeforeAuthHandler = (
   req: NextRequest,
@@ -85,6 +90,12 @@ type AuthMiddlewareParams = WithAuthOptions & {
    */
   ignoredRoutes?: IgnoredRoutesParam;
   /**
+   * A list of routes that should be treated as API endpoints.
+   * When user is signed out, the middleware will return a 401 response for these routes, instead of redirecting the user.
+   * If omitted, these default API routes will be used: `['/api/(.*)', '/trpc/(.*)']` together with some heuristics.
+   */
+  apiRoutes?: ApiRoutesParam;
+  /**
    * Enables extra debug logging.
    */
   debug?: boolean;
@@ -96,11 +107,12 @@ export interface AuthMiddleware {
 
 const authMiddleware: AuthMiddleware = (...args: unknown[]) => {
   const [params = {}] = args as [AuthMiddlewareParams?];
-  const { beforeAuth, afterAuth, publicRoutes, ignoredRoutes, ...options } = params;
+  const { beforeAuth, afterAuth, publicRoutes, ignoredRoutes, apiRoutes, ...options } = params;
 
   const isIgnoredRoute = createRouteMatcher(ignoredRoutes || DEFAULT_IGNORED_ROUTES);
   const isPublicRoute = createRouteMatcher(withDefaultPublicRoutes(publicRoutes));
-  const defaultAfterAuth = createDefaultAfterAuth(isPublicRoute);
+  const isApiRoute = createApiRoutes(apiRoutes);
+  const defaultAfterAuth = createDefaultAfterAuth(isPublicRoute, isApiRoute);
 
   return withLogger('authMiddleware', logger => async (req: NextRequest, evt: NextFetchEvent) => {
     if (options.debug) {
@@ -130,12 +142,18 @@ const authMiddleware: AuthMiddleware = (...args: unknown[]) => {
     if (requestState.isUnknown) {
       logger.debug('authenticateRequest state is unknown', requestState);
       return handleUnknownState(requestState);
+    } else if (requestState.isInterstitial && isApiRoute(req)) {
+      logger.debug('authenticateRequest state is interstitial in an API route', requestState);
+      return handleUnknownState(requestState);
     } else if (requestState.isInterstitial) {
       logger.debug('authenticateRequest state is interstitial', requestState);
       return handleInterstitialState(requestState, options);
     }
 
-    const auth = Object.assign(requestState.toAuth(), { isPublicRoute: isPublicRoute(req) });
+    const auth = Object.assign(requestState.toAuth(), {
+      isPublicRoute: isPublicRoute(req),
+      isApiRoute: isApiRoute(req),
+    });
     logger.debug(() => ({ auth: JSON.stringify(auth) }));
     const afterAuthRes = await (afterAuth || defaultAfterAuth)(auth, req, evt);
     const finalRes = mergeResponses(beforeAuthRes, afterAuthRes) || NextResponse.next();
@@ -173,9 +191,14 @@ export const createRouteMatcher = (routes: RouteMatcherParam) => {
   return (req: NextRequest) => matchers.some(matcher => matcher.test(req.nextUrl.pathname));
 };
 
-const createDefaultAfterAuth = (isPublicRoute: ReturnType<typeof createRouteMatcher>) => {
+const createDefaultAfterAuth = (
+  isPublicRoute: ReturnType<typeof createRouteMatcher>,
+  isApiRoute: ReturnType<typeof createApiRoutes>,
+) => {
   return (auth: AuthObject, req: NextRequest) => {
-    if (!auth.userId && !isPublicRoute(req)) {
+    if (!auth.userId && !isPublicRoute(req) && isApiRoute(req)) {
+      return apiEndpointUnauthorizedNextResponse();
+    } else if (!auth.userId && !isPublicRoute(req)) {
       return redirectToSignIn({ returnBackUrl: req.url });
     }
     return NextResponse.next();
@@ -222,4 +245,31 @@ const appendDevBrowserOnDevOrStaging = (req: NextRequest, res: Response) => {
     return NextResponse.redirect(urlWithDevBrowser, res);
   }
   return res;
+};
+
+// - Default behavior:
+//    If the route path is `['/api/(.*)*', '*/trpc/(.*)']`
+//    or Request has `Content-Type: application/json`
+//    or Request method is not-GET,OPTIONS,HEAD,
+//    then this is considered an API route.
+//
+// - If the user has provided a specific `apiRoutes` prop in `authMiddleware` then all the above are discarded,
+//   and only routes that match the user’s provided paths are considered API routes.
+const createApiRoutes = (apiRoutes: RouteMatcherParam | undefined): ((req: NextRequest) => boolean) => {
+  if (apiRoutes) {
+    return createRouteMatcher(apiRoutes);
+  }
+  const isDefaultApiRoute = createRouteMatcher(DEFAULT_API_ROUTES);
+  return (req: NextRequest) =>
+    isDefaultApiRoute(req) || isRequestMethodIndicatingApiRoute(req) || isRequestContentTypeJson(req);
+};
+
+const isRequestContentTypeJson = (req: NextRequest): boolean => {
+  const requestContentType = req.headers.get(constants.Headers.ContentType);
+  return requestContentType === constants.ContentTypes.Json;
+};
+
+const isRequestMethodIndicatingApiRoute = (req: NextRequest): boolean => {
+  const requestMethod = req.method.toLowerCase();
+  return !['get', 'head', 'options'].includes(requestMethod);
 };

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -50,7 +50,7 @@ type RouteMatcherParam =
   | ((req: NextRequest) => boolean);
 
 type IgnoredRoutesParam = Array<RegExp | string> | RegExp | string | ((req: NextRequest) => boolean);
-type ApiRoutesParam = Array<RegExp | string> | RegExp | string | ((req: NextRequest) => boolean);
+type ApiRoutesParam = IgnoredRoutesParam;
 
 type BeforeAuthHandler = (
   req: NextRequest,
@@ -92,7 +92,13 @@ type AuthMiddlewareParams = WithAuthOptions & {
   /**
    * A list of routes that should be treated as API endpoints.
    * When user is signed out, the middleware will return a 401 response for these routes, instead of redirecting the user.
-   * If omitted, these default API routes will be used: `['/api/(.*)', '/trpc/(.*)']` together with some heuristics.
+   *
+   * If omitted, the following heuristics will be used to determine an API endpoint:
+   * - The route path is ['/api/(.*)', '/trpc/(.*)'],
+   * - or the request has `Content-Type` set to `application/json`,
+   * - or the request method is not one of: `GET`, `OPTIONS` ,` HEAD`
+   *
+   * @default undefined
    */
   apiRoutes?: ApiRoutesParam;
   /**

--- a/packages/nextjs/src/server/authenticateRequest.ts
+++ b/packages/nextjs/src/server/authenticateRequest.ts
@@ -13,7 +13,7 @@ import {
   SECRET_KEY,
 } from './clerkClient';
 import type { WithAuthOptions } from './types';
-import { getCookie } from './utils';
+import { apiEndpointUnauthorizedNextResponse, getCookie } from './utils';
 import { decorateResponseWithObservabilityHeaders } from './withClerkMiddleware';
 
 export const authenticateRequest = async (req: NextRequest, opts: WithAuthOptions) => {
@@ -40,7 +40,7 @@ export const authenticateRequest = async (req: NextRequest, opts: WithAuthOption
 };
 
 export const handleUnknownState = (requestState: RequestState) => {
-  const response = new NextResponse(null, { status: 401, headers: { 'Content-Type': 'text/html' } });
+  const response = apiEndpointUnauthorizedNextResponse();
   decorateResponseWithObservabilityHeaders(response, requestState);
   return response;
 };

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -249,11 +249,5 @@ export function decorateRequest(
 }
 
 export const apiEndpointUnauthorizedNextResponse = () => {
-  const error = {
-    status: 401,
-    error: 'Unauthorized',
-    message: 'Not authorized to access this resource',
-  };
-
-  return NextResponse.json({ error }, { status: 401 });
+  return NextResponse.json(null, { status: 401, statusText: 'Unauthorized' });
 };

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -247,3 +247,13 @@ export function decorateRequest(
 
   return res;
 }
+
+export const apiEndpointUnauthorizedNextResponse = () => {
+  const error = {
+    status: 401,
+    error: 'Unauthorized',
+    message: 'Not authorized to access this resource',
+  };
+
+  return NextResponse.json({ error }, { status: 401 });
+};


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This commit introduces a new `apiRoutes` param on `authMiddleware`.

If `apiRoutes` is omitted, then the following heuristic is used: 
- If the route path is `['/api/(.*)', '/trpc/(.*)']` 
- or Request has `Content-Type: application/json` 
- or Request method is not-`GET,OPTIONS,HEAD`,

then this is considered an API route.

After this commit, a 401 JSON Response is returned on the following 3 cases:
- When the `authenticateRequest` function returns the `Unknown` state.
- When the `authenticateRequest` function returns the `Interstitial` state and the route is an API route.
- When the user is signed out, the route is protected (not public), and the route is an API route. _(this one happens inside our default implementation of `afterAuth`. If it is overwritten, then the user needs to handle this case themselves)_

<!-- Fixes # (issue number) -->
