### PR TITLE
Missing fr-FR translations use_email & use_phone

### DIFF
--- a/.changeset/eighty-planes-taste.md
+++ b/.changeset/eighty-planes-taste.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Add missing fr-FR translations (use_email & use_phone)

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -112,8 +112,8 @@ export const frFR: LocalizationResource = {
       subtitle: 'pour continuer vers {{applicationName}}',
       actionText: "Vous n'avez pas encore de compte ?",
       actionLink: "S'inscrire",
-      actionLink__use_email: "Utiliser e-mail",
-      actionLink__use_phone: "Utiliser téléphone",
+      actionLink__use_email: 'Utiliser e-mail',
+      actionLink__use_phone: 'Utiliser téléphone',
     },
     password: {
       title: 'Tapez votre mot de passe',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -112,6 +112,8 @@ export const frFR: LocalizationResource = {
       subtitle: 'pour continuer vers {{applicationName}}',
       actionText: "Vous n'avez pas encore de compte ?",
       actionLink: "S'inscrire",
+      actionLink__use_email: "Utiliser e-mail",
+      actionLink__use_phone: "Utiliser téléphone",
     },
     password: {
       title: 'Tapez votre mot de passe',


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

Missing fr-FR translations use_email & use_phone (see screenshots).

![Screenshot 2023-06-19 at 14 55 55](https://github.com/clerkinc/javascript/assets/118519715/265206ac-c4ff-4935-80e4-edde497c6ff9)
![Screenshot 2023-06-19 at 15 00 22](https://github.com/clerkinc/javascript/assets/118519715/cc7a62c3-524e-4eaf-baf0-75c89f4b1df6)