### PR TITLE
fix(localizations): Missing pt-BR translations

### DIFF
--- a/.changeset/pretty-moose-taste.md
+++ b/.changeset/pretty-moose-taste.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Add missing pt-BR translations

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -556,6 +556,8 @@ export const ptBR: LocalizationResource = {
     },
     zxcvbn: {
       notEnough: 'Sua senha não é forte o suficiente.',
+      couldBeStronger: 'Sua senha funciona, mas poderia ser mais forte. Tente adicionar mais caracteres.',
+      goodPassword: 'Bom trabalho. Esta é uma ótima senha.',
       warnings: {
         straightRow: 'Letras que vêm em sequência no teclado são fáceis de adivinhar.',
         keyPattern: 'Padrões de teclado curtos são fáceis de adivinhar.',


### PR DESCRIPTION
fix(localizations): Missing pt-BR translations couldBeStronger & goodPassword

screenshot of the bug:
![updatePTBRLocalization](https://github.com/clerkinc/javascript/assets/68567054/1e19dcfa-4f5a-453f-90f9-6436ff2320db)

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
