### PR TITLE
fix(nextjs): Support req.clerkUrl to fix issue with NextJS hostname on proxied apps

### DIFF
--- a/.changeset/nice-kangaroos-teach.md
+++ b/.changeset/nice-kangaroos-teach.md
@@ -2,4 +2,4 @@
 '@clerk/nextjs': patch
 ---
 
-Support non-Vercel platforms to override hostname of the url to fix the `localhost:3000` redirect from authMiddleware
+Support hosting NextJs apps on non-Vercel platforms by constructing req.url using host-related headers instead of using on `req.url` directly. In order to enable this feature, set the `CLERK_TRUST_HOST` env variable to `true` 

--- a/.changeset/nice-kangaroos-teach.md
+++ b/.changeset/nice-kangaroos-teach.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Support non-Vercel platforms to override hostname of the url to fix the `localhost:3000` redirect from authMiddleware

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -134,22 +134,6 @@ export interface AuthMiddleware {
   (params?: AuthMiddlewareParams): NextMiddleware;
 }
 
-const getFirstValueFromHeader = (req: NextRequest, key: string) => {
-  const value = req.headers.get(key);
-  return value?.split(',')[0];
-};
-
-const withNormalizedClerkUrl = (req: NextRequest): WithClerkUrl<NextRequest> => {
-  if (!TRUST_HOST) {
-    return Object.assign(req, { experimental_clerkUrl: req.nextUrl });
-  }
-  const clerkUrl = req.nextUrl.clone();
-  clerkUrl.protocol = getFirstValueFromHeader(req, constants.Headers.ForwardedProto) ?? clerkUrl.protocol;
-  clerkUrl.host = getFirstValueFromHeader(req, constants.Headers.ForwardedHost) ?? clerkUrl.host;
-  clerkUrl.port = getFirstValueFromHeader(req, constants.Headers.ForwardedPort) ?? clerkUrl.port;
-  return Object.assign(req, { experimental_clerkUrl: clerkUrl });
-};
-
 const authMiddleware: AuthMiddleware = (...args: unknown[]) => {
   const [params = {}] = args as [AuthMiddlewareParams?];
   const { beforeAuth, afterAuth, publicRoutes, ignoredRoutes, apiRoutes, ...options } = params;
@@ -376,3 +360,19 @@ A bug that may have already been fixed in the latest version of Clerk NextJS pac
 How to resolve:
 -> Make sure you are using the latest version of '@clerk/nextjs' and 'next'.
   `;
+
+const getFirstValueFromHeader = (req: NextRequest, key: string) => {
+  const value = req.headers.get(key);
+  return value?.split(',')[0];
+};
+
+const withNormalizedClerkUrl = (req: NextRequest): WithClerkUrl<NextRequest> => {
+  if (!TRUST_HOST) {
+    return Object.assign(req, { experimental_clerkUrl: req.nextUrl });
+  }
+  const clerkUrl = req.nextUrl.clone();
+  clerkUrl.protocol = getFirstValueFromHeader(req, constants.Headers.ForwardedProto) ?? clerkUrl.protocol;
+  clerkUrl.host = getFirstValueFromHeader(req, constants.Headers.ForwardedHost) ?? clerkUrl.host;
+  clerkUrl.port = getFirstValueFromHeader(req, constants.Headers.ForwardedPort) ?? clerkUrl.port;
+  return Object.assign(req, { experimental_clerkUrl: clerkUrl });
+};

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -17,6 +17,7 @@ export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';
 export const IS_SATELLITE = process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true' || false;
 export const SIGN_IN_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '';
 export const SIGN_UP_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '';
+export const USE_X_FWD_HEADERS = process.env.CLERK_USE_X_FWD_HEADERS === 'true';
 
 const clerkClient = Clerk({
   apiKey: API_KEY,

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -17,7 +17,7 @@ export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';
 export const IS_SATELLITE = process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true' || false;
 export const SIGN_IN_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '';
 export const SIGN_UP_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '';
-export const USE_X_FWD_HEADERS = process.env.CLERK_USE_X_FWD_HEADERS === 'true';
+export const TRUST_HOST = (process.env.CLERK_TRUST_HOST || process.env.CLERK_USE_X_FWD_HEADERS) === 'true';
 
 const clerkClient = Clerk({
   apiKey: API_KEY,


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [] `npm test` runs as expected.
- [] `npm run build` runs as expected.

Override the `req.nextUrl` host with the `HOSTNAME` environment variable.
With this fix we can resolve the incorrect hostname in the NextJS applications deployed outside Vercel platform.
