### PR TITLE
Introduce `RequestAdapter` interface for `authenticateRequest`

### DIFF
--- a/.changeset/nine-cups-approve.md
+++ b/.changeset/nine-cups-approve.md
@@ -1,0 +1,45 @@
+---
+'gatsby-plugin-clerk': minor
+'@clerk/clerk-sdk-node': minor
+'@clerk/backend': minor
+'@clerk/fastify': minor
+'@clerk/nextjs': minor
+'@clerk/remix': minor
+---
+
+Introduce a new `RequestAdapter` interface that may be implemented by any framework that uses the `@clerk/backend` package. A custom `RequestAdapter` instance will be passed to `authenticateRequest` instead of each header/cookie/searchParams as a prop.
+
+Example usage:
+
+```ts
+// CustomRequestAdapter.ts
+// How we access the headers/cookies/searchParams depends on the specific framework's request representation
+export class CustomRequestAdapter implements RequestAdapter {
+  constructor(readonly req: CustomRequest) {}
+
+  headers(key: string) {
+    return this.req?.headers?.[key];
+  }
+  cookies(key: string) {
+    return this.req?.cookies?.[key];
+  }
+  searchParams() {
+    return new URL(this.req.url).searchParams;
+  }
+}
+```
+
+```ts
+// FrameworkClerkMiddleware.ts
+...
+export const withClerkMiddleware = (options: ClerkCustomOptions) => {
+  return async (req: CustomFrameworkRequest, ...) => {
+    const requestState = await clerkClient.authenticateRequest({
+      ...options,
+      secretKey,
+      publishableKey,
+      requestAdapter: new CustomRequestAdapter(req),
+    });
+   ...
+};
+```

--- a/.changeset/pink-carpets-matter.md
+++ b/.changeset/pink-carpets-matter.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+---
+
+- One pair of legacy or new instance keys are required now and not all 4 of them
+- `@clerk/backend` now can handle the `"Bearer "` prefix in Authorization header for better DX
+- `host` parameter is now optional in `@clerk/backend`

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -3,6 +3,8 @@ import { createBackendApiClient } from './api';
 import type { CreateAuthenticateRequestOptions } from './tokens';
 import { createAuthenticateRequest } from './tokens';
 
+export type { InstanceKeys } from './tokens';
+
 export * from './api/resources';
 export * from './tokens';
 export * from './tokens/jwt';

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -3,7 +3,7 @@ import { createBackendApiClient } from './api';
 import type { CreateAuthenticateRequestOptions } from './tokens';
 import { createAuthenticateRequest } from './tokens';
 
-export type { InstanceKeys } from './tokens';
+export type { InstanceKeys, RequestAdapter } from './tokens';
 
 export * from './api/resources';
 export * from './tokens';

--- a/packages/backend/src/tokens/index.ts
+++ b/packages/backend/src/tokens/index.ts
@@ -8,3 +8,4 @@ export {
   OptionalVerifyTokenOptions,
   RequiredVerifyTokenOptions,
 } from './request';
+export type { InstanceKeys } from './request';

--- a/packages/backend/src/tokens/index.ts
+++ b/packages/backend/src/tokens/index.ts
@@ -8,4 +8,4 @@ export {
   OptionalVerifyTokenOptions,
   RequiredVerifyTokenOptions,
 } from './request';
-export type { InstanceKeys } from './request';
+export type { InstanceKeys, RequestAdapter } from './request';

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -37,9 +37,59 @@ export type OptionalVerifyTokenOptions = Partial<
   Pick<VerifyTokenOptions, 'authorizedParties' | 'clockSkewInSeconds' | 'jwksCacheTtlInMs' | 'skipJwksCache' | 'jwtKey'>
 >;
 
-export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
+type PublicKeys =
+  | {
+      publishableKey: string;
+      /**
+       * @deprecated Use `publishableKey` instead.
+       */
+      frontendApi: never;
+    }
+  | {
+      publishableKey: never;
+      /**
+       * @deprecated Use `publishableKey` instead.
+       */
+      frontendApi: string;
+    }
+  | {
+      publishableKey: string;
+      /**
+       * @deprecated Use `publishableKey` instead.
+       */
+      frontendApi: string;
+    };
+
+type SecretKeys =
+  | {
+      secretKey: string;
+      /**
+       * @deprecated Use `secretKey` instead.
+       */
+      apiKey: never;
+    }
+  | {
+      secretKey: never;
+      /**
+       * @deprecated Use `secretKey` instead.
+       */
+      apiKey: string;
+    }
+  | {
+      secretKey: string;
+      /**
+       * @deprecated Use `secretKey` instead.
+       */
+      apiKey: string;
+    };
+
+export type InstanceKeys = PublicKeys & SecretKeys;
+
+export type AuthenticateRequestOptions = InstanceKeys &
   OptionalVerifyTokenOptions &
   LoadResourcesOptions & {
+    apiVersion?: string;
+    apiUrl?: string;
     /* Client token cookie value */
     cookieToken?: string;
     /* Client uat cookie value */
@@ -48,12 +98,8 @@ export type AuthenticateRequestOptions = RequiredVerifyTokenOptions &
     headerToken?: string;
     /* Request origin header value */
     origin?: string;
-    /* Clerk frontend Api value */
-    frontendApi: string;
-    /* Clerk Publishable Key value */
-    publishableKey: string;
     /* Request host header value */
-    host: string;
+    host?: string;
     /* Request forwarded host value */
     forwardedHost?: string;
     /* Request forwarded port value */
@@ -102,6 +148,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
   options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
   options.apiUrl = options.apiUrl || API_URL;
   options.apiVersion = options.apiVersion || API_VERSION;
+  options.headerToken = options.headerToken?.replace('Bearer ', '');
 
   assertValidSecretKey(options.secretKey || options.apiKey);
 

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -1,4 +1,4 @@
-import { API_URL, API_VERSION } from '../constants';
+import { API_URL, API_VERSION, constants } from '../constants';
 import { assertValidSecretKey } from '../util/assertValidSecretKey';
 import { isDevelopmentFromApiKey } from '../util/instance';
 import { parsePublishableKey } from '../util/parsePublishableKey';
@@ -22,6 +22,31 @@ import {
   satelliteInDevReturningFromPrimary,
 } from './interstitialRule';
 import type { VerifyTokenOptions } from './verify';
+
+export interface RequestAdapter {
+  /**
+   * The headers method returns the value of the specified header. Keys given to this method are
+   * normalized to lowercase, as they exist in `packages/backend/src/constants.ts`.
+   * Implementing this method requires the user to manipulate the header keys accordingly.
+   *
+   * @param key The header name to retrieve
+   */
+  headers(key: string): string | undefined;
+
+  /**
+   * The cookies method returns the value of the specified cookie.
+   * Keys given to this method exist in `packages/backend/src/constants.ts`.
+   *
+   * @param key The cookie name to retrieve
+   */
+  cookies(key: string): string | undefined;
+
+  /**
+   * The searchParams method returns a URLSearchParams object that contains the query parameters
+   * of the request.
+   */
+  searchParams(): URLSearchParams | undefined;
+}
 
 export type LoadResourcesOptions = {
   loadSession?: boolean;
@@ -130,6 +155,7 @@ export type AuthenticateRequestOptions = InstanceKeys &
      * @experimental
      */
     signInUrl?: string;
+    requestAdapter?: RequestAdapter;
   };
 
 function assertSignInUrlExists(signInUrl: string | undefined, key: string): asserts signInUrl is string {
@@ -145,10 +171,29 @@ function assertProxyUrlOrDomain(proxyUrlOrDomain: string | undefined) {
 }
 
 export async function authenticateRequest(options: AuthenticateRequestOptions): Promise<RequestState> {
-  options.frontendApi = parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi || '';
-  options.apiUrl = options.apiUrl || API_URL;
-  options.apiVersion = options.apiVersion || API_VERSION;
-  options.headerToken = options.headerToken?.replace('Bearer ', '');
+  options = {
+    ...options,
+    frontendApi: parsePublishableKey(options.publishableKey)?.frontendApi || options.frontendApi,
+    apiUrl: options.apiUrl || API_URL,
+    apiVersion: options.apiVersion || API_VERSION,
+    headerToken:
+      stripAuthorizationHeader(options.headerToken) ||
+      stripAuthorizationHeader(options.requestAdapter?.headers(constants.Headers.Authorization)) ||
+      undefined,
+    cookieToken: options.cookieToken || options.requestAdapter?.cookies(constants.Cookies.Session) || undefined,
+    clientUat: options.clientUat || options.requestAdapter?.cookies(constants.Cookies.ClientUat) || undefined,
+    origin: options.origin || options.requestAdapter?.headers(constants.Headers.Origin) || undefined,
+    host: options.host || options.requestAdapter?.headers(constants.Headers.Host) || undefined,
+    forwardedHost:
+      options.forwardedHost || options.requestAdapter?.headers(constants.Headers.ForwardedHost) || undefined,
+    forwardedPort:
+      options.forwardedPort || options.requestAdapter?.headers(constants.Headers.ForwardedPort) || undefined,
+    forwardedProto:
+      options.forwardedProto || options.requestAdapter?.headers(constants.Headers.ForwardedProto) || undefined,
+    referrer: options.referrer || options.requestAdapter?.headers(constants.Headers.Referrer) || undefined,
+    userAgent: options.userAgent || options.requestAdapter?.headers(constants.Headers.UserAgent) || undefined,
+    searchParams: options.searchParams || options.requestAdapter?.searchParams() || undefined,
+  };
 
   assertValidSecretKey(options.secretKey || options.apiKey);
 
@@ -221,3 +266,7 @@ export const debugRequestState = (params: RequestState) => {
 };
 
 export type DebugRequestSate = ReturnType<typeof debugRequestState>;
+
+const stripAuthorizationHeader = (authValue: string | undefined): string | undefined => {
+  return authValue?.replace('Bearer ', '');
+};

--- a/packages/backend/src/util/request.ts
+++ b/packages/backend/src/util/request.ts
@@ -13,7 +13,7 @@ export function checkCrossOrigin({
   forwardedProto,
 }: {
   originURL: URL;
-  host: string;
+  host?: string | null;
   forwardedHost?: string | null;
   forwardedPort?: string | null;
   forwardedProto?: string | null;
@@ -37,7 +37,7 @@ export function checkCrossOrigin({
 
   const protocol = fwdProto || originProtocol;
   /* The forwarded host prioritised over host to be checked against the referrer.  */
-  const finalURL = convertHostHeaderValueToURL(forwardedHost || host, protocol);
+  const finalURL = convertHostHeaderValueToURL(forwardedHost || host || undefined, protocol);
   finalURL.port = fwdPort || finalURL.port;
 
   if (getPort(finalURL) !== getPort(originURL)) {
@@ -50,7 +50,7 @@ export function checkCrossOrigin({
   return false;
 }
 
-export function convertHostHeaderValueToURL(host: string, protocol = 'https'): URL {
+export function convertHostHeaderValueToURL(host?: string | undefined, protocol = 'https'): URL {
   /**
    * The protocol is added for the URL constructor to work properly.
    * We do not check for the protocol at any point later on.

--- a/packages/fastify/src/utils.test.ts
+++ b/packages/fastify/src/utils.test.ts
@@ -1,4 +1,8 @@
-import { getSingleValueFromArrayHeader } from './utils';
+import { constants } from '@clerk/backend';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import Fastify from 'fastify';
+
+import { FastifyRequestAdapter, getSingleValueFromArrayHeader } from './utils';
 
 describe('utils', () => {
   describe('getSingleValueFromArrayHeader(value)', () => {
@@ -14,5 +18,47 @@ describe('utils', () => {
     test('returns first value if value is array', () => {
       expect(getSingleValueFromArrayHeader(['aloha', '2'])).toEqual('aloha');
     });
+  });
+
+  test('FastifyRequestAdapter', async () => {
+    const fastify = Fastify();
+
+    fastify.get('/', (request: FastifyRequest, reply: FastifyReply) => {
+      const requestAdapter = new FastifyRequestAdapter(request);
+      expect(requestAdapter.headers(constants.Headers.Authorization)).toEqual('Bearer deadbeef');
+      expect(requestAdapter.headers(constants.Headers.Origin)).toEqual('http://origin.com');
+      expect(requestAdapter.headers(constants.Headers.ForwardedPort)).toEqual('1234');
+      expect(requestAdapter.headers(constants.Headers.ForwardedHost)).toEqual('forwarded-host.com');
+      expect(requestAdapter.headers(constants.Headers.Host)).toEqual('host.com');
+      expect(requestAdapter.headers(constants.Headers.Referrer)).toEqual('referer.com');
+      expect(requestAdapter.headers(constants.Headers.UserAgent)).toEqual(
+        'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+      );
+      expect(requestAdapter.cookies(constants.Cookies.Session)).toEqual('tokenSession');
+      expect(requestAdapter.cookies(constants.Cookies.ClientUat)).toEqual('tokenClientUat');
+      expect(requestAdapter.searchParams()).toBeUndefined();
+      reply.send({});
+    });
+
+    const response = await fastify.inject({
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer deadbeef',
+        Origin: 'http://origin.com',
+        Host: 'host.com',
+        'X-Forwarded-Port': '1234',
+        'X-Forwarded-Host': 'forwarded-host.com',
+        Referer: 'referer.com',
+        'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+      },
+      cookies: {
+        __session: 'tokenSession',
+        __client_uat: 'tokenClientUat',
+      },
+      query: { __query: 'true' },
+      url: '/',
+    });
+
+    expect(response.statusCode).toEqual(200);
   });
 });

--- a/packages/fastify/src/utils.ts
+++ b/packages/fastify/src/utils.ts
@@ -1,3 +1,28 @@
+import type { RequestAdapter } from '@clerk/backend';
+import { constants } from '@clerk/backend';
+import { parse } from 'cookie';
+import type { FastifyRequest } from 'fastify';
+
 export const getSingleValueFromArrayHeader = (value?: string[] | string): string | undefined => {
   return (Array.isArray(value) ? value[0] : value) || undefined;
 };
+
+export class FastifyRequestAdapter implements RequestAdapter {
+  readonly reqCookies: Record<string, string>;
+  constructor(readonly req: FastifyRequest) {
+    this.reqCookies = parse(req?.raw?.headers?.cookie || '');
+  }
+
+  headers(key: string) {
+    if (key === constants.Headers.ForwardedHost || key === constants.Headers.ForwardedPort) {
+      return getSingleValueFromArrayHeader(this.req?.headers?.[key]);
+    }
+    return (this.req?.headers?.[key] as string) || undefined;
+  }
+  cookies(key: string) {
+    return this.reqCookies?.[key] || undefined;
+  }
+  searchParams(): URLSearchParams | undefined {
+    return undefined;
+  }
+}

--- a/packages/fastify/src/withClerkMiddleware.test.ts
+++ b/packages/fastify/src/withClerkMiddleware.test.ts
@@ -2,6 +2,7 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import Fastify from 'fastify';
 
 import { clerkPlugin, getAuth } from './index';
+import { FastifyRequestAdapter } from './utils';
 
 const authenticateRequestMock = jest.fn();
 const localInterstitialMock = jest.fn();
@@ -59,15 +60,7 @@ describe('withClerkMiddleware(options)', () => {
       expect.objectContaining({
         secretKey: 'TEST_API_KEY',
         apiKey: 'TEST_API_KEY',
-        headerToken: 'deadbeef',
-        cookieToken: undefined,
-        clientUat: undefined,
-        origin: 'http://origin.com',
-        host: 'host.com',
-        forwardedPort: '1234',
-        forwardedHost: 'forwarded-host.com',
-        referrer: 'referer.com',
-        userAgent: 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+        requestAdapter: expect.any(FastifyRequestAdapter),
       }),
     );
   });
@@ -107,15 +100,7 @@ describe('withClerkMiddleware(options)', () => {
       expect.objectContaining({
         secretKey: 'TEST_API_KEY',
         apiKey: 'TEST_API_KEY',
-        cookieToken: 'deadbeef',
-        headerToken: undefined,
-        clientUat: '1675692233',
-        origin: 'http://origin.com',
-        host: 'host.com',
-        forwardedPort: '1234',
-        forwardedHost: 'forwarded-host.com',
-        referrer: 'referer.com',
-        userAgent: 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+        requestAdapter: expect.any(FastifyRequestAdapter),
       }),
     );
   });
@@ -211,9 +196,7 @@ describe('withClerkMiddleware(options)', () => {
       expect.objectContaining({
         secretKey: 'TEST_API_KEY',
         apiKey: 'TEST_API_KEY',
-        headerToken: 'deadbeef',
-        cookieToken: undefined,
-        clientUat: undefined,
+        requestAdapter: expect.any(FastifyRequestAdapter),
       }),
     );
   });

--- a/packages/fastify/src/withClerkMiddleware.ts
+++ b/packages/fastify/src/withClerkMiddleware.ts
@@ -1,23 +1,14 @@
-import { parse } from 'cookie';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 
 import { clerkClient } from './clerkClient';
 import * as constants from './constants';
 import type { ClerkFastifyOptions } from './types';
-import { getSingleValueFromArrayHeader } from './utils';
+import { FastifyRequestAdapter } from './utils';
 
 export const withClerkMiddleware = (options: ClerkFastifyOptions) => {
   return async (req: FastifyRequest, reply: FastifyReply) => {
-    const cookies = parse(req.raw.headers.cookie || '');
     const secretKey = options.secretKey || constants.SECRET_KEY;
     const publishableKey = options.publishableKey || constants.PUBLISHABLE_KEY;
-
-    // get auth state, check if we need to return an interstitial
-    const cookieToken = cookies[constants.Cookies.Session];
-    const headerToken = req.headers['authorization']?.replace('Bearer ', '');
-
-    const forwardedPort = getSingleValueFromArrayHeader(req.headers['x-forwarded-port']);
-    const forwardedHost = getSingleValueFromArrayHeader(req.headers['x-forwarded-host']);
 
     const requestState = await clerkClient.authenticateRequest({
       ...options,
@@ -25,15 +16,7 @@ export const withClerkMiddleware = (options: ClerkFastifyOptions) => {
       publishableKey,
       apiKey: constants.API_KEY,
       frontendApi: constants.FRONTEND_API,
-      cookieToken,
-      headerToken,
-      clientUat: cookies[constants.Cookies.ClientUat],
-      origin: req.headers['origin'] || undefined,
-      host: req.headers['host'] as string,
-      forwardedPort,
-      forwardedHost,
-      referrer: req.headers['referer'] || undefined,
-      userAgent: req.headers['user-agent'] || undefined,
+      requestAdapter: new FastifyRequestAdapter(req),
     });
 
     // Interstitial cases

--- a/packages/gatsby-plugin-clerk/src/ssr/authenticateRequest.ts
+++ b/packages/gatsby-plugin-clerk/src/ssr/authenticateRequest.ts
@@ -1,52 +1,16 @@
 import type { GetServerDataProps } from 'gatsby';
 
-import { API_KEY, clerkClient, constants, FRONTEND_API, PUBLISHABLE_KEY, SECRET_KEY } from './clerkClient';
+import { API_KEY, clerkClient, FRONTEND_API, PUBLISHABLE_KEY, SECRET_KEY } from './clerkClient';
 import type { WithServerAuthOptions } from './types';
-import { parseCookies } from './utils';
+import { GatsbyRequestAdapter } from './utils';
 
 export function authenticateRequest(context: GetServerDataProps, options: WithServerAuthOptions) {
-  const { headers } = context;
-  const cookies = parseCookies(headers);
-  const cookieToken = cookies[constants.Cookies.Session];
-  const headerToken = (headers.get(constants.Headers.Authorization) as string)?.replace('Bearer ', '');
-
   return clerkClient.authenticateRequest({
     ...options,
-    cookieToken,
-    headerToken,
-    clientUat: cookies[constants.Cookies.ClientUat],
-    host: headers.get(constants.Headers.Host) as string,
-    forwardedPort: headers.get(constants.Headers.ForwardedPort) as string,
-    forwardedHost: returnReferrerAsXForwardedHostToFixLocalDevGatsbyProxy(headers),
-    referrer: headers.get(constants.Headers.Referrer) as string,
-    userAgent: headers.get(constants.Headers.UserAgent) as string,
     apiKey: API_KEY,
     secretKey: SECRET_KEY,
     frontendApi: FRONTEND_API,
     publishableKey: PUBLISHABLE_KEY,
+    requestAdapter: new GatsbyRequestAdapter(context),
   });
-}
-
-const returnReferrerAsXForwardedHostToFixLocalDevGatsbyProxy = (headers: Map<string, unknown>) => {
-  if (process.env.NODE_ENV !== 'development') {
-    return headers.get(constants.Headers.ForwardedHost) as string;
-  }
-
-  const forwardedHost = headers.get(constants.Headers.ForwardedHost) as string;
-  if (forwardedHost) {
-    return forwardedHost;
-  }
-
-  const referrerUrl = new URL(headers.get(constants.Headers.Referrer) as string);
-  const hostUrl = new URL('https://' + (headers.get(constants.Headers.Host) as string));
-
-  if (isDevelopmentOrStaging(SECRET_KEY || API_KEY || '') && hostUrl.hostname === referrerUrl.hostname) {
-    return referrerUrl.host;
-  }
-
-  return forwardedHost;
-};
-
-function isDevelopmentOrStaging(apiKey: string): boolean {
-  return apiKey.startsWith('test_') || apiKey.startsWith('sk_test_');
 }

--- a/packages/nextjs/src/server/__tests__/utils.test.ts
+++ b/packages/nextjs/src/server/__tests__/utils.test.ts
@@ -1,0 +1,36 @@
+import { constants } from '@clerk/backend';
+import { NextRequest } from 'next/server';
+
+import { NextRequestAdapter } from '../utils';
+
+describe('utils', () => {
+  it('NextRequestAdapter', () => {
+    const req = new NextRequest(new URL('https://example.com?__query=true'), {
+      headers: {
+        ['cookie']: `__session=tokenSession; expires=Mon, 27 june 2022 12:00:00 UTC;__client_uat=tokenClientUat; expires=Mon, 27 june 2022 12:00:00 UTC;`,
+        ['authorization']: 'Bearer tokenValue',
+        ['x-forwarded-port']: 'forwarded-port',
+        ['x-forwarded-host']: 'forwarded-host',
+        ['x-forwarded-proto']: 'forwarded-proto',
+        host: 'host',
+        referer: 'referer',
+        'user-agent': 'user-agent',
+        origin: 'origin',
+      },
+    });
+
+    const reqAdapter = new NextRequestAdapter(req);
+
+    expect(reqAdapter.cookies(constants.Cookies.Session)).toBe('tokenSession');
+    expect(reqAdapter.cookies(constants.Cookies.ClientUat)).toBe('tokenClientUat');
+    expect(reqAdapter.headers(constants.Headers.Authorization)).toBe('Bearer tokenValue');
+    expect(reqAdapter.headers(constants.Headers.ForwardedPort)).toBe('forwarded-port');
+    expect(reqAdapter.headers(constants.Headers.ForwardedHost)).toBe('forwarded-host');
+    expect(reqAdapter.headers(constants.Headers.ForwardedProto)).toBe('forwarded-proto');
+    expect(reqAdapter.headers(constants.Headers.Host)).toBe('host');
+    expect(reqAdapter.headers(constants.Headers.Referrer)).toBe('referer');
+    expect(reqAdapter.headers(constants.Headers.UserAgent)).toBe('user-agent');
+    expect(reqAdapter.headers(constants.Headers.Origin)).toBe('origin');
+    expect(reqAdapter.searchParams().get('__query')).toBe('true');
+  });
+});

--- a/packages/nextjs/src/server/authenticateRequest.ts
+++ b/packages/nextjs/src/server/authenticateRequest.ts
@@ -1,4 +1,3 @@
-import { constants } from '@clerk/backend';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
@@ -13,30 +12,17 @@ import {
   SECRET_KEY,
 } from './clerkClient';
 import type { WithAuthOptions } from './types';
-import { apiEndpointUnauthorizedNextResponse, getCookie } from './utils';
+import { apiEndpointUnauthorizedNextResponse, NextRequestAdapter } from './utils';
 import { decorateResponseWithObservabilityHeaders } from './withClerkMiddleware';
 
 export const authenticateRequest = async (req: NextRequest, opts: WithAuthOptions) => {
-  const cookieToken = getCookie(req, constants.Cookies.Session);
-  const headers = req.headers;
-  const headerToken = headers.get('authorization')?.replace('Bearer ', '');
   return await clerkClient.authenticateRequest({
     ...opts,
     apiKey: opts.apiKey || API_KEY,
     secretKey: opts.secretKey || SECRET_KEY,
     frontendApi: opts.frontendApi || FRONTEND_API,
     publishableKey: opts.publishableKey || PUBLISHABLE_KEY,
-    cookieToken,
-    headerToken,
-    clientUat: getCookie(req, constants.Cookies.ClientUat),
-    origin: headers.get('origin') || undefined,
-    host: headers.get('host') as string,
-    forwardedPort: headers.get('x-forwarded-port') || undefined,
-    forwardedHost: headers.get('x-forwarded-host') || undefined,
-    forwardedProto: headers.get('x-forwarded-proto') || undefined,
-    referrer: headers.get('referer') || undefined,
-    userAgent: headers.get('user-agent') || undefined,
-    searchParams: new URL(req.url).searchParams,
+    requestAdapter: new NextRequestAdapter(req),
   } as any);
 };
 

--- a/packages/nextjs/src/server/utils.ts
+++ b/packages/nextjs/src/server/utils.ts
@@ -1,4 +1,4 @@
-import type { RequestState } from '@clerk/backend';
+import type { RequestAdapter, RequestState } from '@clerk/backend';
 import { constants } from '@clerk/backend';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -257,3 +257,17 @@ export const isCrossOrigin = (from: string | URL, to: string | URL) => {
   const toUrl = new URL(to);
   return fromUrl.origin !== toUrl.origin;
 };
+
+export class NextRequestAdapter implements RequestAdapter {
+  constructor(readonly req: NextRequest) {}
+
+  headers(key: string) {
+    return this.req?.headers?.get(key) || undefined;
+  }
+  cookies(key: string) {
+    return getCookie(this.req, key) || undefined;
+  }
+  searchParams(): URLSearchParams {
+    return new URL(this.req?.url)?.searchParams;
+  }
+}

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -9,7 +9,7 @@ import {
 } from '../errors';
 import { getEnvVariable } from '../utils';
 import type { LoaderFunctionArgs, RootAuthLoaderOptions } from './types';
-import { parseCookies } from './utils';
+import { RemixRequestAdapter } from './utils';
 
 function isDevelopmentFromApiKey(apiKey: string): boolean {
   return apiKey.startsWith('test_') || apiKey.startsWith('sk_test_');
@@ -83,12 +83,6 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     throw new Error(satelliteAndMissingSignInUrl);
   }
 
-  const { headers } = request;
-  const cookies = parseCookies(request);
-
-  const cookieToken = cookies['__session'];
-  const headerToken = headers.get('authorization')?.replace('Bearer ', '');
-
   return Clerk({ apiUrl, apiKey, secretKey, jwtKey, proxyUrl, isSatellite, domain }).authenticateRequest({
     apiKey,
     secretKey,
@@ -98,20 +92,11 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
     loadUser,
     loadSession,
     loadOrganization,
-    cookieToken,
-    headerToken,
-    clientUat: cookies['__client_uat'],
-    origin: headers.get('origin') || '',
-    host: headers.get('host') as string,
-    forwardedPort: headers.get('x-forwarded-port') as string,
-    forwardedHost: headers.get('x-forwarded-host') as string,
-    referrer: headers.get('referer') || '',
-    userAgent: headers.get('user-agent') as string,
     authorizedParties,
     proxyUrl,
     isSatellite,
     domain,
-    searchParams: new URL(request.url).searchParams,
     signInUrl,
+    requestAdapter: new RemixRequestAdapter(request),
   });
 }

--- a/packages/remix/src/ssr/utils.ts
+++ b/packages/remix/src/ssr/utils.ts
@@ -1,4 +1,4 @@
-import type { AuthObject, RequestState } from '@clerk/backend';
+import type { AuthObject, RequestAdapter, RequestState } from '@clerk/backend';
 import { constants, debugRequestState, loadInterstitialFromLocal } from '@clerk/backend';
 import { json } from '@remix-run/server-runtime';
 import cookie from 'cookie';
@@ -128,3 +128,20 @@ export const injectRequestStateIntoResponse = async (response: Response, request
 export const wrapWithClerkState = (data: any) => {
   return { clerkState: { __internal_clerk_state: { ...data } } };
 };
+
+export class RemixRequestAdapter implements RequestAdapter {
+  readonly reqCookies: Record<string, string>;
+  constructor(readonly req: Request) {
+    this.reqCookies = parseCookies(req);
+  }
+
+  headers(key: string) {
+    return this.req?.headers?.get(key) || undefined;
+  }
+  cookies(key: string) {
+    return this.reqCookies?.[key] || undefined;
+  }
+  searchParams(): URLSearchParams {
+    return new URL(this.req?.url)?.searchParams;
+  }
+}

--- a/packages/sdk-node/src/__tests__/utils.test.ts
+++ b/packages/sdk-node/src/__tests__/utils.test.ts
@@ -1,0 +1,33 @@
+import { constants } from '@clerk/backend';
+import type { Request } from 'express';
+
+import { NodeRequestAdapter } from '../utils';
+
+describe('NodeRequestAdapter', () => {
+  it('returns the correct headers, cookies and searchParams', () => {
+    const req = {
+      headers: {
+        ['cookie']: `__session=tokenSession; expires=Mon, 27 june 2022 12:00:00 UTC;__client_uat=tokenClientUat; expires=Mon, 27 june 2022 12:00:00 UTC;`,
+        ['authorization']: 'Bearer tokenValue',
+        ['x-forwarded-port']: 'forwarded-port',
+        ['x-forwarded-host']: 'forwarded-host',
+        host: 'host',
+        referer: 'referer',
+        'user-agent': 'user-agent',
+      },
+      url: '/whatever?__query=true',
+    } as any as Request;
+
+    const requestAdapter = new NodeRequestAdapter(req);
+
+    expect(requestAdapter.headers(constants.Headers.Authorization)).toEqual('Bearer tokenValue');
+    expect(requestAdapter.headers(constants.Headers.ForwardedPort)).toEqual('forwarded-port');
+    expect(requestAdapter.headers(constants.Headers.ForwardedHost)).toEqual('forwarded-host');
+    expect(requestAdapter.headers(constants.Headers.Host)).toEqual('host');
+    expect(requestAdapter.headers(constants.Headers.Referrer)).toEqual('referer');
+    expect(requestAdapter.headers(constants.Headers.UserAgent)).toEqual('user-agent');
+    expect(requestAdapter.cookies(constants.Cookies.Session)).toEqual('tokenSession');
+    expect(requestAdapter.cookies(constants.Cookies.ClientUat)).toEqual('tokenClientUat');
+    expect(requestAdapter.searchParams().toString()).toEqual('__query=true');
+  });
+});

--- a/packages/sdk-node/src/authenticateRequest.test.ts
+++ b/packages/sdk-node/src/authenticateRequest.test.ts
@@ -2,6 +2,7 @@ import { constants } from '@clerk/backend';
 import type { Request } from 'express';
 
 import { authenticateRequest } from './authenticateRequest';
+import { NodeRequestAdapter } from './utils';
 
 const mockNext = jest.fn();
 
@@ -50,26 +51,20 @@ describe('authenticateRequest', () => {
       req,
       options,
     });
-    expect(clerkClient.authenticateRequest).toHaveBeenCalledWith({
-      authorizedParties: ['party1'],
-      clientUat: 'token',
-      cookieToken: 'token',
-      forwardedHost: 'host',
-      forwardedPort: 'port',
-      apiKey: apiKey,
-      secretKey: secretKey,
-      frontendApi: frontendApi,
-      publishableKey: publishableKey,
-      headerToken: 'token',
-      host: 'host',
-      jwtKey: 'jwtKey',
-      referrer: 'referer',
-      userAgent: 'user-agent',
-      isSatellite: false,
-      proxyUrl: undefined,
-      signInUrl: '',
-      domain: '',
-      searchParams,
-    });
+    expect(clerkClient.authenticateRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizedParties: ['party1'],
+        apiKey: apiKey,
+        secretKey: secretKey,
+        frontendApi: frontendApi,
+        publishableKey: publishableKey,
+        jwtKey: 'jwtKey',
+        isSatellite: false,
+        proxyUrl: undefined,
+        signInUrl: '',
+        domain: '',
+        requestAdapter: expect.any(NodeRequestAdapter),
+      }),
+    );
   });
 });

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -1,16 +1,14 @@
-import type { Clerk, RequestState } from '@clerk/backend';
+import type { RequestState } from '@clerk/backend';
 import { constants } from '@clerk/backend';
 import cookie from 'cookie';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 import { handleValueOrFn, isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from './shared';
-import type { ClerkMiddlewareOptions } from './types';
+import type { AuthenticateRequestParams, ClerkClient } from './types';
 
 const parseCookies = (req: IncomingMessage) => {
   return cookie.parse(req.headers['cookie'] || '');
 };
-
-type ClerkClient = ReturnType<typeof Clerk>;
 
 export async function loadInterstitial({
   clerkClient,
@@ -36,15 +34,7 @@ export async function loadInterstitial({
   return await clerkClient.remotePrivateInterstitial();
 }
 
-export const authenticateRequest = (opts: {
-  clerkClient: ReturnType<typeof Clerk>;
-  apiKey: string;
-  secretKey: string;
-  frontendApi: string;
-  publishableKey: string;
-  req: IncomingMessage;
-  options?: ClerkMiddlewareOptions;
-}) => {
+export const authenticateRequest = (opts: AuthenticateRequestParams) => {
   const { clerkClient, apiKey, secretKey, frontendApi, publishableKey, req, options } = opts;
   const cookies = parseCookies(req);
   const { jwtKey, authorizedParties } = options || {};
@@ -63,7 +53,7 @@ export const authenticateRequest = (opts: {
     throw new Error(satelliteAndMissingProxyUrlAndDomain);
   }
 
-  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromApiKey(secretKey)) {
+  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromApiKey(secretKey || apiKey)) {
     throw new Error(satelliteAndMissingSignInUrl);
   }
 

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -1,6 +1,7 @@
-import type { AuthObject, SignedInAuthObject } from '@clerk/backend';
+import type { AuthObject, Clerk, InstanceKeys, SignedInAuthObject } from '@clerk/backend';
 import type { MultiDomainAndOrProxy } from '@clerk/types';
 import type { NextFunction, Request, Response } from 'express';
+import type { IncomingMessage } from 'http';
 
 type LegacyAuthObject<T extends AuthObject> = Pick<T, 'sessionId' | 'userId' | 'actor' | 'getToken' | 'debug'> & {
   claims: AuthObject['sessionClaims'];
@@ -33,3 +34,11 @@ export type ClerkMiddlewareOptions = {
   strict?: boolean;
   signInUrl?: string;
 } & MultiDomainAndOrProxy;
+
+export type ClerkClient = ReturnType<typeof Clerk>;
+
+export type AuthenticateRequestParams = InstanceKeys & {
+  clerkClient: ReturnType<typeof Clerk>;
+  req: IncomingMessage;
+  options?: ClerkMiddlewareOptions;
+};

--- a/packages/sdk-node/src/utils.ts
+++ b/packages/sdk-node/src/utils.ts
@@ -1,4 +1,8 @@
+import type { RequestAdapter } from '@clerk/backend';
+import cookie from 'cookie';
 import type { IncomingMessage, ServerResponse } from 'http';
+
+import { getRequestUrl } from './authenticateRequest';
 
 // https://nextjs.org/docs/api-routes/api-middlewares#connectexpress-middleware-support
 export function runMiddleware(req: IncomingMessage, res: ServerResponse, fn: (...args: any) => any) {
@@ -11,4 +15,25 @@ export function runMiddleware(req: IncomingMessage, res: ServerResponse, fn: (..
       return resolve(result);
     });
   });
+}
+
+const parseCookies = (req: IncomingMessage) => {
+  return cookie.parse(req.headers['cookie'] || '');
+};
+
+export class NodeRequestAdapter implements RequestAdapter {
+  readonly reqCookies: Record<string, string>;
+  constructor(readonly req: IncomingMessage) {
+    this.reqCookies = parseCookies(req);
+  }
+
+  headers(key: string) {
+    return (this.req?.headers?.[key] as string) || undefined;
+  }
+  cookies(key: string) {
+    return this.reqCookies?.[key] || undefined;
+  }
+  searchParams(): URLSearchParams {
+    return getRequestUrl(this.req)?.searchParams;
+  }
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [x] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [x] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
### This PR is built upon changes of #1329 

This PR introduces a new `RequestAdapter` interface that may be implemented by any framework that uses the  `@clerk/backend` package. The custom `RequestAdapter` instance will be passed to `authenticateRequest` instead of each header/cookie/searchParams as a prop.

Example usage:
```ts
// CustomRequestAdapter.ts
// How we access the headers/cookies/searchParams depends on the specific framework's request representation
export class CustomRequestAdapter implements RequestAdapter {
  constructor(readonly req: CustomRequest) {}

  headers(key: string) {
    return this.req?.headers?.[key];
  }
  cookies(key: string) {
    return this.req?.cookies?.[key];
  }
  searchParams() {
    return new URL(this.req.url).searchParams;
  }
}
```
```ts
// FrameworkClerkMiddleware.ts
...
export const withClerkMiddleware = (options: ClerkCustomOptions) => {
  return async (req: CustomFrameworkRequest, ...) => {
    const requestState = await clerkClient.authenticateRequest({
      ...options,
      secretKey,
      publishableKey,
      requestAdapter: new CustomRequestAdapter(req),
    });
   ...
};
```
<!-- Fixes # (issue number) -->
