### PR TITLE
Move 'delete account' UI to security section (USR-58)

### DIFF
--- a/.changeset/bright-rules-agree.md
+++ b/.changeset/bright-rules-agree.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Move UI for deleting account to bottom of user profile component in the security section

--- a/packages/clerk-js/src/ui/components/UserProfile/RootPage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/RootPage.tsx
@@ -56,7 +56,6 @@ export const RootPage = withCardStateProvider(() => {
         {showConnectedAccounts && <ConnectedAccountsSection />}
         {showSamlAccounts && <EnterpriseAccountsSection />}
         {showWeb3 && <Web3Section />}
-        {showDelete && <DeleteSection />}
       </Col>
       <Col
         elementDescriptor={descriptors.profilePage}
@@ -73,6 +72,7 @@ export const RootPage = withCardStateProvider(() => {
         {showPassword && <PasswordSection />}
         {showMfa && <MfaSection />}
         <ActiveDevicesSection />
+        {showDelete && <DeleteSection />}
       </Col>
     </Col>
   );


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

Moves the "delete account" UI down to the bottom of the profile page UI, under the security section
