### PR TITLE
fix(nextjs): Add isApiRoute to AfterAuthHandler['auth'] type

### DIFF
--- a/.changeset/new-llamas-complain.md
+++ b/.changeset/new-llamas-complain.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Add isApiRoute to AfterAuthHandler['auth'] type

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -67,7 +67,7 @@ type BeforeAuthHandler = (
 ) => NextMiddlewareResult | Promise<NextMiddlewareResult> | false | Promise<false>;
 
 type AfterAuthHandler = (
-  auth: AuthObject & { isPublicRoute: boolean },
+  auth: AuthObject & { isPublicRoute: boolean; isApiRoute: boolean },
   req: NextRequest,
   evt: NextFetchEvent,
 ) => NextMiddlewareResult | Promise<NextMiddlewareResult>;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Even though the `isApiRoute` is added to AfterAuthHandler['auth'] object, the type is not updated to indicate this.
