### PR TITLE
Non browsers requests to satellite apps  should not throw intestitial

### DIFF
--- a/.changeset/proud-cycles-type.md
+++ b/.changeset/proud-cycles-type.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Treat expired JWT as signed-out state for requests originated from non-browser clients on satellite apps


### PR DESCRIPTION
Requests to satellite apps visited by non browsers should be treated as signed out

This is necessary, because tools like `opengraph.xyz` will not follow redirects, and they will always end up with parsing our interstitial template.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
