### PR TITLE
Correctly initialize clerkClient in clerk-sdk-node

### DIFF
--- a/.changeset/slow-falcons-design.md
+++ b/.changeset/slow-falcons-design.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-sdk-node': patch
+---
+
+Correctly display "Missing Clerk keys" error instead of simply throwing during initialization

--- a/packages/backend/src/api/resources/index.ts
+++ b/packages/backend/src/api/resources/index.ts
@@ -4,7 +4,18 @@ export * from './DeletedObject';
 export * from './Deserializer';
 export * from './Email';
 export * from './EmailAddress';
-export * from './Enums';
+
+export type {
+  InvitationStatus,
+  OAuthProvider,
+  OAuthStrategy,
+  OrganizationInvitationStatus,
+  OrganizationMembershipRole,
+  SignInStatus,
+  SignUpAttributeRequirements,
+  SignUpStatus,
+} from './Enums';
+
 export * from './ExternalAccount';
 export * from './IdentificationLink';
 export * from './Invitation';
@@ -21,4 +32,15 @@ export * from './SMSMessage';
 export * from './Token';
 export * from './User';
 export * from './Verification';
-export * from './Webhooks';
+
+export type {
+  EmailWebhookEvent,
+  OrganizationInvitationWebhookEvent,
+  OrganizationMembershipWebhookEvent,
+  OrganizationWebhookEvent,
+  SessionWebhookEvent,
+  SMSWebhookEvent,
+  UserWebhookEvent,
+  WebhookEvent,
+  WebhookEventType,
+} from './Webhooks';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "dev:publish": "npm run dev -- --env.PUBLISH=true",
+    "dev:publish": "npm run dev -- --env.publish",
     "build:declarations": "tsc -p tsconfig.declarations.json",
     "publish:local": "npx yalc push --replace  --sig",
     "clean": "rimraf ./dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,8 +34,8 @@
     "publish:local": "npx yalc push --replace  --sig",
     "clean": "rimraf ./dist",
     "lint": "eslint .",
-    "test:coverage": "echo \"Error: no test specified yet\"",
-    "test": "jest"
+    "test": "jest",
+    "test:ci": "jest --maxWorkers=50%"
   },
   "dependencies": {
     "@clerk/shared": "^0.19.0",

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(overrideOptions => {
     define: {
       PACKAGE_NAME: `"${name}"`,
       PACKAGE_VERSION: `"${version}"`,
-      __DEV__: `${!isWatch}`,
+      __DEV__: `${isWatch}`,
     },
   };
 

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -7,7 +7,7 @@ import { name, version } from './package.json';
 
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
-  const shouldPublish = overrideOptions.env?.PUBLISH === 'true';
+  const shouldPublish = !!overrideOptions.env?.publish;
 
   const common: Options = {
     entry: ['./src/**/*.{ts,tsx,js,jsx}'],

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -2,25 +2,25 @@
   "version": "4.10.6",
   "license": "MIT",
   "type": "commonjs",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
     },
     "./esm/instance": {
       "types": "./dist/types/instance.d.ts",
-      "require": "./dist/instance.js",
-      "import": "./dist/instance.mjs"
+      "require": "./dist/cjs/instance.js",
+      "import": "./dist/esm/instance.js"
     },
     "./cjs/instance": {
       "types": "./dist/types/instance.d.ts",
-      "require": "./dist/instance.js",
-      "import": "./dist/instance.mjs"
+      "require": "./dist/cjs/instance.js",
+      "import": "./dist/esm/instance.js"
     }
   },
   "files": [
@@ -32,13 +32,15 @@
     "node": ">=14"
   },
   "scripts": {
+    "build": "npm run clean && tsup",
     "dev": "tsup --watch",
-    "build": "tsup --env.NODE_ENV production",
+    "dev:publish": "npm run dev -- --env.publish",
+    "build:declarations": "tsc -p tsconfig.declarations.json",
+    "publish:local": "npx yalc push --replace  --sig",
     "clean": "rimraf ./dist",
     "lint": "eslint .",
     "test": "jest",
-    "test:ci": "jest --maxWorkers=50%",
-    "pack": "npm pack"
+    "test:ci": "jest --maxWorkers=50%"
   },
   "name": "@clerk/clerk-sdk-node",
   "author": {

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -3,9 +3,9 @@ import { constants } from '@clerk/backend';
 import cookie from 'cookie';
 import type { IncomingMessage, ServerResponse } from 'http';
 
-import { loadApiEnv, loadClientEnv } from './clerkClient';
 import { handleValueOrFn, isHttpOrHttps, isProxyUrlRelative, isValidProxyUrl } from './shared';
 import type { ClerkMiddlewareOptions } from './types';
+import { loadApiEnv, loadClientEnv } from './utils';
 
 const parseCookies = (req: IncomingMessage) => {
   return cookie.parse(req.headers['cookie'] || '');

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -45,15 +45,21 @@ let clerkClientSingleton = {} as unknown as ReturnType<typeof Clerk>;
 
 export const clerkClient = new Proxy(clerkClientSingleton, {
   get(_target, property) {
+    const hasBeenInitialised = !!clerkClientSingleton.authenticateRequest;
+    if (hasBeenInitialised) {
+      // @ts-expect-error
+      return clerkClientSingleton[property];
+    }
+
     const env = { ...loadApiEnv(), ...loadClientEnv() };
     if (env.secretKey) {
-      clerkClientSingleton = Clerk({
-        ...env,
-        userAgent: '@clerk/clerk-sdk-node',
-      });
+      clerkClientSingleton = Clerk({ ...env, userAgent: '@clerk/clerk-sdk-node' });
+      // @ts-expect-error
+      return clerkClientSingleton[property];
     }
-    // @ts-ignore
-    return clerkClientSingleton[property];
+
+    // @ts-expect-error
+    return Clerk({ ...env, userAgent: '@clerk/clerk-sdk-node' })[property];
   },
   set() {
     return false;

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -3,28 +3,7 @@ import { Clerk as _Clerk, decodeJwt, verifyToken as _verifyToken } from '@clerk/
 
 import { createClerkExpressRequireAuth } from './clerkExpressRequireAuth';
 import { createClerkExpressWithAuth } from './clerkExpressWithAuth';
-
-export const loadClientEnv = () => {
-  return {
-    publishableKey: process.env.CLERK_PUBLISHABLE_KEY || '',
-    frontendApi: process.env.CLERK_FRONTEND_API || '',
-    clerkJSUrl: process.env.CLERK_JS || '',
-    clerkJSVersion: process.env.CLERK_JS_VERSION || '',
-  };
-};
-
-export const loadApiEnv = () => {
-  return {
-    secretKey: process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '',
-    apiKey: process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '',
-    apiUrl: process.env.CLERK_API_URL || 'https://api.clerk.dev',
-    apiVersion: process.env.CLERK_API_VERSION || 'v1',
-    domain: process.env.CLERK_DOMAIN || '',
-    proxyUrl: process.env.CLERK_PROXY_URL || '',
-    signInUrl: process.env.CLERK_SIGN_IN_URL || '',
-    isSatellite: process.env.CLERK_IS_SATELLITE === 'true',
-  };
-};
+import { loadApiEnv, loadClientEnv } from './utils';
 
 /**
  * This needs to be a *named* function in order to support the older

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -46,7 +46,7 @@ let clerkClientSingleton = {} as unknown as ReturnType<typeof Clerk>;
 export const clerkClient = new Proxy(clerkClientSingleton, {
   get(_target, property) {
     const env = { ...loadApiEnv(), ...loadClientEnv() };
-    if (!env.secretKey) {
+    if (env.secretKey) {
       clerkClientSingleton = Clerk({
         ...env,
         userAgent: '@clerk/clerk-sdk-node',

--- a/packages/sdk-node/src/instance.ts
+++ b/packages/sdk-node/src/instance.ts
@@ -2,7 +2,7 @@ import { Clerk } from './clerkClient';
 
 export default Clerk;
 
-export { WithAuthProp, RequireAuthProp } from './types';
+export type { WithAuthProp, RequireAuthProp } from './types';
 
 export {
   AllowlistIdentifier,

--- a/packages/sdk-node/src/utils.ts
+++ b/packages/sdk-node/src/utils.ts
@@ -12,3 +12,25 @@ export function runMiddleware(req: IncomingMessage, res: ServerResponse, fn: (..
     });
   });
 }
+
+export const loadClientEnv = () => {
+  return {
+    publishableKey: process.env.CLERK_PUBLISHABLE_KEY || '',
+    frontendApi: process.env.CLERK_FRONTEND_API || '',
+    clerkJSUrl: process.env.CLERK_JS || '',
+    clerkJSVersion: process.env.CLERK_JS_VERSION || '',
+  };
+};
+
+export const loadApiEnv = () => {
+  return {
+    secretKey: process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '',
+    apiKey: process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '',
+    apiUrl: process.env.CLERK_API_URL || 'https://api.clerk.dev',
+    apiVersion: process.env.CLERK_API_VERSION || 'v1',
+    domain: process.env.CLERK_DOMAIN || '',
+    proxyUrl: process.env.CLERK_PROXY_URL || '',
+    signInUrl: process.env.CLERK_SIGN_IN_URL || '',
+    isSatellite: process.env.CLERK_IS_SATELLITE === 'true',
+  };
+};

--- a/packages/sdk-node/tsconfig.declarations.json
+++ b/packages/sdk-node/tsconfig.declarations.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+    "sourceMap": false,
+    "declarationDir": "./dist/types"
+  }
+}

--- a/packages/sdk-node/tsconfig.json
+++ b/packages/sdk-node/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "declarationDir": "dist/types",
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
+    "declarationMap": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
+    "isolatedModules": true,
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
@@ -15,6 +14,7 @@
     "sourceMap": false,
     "strict": true,
     "target": "ES2020",
+    "outDir": "dist",
     "types": ["jest"]
   },
   "exclude": ["node_modules"],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "dev:publish": "npm run dev -- --env.PUBLISH=true",
+    "dev:publish": "npm run dev -- --env.publish",
     "build:declarations": "tsc -p tsconfig.json",
     "publish:local": "npx yalc push --replace  --sig",
     "clean": "rimraf ./dist",

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -10,7 +10,7 @@ import { name, version } from './package.json';
 
 export default defineConfig(overrideOptions => {
   const isWatch = !!overrideOptions.watch;
-  const shouldPublish = overrideOptions.env?.PUBLISH === 'true';
+  const shouldPublish = !!overrideOptions.env?.publish;
 
   const common: Options = {
     entry: ['./src/**/*.{ts,tsx,js,jsx}'],

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(overrideOptions => {
     define: {
       PACKAGE_NAME: `"${name}"`,
       PACKAGE_VERSION: `"${version}"`,
-      __DEV__: `${!isWatch}`,
+      __DEV__: `${isWatch}`,
     },
   };
 

--- a/playground/express/package.json
+++ b/playground/express/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "ts-node ./src/server.ts",
-    "yalc:add": "yalc add -- @clerk/types @clerk/backend @clerk/clerk-sdk-node"
+    "yalc:add": "yalc add -- @clerk/types @clerk/backend @clerk/clerk-sdk-node",
+    "dev:fromlocal": " nodemon --watch .yalc --watch src --exec \"npm run yalc:add && npm run start\""
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
- fix proxy initialisation. The clerkClient never initialised before
- align esm/cjs build config with the other related packages
- various cleanups
- enable isolatedModules for clerk/clerk-sdk-node

A proxy is used for the top-levle clerkClient object as we want to read the env variables only when clerkClient is actually used for the first time.

The alternative approach would be to turn all env-related props into getters, however, we're making heavy use of the `...` destructuring operator. When a getter is destructured into a new object, the value is copied and not the getter function.
<!-- Fixes # (issue number) -->
