### PR TITLE
Fix - JS-451:  empty object requirement expo startOAuthFlow 

### DIFF
--- a/packages/expo/src/useOAuth.ts
+++ b/packages/expo/src/useOAuth.ts
@@ -31,7 +31,7 @@ export function useOAuth(useOAuthParams: UseOAuthFlowParams) {
   const { signIn, setActive, isLoaded: isSignInLoaded } = useSignIn();
   const { signUp, isLoaded: isSignUpLoaded } = useSignUp();
 
-  async function startOAuthFlow(startOAuthFlowParams: StartOAuthFlowParams): Promise<StartOAuthFlowReturnType> {
+  async function startOAuthFlow(startOAuthFlowParams?: StartOAuthFlowParams): Promise<StartOAuthFlowReturnType> {
     if (!isSignInLoaded || !isSignUpLoaded) {
       return {
         createdSessionId: '',
@@ -49,7 +49,7 @@ export function useOAuth(useOAuthParams: UseOAuthFlowParams) {
     // For more information go to:
     // https://docs.expo.dev/versions/latest/sdk/auth-session/#authsessionmakeredirecturi
     const oauthRedirectUrl =
-      startOAuthFlowParams.redirectUrl ||
+      startOAuthFlowParams?.redirectUrl ||
       useOAuthParams.redirectUrl ||
       AuthSession.makeRedirectUri({
         path: 'oauth-native-callback',
@@ -93,7 +93,7 @@ export function useOAuth(useOAuthParams: UseOAuthFlowParams) {
     } else if (firstFactorVerification.status === 'transferable') {
       await signUp.create({
         transfer: true,
-        unsafeMetadata: startOAuthFlowParams.unsafeMetadata || useOAuthParams.unsafeMetadata,
+        unsafeMetadata: startOAuthFlowParams?.unsafeMetadata || useOAuthParams.unsafeMetadata,
       });
       createdSessionId = signUp.createdSessionId || '';
     }


### PR DESCRIPTION
This fixes the empty object requirement to use startOAuthFlow. All parameters are optional anyway so we shouldn't require the empty object.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This fixes the requirement of sending an empty object to start an OAuth flow.
<!-- Fixes # (issue number) -->
JS-451