### PR TITLE
fix(localizations): Added missing translation in de-DE.ts

### DIFF
--- a/.changeset/orange-bats-learn.md
+++ b/.changeset/orange-bats-learn.md
@@ -1,0 +1,5 @@
+---
+"@clerk/localizations": patch
+---
+
+Add missing translations in de-DE.ts

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -321,6 +321,12 @@ export const deDE: LocalizationResource = {
         destructiveActionSubtitle: 'Entfernen Sie dieses Web3-Wallet aus Ihrem Konto',
         destructiveAction: 'Wallet entfernen',
       },
+      dangerSection: {
+        title: 'Achtung',
+        deleteAccountButton: 'Konto löschen',
+        deleteAccountTitle: 'Konto löschen',
+        deleteAccountDescription: 'Löschen Sie ihr Konto und alle damit verknüpften Daten',
+      },
     },
     profilePage: {
       title: 'Profil aktualisieren',


### PR DESCRIPTION
added missing translation for "deleting an account" in the  dangerSection of the userProfile

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other: Added missing translation

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
