### PR TITLE
fix(nextjs): Avoid setting clerkUrl port when http(s) forwarded port and protocol is defined

### DIFF
--- a/.changeset/slow-needles-jam.md
+++ b/.changeset/slow-needles-jam.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Resolve issue of appending :80 in urls when using CLERK_TRUST_HOST


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

Issue: https://github.com/clerkinc/javascript/issues/1413
PR introducing issue: https://github.com/clerkinc/javascript/pull/1394

