### PR TITLE
feat(fastify): Support `{hookName: 'onRequest'}`

### DIFF
--- a/.changeset/silent-maps-complain.md
+++ b/.changeset/silent-maps-complain.md
@@ -1,0 +1,5 @@
+---
+'@clerk/fastify': minor
+---
+
+Add support for binding middleware to `onRequest` in addition to `preHandler`

--- a/packages/fastify/src/clerkPlugin.test.ts
+++ b/packages/fastify/src/clerkPlugin.test.ts
@@ -8,7 +8,7 @@ import { clerkPlugin } from './clerkPlugin';
 import { createFastifyInstanceMock } from './test/utils';
 
 describe('clerkPlugin()', () => {
-  test('adds withClerkMiddleware as preHandler', () => {
+  test('adds withClerkMiddleware as preHandler by default', () => {
     const doneFn = jest.fn();
     const fastify = createFastifyInstanceMock();
 
@@ -17,6 +17,28 @@ describe('clerkPlugin()', () => {
     expect(fastify.addHook).toBeCalledWith('preHandler', 'withClerkMiddlewareMocked');
     expect(doneFn).toBeCalled();
   });
+
+  test('adds withClerkMiddleware as onRequest when specified', () => {
+    const doneFn = jest.fn();
+    const fastify = createFastifyInstanceMock();
+
+    clerkPlugin(fastify, { hookName: 'onRequest' }, doneFn);
+
+    expect(fastify.addHook).toBeCalledWith('onRequest', 'withClerkMiddlewareMocked');
+    expect(doneFn).toBeCalled();
+  });
+
+  test.each(['preParsing', 'preValidation', 'preSerialization', 'NOT_A_VALID_HOOK_NAME'])(
+    'throws when hookName is %s',
+    hookName => {
+      const doneFn = jest.fn();
+      const fastify = createFastifyInstanceMock();
+
+      expect(() => {
+        clerkPlugin(fastify, { hookName }, doneFn);
+      }).toThrowError(`Unsupported hookName: ${hookName}`);
+    },
+  );
 
   test('adds auth decorator', () => {
     const doneFn = jest.fn();

--- a/packages/fastify/src/clerkPlugin.ts
+++ b/packages/fastify/src/clerkPlugin.ts
@@ -2,12 +2,19 @@ import type { FastifyInstance, FastifyPluginCallback } from 'fastify';
 import fp from 'fastify-plugin';
 
 import type { ClerkFastifyOptions } from './types';
+import { ALLOWED_HOOKS } from './types';
 import { withClerkMiddleware } from './withClerkMiddleware';
 
 const plugin: FastifyPluginCallback = (instance: FastifyInstance, opts: ClerkFastifyOptions, done) => {
   instance.decorateRequest('auth', null);
   // run clerk as a middleware to all scoped routes
-  instance.addHook('preHandler', withClerkMiddleware(opts));
+  const hookName = opts.hookName || 'preHandler';
+  if (!ALLOWED_HOOKS.includes(hookName)) {
+    throw new Error(`Unsupported hookName: ${hookName}`);
+  }
+
+  // @ts-expect-error unions don't play well with TS overload signatures
+  instance.addHook(hookName, withClerkMiddleware(opts));
 
   done();
 };

--- a/packages/fastify/src/types.ts
+++ b/packages/fastify/src/types.ts
@@ -1,3 +1,7 @@
 import type { ClerkOptions } from '@clerk/backend';
 
-export type ClerkFastifyOptions = Omit<ClerkOptions, 'apiKey'>;
+export const ALLOWED_HOOKS = ['onRequest', 'preHandler'] as const;
+
+export type ClerkFastifyOptions = Omit<ClerkOptions, 'apiKey'> & {
+  hookName?: (typeof ALLOWED_HOOKS)[number];
+};


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [x] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Adds support for option `{hookName: 'onRequest'}`, which binds the callback to the specified hook.

By default, or when specified as such, the callback will continue to be bound to `preHandler`.

This update prevents binding to any other hook to minimize compatibility requirements going forward.

<!-- Fixes #1350 -->
Fixes #1350
