### PR TITLE
fix(clerk-sdk-node): Add jwtKey in api envs and use it redwood compatibility

### DIFF
--- a/.changeset/lucky-panthers-draw.md
+++ b/.changeset/lucky-panthers-draw.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-sdk-node': patch
+---
+
+Load `jwtKey` from `CLERK_JWT_KEY` env variable

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -30,10 +30,11 @@ export function Clerk(options: ClerkOptions) {
 
 const createBasePropForRedwoodCompatibility = () => {
   const verifySessionToken = (token: string) => {
+    const { jwtKey } = loadApiEnv();
     const { payload } = decodeJwt(token);
     return _verifyToken(token, {
       issuer: payload.iss,
-      jwtKey: process.env.CLERK_JWT_KEY,
+      jwtKey,
     });
   };
   return { base: { verifySessionToken } };

--- a/packages/sdk-node/src/utils.ts
+++ b/packages/sdk-node/src/utils.ts
@@ -32,5 +32,6 @@ export const loadApiEnv = () => {
     proxyUrl: process.env.CLERK_PROXY_URL || '',
     signInUrl: process.env.CLERK_SIGN_IN_URL || '',
     isSatellite: process.env.CLERK_IS_SATELLITE === 'true',
+    jwtKey: process.env.CLERK_JWT_KEY || '',
   };
 };


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
