### PR TITLE
docs(clerk-js): Fix instructions in the README

### DIFF
--- a/packages/clerk-js/README.md
+++ b/packages/clerk-js/README.md
@@ -46,7 +46,7 @@ Once you have installed the package, you will need to import the ClerkJS object 
 ```js
 import Clerk from '@clerk/clerk-js';
 
-const clerkFrontendApi = 'clerk.[your-domain].com';
+const clerkFrontendApi = 'pk_[publishable_key]';
 const clerk = new Clerk(clerkFrontendApi);
 await clerk.load({
   // Set load options here...
@@ -61,13 +61,15 @@ Add the following script to your site's `<body>` element:
 
 ```html
 <script>
-  // Get this URL from the Clerk Dashboard
-  const frontendApi = 'clerk.[your-domain].com';
+  // Get this URL and Publishable Key from the Clerk Dashboard
+  const clerkFrontendApi = 'pk_[publishable_key]';
+  const frontendApi = '[your-domain].clerk.accounts.dev';
   const version = '@latest'; // Set to appropriate version
 
-  // Creates asyncronous script
+  // Creates asynchronous script
   const script = document.createElement('script');
   script.setAttribute('data-clerk-frontend-api', frontendApi);
+  script.setAttribute('data-clerk-publishable-key', clerkFrontendApi);
   script.async = true;
   script.src = `https://${frontendApi}/npm/@clerk/clerk-js${version}/dist/clerk.browser.js`;
 


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

In the README of the `clerk-js` package, the instructions to get up and running are incorrect, as they're missing the publishable key.

I discovered this while working on the Clerk beta docs, and think that we should make sure that the README of the package is up-to-date with our new docs.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
