### PR TITLE
chore(shared): Deprecate useOrganizations

### DIFF
--- a/.changeset/nervous-poets-remember.md
+++ b/.changeset/nervous-poets-remember.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': minor
+---
+
+Deprecate the `useOrganizations` react hook. The hook can be replaced from useClerk, useOrganization, useOrganizationList

--- a/packages/shared/src/hooks/useOrganizations.tsx
+++ b/packages/shared/src/hooks/useOrganizations.tsx
@@ -5,19 +5,51 @@ import { useClerkInstanceContext } from './contexts';
 type UseOrganizationsReturn =
   | {
       isLoaded: false;
+
+      /**
+       * @deprecated Use `createOrganization` from `useOrganizationList`
+       * Example const {createOrganization} = useOrganizationList()
+       */
       createOrganization: undefined;
+
+      /**
+       * @deprecated Use `membershipList` from `useOrganization`
+       * Example const {membershipList} = useOrganization()
+       */
       getOrganizationMemberships: undefined;
+
+      /**
+       * @deprecated Use `getOrganization` from `useClerk`
+       * Example const {getOrganization} = useClerk()
+       */
       getOrganization: undefined;
     }
   | {
       isLoaded: true;
+      /**
+       * @deprecated Use `createOrganization` from `useOrganizationList`
+       * Example const {createOrganization} = useOrganizationList()
+       */
       createOrganization: (params: CreateOrganizationParams) => Promise<OrganizationResource>;
+
+      /**
+       * @deprecated Use `membershipList` from `useOrganization`
+       * Example const {membershipList} = useOrganization()
+       */
       getOrganizationMemberships: () => Promise<OrganizationMembershipResource[]>;
+
+      /**
+       * @deprecated Use `getOrganization` from `useClerk`
+       * Example const {getOrganization} = useClerk()
+       */
       getOrganization: (organizationId: string) => Promise<OrganizationResource | undefined>;
     };
 
 type UseOrganizations = () => UseOrganizationsReturn;
 
+/**
+ * @deprecated Use useOrganizationList, useOrganization, or useClerk instead
+ */
 export const useOrganizations: UseOrganizations = () => {
   const clerk = useClerkInstanceContext();
   if (!clerk.loaded) {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

The `useOrganizations` only contains logic that can be directly exported from `useClerk()` and `useOrganization` and `useOrganizationList` can be used as replacement with more functionality and better DX

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
