### PR TITLE
fix(clerk-js): In <CreateOrganization /> skip invitation page if max allowed memberships equal 1

### DIFF
--- a/.changeset/thin-hounds-arrive.md
+++ b/.changeset/thin-hounds-arrive.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+In the <CreateOrganization /> component, if the newly created organization has max allowed membership equal to 1, skip the invitation page


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This commit modifies the logic of the <CreateOrganization /> component to handle the case the newly create organization has max allowed memberships equal to 1. In this case, we shouldn't render the invitation page, as the user can't invite any more members, and they will need to skip it either way

### Before

https://github.com/clerkinc/javascript/assets/22435234/b53378f0-1326-40c2-9e30-1d6daba6702b

### After

https://github.com/clerkinc/javascript/assets/22435234/b67868b5-ee15-4bfa-9ecf-caddecdcf394

<!-- Fixes # (issue number) -->
