### PR TITLE
feat(clerk-js): Use fapi client url to load CF turnstile

### DIFF
--- a/.changeset/pretty-horses-suffer.md
+++ b/.changeset/pretty-horses-suffer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Load CF turnstile from FAPI

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -217,6 +217,19 @@ export default class Clerk implements ClerkInterface {
     return null;
   }
 
+  get experimental_captchaURL(): string | null {
+    if (this.#fapiClient) {
+      return this.#fapiClient
+        .buildUrl({
+          path: 'cloudflare/turnstile/v0/api.js',
+          pathPrefix: '',
+          search: '?render=explicit',
+        })
+        .toString();
+    }
+    return null;
+  }
+
   public constructor(key: string, options?: DomainOrProxyUrl) {
     key = (key || '').trim();
 

--- a/packages/clerk-js/src/core/fapiClient.ts
+++ b/packages/clerk-js/src/core/fapiClient.ts
@@ -12,6 +12,7 @@ export type FapiRequestInit = RequestInit & {
   search?: string | URLSearchParams | string[][] | Record<string, string> | undefined;
   sessionId?: string;
   rotatingTokenNonce?: string;
+  pathPrefix?: string;
   url?: URL;
 };
 
@@ -126,7 +127,7 @@ export default function createFapiClient(clerkInstance: Clerk): FapiClient {
   }
 
   function buildUrl(requestInit: FapiRequestInit): URL {
-    const { path } = requestInit;
+    const { path, pathPrefix = 'v1' } = requestInit;
 
     const { proxyUrl, domain, frontendApi, instanceType } = clerkInstance;
 
@@ -138,7 +139,7 @@ export default function createFapiClient(clerkInstance: Clerk): FapiClient {
       return buildUrlUtil(
         {
           base: proxyBase.origin,
-          pathname: `${proxyPath}/v1${path}`,
+          pathname: `${proxyPath}/${pathPrefix}${path}`,
           search: buildQueryString(requestInit),
         },
         { stringify: false },
@@ -148,7 +149,7 @@ export default function createFapiClient(clerkInstance: Clerk): FapiClient {
     return buildUrlUtil(
       {
         base: `https://${domainOnlyInProd || frontendApi}`,
-        pathname: `v1${path}`,
+        pathname: `${pathPrefix}${path}`,
         search: buildQueryString(requestInit),
       },
       { stringify: false },

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -67,10 +67,13 @@ export class SignUp extends BaseResource implements SignUpResource {
 
   create = async (params: SignUpCreateParams): Promise<SignUpResource> => {
     let captchaToken = '';
-    const { experimental_canUseCaptcha, experimental_captchaSiteKey } = SignUp.clerk;
+    const { experimental_captchaSiteKey, experimental_canUseCaptcha, experimental_captchaURL } = SignUp.clerk;
 
-    if (experimental_canUseCaptcha && experimental_captchaSiteKey) {
-      captchaToken = await getCaptchaToken(experimental_captchaSiteKey);
+    if (experimental_canUseCaptcha && experimental_captchaSiteKey && experimental_captchaURL) {
+      captchaToken = await getCaptchaToken({
+        siteKey: experimental_captchaSiteKey,
+        scriptUrl: experimental_captchaURL,
+      });
     }
 
     return this._basePost({

--- a/packages/clerk-js/src/utils/captcha.ts
+++ b/packages/clerk-js/src/utils/captcha.ts
@@ -13,13 +13,12 @@ declare global {
   }
 }
 
-const SCRIPT_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
 const WIDGET_CLASSNAME = 'clerk-captcha';
 
-export async function loadCaptcha() {
+export async function loadCaptcha(url: string) {
   return new Promise(resolve => {
     resolve(
-      loadScript(SCRIPT_URL, {
+      loadScript(url, {
         defer: true,
         globalObject: window.turnstile,
       }),
@@ -27,18 +26,19 @@ export async function loadCaptcha() {
   }).then(() => window.turnstile);
 }
 
-export const getCaptchaToken = async (captchaSiteKey: string) => {
+export const getCaptchaToken = async (captchaOptions: { siteKey: string; scriptUrl: string }) => {
+  const { siteKey: sitekey, scriptUrl } = captchaOptions;
   let captchaToken = '';
 
   const div = document.createElement('div');
   div.classList.add(WIDGET_CLASSNAME);
   document.body.appendChild(div);
-  const captcha = await loadCaptcha();
+  const captcha = await loadCaptcha(scriptUrl);
 
   const handleCaptchaTokenGeneration = (): Promise<string> => {
     return new Promise((resolve, reject) => {
       return captcha.execute(`.${WIDGET_CLASSNAME}`, {
-        sitekey: captchaSiteKey,
+        sitekey,
         retry: 'never',
         callback: function (token: string) {
           resolve(token);


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
