### PR TITLE
fix(clerk-js,types): Add keys targeting avatar buttons

### DIFF
--- a/.changeset/stupid-worms-change.md
+++ b/.changeset/stupid-worms-change.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Enable the ability to target the avatar upload and remove action buttons

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -99,6 +99,9 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
 
   'avatarBox',
   'avatarImage',
+  'avatarImageActions',
+  'avatarImageActionsUpload',
+  'avatarImageActionsReset',
 
   'userButtonBox',
   'userButtonOuterIdentifier',

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -101,7 +101,7 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'avatarImage',
   'avatarImageActions',
   'avatarImageActionsUpload',
-  'avatarImageActionsReset',
+  'avatarImageActionsRemove',
 
   'userButtonBox',
   'userButtonOuterIdentifier',

--- a/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
+++ b/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type { LocalizationKey } from '../customizables';
-import { Button, Col, Flex, localizationKeys, Text } from '../customizables';
+import { Button, Col, descriptors, Flex, localizationKeys, Text } from '../customizables';
 import { handleError } from '../utils';
 import { useCardState } from './contexts';
 import { FileDropArea } from './FileDropArea';
@@ -67,8 +67,12 @@ export const AvatarUploader = (props: AvatarUploaderProps) => {
             localizationKey={title}
             variant='regularMedium'
           />
-          <Flex gap={4}>
+          <Flex
+            elementDescriptor={descriptors.avatarImageActions}
+            gap={4}
+          >
             <Button
+              elementDescriptor={descriptors.avatarImageActionsUpload}
               localizationKey={
                 !showUpload
                   ? localizationKeys('userProfile.profilePage.imageFormSubtitle')
@@ -84,6 +88,7 @@ export const AvatarUploader = (props: AvatarUploaderProps) => {
 
             {!!onAvatarRemove && !showUpload && (
               <Button
+                elementDescriptor={descriptors.avatarImageActionsReset}
                 localizationKey={localizationKeys('userProfile.profilePage.imageFormDestructiveActionSubtitle')}
                 isDisabled={card.isLoading}
                 sx={t => ({ color: t.colors.$danger500 })}

--- a/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
+++ b/packages/clerk-js/src/ui/elements/AvatarUploader.tsx
@@ -88,7 +88,7 @@ export const AvatarUploader = (props: AvatarUploaderProps) => {
 
             {!!onAvatarRemove && !showUpload && (
               <Button
-                elementDescriptor={descriptors.avatarImageActionsReset}
+                elementDescriptor={descriptors.avatarImageActionsRemove}
                 localizationKey={localizationKeys('userProfile.profilePage.imageFormDestructiveActionSubtitle')}
                 isDisabled={card.isLoading}
                 sx={t => ({ color: t.colors.$danger500 })}

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -238,6 +238,9 @@ export type ElementsConfig = {
 
   avatarBox: WithOptions<never, never, never>;
   avatarImage: WithOptions<never, never, never>;
+  avatarImageActions: WithOptions<never, never, never>;
+  avatarImageActionsUpload: WithOptions<never, never, never>;
+  avatarImageActionsReset: WithOptions<never, never, never>;
 
   // TODO: We can remove "Popover" from these:
   userButtonBox: WithOptions<never, 'open', never>;

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -240,7 +240,7 @@ export type ElementsConfig = {
   avatarImage: WithOptions<never, never, never>;
   avatarImageActions: WithOptions<never, never, never>;
   avatarImageActionsUpload: WithOptions<never, never, never>;
-  avatarImageActionsReset: WithOptions<never, never, never>;
+  avatarImageActionsRemove: WithOptions<never, never, never>;
 
   // TODO: We can remove "Popover" from these:
   userButtonBox: WithOptions<never, 'open', never>;


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Enables the ability to target the Avatar upload and remove action buttons.

<!-- Fixes # (issue number) -->
Fixes USR-98