### PR TITLE
Implement organization creation permission controls

### DIFF
--- a/.changeset/fifty-eels-work.md
+++ b/.changeset/fifty-eels-work.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': minor
+---
+
+If user does not have permission to create an org, create org button will not display in the OrganizationSwitcher UI

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -80,6 +80,7 @@ export class User extends BaseResource implements UserResource {
   publicMetadata: UserPublicMetadata = {};
   unsafeMetadata: UserUnsafeMetadata = {};
   lastSignInAt: Date | null = null;
+  createOrganizationEnabled = false;
   updatedAt: Date | null = null;
   createdAt: Date | null = null;
 
@@ -320,7 +321,6 @@ export class User extends BaseResource implements UserResource {
     this.twoFactorEnabled = data.two_factor_enabled;
 
     this.createOrganizationEnabled = data.create_organization_enabled;
-    this.deleteSelfEnabled = data.delete_self_enabled;
 
     if (data.last_sign_in_at) {
       this.lastSignInAt = unixEpochToDate(data.last_sign_in_at);

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -319,6 +319,9 @@ export class User extends BaseResource implements UserResource {
     this.backupCodeEnabled = data.backup_code_enabled;
     this.twoFactorEnabled = data.two_factor_enabled;
 
+    this.createOrganizationEnabled = data.create_organization_enabled;
+    this.deleteSelfEnabled = data.delete_self_enabled;
+
     if (data.last_sign_in_at) {
       this.lastSignInAt = unixEpochToDate(data.last_sign_in_at);
     }

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -17,6 +17,10 @@ import { BaseResource } from './internal';
 const defaultMaxPasswordLength = 72;
 const defaultMinPasswordLength = 8;
 
+export type Actions = {
+  create_organization: boolean;
+};
+
 /**
  * @internal
  */

--- a/packages/clerk-js/src/core/resources/UserSettings.ts
+++ b/packages/clerk-js/src/core/resources/UserSettings.ts
@@ -1,6 +1,5 @@
 import type {
   Attributes,
-  Actions,
   OAuthProviders,
   OAuthStrategy,
   PasswordSettingsData,
@@ -19,6 +18,7 @@ const defaultMinPasswordLength = 8;
 
 export type Actions = {
   create_organization: boolean;
+  delete_self: boolean;
 };
 
 /**

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OtherOrganizationActions.tsx
@@ -84,7 +84,7 @@ export const OrganizationActionList = (props: OrganizationActionListProps) => {
           </PreviewButton>
         ))}
       </Box>
-      {createOrganizationButton}
+      {user.createOrganizationEnabled && createOrganizationButton}
     </SecondaryActions>
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -46,7 +46,7 @@ describe('OrganizationSwitcher', () => {
     it('opens the organization switcher popover when clicked', async () => {
       const { wrapper, props } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.dev'], create_organization_enabled: true });
       });
       props.setProps({ hidePersonal: true });
       const { getByText, getByRole, userEvent } = render(<OrganizationSwitcher />, { wrapper });
@@ -107,6 +107,7 @@ describe('OrganizationSwitcher', () => {
         f.withUser({
           email_addresses: ['test@clerk.dev'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
+          create_organization_enabled: true,
         });
       });
       props.setProps({ hidePersonal: true });
@@ -114,6 +115,20 @@ describe('OrganizationSwitcher', () => {
       await userEvent.click(getByRole('button'));
       await userEvent.click(getByRole('button', { name: 'Create Organization' }));
       expect(fixtures.clerk.openCreateOrganization).toHaveBeenCalled();
+    });
+
+    it('does not display create organization button if permissions not present', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.dev'],
+          organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
+          create_organization_enabled: false,
+        });
+      });
+      props.setProps({ hidePersonal: true });
+      const { queryByRole } = render(<OrganizationSwitcher />, { wrapper });
+      expect(queryByRole('button', { name: 'Create Organization' })).not.toBeInTheDocument();
     });
 
     it.todo('switches between active organizations when one is clicked');

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -214,6 +214,7 @@ export interface UserJSON extends ClerkResourceJSON {
   public_metadata: UserPublicMetadata;
   unsafe_metadata: UserUnsafeMetadata;
   last_sign_in_at: number | null;
+  create_organization_enabled: boolean;
   updated_at: number;
   created_at: number;
 }

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -77,6 +77,8 @@ export interface UserResource extends ClerkResource {
   publicMetadata: UserPublicMetadata;
   unsafeMetadata: UserUnsafeMetadata;
   lastSignInAt: Date | null;
+  createOrganizationEnabled: boolean;
+  deleteSelfEnabled: boolean;
   updatedAt: Date | null;
   createdAt: Date | null;
 

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -78,7 +78,6 @@ export interface UserResource extends ClerkResource {
   unsafeMetadata: UserUnsafeMetadata;
   lastSignInAt: Date | null;
   createOrganizationEnabled: boolean;
-  deleteSelfEnabled: boolean;
   updatedAt: Date | null;
   createdAt: Date | null;
 

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -84,6 +84,7 @@ export type Attributes = {
 
 export type Actions = {
   create_organization: boolean;
+  delete_self: boolean;
 };
 
 export interface UserSettingsJSON extends ClerkResourceJSON {
@@ -101,7 +102,6 @@ export interface UserSettingsJSON extends ClerkResourceJSON {
   sign_in: SignInData;
   sign_up: SignUpData;
   password_settings: PasswordSettingsData;
-  actions: Actions;
 }
 
 export interface UserSettingsResource extends ClerkResource {

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -83,8 +83,8 @@ export type Attributes = {
 };
 
 export type Actions = {
-  create_organization: boolean;
   delete_self: boolean;
+  create_organization: boolean;
 };
 
 export interface UserSettingsJSON extends ClerkResourceJSON {

--- a/packages/types/src/userSettings.ts
+++ b/packages/types/src/userSettings.ts
@@ -83,7 +83,6 @@ export type Attributes = {
 };
 
 export type Actions = {
-  delete_self: boolean;
   create_organization: boolean;
 };
 
@@ -91,6 +90,7 @@ export interface UserSettingsJSON extends ClerkResourceJSON {
   id: never;
   object: never;
   attributes: AttributesJSON;
+  actions: Actions;
   social: OAuthProviders;
 
   /**


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
If the "user can create organizations" permission is false, the "create organization" button will not appear in the `OrganizationSwitcher` component.
