### PR TITLE
User.setProfileImage accepts file a Base64 string

### DIFF
--- a/packages/clerk-js/src/core/resources/Image.ts
+++ b/packages/clerk-js/src/core/resources/Image.ts
@@ -10,7 +10,7 @@ export class Image extends BaseResource implements ImageResource {
   static async create(path: string, body: any = {}): Promise<ImageResource> {
     let fd = body;
 
-    if (body['file']) {
+    if (body['file'] && typeof body['file'] !== 'string') {
       fd = new FormData();
       fd.append('file', body['file']);
     }

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -107,7 +107,7 @@ export interface UserResource extends ClerkResource {
 export type CreateEmailAddressParams = { email: string };
 export type CreatePhoneNumberParams = { phoneNumber: string };
 export type CreateWeb3WalletParams = { web3Wallet: string };
-export type SetProfileImageParams = { file: Blob | File | null };
+export type SetProfileImageParams = { file: Blob | File | string | null };
 export type CreateExternalAccountParams = {
   strategy: OAuthStrategy;
   redirectUrl?: string;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
```tsx
import { useUser } from '@clerk/nextjs';

const toBase64 = (file: File) =>
  new Promise<string>((resolve, reject) => {
    const reader = new FileReader();
    reader.readAsDataURL(file);
    reader.onload = () => resolve(reader.result as string);
    reader.onerror = reject;
  });

const UserProfilePage = () => {
  const { user } = useUser();
  return (
      <input
        type='file'
        onChange={async event => {
          const file = event.target.files[0];
          const base64 = await toBase64(file);

          const imgRes = await user?.setProfileImage({
            file: base64,
          })
        }}
      />
  );
};
```

<!-- Fixes # (issue number) -->
