### PR TITLE
fix(backend): Make all 4 keys (legacy and new) optional in `authenticateRequest`

### DIFF
--- a/.changeset/shaggy-spiders-sit.md
+++ b/.changeset/shaggy-spiders-sit.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+---
+
+Make all 4 keys (legacy and new) optional in authenticateRequest params

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -3,8 +3,6 @@ import { createBackendApiClient } from './api';
 import type { CreateAuthenticateRequestOptions } from './tokens';
 import { createAuthenticateRequest } from './tokens';
 
-export type { InstanceKeys } from './tokens';
-
 export * from './api/resources';
 export * from './tokens';
 export * from './tokens/jwt';

--- a/packages/backend/src/tokens/index.ts
+++ b/packages/backend/src/tokens/index.ts
@@ -8,4 +8,3 @@ export {
   OptionalVerifyTokenOptions,
   RequiredVerifyTokenOptions,
 } from './request';
-export type { InstanceKeys } from './request';

--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -26,7 +26,7 @@ const isBrowser = (userAgent: string | undefined) => VALID_USER_AGENTS.test(user
 // automatically treated as signed out. This exception is needed for development, because the any // missing uat throws an interstitial in development.
 export const nonBrowserRequestInDevRule: InterstitialRule = options => {
   const { apiKey, secretKey, userAgent } = options;
-  const key = secretKey || apiKey;
+  const key = secretKey || apiKey || '';
   if (isDevelopmentFromApiKey(key) && !isBrowser(userAgent)) {
     return signedOut(options, AuthErrorReason.HeaderMissingNonBrowser);
   }
@@ -53,7 +53,7 @@ export const crossOriginRequestWithoutHeader: InterstitialRule = options => {
 
 export const isPrimaryInDevAndRedirectsToSatellite: InterstitialRule = options => {
   const { apiKey, secretKey, isSatellite, searchParams } = options;
-  const key = secretKey || apiKey;
+  const key = secretKey || apiKey || '';
   const isDev = isDevelopmentFromApiKey(key);
 
   if (isDev && !isSatellite && shouldRedirectToSatelliteUrl(searchParams)) {
@@ -64,7 +64,7 @@ export const isPrimaryInDevAndRedirectsToSatellite: InterstitialRule = options =
 
 export const potentialFirstLoadInDevWhenUATMissing: InterstitialRule = options => {
   const { apiKey, secretKey, clientUat } = options;
-  const key = secretKey || apiKey;
+  const key = secretKey || apiKey || '';
   const res = isDevelopmentFromApiKey(key);
   if (res && !clientUat) {
     return interstitial(options, AuthErrorReason.CookieUATMissing);
@@ -80,7 +80,7 @@ export const potentialRequestAfterSignInOrOutFromClerkHostedUiInDev: Interstitia
   const { apiKey, secretKey, referrer, host, forwardedHost, forwardedPort, forwardedProto } = options;
   const crossOriginReferrer =
     referrer && checkCrossOrigin({ originURL: new URL(referrer), host, forwardedHost, forwardedPort, forwardedProto });
-  const key = secretKey || apiKey;
+  const key = secretKey || apiKey || '';
 
   if (isDevelopmentFromApiKey(key) && crossOriginReferrer) {
     return interstitial(options, AuthErrorReason.CrossOriginReferrer);
@@ -91,7 +91,7 @@ export const potentialRequestAfterSignInOrOutFromClerkHostedUiInDev: Interstitia
 export const satelliteInDevReturningFromPrimary: InterstitialRule = options => {
   const { apiKey, secretKey, isSatellite, searchParams } = options;
 
-  const key = secretKey || apiKey;
+  const key = secretKey || apiKey || '';
 
   if (isSatellite && isReturningFromPrimary(searchParams) && isDevelopmentFromApiKey(key)) {
     return interstitial(options, AuthErrorReason.SatelliteReturnsFromPrimary);
@@ -101,7 +101,7 @@ export const satelliteInDevReturningFromPrimary: InterstitialRule = options => {
 
 export const potentialFirstRequestOnProductionEnvironment: InterstitialRule = options => {
   const { apiKey, secretKey, clientUat, cookieToken } = options;
-  const key = secretKey || apiKey;
+  const key = secretKey || apiKey || '';
 
   if (isProductionFromApiKey(key) && !clientUat && !cookieToken) {
     return signedOut(options, AuthErrorReason.CookieAndUATMissing);
@@ -189,7 +189,7 @@ async function verifyRequestState(options: AuthenticateRequestOptions, token: st
 export const isSatelliteAndNeedsSyncing: InterstitialRule = options => {
   const { clientUat, isSatellite, searchParams, secretKey, apiKey, userAgent } = options;
 
-  const key = secretKey || apiKey;
+  const key = secretKey || apiKey || '';
   const isDev = isDevelopmentFromApiKey(key);
 
   const isSignedOut = !clientUat || clientUat === '0';

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -40,57 +40,18 @@ export type OptionalVerifyTokenOptions = Partial<
   >
 >;
 
-type PublicKeys =
-  | {
-      publishableKey: string;
-      /**
-       * @deprecated Use `publishableKey` instead.
-       */
-      frontendApi: never;
-    }
-  | {
-      publishableKey: never;
-      /**
-       * @deprecated Use `publishableKey` instead.
-       */
-      frontendApi: string;
-    }
-  | {
-      publishableKey: string;
-      /**
-       * @deprecated Use `publishableKey` instead.
-       */
-      frontendApi: string;
-    };
-
-type SecretKeys =
-  | {
-      secretKey: string;
-      /**
-       * @deprecated Use `secretKey` instead.
-       */
-      apiKey: never;
-    }
-  | {
-      secretKey: never;
-      /**
-       * @deprecated Use `secretKey` instead.
-       */
-      apiKey: string;
-    }
-  | {
-      secretKey: string;
-      /**
-       * @deprecated Use `secretKey` instead.
-       */
-      apiKey: string;
-    };
-
-export type InstanceKeys = PublicKeys & SecretKeys;
-
-export type AuthenticateRequestOptions = InstanceKeys &
-  OptionalVerifyTokenOptions &
+export type AuthenticateRequestOptions = OptionalVerifyTokenOptions &
   LoadResourcesOptions & {
+    publishableKey?: string;
+    secretKey?: string;
+    /**
+     * @deprecated Use `publishableKey` instead.
+     */
+    frontendApi?: string;
+    /**
+     * @deprecated Use `secretKey` instead.
+     */
+    apiKey?: string;
     apiVersion?: string;
     apiUrl?: string;
     /* Client token cookie value */
@@ -156,7 +117,7 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
   assertValidSecretKey(options.secretKey || options.apiKey);
 
   if (options.isSatellite) {
-    assertSignInUrlExists(options.signInUrl, options.secretKey || options.apiKey);
+    assertSignInUrlExists(options.signInUrl, (options.secretKey || options.apiKey) as string);
     assertProxyUrlOrDomain(options.proxyUrl || options.domain);
   }
 

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -57,7 +57,7 @@ export const authenticateRequest = (opts: AuthenticateRequestParams) => {
     throw new Error(satelliteAndMissingProxyUrlAndDomain);
   }
 
-  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromApiKey(secretKey || apiKey)) {
+  if (isSatellite && !isHttpOrHttps(signInUrl) && isDevelopmentFromApiKey(secretKey || apiKey || '')) {
     throw new Error(satelliteAndMissingSignInUrl);
   }
 

--- a/packages/sdk-node/src/types.ts
+++ b/packages/sdk-node/src/types.ts
@@ -1,4 +1,4 @@
-import type { AuthenticateRequestOptions, AuthObject, Clerk, InstanceKeys, SignedInAuthObject } from '@clerk/backend';
+import type { AuthenticateRequestOptions, AuthObject, Clerk, SignedInAuthObject } from '@clerk/backend';
 import type { MultiDomainAndOrProxy } from '@clerk/types';
 import type { NextFunction, Request, Response } from 'express';
 import type { IncomingMessage } from 'http';
@@ -38,8 +38,18 @@ export type ClerkMiddlewareOptions = {
 
 export type ClerkClient = ReturnType<typeof Clerk>;
 
-export type AuthenticateRequestParams = InstanceKeys & {
+export type AuthenticateRequestParams = {
   clerkClient: ClerkClient;
+  publishableKey?: string;
+  secretKey?: string;
+  /**
+   * @deprecated Use `publishableKey` instead.
+   */
+  frontendApi?: string;
+  /**
+   * @deprecated Use `secretKey` instead.
+   */
+  apiKey?: string;
   req: IncomingMessage;
   options?: ClerkMiddlewareOptions;
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Make all 4 keys (legacy and new) optional in `authenticateRequest`. That will make the `@clerk/backend` easier to use.
<!-- Fixes # (issue number) -->
