### PR TITLE
fix(types): Deprecate OrganizationResource.logoUrl

### DIFF
--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -27,6 +27,9 @@ export interface OrganizationResource extends ClerkResource {
   id: string;
   name: string;
   slug: string | null;
+  /**
+   * @deprecated Use `imageUrl` instead.
+   */
   logoUrl: string | null;
   imageUrl: string;
   membersCount: number;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
OrganizationResource.logoUrl is deprecated in favor of OrganizationResource.imageUrl
<!-- Fixes # (issue number) -->
