### PR TITLE
fix(nextjs): Append DevBrowser on cross-origin redirects

### DIFF
--- a/.changeset/lemon-trains-wash.md
+++ b/.changeset/lemon-trains-wash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+The devBrowser JWT is now added to all cross-origin redirects triggered by calling `redirectToSignIn` or `redirectToSignUp`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44124,7 +44124,7 @@
         "@types/react-dom": "*",
         "expect-type": "^0.15.0",
         "jest": "*",
-        "node-fetch-native": "^0.1.8",
+        "node-fetch-native": "1.1.1",
         "ts-jest": "*",
         "typescript": "*"
       },
@@ -44138,9 +44138,9 @@
       }
     },
     "packages/nextjs/node_modules/node-fetch-native": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-0.1.8.tgz",
-      "integrity": "sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.1.1.tgz",
+      "integrity": "sha512-9VvspTSUp2Sxbl+9vbZTlFGq9lHwE8GDVVekxx6YsNd1YH59sb3Ba8v3Y3cD8PkLNcileGGcA21PFjVl0jzDaw==",
       "dev": true
     },
     "packages/nextjs/node_modules/tslib": {

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -21,6 +21,7 @@ const Headers = {
   AuthReason: 'x-clerk-auth-reason',
   AuthMessage: 'x-clerk-auth-message',
   EnableDebug: 'x-clerk-debug',
+  ClerkRedirectTo: 'x-clerk-redirect-to',
   Authorization: 'authorization',
   ForwardedPort: 'x-forwarded-port',
   ForwardedProto: 'x-forwarded-proto',

--- a/packages/fastify/src/__snapshots__/constants.test.ts.snap
+++ b/packages/fastify/src/__snapshots__/constants.test.ts.snap
@@ -15,6 +15,7 @@ exports[`constants from environment variables 1`] = `
     "AuthReason": "x-clerk-auth-reason",
     "AuthStatus": "x-clerk-auth-status",
     "Authorization": "authorization",
+    "ClerkRedirectTo": "x-clerk-redirect-to",
     "ContentType": "content-type",
     "EnableDebug": "x-clerk-debug",
     "ForwardedHost": "x-forwarded-host",

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -12,7 +12,13 @@ import { DEV_BROWSER_JWT_MARKER, setDevBrowserJWTInURL } from './devBrowser';
 import { receivedRequestForIgnoredRoute } from './errors';
 import { redirectToSignIn } from './redirect';
 import type { NextMiddlewareResult, WithAuthOptions } from './types';
-import { apiEndpointUnauthorizedNextResponse, decorateRequest, isCrossOrigin, isDevelopmentFromApiKey, setRequestHeadersOnNextResponse } from './utils';
+import {
+  apiEndpointUnauthorizedNextResponse,
+  decorateRequest,
+  isCrossOrigin,
+  isDevelopmentFromApiKey,
+  setRequestHeadersOnNextResponse,
+} from './utils';
 
 type WithPathPatternWildcard<T> = `${T & string}(.*)`;
 type NextTypedRoute<T = Parameters<typeof Link>['0']['href']> = T extends string ? T : never;

--- a/packages/nextjs/src/server/redirect.ts
+++ b/packages/nextjs/src/server/redirect.ts
@@ -1,9 +1,13 @@
-import { redirect } from '@clerk/backend';
+import { constants, redirect } from '@clerk/backend';
 import { NextResponse } from 'next/server';
 
+import { setHeader } from '../utils';
 import { FRONTEND_API, PUBLISHABLE_KEY, SIGN_IN_URL, SIGN_UP_URL } from './clerkClient';
 
-const redirectAdapter = (url: string) => NextResponse.redirect(url);
+const redirectAdapter = (url: string) => {
+  const res = NextResponse.redirect(url);
+  return setHeader(res, constants.Headers.ClerkRedirectTo, 'true');
+};
 
 export const { redirectToSignIn, redirectToSignUp } = redirect({
   redirectAdapter,
@@ -12,27 +16,3 @@ export const { redirectToSignIn, redirectToSignUp } = redirect({
   publishableKey: PUBLISHABLE_KEY,
   frontendApi: FRONTEND_API,
 });
-
-// TODO: This is a duplicate of the function in packages/shared/src/utils/keys.ts
-// TODO: To be removed when we can import @clerk/shared
-export const isDevOrStagingUrl = (url: string) => {
-  if (!url) {
-    return false;
-  }
-
-  const DEV_OR_STAGING_SUFFIXES = [
-    '.lcl.dev',
-    '.stg.dev',
-    '.lclstage.dev',
-    '.stgstage.dev',
-    '.dev.lclclerk.com',
-    '.stg.lclclerk.com',
-    '.accounts.lclclerk.com',
-    'accountsstage.dev',
-    'accounts.dev',
-  ];
-
-  const { hostname } = new URL(url);
-
-  return DEV_OR_STAGING_SUFFIXES.some(s => hostname.endsWith(s));
-};

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -251,3 +251,9 @@ export function decorateRequest(
 export const apiEndpointUnauthorizedNextResponse = () => {
   return NextResponse.json(null, { status: 401, statusText: 'Unauthorized' });
 };
+
+export const isCrossOrigin = (from: string | URL, to: string | URL) => {
+  const fromUrl = new URL(from);
+  const toUrl = new URL(to);
+  return fromUrl.origin !== toUrl.origin;
+};


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR refactors and improves #1241.

This PR also introduces a new header `x-clerk-redirect-to` which indicates that `redirectToSignIn` or `redirectToSignUp` have been called.

After this PR, Dev Browser on redirects will only be appended if all of the following conditions apply:

- `redirectToSignIn` or `redirectToSignUp` have been called,
- the Secret Key hints a development Clerk instance,
- the redirection is cross-origin

This change fixes the dev browser issue on implementations that use custom domains for sign-in or sign-up pages, other than Clerk Hosted Pages.

<!-- Fixes # (issue number) -->
