### PR TITLE
fix(backend):  Remove unused `url` prop from `redirectToSignIn` and `…

### DIFF
--- a/.changeset/thin-carpets-reflect.md
+++ b/.changeset/thin-carpets-reflect.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Remove unused `url` prop from `redirectToSignIn` and `redirectToSignUp` helpers

--- a/packages/backend/src/redirections.ts
+++ b/packages/backend/src/redirections.ts
@@ -2,8 +2,8 @@ import { parsePublishableKey } from './util/parsePublishableKey';
 
 type RedirectAdapter = (url: string) => any;
 
-type SignUpParams = { url?: string; returnBackUrl?: string };
-type SignInParams = { url?: string; returnBackUrl?: string };
+type SignUpParams = { returnBackUrl?: string };
+type SignInParams = { returnBackUrl?: string };
 
 const buildUrl = (targetUrl: string, redirectUrl?: string) => {
   let url;


### PR DESCRIPTION
…redirectToSignUp` helpers

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
