### PR TITLE
Remove user identifiers from OrganizationSwitcher + Hide avatar on `hidePersonal`

### DIFF
--- a/.changeset/six-carrots-visit.md
+++ b/.changeset/six-carrots-visit.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+---
+Changes to OrganizationSwitcher
+- Removal of user identifier from the trigger & popover
+- Hidden avatar of active user when `hidePersonal` is true

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -52,6 +52,8 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
     } = useOrganizationSwitcherContext();
 
     const user = useCoreUser();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { username, primaryEmailAddress, primaryPhoneNumber, ...userWithoutIdentifiers } = user;
 
     if (!isLoaded) {
       return null;
@@ -139,7 +141,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
               !hidePersonal && (
                 <PersonalWorkspacePreview
                   gap={4}
-                  user={user}
+                  user={userWithoutIdentifiers}
                   sx={theme => ({ padding: `0 ${theme.space.$6}`, marginBottom: theme.space.$6 })}
                   title={localizationKeys('organizationSwitcher.personalWorkspace')}
                 />

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -41,6 +41,7 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
             size={'sm'}
             gap={3}
             user={userWithoutIdentifiers}
+            showAvatar={!hidePersonal}
             title={
               hidePersonal
                 ? localizationKeys('organizationSwitcher.notSelected')

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherTrigger.tsx
@@ -13,7 +13,8 @@ type OrganizationSwitcherTriggerProps = PropsOfComponent<typeof Button> & {
 export const OrganizationSwitcherTrigger = withAvatarShimmer(
   forwardRef<HTMLButtonElement, OrganizationSwitcherTriggerProps>((props, ref) => {
     const { sx, ...rest } = props;
-    const user = useCoreUser();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { username, primaryEmailAddress, primaryPhoneNumber, ...userWithoutIdentifiers } = useCoreUser();
     const { organization } = useCoreOrganization();
     const { hidePersonal } = useOrganizationSwitcherContext();
 
@@ -39,7 +40,7 @@ export const OrganizationSwitcherTrigger = withAvatarShimmer(
           <PersonalWorkspacePreview
             size={'sm'}
             gap={3}
-            user={user}
+            user={userWithoutIdentifiers}
             title={
               hidePersonal
                 ? localizationKeys('organizationSwitcher.notSelected')

--- a/packages/clerk-js/src/ui/elements/UserPreview.tsx
+++ b/packages/clerk-js/src/ui/elements/UserPreview.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { getFullName, getIdentifier } from '../../utils/user';
 import type { LocalizationKey } from '../customizables';
 import { descriptors, Flex, Text, useLocalizations } from '../customizables';
-import type { PropsOfComponent, ThemableCssProp } from '../styledSystem';
+import type { InternalTheme, PropsOfComponent, ThemableCssProp } from '../styledSystem';
 import { UserAvatar } from './UserAvatar';
 
 // TODO Make this accept an interface with the superset of fields in:
@@ -66,6 +66,8 @@ export const UserPreview = (props: UserPreviewProps) => {
 
   const imageUrl = imageUrlProp || user?.imageUrl || externalAccount?.imageUrl;
 
+  const getAvatarSizes = (t: InternalTheme) => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size]);
+
   return (
     <Flex
       elementDescriptor={descriptors.userPreview}
@@ -75,7 +77,7 @@ export const UserPreview = (props: UserPreviewProps) => {
       sx={[{ minWidth: '0px', width: '100%' }, sx]}
       {...rest}
     >
-      {showAvatar && (
+      {showAvatar ? (
         <Flex
           elementDescriptor={descriptors.userPreviewAvatarContainer}
           elementId={descriptors.userPreviewAvatarContainer.setId(elementId)}
@@ -90,13 +92,23 @@ export const UserPreview = (props: UserPreviewProps) => {
             {...samlAccount}
             name={name}
             avatarUrl={imageUrl}
-            size={t => ({ sm: t.sizes.$8, md: t.sizes.$11, lg: t.sizes.$12x5 }[size])}
+            size={getAvatarSizes}
             sx={avatarSx}
             rounded={rounded}
           />
 
           {icon && <Flex sx={{ position: 'absolute', left: 0, bottom: 0 }}>{icon}</Flex>}
         </Flex>
+      ) : (
+        // Reserve layout space when avatar is not visible
+        <Flex
+          elementDescriptor={descriptors.userPreviewAvatarContainer}
+          elementId={descriptors.userPreviewAvatarContainer.setId(elementId)}
+          justify='center'
+          sx={t => ({
+            height: getAvatarSizes(t),
+          })}
+        />
       )}
 
       <Flex


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
### Removing the identifier from the popover  & trigger
![image](https://github.com/clerkinc/javascript/assets/19269911/f3251ea9-c52a-4ca2-9a24-0644132a686c)

### `hidePersonal` removes avatar of user
![image](https://github.com/clerkinc/javascript/assets/19269911/29da87b6-d276-423e-a3f9-cffadf3ca898)



<!-- Fixes # (issue number) -->
