### PR TITLE
fix(clerk-js): Remove leftover strings in SignInStart and SignUpStart

### DIFF
--- a/.changeset/fifty-keys-burn.md
+++ b/.changeset/fifty-keys-burn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixed a bug where overriding some localization values in the sign in/up start pages with an empty string would result in showing the english translation.

--- a/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/SignInStart.tsx
@@ -278,22 +278,18 @@ export function _SignInStart(): JSX.Element {
                   />
                 </Form.ControlRow>
                 <InstantPasswordRow field={passwordBasedInstance ? instantPasswordField : undefined} />
-                <Form.SubmitButton>Continue</Form.SubmitButton>
+                <Form.SubmitButton />
               </Form.Root>
             ) : null}
           </SocialButtonsReversibleContainerWithDivider>
         </Col>
         <Footer.Root>
           <Footer.Action elementId='signIn'>
-            <Footer.ActionText localizationKey={localizationKeys('signIn.start.actionText')}>
-              No account?
-            </Footer.ActionText>
+            <Footer.ActionText localizationKey={localizationKeys('signIn.start.actionText')} />
             <Footer.ActionLink
               localizationKey={localizationKeys('signIn.start.actionLink')}
               to={clerk.buildUrlWithAuth(signUpUrl)}
-            >
-              Sign up
-            </Footer.ActionLink>
+            />
           </Footer.Action>
           <Footer.Links />
         </Footer.Root>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -240,10 +240,8 @@ function _SignUpStart(): JSX.Element {
       <Card>
         <CardAlert>{card.error}</CardAlert>
         <Header.Root>
-          <Header.Title localizationKey={localizationKeys('signUp.start.title')}>Create your account</Header.Title>
-          <Header.Subtitle localizationKey={localizationKeys('signUp.start.subtitle')}>
-            to continue to {displayConfig.applicationName}
-          </Header.Subtitle>
+          <Header.Title localizationKey={localizationKeys('signUp.start.title')} />
+          <Header.Subtitle localizationKey={localizationKeys('signUp.start.subtitle')} />
         </Header.Root>
         <Flex
           direction='col'
@@ -271,9 +269,7 @@ function _SignUpStart(): JSX.Element {
         </Flex>
         <Footer.Root>
           <Footer.Action elementId='signUp'>
-            <Footer.ActionText localizationKey={localizationKeys('signUp.start.actionText')}>
-              Have an account?
-            </Footer.ActionText>
+            <Footer.ActionText localizationKey={localizationKeys('signUp.start.actionText')} />
             <Footer.ActionLink
               localizationKey={localizationKeys('signUp.start.actionLink')}
               to={clerk.buildUrlWithAuth(signInUrl)}


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Although this doesn't seem like a big deal, it causes problem when a developer wants to override a value with an empty string. When that happens, we would render the children that I've removed instead of the empty string.

<!-- Fixes # (issue number) -->
