### PR TITLE
fix(localizations): Missing fr-FR translations for reset password page

### DIFF
--- a/.changeset/fifty-ravens-double.md
+++ b/.changeset/fifty-ravens-double.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Add missing `fr-FR` translations for reset password page

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -36,6 +36,8 @@ export const frFR: LocalizationResource = {
   formFieldInputPlaceholder__lastName: '',
   formFieldInputPlaceholder__backupCode: '',
   formFieldInputPlaceholder__organizationName: '',
+  formFieldError__notMatchingPasswords: 'Les mots de passe ne correspondent pas.',
+  formFieldError__matchingPasswords: 'Les mots de passe correspondent.',
   formFieldAction__forgotPassword: 'Mot de passe oublié?',
   formFieldHintText__optional: 'Optionnel',
   formButtonPrimary: 'Continuer',
@@ -119,6 +121,11 @@ export const frFR: LocalizationResource = {
       title: 'Tapez votre mot de passe',
       subtitle: 'pour continuer à {{applicationName}}',
       actionLink: 'Utiliser une autre méthode',
+    },
+    resetPassword: {
+      title: 'Réinitialiser le mot de passe',
+      formButtonPrimary: 'Réinitialiser',
+      successMessage: 'Votre mot de passe a été modifié avec succès. Nous vous reconnectons, veuillez patienter un instant.',
     },
     emailCode: {
       title: 'Vérifiez votre messagerie',

--- a/packages/localizations/src/fr-FR.ts
+++ b/packages/localizations/src/fr-FR.ts
@@ -125,7 +125,8 @@ export const frFR: LocalizationResource = {
     resetPassword: {
       title: 'Réinitialiser le mot de passe',
       formButtonPrimary: 'Réinitialiser',
-      successMessage: 'Votre mot de passe a été modifié avec succès. Nous vous reconnectons, veuillez patienter un instant.',
+      successMessage:
+        'Votre mot de passe a été modifié avec succès. Nous vous reconnectons, veuillez patienter un instant.',
     },
     emailCode: {
       title: 'Vérifiez votre messagerie',


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
Missing fr-FR translations for reset password page (see screenshots).

<img width="472" alt="Screenshot 2023-06-20 at 19 34 28" src="https://github.com/clerkinc/javascript/assets/118519715/e4230656-4121-4c7b-a13f-d4b4afb9394b">