### PR TITLE
fix(clerk-js): SMS TOP autofill broken in Chrome for iOS

### DIFF
--- a/.changeset/small-bikes-complain.md
+++ b/.changeset/small-bikes-complain.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Support OTP autofill for Chrome on iOS
+- Fixes a bug preventing OTP being correctly autofilled when received via SMS


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

This PR fixes an issue SMS Otp autofill in iOS devices that use Chrome. I could not figure exactly why but [this](https://github.com/chakra-ui/chakra-ui/issues/4095#issuecomment-1057077519) might give a hint about why this issue exist.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
