### PR TITLE
fix(backend): Access the correct headers to determine the Response Content-Type

### DIFF
--- a/.changeset/four-monkeys-smell.md
+++ b/.changeset/four-monkeys-smell.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix the headers checked to determine the Response Content-Type

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -2,7 +2,7 @@ import type { ClerkAPIError, ClerkAPIErrorJSON } from '@clerk/types';
 import deepmerge from 'deepmerge';
 import snakecaseKeys from 'snakecase-keys';
 
-import { API_URL, API_VERSION, USER_AGENT } from '../constants';
+import { API_URL, API_VERSION, constants, USER_AGENT } from '../constants';
 // DO NOT CHANGE: Runtime needs to be imported as a default export so that we can stub its dependencies with Sinon.js
 // For more information refer to https://sinonjs.org/how-to/stub-dependency/
 import runtime from '../runtime';
@@ -128,7 +128,8 @@ export function buildRequest(options: CreateBackendApiOptions) {
       }
 
       // TODO: Parse JSON or Text response based on a response header
-      const isJSONResponse = headers['Content-Type'] === 'application/json';
+      const isJSONResponse =
+        res?.headers && res.headers?.get(constants.Headers.ContentType) === constants.ContentTypes.Json;
       const data = await (isJSONResponse ? res.json() : res.text());
 
       if (!res.ok) {

--- a/packages/backend/src/util/mockFetch.ts
+++ b/packages/backend/src/util/mockFetch.ts
@@ -1,11 +1,11 @@
+import { constants } from '../constants';
+
 export function jsonOk(body: unknown, status = 200) {
   // Mock response object that satisfies the window.Response interface
   const mockResponse = {
     ok: true,
     status,
-    headers: {
-      'Content-type': 'application/json',
-    },
+    headers: { get: mockHeadersGet },
     json() {
       return Promise.resolve(body);
     },
@@ -19,9 +19,7 @@ export function jsonNotOk(body: unknown) {
   const mockResponse = {
     ok: false,
     status: 422,
-    headers: {
-      'Content-type': 'application/json',
-    },
+    headers: { get: mockHeadersGet },
     json() {
       return Promise.resolve(body);
     },
@@ -35,9 +33,7 @@ export function jsonError(body: unknown, status = 500) {
   const mockResponse = {
     ok: false,
     status: status,
-    headers: {
-      'Content-type': 'application/json',
-    },
+    headers: { get: mockHeadersGet },
     json() {
       return Promise.resolve(body);
     },
@@ -45,3 +41,5 @@ export function jsonError(body: unknown, status = 500) {
 
   return Promise.resolve(mockResponse);
 }
+
+const mockHeadersGet = (key: string) => (key === constants.Headers.ContentType ? constants.ContentTypes.Json : null);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR introduces a small fix for the Response Headers Content-Type check.
<!-- Fixes # (issue number) -->
