### PR TITLE
fix(nextjs): Add incorrect keys as a reason on the Infinite Loop Detection error text

### DIFF
--- a/.changeset/swift-doors-shop.md
+++ b/.changeset/swift-doors-shop.md
@@ -1,5 +1,0 @@
----
-'@clerk/nextjs': patch
----
-
-Add incorrect keys as a reason on the Infinite Loop Detection error text

--- a/.changeset/swift-doors-shop.md
+++ b/.changeset/swift-doors-shop.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Add incorrect keys as a reason on the Infinite Loop Detection error text

--- a/packages/nextjs/src/server/authMiddleware.ts
+++ b/packages/nextjs/src/server/authMiddleware.ts
@@ -351,9 +351,9 @@ How to resolve:
 -> Make sure your system's clock is set to the correct time (e.g. turn off and on automatic time synchronization).
 
 Reason 2:
-You changed Clerk instance keys (Publishable Key, Secret Key).
+Your Clerk instance keys are incorrect, or you recently changed keys (Publishable Key, Secret Key).
 How to resolve:
--> Make sure you have cleared your browser's application data and cookies everytime you change keys.
+-> Make sure you're using the correct keys from the Clerk Dashboard. If you changed keys recently, make sure to clear your browser application data and cookies.
 
 Reason 3:
 A bug that may have already been fixed in the latest version of Clerk NextJS package.


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR adds incorrect keys as a reason on the Infinite Loop Detection error text.

Before:
```
Reason 2:
You changed Clerk instance keys (Publishable Key, Secret Key).
How to resolve:
-> Make sure you have cleared your browser's application data and cookies everytime you change keys.
```

After:
```
Reason 2:
Your Clerk instance keys are incorrect, or you recently changed keys (Publishable Key, Secret Key).
How to resolve:
-> Make sure you're using the correct keys from the Clerk Dashboard. If you changed keys recently, make sure to clear your browser application data and cookies.
```

<!-- Fixes # (issue number) -->
