### PR TITLE
Add ability to delete an organization

### DIFF
--- a/.changeset/old-eggs-own.md
+++ b/.changeset/old-eggs-own.md
@@ -1,0 +1,7 @@
+---
+'@clerk/localizations': minor
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+Add ability for organization admins to delete an organization if they have permission to do so

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -27,6 +27,7 @@ export class Organization extends BaseResource implements OrganizationResource {
   logoUrl!: string;
   imageUrl!: string;
   publicMetadata: OrganizationPublicMetadata = {};
+  adminDeleteEnabled!: boolean;
   createdAt!: Date;
   updatedAt!: Date;
   membersCount = 0;
@@ -179,6 +180,7 @@ export class Organization extends BaseResource implements OrganizationResource {
     this.publicMetadata = data.public_metadata;
     this.membersCount = data.members_count;
     this.pendingInvitationsCount = data.pending_invitations_count;
+    this.adminDeleteEnabled = data.admin_delete_enabled;
     this.createdAt = unixEpochToDate(data.created_at);
     this.updatedAt = unixEpochToDate(data.updated_at);
     return this;

--- a/packages/clerk-js/src/core/resources/OrganizationSettings.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationSettings.ts
@@ -5,6 +5,9 @@ import { BaseResource } from './internal';
 export class OrganizationSettings extends BaseResource implements OrganizationSettingsResource {
   enabled!: boolean;
   maxAllowedMemberships!: number;
+  actions!: {
+    adminDelete: boolean;
+  };
 
   public constructor(data: OrganizationSettingsJSON) {
     super();
@@ -12,9 +15,10 @@ export class OrganizationSettings extends BaseResource implements OrganizationSe
   }
 
   protected fromJSON(data: OrganizationSettingsJSON | null): this {
-    const { enabled = false, max_allowed_memberships = 0 } = data || {};
+    const { enabled = false, max_allowed_memberships = 0, actions } = data || {};
     this.enabled = enabled;
     this.maxAllowedMemberships = max_allowed_memberships;
+    this.actions = { adminDelete: actions?.admin_delete || false };
     return this;
   }
 }

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -82,8 +82,6 @@ export class User extends BaseResource implements UserResource {
   createOrganizationEnabled = false;
   deleteSelfEnabled = false;
   lastSignInAt: Date | null = null;
-  createOrganizationEnabled = false;
-  deleteSelfEnabled = false;
   updatedAt: Date | null = null;
   createdAt: Date | null = null;
 

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -79,6 +79,8 @@ export class User extends BaseResource implements UserResource {
   backupCodeEnabled = false;
   publicMetadata: UserPublicMetadata = {};
   unsafeMetadata: UserUnsafeMetadata = {};
+  createOrganizationEnabled = false;
+  deleteSelfEnabled = false;
   lastSignInAt: Date | null = null;
   createOrganizationEnabled = false;
   deleteSelfEnabled = false;

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Organization has the same initial properties 1`] = `
 Organization {
   "addMember": [Function],
+  "adminDeleteEnabled": undefined,
   "createdAt": 1970-01-01T00:00:12.345Z,
   "destroy": [Function],
   "getMemberships": [Function],

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -7,6 +7,7 @@ OrganizationMembership {
   "id": "test_id",
   "organization": Organization {
     "addMember": [Function],
+    "adminDeleteEnabled": undefined,
     "createdAt": 1970-01-01T00:00:12.345Z,
     "destroy": [Function],
     "getMemberships": [Function],

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActionConfirmationPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActionConfirmationPage.tsx
@@ -42,6 +42,33 @@ export const LeaveOrganizationPage = () => {
   );
 };
 
+export const DeleteOrganizationPage = () => {
+  const card = useCardState();
+  const { navigateAfterLeaveOrganization } = useOrganizationProfileContext();
+  const { organization, membership } = useCoreOrganization();
+
+  if (!organization || !membership) {
+    return null;
+  }
+
+  const deleteOrg = () => {
+    return card.runAsync(organization.destroy()).then(navigateAfterLeaveOrganization);
+  };
+
+  return (
+    <ActionConfirmationPage
+      title={localizationKeys('organizationProfile.profilePage.dangerSection.deleteOrganization.title')}
+      messageLine1={localizationKeys('organizationProfile.profilePage.dangerSection.deleteOrganization.messageLine1')}
+      messageLine2={localizationKeys('organizationProfile.profilePage.dangerSection.deleteOrganization.messageLine2')}
+      submitLabel={localizationKeys('organizationProfile.profilePage.dangerSection.deleteOrganization.title')}
+      successMessage={localizationKeys(
+        'organizationProfile.profilePage.dangerSection.deleteOrganization.successMessage',
+      )}
+      onConfirmation={deleteOrg}
+    />
+  );
+};
+
 type ActionConfirmationPageProps = {
   title: LocalizationKey;
   messageLine1: LocalizationKey;

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -1,7 +1,7 @@
 import { ProfileCardContent } from '../../elements';
 import { Route, Switch } from '../../router';
 import type { PropsOfComponent } from '../../styledSystem';
-import { LeaveOrganizationPage } from './ActionConfirmationPage';
+import { LeaveOrganizationPage, DeleteOrganizationPage } from './ActionConfirmationPage';
 import { InviteMembersPage } from './InviteMembersPage';
 import { OrganizationMembers } from './OrganizationMembers';
 import { OrganizationSettings } from './OrganizationSettings';
@@ -23,6 +23,12 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
             flowStart
           >
             <LeaveOrganizationPage />
+          </Route>
+          <Route
+            path='delete'
+            flowStart
+          >
+            <DeleteOrganizationPage />
           </Route>
           <Route index>
             <OrganizationSettings />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
@@ -1,4 +1,4 @@
-import { useCoreOrganization, useEnvironment } from '../../contexts';
+import { useCoreOrganization } from '../../contexts';
 import { Col, descriptors, Flex, Icon, localizationKeys } from '../../customizables';
 import { Header, IconButton, NavbarMenuButtonRow, OrganizationPreview, ProfileSection } from '../../elements';
 import { Times } from '../../icons';
@@ -60,8 +60,7 @@ const OrganizationProfileSection = () => {
 const OrganizationDangerSection = () => {
   const { organization, membership } = useCoreOrganization();
   const { navigate } = useRouter();
-  const environment = useEnvironment();
-  const adminDeleteEnabled = environment.organizationSettings.actions.adminDelete;
+  const adminDeleteEnabled = organization?.adminDeleteEnabled;
 
   if (!organization || !membership) {
     return null;

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
@@ -1,4 +1,4 @@
-import { useCoreOrganization } from '../../contexts';
+import { useCoreOrganization, useEnvironment } from '../../contexts';
 import { Col, descriptors, Flex, Icon, localizationKeys } from '../../customizables';
 import { Header, IconButton, NavbarMenuButtonRow, OrganizationPreview, ProfileSection } from '../../elements';
 import { Times } from '../../icons';
@@ -60,6 +60,8 @@ const OrganizationProfileSection = () => {
 const OrganizationDangerSection = () => {
   const { organization, membership } = useCoreOrganization();
   const { navigate } = useRouter();
+  const environment = useEnvironment();
+  const adminDeleteEnabled = environment.organizationSettings.actions.adminDelete;
 
   if (!organization || !membership) {
     return null;
@@ -88,6 +90,23 @@ const OrganizationDangerSection = () => {
           isDisabled={membership.role === 'admin'}
           localizationKey={localizationKeys('organizationProfile.profilePage.dangerSection.leaveOrganization.title')}
         />
+        {membership.role === 'admin' && adminDeleteEnabled && (
+          <IconButton
+            aria-label='Delete organization'
+            icon={
+              <Icon
+                icon={Times}
+                size={'sm'}
+                sx={t => ({ marginRight: t.space.$2 })}
+              />
+            }
+            variant='outline'
+            colorScheme='danger'
+            textVariant='buttonExtraSmallBold'
+            onClick={() => navigate('delete')}
+            localizationKey={localizationKeys('organizationProfile.profilePage.dangerSection.deleteOrganization.title')}
+          />
+        )}
       </Flex>
     </ProfileSection>
   );

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationSettings.tsx
@@ -60,11 +60,12 @@ const OrganizationProfileSection = () => {
 const OrganizationDangerSection = () => {
   const { organization, membership } = useCoreOrganization();
   const { navigate } = useRouter();
-  const adminDeleteEnabled = organization?.adminDeleteEnabled;
 
   if (!organization || !membership) {
     return null;
   }
+
+  const adminDeleteEnabled = organization.adminDeleteEnabled;
 
   return (
     <ProfileSection

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -546,6 +546,12 @@ export const enUS: LocalizationResource = {
           messageLine2: 'This action is permanent and irreversible.',
           successMessage: 'You have left the organization.',
         },
+        deleteOrganization: {
+          title: 'Delete organization',
+          messageLine1: 'Are you sure you want to delete this organization?',
+          messageLine2: 'This action is permanent and irreversible.',
+          successMessage: 'You have deleted the organization.',
+        },
       },
     },
     invitePage: {

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -307,6 +307,7 @@ export interface OrganizationJSON extends ClerkResourceJSON {
   updated_at: number;
   members_count: number;
   pending_invitations_count: number;
+  admin_delete_enabled: boolean;
 }
 
 export interface OrganizationMembershipJSON extends ClerkResourceJSON {

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -566,6 +566,12 @@ type _LocalizationResource = {
           messageLine2: LocalizationValue;
           successMessage: LocalizationValue;
         };
+        deleteOrganization: {
+          title: LocalizationValue;
+          messageLine1: LocalizationValue;
+          messageLine2: LocalizationValue;
+          successMessage: LocalizationValue;
+        };
       };
     };
     invitePage: {

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -32,6 +32,7 @@ export interface OrganizationResource extends ClerkResource {
   membersCount: number;
   pendingInvitationsCount: number;
   publicMetadata: OrganizationPublicMetadata;
+  adminDeleteEnabled: boolean;
   createdAt: Date;
   updatedAt: Date;
   update: (params: UpdateOrganizationParams) => Promise<OrganizationResource>;

--- a/packages/types/src/organizationSettings.ts
+++ b/packages/types/src/organizationSettings.ts
@@ -6,9 +6,15 @@ export interface OrganizationSettingsJSON extends ClerkResourceJSON {
   object: never;
   enabled: boolean;
   max_allowed_memberships: number;
+  actions: {
+    admin_delete: boolean;
+  };
 }
 
 export interface OrganizationSettingsResource extends ClerkResource {
   enabled: boolean;
   maxAllowedMemberships: number;
+  actions: {
+    adminDelete: boolean;
+  };
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
Adds the ability for admins to delete organizations from the UI, as long as the `adminDelete` permission is present.
