### PR TITLE
feat(backend): Deprecate clockSkewInSeconds in favour of clockSkewInMs

### DIFF
--- a/.changeset/smooth-crabs-build.md
+++ b/.changeset/smooth-crabs-build.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+The `clockSkewInSeconds` property is now deprecated from the `verifyJWT` options in favour of the new `clockSkewInMs` property. The old value incorrectly accepted a value in milliseconds so the behaviour will remain the same.

--- a/.changeset/smooth-crabs-build.md
+++ b/.changeset/smooth-crabs-build.md
@@ -2,4 +2,4 @@
 '@clerk/backend': minor
 ---
 
-The `clockSkewInSeconds` property is now deprecated from the `verifyJWT` options in favour of the new `clockSkewInMs` property. The old value incorrectly accepted a value in milliseconds so the behaviour will remain the same.
+The `clockSkewInSeconds` property is now deprecated from the `verifyJWT` options in favour of the new `clockSkewInMs` property. The old property accepted a value in milliseconds, so this change fixes the property name.

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -36,7 +36,13 @@ export type RequiredVerifyTokenOptions = Required<
 export type OptionalVerifyTokenOptions = Partial<
   Pick<
     VerifyTokenOptions,
-    'audience' | 'authorizedParties' | 'clockSkewInSeconds' | 'jwksCacheTtlInMs' | 'skipJwksCache' | 'jwtKey'
+    | 'audience'
+    | 'authorizedParties'
+    | 'clockSkewInSeconds'
+    | 'clockSkewInMs'
+    | 'jwksCacheTtlInMs'
+    | 'skipJwksCache'
+    | 'jwtKey'
   >
 >;
 

--- a/packages/backend/src/tokens/verify.ts
+++ b/packages/backend/src/tokens/verify.ts
@@ -11,7 +11,7 @@ import { loadClerkJWKFromLocal, loadClerkJWKFromRemote } from './keys';
  */
 export type VerifyTokenOptions = Pick<
   VerifyJwtOptions,
-  'authorizedParties' | 'audience' | 'issuer' | 'clockSkewInSeconds'
+  'authorizedParties' | 'audience' | 'issuer' | 'clockSkewInSeconds' | 'clockSkewInMs'
 > & { jwtKey?: string; proxyUrl?: string } & Pick<
     LoadClerkJWKFromRemoteOptions,
     'apiKey' | 'secretKey' | 'apiUrl' | 'apiVersion' | 'jwksCacheTtlInMs' | 'skipJwksCache'
@@ -26,6 +26,7 @@ export async function verifyToken(token: string, options: VerifyTokenOptions): P
     audience,
     authorizedParties,
     clockSkewInSeconds,
+    clockSkewInMs,
     issuer,
     jwksCacheTtlInMs,
     jwtKey,
@@ -57,6 +58,7 @@ export async function verifyToken(token: string, options: VerifyTokenOptions): P
     audience,
     authorizedParties,
     clockSkewInSeconds,
+    clockSkewInMs,
     key,
     issuer,
   });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The `clockSkewInSeconds` property is now deprecated from the `verifyJWT` options in favour of the new `clockSkewInMs` property. The old value incorrectly accepted a value in milliseconds so the behaviour will remain the same.
<!-- Fixes # (issue number) -->
