### PR TITLE
Support `experimental_ignoreInterstitial` option and use it for api routes

### DIFF
--- a/.changeset/gentle-clocks-reflect.md
+++ b/.changeset/gentle-clocks-reflect.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-sdk-node': minor
+'@clerk/backend': minor
+---
+
+Experimental support to disable interstitial in api routes

--- a/packages/sdk-node/src/authenticateRequest.test.ts
+++ b/packages/sdk-node/src/authenticateRequest.test.ts
@@ -70,6 +70,48 @@ describe('authenticateRequest', () => {
       signInUrl: '',
       domain: '',
       searchParams,
+      audience: undefined,
+      experimental_ignoreInterstitial: false,
     });
+  });
+
+  it('correctly evaluates and passes experimental_IsApiRoute as experimental_ignoreInterstitial', async () => {
+    const req = {
+      headers: {
+        ['cookie']: `${constants.Cookies.Session}=token; expires=Mon, 27 june 2022 12:00:00 UTC;${constants.Cookies.ClientUat}=token; expires=Mon, 27 june 2022 12:00:00 UTC;`,
+        [constants.Headers.Authorization]: 'Bearer token',
+        [constants.Headers.ForwardedPort]: 'port',
+        [constants.Headers.ForwardedHost]: 'host',
+        host: 'host',
+        referer: 'referer',
+        'user-agent': 'user-agent',
+      },
+      url: '/whatever?__query=true',
+    } as any as Request;
+
+    const options = {
+      jwtKey: 'jwtKey',
+      authorizedParties: ['party1'],
+      experimental_isApiRoute: (url: URL) => url.pathname === '/whatever',
+    };
+
+    const clerkClient = mockClerkClient();
+    const apiKey = 'apiKey';
+    const secretKey = '';
+    const frontendApi = 'frontendApi';
+    const publishableKey = 'publishableKey';
+    const searchParams = new URLSearchParams();
+    searchParams.set('__query', 'true');
+
+    await authenticateRequest({
+      clerkClient: clerkClient as any,
+      apiKey,
+      secretKey,
+      frontendApi,
+      publishableKey,
+      req,
+      options,
+    });
+    expect(clerkClient.authenticateRequest.mock.calls[0][0].experimental_ignoreInterstitial).toEqual(true);
   });
 });

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -53,6 +53,8 @@ export const authenticateRequest = (opts: AuthenticateRequestParams) => {
     requestUrl.toString(),
   );
 
+  const experimental_ignoreInterstitial = !!handleValueOrFn(options?.experimental_isApiRoute, requestUrl);
+
   if (isSatellite && !proxyUrl && !domain) {
     throw new Error(satelliteAndMissingProxyUrlAndDomain);
   }
@@ -84,6 +86,7 @@ export const authenticateRequest = (opts: AuthenticateRequestParams) => {
     domain,
     signInUrl,
     searchParams: requestUrl.searchParams,
+    experimental_ignoreInterstitial,
   });
 };
 export const handleUnknownCase = (res: ServerResponse, requestState: RequestState) => {

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -7,6 +7,8 @@ type LegacyAuthObject<T extends AuthObject> = Pick<T, 'sessionId' | 'userId' | '
   claims: AuthObject['sessionClaims'];
 };
 
+type BooleanOrURLFnToBoolean = boolean | ((url: URL) => boolean);
+
 export type MiddlewareWithAuthProp = (
   // req: WithAuthProp<Request>
   req: Request,
@@ -34,6 +36,10 @@ export type ClerkMiddlewareOptions = {
   jwtKey?: string;
   strict?: boolean;
   signInUrl?: string;
+  /**
+   * @experimental
+   */
+  experimental_isApiRoute?: BooleanOrURLFnToBoolean;
 } & MultiDomainAndOrProxy;
 
 export type ClerkClient = ReturnType<typeof Clerk>;

--- a/playground/express/package.json
+++ b/playground/express/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "start": "ts-node ./src/server.ts",
-    "yalc:add": "yalc add -- @clerk/types @clerk/backend @clerk/clerk-sdk-node",
-    "dev:fromlocal": " nodemon --watch .yalc --watch src --exec \"npm run yalc:add && npm run start\""
+    "dev": "ts-node ./src/server.ts",
+    "yalc": "yalc add -- @clerk/types @clerk/backend @clerk/clerk-sdk-node"
   },
   "author": "",
   "license": "ISC",

--- a/playground/express/src/routes/private.ts
+++ b/playground/express/src/routes/private.ts
@@ -1,11 +1,11 @@
 import type { Response } from 'express';
 
-import { ClerkExpressRequireAuth, clerkClient } from '@clerk/clerk-sdk-node';
+import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';
 import { Router } from 'express';
 
 const router = Router();
 
-router.use(ClerkExpressRequireAuth({ clerkClient }));
+router.use(ClerkExpressRequireAuth());
 
 router.get('/me', async (req, reply: Response) => {
   return reply.json({ auth: req.auth });

--- a/playground/express/src/routes/public.ts
+++ b/playground/express/src/routes/public.ts
@@ -1,6 +1,10 @@
 import { Router } from 'express';
+import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
 const router = Router();
+
+const experimental_isApiRoute = (url: URL) => url.pathname === '/public';
+router.use(ClerkExpressWithAuth({ experimental_isApiRoute }));
 
 router.get('/public', async (_req, reply) => {
   return reply.json({ hello: 'world' });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Handle interstitial as signed-out for API routes.
Example usages
```typescript
// 1. @clerk/backend
import { clerkClient } from "@clerk/backend";

clerkClient.authenticateRequest({
  experimental_ignoreInterstitial: true
});

// 2. @clerk/clerk-sdk-node with optional authentication for specific route

import { ClerkExpressWithAuth } from '@clerk/clerk-sdk-node';

const experimentalIsApiRoute = (url: URL) => url.pathname == '/public';
router.use(ClerkExpressWithAuth({ experimental_isApiRoute }));

// 3. @clerk/clerk-sdk-node with required authentication for all routes

import { ClerkExpressRequireAuth } from '@clerk/clerk-sdk-node';

router.use(ClerkExpressRequireAuth({ experimental_isApiRoute: true }));
```
<!-- Fixes # (issue number) -->
