### PR TITLE
Optimize images

### DIFF
--- a/.changeset/wise-turtles-study.md
+++ b/.changeset/wise-turtles-study.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/shared": patch
+---
+
+Optimize all images displayed within the Clerk components, such as Avatars, static OAuth provider assets etc. All images are now resized and compressed. Additionally, all images are automatically converted into more efficient formats (`avif`, `webp`) if they are supported by the user's browser, otherwise all images fall back to `jpeg`.

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileAvatarUploader.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileAvatarUploader.tsx
@@ -16,7 +16,6 @@ export const OrganizationProfileAvatarUploader = (
       avatarPreview={
         <OrganizationAvatar
           size={theme => theme.sizes.$11}
-          optimize
           {...organization}
         />
       }

--- a/packages/clerk-js/src/ui/components/UserButton/UserButtonTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/UserButtonTrigger.tsx
@@ -26,7 +26,6 @@ export const UserButtonTrigger = withAvatarShimmer(
           boxElementDescriptor={descriptors.userButtonAvatarBox}
           imageElementDescriptor={descriptors.userButtonAvatarImage}
           {...user}
-          optimize
           size={theme => theme.sizes.$8}
         />
       </Button>

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileAvatarUploader.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileAvatarUploader.tsx
@@ -15,7 +15,6 @@ export const UserProfileAvatarUploader = (
       avatarPreview={
         <UserAvatar
           size={theme => theme.sizes.$11}
-          optimize
           {...user}
         />
       }

--- a/packages/clerk-js/src/ui/customizables/index.ts
+++ b/packages/clerk-js/src/ui/customizables/index.ts
@@ -2,6 +2,7 @@ import { makeLocalizable } from '../localization';
 import * as Primitives from '../primitives';
 import { descriptors } from './elementDescriptors';
 import { makeCustomizable } from './makeCustomizable';
+import { makeResponsive } from './makeResponsive';
 import { sanitizeDomProps } from './sanitizeDomProps';
 
 export * from './Flow';
@@ -24,7 +25,9 @@ export const SimpleButton = makeCustomizable(makeLocalizable(sanitizeDomProps(Pr
 export const Heading = makeCustomizable(makeLocalizable(sanitizeDomProps(Primitives.Heading)));
 export const Link = makeCustomizable(makeLocalizable(sanitizeDomProps(Primitives.Link)));
 export const Text = makeCustomizable(makeLocalizable(sanitizeDomProps(Primitives.Text)));
-export const Image = makeCustomizable(sanitizeDomProps(Primitives.Image));
+
+export const Image = makeCustomizable(sanitizeDomProps(makeResponsive(Primitives.Image)));
+
 export const Alert = makeCustomizable(sanitizeDomProps(Primitives.Alert));
 export const AlertIcon = makeCustomizable(sanitizeDomProps(Primitives.AlertIcon));
 export const Input = makeCustomizable(sanitizeDomProps(Primitives.Input));

--- a/packages/clerk-js/src/ui/customizables/makeResponsive.tsx
+++ b/packages/clerk-js/src/ui/customizables/makeResponsive.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { isDataUri, isValidUrl } from '../../utils';
+
+type Responsive<T = Record<never, never>> = T & {
+  size?: number;
+  xDescriptors?: number[];
+};
+
+type ResponsivePrimitive<T> = React.FunctionComponent<Responsive<T>>;
+
+export const makeResponsive = <P extends React.JSX.IntrinsicElements['img']>(
+  Component: React.FunctionComponent<P>,
+): ResponsivePrimitive<P> => {
+  const responsiveComponent = React.forwardRef((props: Responsive<any>, ref) => {
+    const { src, size = 80, xDescriptors = [1, 2], ...restProps } = props;
+    const shouldOptimize = isClerkImage(src);
+
+    return (
+      <Component
+        srcSet={shouldOptimize ? generateSrcSet({ src, width: size, xDescriptors }) : undefined}
+        src={shouldOptimize ? generateSrc({ src, width: size * 2 }) : src}
+        {...restProps}
+        ref={ref}
+      />
+    );
+  });
+
+  const displayName = Component.displayName || Component.name || 'Component';
+  responsiveComponent.displayName = `Responsive${displayName}`.replace('_', '');
+  return responsiveComponent as ResponsivePrimitive<P>;
+};
+
+const CLERK_IMAGE_URL_BASES = [
+  'https://img.clerk.com/',
+  'https://img.clerk.dev/',
+  'https://img.clerkstage.dev/',
+  'https://img.lclclerk.com/',
+];
+
+const isClerkImage = (src?: string): boolean => {
+  return !!CLERK_IMAGE_URL_BASES.some(base => src?.includes(base));
+};
+
+const generateSrcSet = ({ src, width, xDescriptors }: { src?: string; width: number; xDescriptors: number[] }) => {
+  if (!src) {
+    return '';
+  }
+
+  return xDescriptors.map(i => `${generateSrc({ src, width: width * i })} ${i}x`).toString();
+};
+
+const generateSrc = ({ src, width }: { src?: string; width: number }) => {
+  if (!isValidUrl(src) || isDataUri(src)) {
+    return src;
+  }
+
+  const newSrc = new URL(src);
+  if (width) {
+    newSrc.searchParams.append('width', width?.toString());
+  }
+
+  return newSrc.href;
+};

--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -31,17 +31,15 @@ export const Avatar = (props: AvatarProps) => {
   } = props;
   const [error, setError] = React.useState(false);
 
-  const src = imageUrl;
-
   const ImgOrFallback =
-    initials && (!src || error) ? (
+    initials && (!imageUrl || error) ? (
       <InitialsAvatarFallback initials={initials} />
     ) : (
       <Image
         elementDescriptor={[imageElementDescriptor, descriptors.avatarImage]}
         title={title}
         alt={title}
-        src={src || ''}
+        src={imageUrl || ''}
         width='100%'
         height='100%'
         sx={{ objectFit: 'cover' }}

--- a/packages/clerk-js/src/ui/elements/Avatar.tsx
+++ b/packages/clerk-js/src/ui/elements/Avatar.tsx
@@ -1,4 +1,3 @@
-import { isRetinaDisplay } from '@clerk/shared';
 import React from 'react';
 
 import { Box, descriptors, Flex, Image, Text } from '../customizables';
@@ -13,7 +12,6 @@ type AvatarProps = PropsOfComponent<typeof Flex> & {
   initials?: string;
   imageUrl?: string | null;
   imageFetchSize?: number;
-  optimize?: boolean;
   rounded?: boolean;
   boxElementDescriptor?: ElementDescriptor;
   imageElementDescriptor?: ElementDescriptor;
@@ -25,22 +23,15 @@ export const Avatar = (props: AvatarProps) => {
     title,
     initials,
     imageUrl,
-    optimize,
     rounded = true,
-    imageFetchSize = 64,
+    imageFetchSize = 80,
     sx,
     boxElementDescriptor,
     imageElementDescriptor,
   } = props;
   const [error, setError] = React.useState(false);
 
-  let src = imageUrl;
-  if (src && !optimize) {
-    const optimizedHeight = Math.max(imageFetchSize) * (isRetinaDisplay() ? 2 : 1);
-    const srcUrl = new URL(src);
-    srcUrl.searchParams.append('height', optimizedHeight.toString());
-    src = srcUrl.toString();
-  }
+  const src = imageUrl;
 
   const ImgOrFallback =
     initials && (!src || error) ? (
@@ -55,6 +46,7 @@ export const Avatar = (props: AvatarProps) => {
         height='100%'
         sx={{ objectFit: 'cover' }}
         onError={() => setError(true)}
+        size={imageFetchSize}
       />
     );
 

--- a/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/OrganizationPreview.tsx
@@ -41,7 +41,6 @@ export const OrganizationPreview = (props: OrganizationPreviewProps) => {
           imageElementDescriptor={descriptors.organizationPreviewAvatarImage}
           {...organization}
           size={t => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size])}
-          optimize
           sx={avatarSx}
           rounded={rounded}
         />

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -91,7 +91,6 @@ export const UserPreview = (props: UserPreviewProps) => {
             name={name}
             avatarUrl={imageUrl}
             size={t => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size])}
-            optimize
             sx={avatarSx}
             rounded={rounded}
           />

--- a/packages/clerk-js/src/ui/primitives/Image.tsx
+++ b/packages/clerk-js/src/ui/primitives/Image.tsx
@@ -1,25 +1,15 @@
 import React from 'react';
 
-import { generateSrc, generateSrcSet, isClerkImage } from '../../utils';
 import type { PrimitiveProps, StateProps } from '../styledSystem';
 import { applyDataStateProps } from './applyDataStateProps';
 
-export type ImageProps = PrimitiveProps<'img'> &
-  StateProps & {
-    size?: number;
-    xDescriptors?: number[];
-  };
+export type ImageProps = PrimitiveProps<'img'> & StateProps;
 
 export const Image = React.forwardRef<HTMLImageElement, ImageProps>((props, ref) => {
-  const { src, size = 80, xDescriptors = [1, 2], ...rest } = props;
-  const shouldAdjustSize = isClerkImage(src);
-
   return (
     <img
       crossOrigin='anonymous'
-      srcSet={shouldAdjustSize ? generateSrcSet({ src, width: size, xDescriptors }) : undefined}
-      src={shouldAdjustSize ? generateSrc({ src, width: size * 2 }) : src}
-      {...applyDataStateProps(rest)}
+      {...applyDataStateProps(props)}
       ref={ref}
     />
   );

--- a/packages/clerk-js/src/ui/styledSystem/types.ts
+++ b/packages/clerk-js/src/ui/styledSystem/types.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import type { Interpolation as _Interpolation } from '@emotion/react';
+import type React from 'react';
 
 import type { InternalTheme } from '../foundations';
 
@@ -15,21 +16,21 @@ type CssProp = { css?: ThemableCssProp };
 export type AsProp = { as?: React.ElementType };
 
 type ElementProps = {
-  div: JSX.IntrinsicElements['div'];
-  input: JSX.IntrinsicElements['input'];
-  button: JSX.IntrinsicElements['button'];
-  heading: JSX.IntrinsicElements['h1'];
-  p: JSX.IntrinsicElements['p'];
-  a: JSX.IntrinsicElements['a'];
-  label: JSX.IntrinsicElements['label'];
-  img: JSX.IntrinsicElements['img'];
-  form: JSX.IntrinsicElements['form'];
-  table: JSX.IntrinsicElements['table'];
-  thead: JSX.IntrinsicElements['thead'];
-  tbody: JSX.IntrinsicElements['tbody'];
-  th: JSX.IntrinsicElements['th'];
-  tr: JSX.IntrinsicElements['tr'];
-  td: JSX.IntrinsicElements['td'];
+  div: React.JSX.IntrinsicElements['div'];
+  input: React.JSX.IntrinsicElements['input'];
+  button: React.JSX.IntrinsicElements['button'];
+  heading: React.JSX.IntrinsicElements['h1'];
+  p: React.JSX.IntrinsicElements['p'];
+  a: React.JSX.IntrinsicElements['a'];
+  label: React.JSX.IntrinsicElements['label'];
+  img: React.JSX.IntrinsicElements['img'];
+  form: React.JSX.IntrinsicElements['form'];
+  table: React.JSX.IntrinsicElements['table'];
+  thead: React.JSX.IntrinsicElements['thead'];
+  tbody: React.JSX.IntrinsicElements['tbody'];
+  th: React.JSX.IntrinsicElements['th'];
+  tr: React.JSX.IntrinsicElements['tr'];
+  td: React.JSX.IntrinsicElements['td'];
 };
 
 /**

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -14,12 +14,6 @@ declare global {
 
 // This is used as a dummy base when we need to invoke "new URL()" but we don't care about the URL origin.
 const DUMMY_URL_BASE = 'http://clerk-dummy';
-const CLERK_IMAGE_URL_BASES = [
-  'https://images.clerk.com/',
-  'https://images.clerk.dev/',
-  'https://images.clerkstage.dev/',
-  'https://images.lclclerk.com/',
-];
 
 export const DEV_OR_STAGING_SUFFIXES = [
   '.lcl.dev',
@@ -257,39 +251,6 @@ export function hasBannedProtocol(val: string | URL) {
   const protocol = new URL(val).protocol;
   return BANNED_URI_PROTOCOLS.some(bp => bp === protocol);
 }
-
-export const isClerkImage = (src?: string): boolean => {
-  return !!CLERK_IMAGE_URL_BASES.some(base => src?.includes(base));
-};
-
-export const generateSrc = ({ src, width }: { src?: string; width: number }) => {
-  if (!isValidUrl(src) || isDataUri(src)) {
-    return src;
-  }
-
-  const newSrc = new URL(src);
-  if (width) {
-    newSrc.searchParams.append('width', width?.toString());
-  }
-
-  return newSrc.href;
-};
-
-export const generateSrcSet = ({
-  src,
-  width,
-  xDescriptors,
-}: {
-  src?: string;
-  width: number;
-  xDescriptors: number[];
-}) => {
-  if (!src) {
-    return '';
-  }
-
-  return xDescriptors.map(i => `${generateSrc({ src, width: width * i })} ${i}x`).toString();
-};
 
 export const hasUrlInFragment = (_url: URL | string) => {
   return new URL(_url, DUMMY_URL_BASE).hash.startsWith('#/');

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -7,7 +7,6 @@ export * from './date';
 export * from './errors';
 export * from './file';
 export * from './keys';
-export * from './isRetinaDisplay';
 export * from './localStorageBroadcastChannel';
 export * from './mimeTypeExtensions';
 export * from './multiDomain';

--- a/packages/shared/src/utils/isRetinaDisplay.ts
+++ b/packages/shared/src/utils/isRetinaDisplay.ts
@@ -1,9 +1,0 @@
-export function isRetinaDisplay(): boolean {
-  if (!window.matchMedia) {
-    return false;
-  }
-  const mq = window.matchMedia(
-    'only screen and (min--moz-device-pixel-ratio: 1.3), only screen and (-o-min-device-pixel-ratio: 2.6/2), only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen  and (min-device-pixel-ratio: 1.3), only screen and (min-resolution: 1.3dppx)',
-  );
-  return (mq && mq.matches) || window.devicePixelRatio > 1;
-}


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This is the complimentary clerk-js work , for more information and examples go to: https://github.com/clerkinc/cloudflare-workers/pull/31 

Introduce a makeResponsive HOC that adds the `srcset` attribute on all images served by the img-service worker. 

Primitives shouldn't be aware of any Clerk-specific logic. All the image optimization logic is now extracted into its own makeResponsive HOC.

Apart from resizing te image, more optimizations are now enabled:
- dynamic format negotiation (avif and webp support, falls back to jpeg when needed). This offers up to ~50% size reduction.
- scale down to a max width of 1920
- set a default quality of 80
- respect height, width, fit and quality params

Before: 
![image](https://github.com/clerkinc/javascript/assets/1811063/751a0aaa-e6c8-4baf-8ad2-5f275ca897cf)

After:
![image](https://github.com/clerkinc/javascript/assets/1811063/0be3e78d-94e9-4b1c-83cc-c3890d40b7fd)
<!-- Fixes # (issue number) -->
