### PR TITLE
Display zxcvbn errors as a warning when focus is not lost

### DIFF
--- a/packages/clerk-js/src/ui/elements/FormControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FormControl.tsx
@@ -48,6 +48,8 @@ type FormControlProps = Omit<PropsOfComponent<typeof Input>, 'label' | 'placehol
   setSuccessful: (message: string) => void;
   successfulText: string;
   hasLostFocus: boolean;
+  setHasPassedComplexity: (b: boolean) => void;
+  hasPassedComplexity: boolean;
   enableErrorAfterBlur?: boolean;
   informationText?: string;
   isFocused: boolean;
@@ -234,6 +236,8 @@ export const FormControl = forwardRef<HTMLInputElement, PropsWithChildren<FormCo
     isFocused: _isFocused,
     warningText,
     setWarning,
+    setHasPassedComplexity,
+    hasPassedComplexity,
     ...rest
   } = props;
   const isDisabled = props.isDisabled || card.isLoading;
@@ -245,6 +249,7 @@ export const FormControl = forwardRef<HTMLInputElement, PropsWithChildren<FormCo
     errorText,
     informationText,
     enableErrorAfterBlur,
+    hasPassedComplexity,
     isFocused: _isFocused,
     hasLostFocus,
     successfulText,
@@ -342,6 +347,7 @@ export const FormControl = forwardRef<HTMLInputElement, PropsWithChildren<FormCo
       setError={setError}
       setSuccessful={setSuccessful}
       setWarning={setWarning}
+      setHasPassedComplexity={setHasPassedComplexity}
       sx={sx}
     >
       {isCheckbox ? (

--- a/packages/clerk-js/src/ui/elements/PasswordInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PasswordInput.tsx
@@ -31,6 +31,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>((p
         formControlProps?.setSuccessful?.(t(localizationKeys('unstable__errors.zxcvbn.goodPassword'))),
       onValidationFailed: errorMessage => formControlProps?.setError?.(errorMessage),
       onValidationWarning: errorMessage => formControlProps?.setWarning?.(errorMessage),
+      onValidationComplexity: hasPassed => formControlProps?.setHasPassedComplexity?.(hasPassed),
     },
   );
 

--- a/packages/clerk-js/src/ui/hooks/usePassword.ts
+++ b/packages/clerk-js/src/ui/hooks/usePassword.ts
@@ -17,12 +17,18 @@ type UsePasswordCbs = {
   onValidationFailed?: (errorMessage: string | undefined) => void;
   onValidationSuccess?: () => void;
   onValidationWarning?: (warningMessage: string) => void;
+  onValidationComplexity?: (b: boolean) => void;
 };
 
 export const MIN_PASSWORD_LENGTH = 8;
 
 export const usePassword = (config: UsePasswordConfig, callbacks?: UsePasswordCbs) => {
-  const { onValidationFailed = noop, onValidationSuccess = noop, onValidationWarning = noop } = callbacks || {};
+  const {
+    onValidationFailed = noop,
+    onValidationSuccess = noop,
+    onValidationWarning = noop,
+    onValidationComplexity = noop,
+  } = callbacks || {};
   const { strengthMeter, show_zxcvbn, complexity } = config;
   const { setPassword: setPasswordComplexity } = usePasswordComplexity(config);
   const { getScore } = usePasswordStrength();
@@ -53,6 +59,7 @@ export const usePassword = (config: UsePasswordConfig, callbacks?: UsePasswordCb
 
       if (complexity) {
         const { failedValidationsText } = setPasswordComplexity(_password);
+        onValidationComplexity(!failedValidationsText);
         complexityError = failedValidationsText;
       }
 
@@ -73,7 +80,16 @@ export const usePassword = (config: UsePasswordConfig, callbacks?: UsePasswordCb
       }
       reportSuccessOrError(complexityError || zxcvbnError, zxcvbnWarning);
     },
-    [onValidationFailed, onValidationSuccess, strengthMeter, show_zxcvbn, complexity, getScore, setPasswordComplexity],
+    [
+      onValidationFailed,
+      onValidationSuccess,
+      onValidationComplexity,
+      strengthMeter,
+      show_zxcvbn,
+      complexity,
+      getScore,
+      setPasswordComplexity,
+    ],
   );
 
   return {

--- a/packages/clerk-js/src/ui/primitives/FormControl.tsx
+++ b/packages/clerk-js/src/ui/primitives/FormControl.tsx
@@ -5,14 +5,16 @@ import type { FormControlProps } from './hooks';
 import { FormControlContextProvider } from './hooks';
 
 export const FormControl = (props: React.PropsWithChildren<FormControlProps>) => {
-  const { hasError, id, isRequired, setError, setSuccessful, setWarning, ...rest } = props;
+  const { hasError, id, isRequired, setError, setSuccessful, setWarning, setHasPassedComplexity, ...rest } = props;
   return (
     <Flex
       direction='col'
       {...rest}
       css={{ position: 'relative', flex: '1 1 auto' }}
     >
-      <FormControlContextProvider {...{ hasError, id, isRequired, setError, setSuccessful, setWarning }}>
+      <FormControlContextProvider
+        {...{ hasError, id, isRequired, setError, setSuccessful, setWarning, setHasPassedComplexity }}
+      >
         {props.children}
       </FormControlContextProvider>
     </Flex>

--- a/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
+++ b/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
@@ -14,6 +14,7 @@ export type FormControlProps = {
   setError: (error: string | ClerkAPIError | undefined) => void;
   setSuccessful: (message: string) => void;
   setWarning: (message: string) => void;
+  setHasPassedComplexity: (b: boolean) => void;
 };
 
 type FormControlContextValue = Required<FormControlProps> & { errorMessageId: string };
@@ -30,6 +31,7 @@ export const FormControlContextProvider = (props: React.PropsWithChildren<FormCo
     setError,
     setSuccessful,
     setWarning,
+    setHasPassedComplexity,
   } = props;
   // TODO: This shouldnt be targettable
   const id = `${propsId}-field`;
@@ -49,9 +51,10 @@ export const FormControlContextProvider = (props: React.PropsWithChildren<FormCo
         setError,
         setSuccessful,
         setWarning,
+        setHasPassedComplexity,
       },
     }),
-    [isRequired, hasError, id, errorMessageId, isDisabled, setError, setSuccessful],
+    [isRequired, hasError, id, errorMessageId, isDisabled, setError, setSuccessful, setHasPassedComplexity],
   );
   return <FormControlContext.Provider value={value}>{props.children}</FormControlContext.Provider>;
 };

--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -43,6 +43,8 @@ type FieldStateProps<Id> = {
   setError: (error: string | ClerkAPIError | undefined) => void;
   setWarning: (message: string) => void;
   setSuccessful: (message: string) => void;
+  setHasPassedComplexity: (b: boolean) => void;
+  hasPassedComplexity: boolean;
   successfulText: string;
   isFocused: boolean;
 } & Omit<Options, 'defaultChecked'>;
@@ -79,6 +81,7 @@ export const useFormControl = <Id extends string>(
   const [successfulText, setSuccessfulText] = React.useState('');
   const [hasLostFocus, setHasLostFocus] = React.useState(false);
   const [isFocused, setFocused] = React.useState(false);
+  const [hasPassedComplexity, setHasPassedComplexity] = React.useState(false);
 
   const onChange: FormControlState['onChange'] = event => {
     if (opts?.type === 'checkbox') {
@@ -144,6 +147,8 @@ export const useFormControl = <Id extends string>(
     enableErrorAfterBlur: restOpts.enableErrorAfterBlur || false,
     setWarning,
     warningText,
+    hasPassedComplexity,
+    setHasPassedComplexity,
     ...restOpts,
   };
 
@@ -178,6 +183,7 @@ type DebouncingOption = {
   successfulText: string | undefined;
   isFocused: boolean;
   informationText: string | undefined;
+  hasPassedComplexity: boolean;
   skipBlur?: boolean;
   delayInMs?: number;
 };
@@ -192,6 +198,7 @@ export const useFormControlFeedback = (opts: DebouncingOption): DebouncedFeedbac
     informationText = '',
     skipBlur = false,
     delayInMs = 100,
+    hasPassedComplexity = false,
   } = opts;
 
   const canDisplayFeedback = useMemo(() => {
@@ -205,8 +212,9 @@ export const useFormControlFeedback = (opts: DebouncingOption): DebouncedFeedbac
   }, [enableErrorAfterBlur, hasLostFocus, skipBlur]);
 
   const feedbackMemo = useMemo(() => {
-    const _errorText = canDisplayFeedback ? errorText : '';
-    const _warningText = warningText;
+    const shouldDisplayErrorAsWarning = hasPassedComplexity ? errorText && !hasLostFocus : false;
+    const _errorText = !shouldDisplayErrorAsWarning && canDisplayFeedback ? errorText : '';
+    const _warningText = shouldDisplayErrorAsWarning ? errorText : warningText;
     const _successfulText = successfulText;
 
     /*


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->


https://github.com/clerkinc/javascript/assets/19269911/70bc9f1e-6c32-4fa2-ad5a-e2e02aebd980




<!-- Fixes # (issue number) -->
