### PR TITLE
fix(clerk-js): Only set the __session cookie as `none` for secure iframes

### DIFF
--- a/.changeset/metal-dolphins-act.md
+++ b/.changeset/metal-dolphins-act.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-js": patch
+---
+
+Set the `__session` cookie with `samesite:none` for secure iframes only

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -1,7 +1,7 @@
 import { addYears } from '@clerk/shared';
 import type { ClientResource } from '@clerk/types';
 
-import { inCrossOriginIframe } from '../../utils';
+import { inSecureCrossOriginIframe } from '../../utils';
 import { getAllETLDs } from '../url';
 import { clientCookie } from './client';
 import { clientUatCookie } from './client_uat';
@@ -22,7 +22,8 @@ export const createCookieHandler = () => {
   const setDevBrowserInittedCookie = () =>
     inittedCookie.set('1', {
       expires: addYears(Date.now(), 1),
-      sameSite: inCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE,
+      sameSite: inSecureCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE,
+      secure: inSecureCrossOriginIframe() ? true : undefined,
       path: COOKIE_PATH,
     });
 
@@ -30,8 +31,8 @@ export const createCookieHandler = () => {
 
   const setSessionCookie = (token: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = inCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE;
-    const secure = window.location.protocol === 'https:';
+    const sameSite = inSecureCrossOriginIframe() ? IFRAME_SAME_SITE : DEFAULT_SAME_SITE;
+    const secure = inSecureCrossOriginIframe() || window.location.protocol === 'https:';
 
     return sessionCookie.set(token, {
       expires,

--- a/packages/clerk-js/src/utils/runtime.ts
+++ b/packages/clerk-js/src/utils/runtime.ts
@@ -6,6 +6,10 @@ export function inActiveBrowserTab() {
   return inBrowser() && globalThis.document.hasFocus();
 }
 
+export function usesHttps() {
+  return inBrowser() && window.location.protocol === 'https:';
+}
+
 export function inIframe() {
   return inBrowser() && window.self !== window.top;
 }
@@ -14,4 +18,8 @@ export function inCrossOriginIframe() {
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/frameElement
   // frameElement: if the document into which it's embedded has a different origin, the value is null instead.
   return inIframe() && !window.frameElement;
+}
+
+export function inSecureCrossOriginIframe() {
+  return inCrossOriginIframe() && usesHttps();
 }


### PR DESCRIPTION


## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
…

This change allows e2e suites running on cypress to work without additional setup.
<!-- Fixes # (issue number) -->
