### PR TITLE
feat(backend): Increase the default value for clock skew in `verifyJwt` from 2 to 5 seconds

### DIFF
--- a/.changeset/thirty-chefs-unite.md
+++ b/.changeset/thirty-chefs-unite.md
@@ -1,5 +1,5 @@
 ---
-'@clerk/backend': minor
+'@clerk/backend': patch
 ---
 
 Increase the default value for clock skew in `verifyJwt` from 2 to 5 seconds

--- a/.changeset/thirty-chefs-unite.md
+++ b/.changeset/thirty-chefs-unite.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Increase the default value for clock skew in `verifyJwt` from 2 to 5 seconds

--- a/packages/backend/src/tokens/jwt/verifyJwt.ts
+++ b/packages/backend/src/tokens/jwt/verifyJwt.ts
@@ -9,7 +9,7 @@ import { assertAudienceClaim } from './assertions';
 
 type IssuerResolver = string | ((iss: string) => boolean);
 
-const DEFAULT_CLOCK_SKEW_IN_SECONDS = 2 * 1000;
+const DEFAULT_CLOCK_SKEW_IN_SECONDS = 5 * 1000;
 
 const algToHash: Record<string, string> = {
   RS256: 'SHA-256',


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This change will make the `verifyJwt` function to be more tolerant by default to clock skew, increasing it from 2 seconds to 5 seconds.

<!-- Fixes # (issue number) -->
