### PR TITLE
Improves sync/link for dev and prod instances

### DIFF
--- a/.changeset/quiet-lamps-fry.md
+++ b/.changeset/quiet-lamps-fry.md
@@ -1,0 +1,10 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+'@clerk/fastify': patch
+'@clerk/nextjs': patch
+'@clerk/remix': patch
+---
+
+Improvements for session syncing across domains (multi-domain) for development and production instances.

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -14,6 +14,7 @@ const Attributes = {
 const Cookies = {
   Session: '__session',
   ClientUat: '__client_uat',
+  SessionUat: '__session_uat',
 } as const;
 
 const Headers = {

--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -184,12 +184,11 @@ async function verifyRequestState(options: AuthenticateRequestOptions, token: st
  * Let the next rule for UatMissing to fire if needed
  */
 export const isSatelliteAndNeedsSyncing: InterstitialRule = options => {
-  const { clientUat, isSatellite, searchParams, secretKey, apiKey } = options;
+  const { sessionUat, clientUat, isSatellite, searchParams } = options;
 
-  const key = secretKey || apiKey;
-  const isDev = isDevelopmentFromApiKey(key);
+  const isSignedOutOrExpired = !clientUat || clientUat === '0' || !sessionUat;
 
-  if (isSatellite && (!clientUat || clientUat === '0') && !hasJustSynced(searchParams) && !isDev) {
+  if (isSatellite && isSignedOutOrExpired && !hasJustSynced(searchParams)) {
     return interstitial(options, AuthErrorReason.SatelliteCookieNeedsSyncing);
   }
 

--- a/packages/backend/src/tokens/request.test.ts
+++ b/packages/backend/src/tokens/request.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 
 import runtime from '../runtime';
 import { jsonOk } from '../util/mockFetch';
-import { type AuthReason, type RequestState, AuthErrorReason, AuthStatus } from './authStatus';
+import { AuthErrorReason, type AuthReason, AuthStatus, type RequestState } from './authStatus';
 import { TokenVerificationErrorReason } from './errors';
 import { mockInvalidSignatureJwt, mockJwks, mockJwt, mockJwtPayload, mockMalformedJwt } from './fixtures';
 import type { AuthenticateRequestOptions } from './request';
@@ -391,6 +391,7 @@ export default (QUnit: QUnit) => {
         cookieToken: mockJwt,
         apiKey: 'pk_test_deadbeef',
         clientUat: '12345',
+        sessionUat: '12345',
         referrer: 'https://clerk.com',
         isSatellite: true,
         signInUrl: 'https://localhost:3000/sign-in/',

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -97,6 +97,8 @@ export type AuthenticateRequestOptions = InstanceKeys &
     cookieToken?: string;
     /* Client uat cookie value */
     clientUat?: string;
+    /* Client uat cookie value */
+    sessionUat?: string;
     /* Client token header value */
     headerToken?: string;
     /* Request origin header value */
@@ -174,8 +176,8 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
       const state = await runInterstitialRules(options, [
         crossOriginRequestWithoutHeader,
         nonBrowserRequestInDevRule,
-        isSatelliteAndNeedsSyncing,
         satelliteInDevReturningFromPrimary,
+        isSatelliteAndNeedsSyncing,
         isPrimaryInDevAndRedirectsToSatellite,
         potentialFirstRequestOnProductionEnvironment,
         potentialFirstLoadInDevWhenUATMissing,

--- a/packages/clerk-js/src/core/services/authentication/SessionCookieService.ts
+++ b/packages/clerk-js/src/core/services/authentication/SessionCookieService.ts
@@ -14,6 +14,12 @@ export class SessionCookieService {
   private environment: EnvironmentResource | undefined;
   private poller: SessionCookiePoller | null = null;
 
+  get isSessionExpired() {
+    const sessionJWTLifeSpan = 60;
+    // truncate timestamp to seconds, since session uat is stored as a unix timestamp
+    return this.cookies.getSessionUatCookie() + sessionJWTLifeSpan <= Math.floor(Date.now() / 1000);
+  }
+
   constructor(private clerk: Clerk) {
     // set cookie on token update
     eventBus.on(events.TokenUpdate, ({ token }) => {
@@ -75,6 +81,7 @@ export class SessionCookieService {
 
   private setSessionCookie(token: TokenResource | string) {
     this.cookies.setSessionCookie(typeof token === 'string' ? token : token.getRawString());
+    this.cookies.setSessionUatCookie();
   }
 
   private updateSessionCookie(token: TokenResource | string | undefined | null) {

--- a/packages/clerk-js/src/core/services/authentication/SessionCookieService.ts
+++ b/packages/clerk-js/src/core/services/authentication/SessionCookieService.ts
@@ -81,10 +81,14 @@ export class SessionCookieService {
 
   private setSessionCookie(token: TokenResource | string) {
     this.cookies.setSessionCookie(typeof token === 'string' ? token : token.getRawString());
-    this.cookies.setSessionUatCookie();
   }
 
   private updateSessionCookie(token: TokenResource | string | undefined | null) {
+    if (token) {
+      this.cookies.setSessionUatCookie();
+    } else {
+      this.cookies.removeSessionUatCookie();
+    }
     return token ? this.setSessionCookie(token) : this.removeSessionCookie();
   }
 

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -65,6 +65,8 @@ export const createCookieHandler = () => {
     });
   };
 
+  const removeSessionUatCookie = () => sessionUatCookie.remove();
+
   const getSessionUatCookie = (): number => {
     return parseInt(sessionUatCookie.get() || '0', 10);
   };
@@ -119,5 +121,6 @@ export const createCookieHandler = () => {
     removeDevBrowserCookie,
     getSessionUatCookie,
     setSessionUatCookie,
+    removeSessionUatCookie,
   };
 };

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -8,6 +8,7 @@ import { clientUatCookie } from './client_uat';
 import { devBrowserCookie } from './devBrowser';
 import { inittedCookie } from './initted';
 import { sessionCookie } from './session';
+import { sessionUatCookie } from './session_uat';
 
 const DEFAULT_SAME_SITE = 'Lax';
 const IFRAME_SAME_SITE = 'None';
@@ -64,6 +65,25 @@ export const createCookieHandler = () => {
     });
   };
 
+  const getSessionUatCookie = (): number => {
+    return parseInt(sessionUatCookie.get() || '0', 10);
+  };
+
+  const setSessionUatCookie = () => {
+    const expires = addYears(Date.now(), 1);
+    const sameSite = 'Lax';
+    const secure = window.location.protocol === 'https:';
+
+    // truncate timestamp to seconds, since this is a unix timestamp
+    const val = Math.floor(Date.now() / 1000).toString();
+
+    return sessionUatCookie.set(val, {
+      expires,
+      sameSite,
+      secure,
+    });
+  };
+
   const setDevBrowserCookie = (jwt: string) => {
     const expires = addYears(Date.now(), 1);
     const sameSite = 'Strict';
@@ -97,5 +117,7 @@ export const createCookieHandler = () => {
     removeAllDevBrowserCookies,
     setDevBrowserCookie,
     removeDevBrowserCookie,
+    getSessionUatCookie,
+    setSessionUatCookie,
   };
 };

--- a/packages/clerk-js/src/utils/cookies/session_uat.ts
+++ b/packages/clerk-js/src/utils/cookies/session_uat.ts
@@ -1,0 +1,21 @@
+import { createCookieHandler } from '@clerk/shared';
+
+const SESSION_UAT_COOKIE_NAME = '__session_uat';
+
+/**
+ *
+ * This is a long-lived JS cookie used in development instances, to
+ * signal to the customer's backend (SDK) when the Client was last updated and
+ * therefore when the SDK should re-concile the state with FAPI.
+ *
+ * For more information refer to the following document:
+ *
+ * https://docs.google.com/document/d/1PGAykkmPjx5Mtdi6j-yHc5Qy-uasjtcXnfGKDy3cHIE/edit#
+ */
+
+/**
+ *
+ * This is a short-lived JS cookie used to signal when the session was last updated
+ * useful for session syncing across domains
+ */
+export const sessionUatCookie = createCookieHandler(SESSION_UAT_COOKIE_NAME);

--- a/packages/clerk-js/src/utils/cookies/session_uat.ts
+++ b/packages/clerk-js/src/utils/cookies/session_uat.ts
@@ -4,18 +4,9 @@ const SESSION_UAT_COOKIE_NAME = '__session_uat';
 
 /**
  *
- * This is a long-lived JS cookie used in development instances, to
- * signal to the customer's backend (SDK) when the Client was last updated and
- * therefore when the SDK should re-concile the state with FAPI.
+ * This is a long-lived JS cookie used to signal when the session was last updated
+ * useful for session syncing across domains.
  *
- * For more information refer to the following document:
- *
- * https://docs.google.com/document/d/1PGAykkmPjx5Mtdi6j-yHc5Qy-uasjtcXnfGKDy3cHIE/edit#
- */
-
-/**
- *
- * This is a short-lived JS cookie used to signal when the session was last updated
- * useful for session syncing across domains
+ * It is used for both development and production instances
  */
 export const sessionUatCookie = createCookieHandler(SESSION_UAT_COOKIE_NAME);

--- a/packages/fastify/src/__snapshots__/constants.test.ts.snap
+++ b/packages/fastify/src/__snapshots__/constants.test.ts.snap
@@ -8,6 +8,7 @@ exports[`constants from environment variables 1`] = `
   "Cookies": {
     "ClientUat": "__client_uat",
     "Session": "__session",
+    "SessionUat": "__session_uat",
   },
   "FRONTEND_API": "CLERK_FRONTEND_API",
   "Headers": {

--- a/packages/nextjs/src/server/authenticateRequest.ts
+++ b/packages/nextjs/src/server/authenticateRequest.ts
@@ -35,6 +35,7 @@ export const authenticateRequest = async (req: NextRequest, opts: WithAuthOption
     cookieToken,
     headerToken,
     clientUat: getCookie(req, constants.Cookies.ClientUat),
+    sessionUat: getCookie(req, constants.Cookies.SessionUat),
     origin: headers.get('origin') || undefined,
     host: headers.get('host') as string,
     forwardedPort: headers.get('x-forwarded-port') || undefined,
@@ -43,7 +44,7 @@ export const authenticateRequest = async (req: NextRequest, opts: WithAuthOption
     referrer: headers.get('referer') || undefined,
     userAgent: headers.get('user-agent') || undefined,
     searchParams: new URL(req.url).searchParams,
-  } as any);
+  });
 };
 
 export const handleUnknownState = (requestState: RequestState) => {

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -53,6 +53,7 @@ export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => 
       cookieToken,
       headerToken,
       clientUat: getCookie(req, constants.Cookies.ClientUat),
+      sessionUat: getCookie(req, constants.Cookies.SessionUat),
       origin: headers.get('origin') || undefined,
       host: headers.get('host') as string,
       forwardedPort: headers.get('x-forwarded-port') || undefined,

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -103,6 +103,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     cookieToken,
     headerToken,
     clientUat: cookies['__client_uat'],
+    sessionUat: cookies['__session_uat'],
     origin: headers.get('origin') || '',
     host: headers.get('host') as string,
     forwardedPort: headers.get('x-forwarded-port') as string,

--- a/packages/sdk-node/src/authenticateRequest.test.ts
+++ b/packages/sdk-node/src/authenticateRequest.test.ts
@@ -17,7 +17,7 @@ describe('authenticateRequest', () => {
   it('correctly parses the req object', async () => {
     const req = {
       headers: {
-        ['cookie']: `${constants.Cookies.Session}=token; expires=Mon, 27 june 2022 12:00:00 UTC;${constants.Cookies.ClientUat}=token; expires=Mon, 27 june 2022 12:00:00 UTC;`,
+        ['cookie']: `${constants.Cookies.Session}=token; expires=Mon, 27 june 2022 12:00:00 UTC;${constants.Cookies.ClientUat}=token;${constants.Cookies.SessionUat}=token; expires=Mon, 27 june 2022 12:00:00 UTC;`,
         [constants.Headers.Authorization]: 'Bearer token',
         [constants.Headers.ForwardedPort]: 'port',
         [constants.Headers.ForwardedHost]: 'host',
@@ -53,6 +53,7 @@ describe('authenticateRequest', () => {
     expect(clerkClient.authenticateRequest).toHaveBeenCalledWith({
       authorizedParties: ['party1'],
       clientUat: 'token',
+      sessionUat: 'token',
       cookieToken: 'token',
       forwardedHost: 'host',
       forwardedPort: 'port',

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -74,6 +74,7 @@ export const authenticateRequest = (opts: AuthenticateRequestParams) => {
     cookieToken: cookies[constants.Cookies.Session] || '',
     headerToken: req.headers[constants.Headers.Authorization]?.replace('Bearer ', '') || '',
     clientUat: cookies[constants.Cookies.ClientUat] || '',
+    sessionUat: cookies[constants.Cookies.SessionUat] || '',
     host: req.headers.host as string,
     forwardedPort: req.headers[constants.Headers.ForwardedPort] as string,
     forwardedHost: req.headers[constants.Headers.ForwardedHost] as string,


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [x] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

This now address the following issues
- Less aggressing syncing in dev instances (not on every refresh)
- more frequent syncing  in prod instances (Previously  syncing would fire only once)
- introduction of a new interstitial rule that will throw interstitial for dev instances with reason SatelliteNeedsSyncing . Previously that was not possible

**_Essentially improves parity for the triggering mechanism of multi-domain session syncing between development and production instances_** 


This PR
- Introduces `__session_uat`
  - Keep track when session was last updated in a cookie named `__session_uat`.
- Throw interstitial when `__session_uat` is missing for satellite apps
  - Now interstitial throws for apps with dev instances when syncing is needed
- Refactor sync/link flow inside clerk-js
  - Don't fetch dev JWT for dev browser until sync link fires
  - Set up dev browser after sync/link
  - Potential redirect back to satellite with a safely store jwt in dev browser
  
### Review per commit might be easier

<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
