### PR TITLE
chore(repo): Streamline the development flow for the app-router playground

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Please note we have a [code of conduct](https://github.com/clerkinc/javascript/b
 
 ## Developing locally
 
-This section is a work-in-progress. More details will be added soon.
+_This section is a work-in-progress. More details will be added soon._
 
 ### Monorepo setup
 
@@ -69,6 +69,37 @@ For package specific setup, refer to the `Build` section of the specific package
 ### Making changes to packages
 
 WIP
+
+#### Using fixtures
+
+This monorepo contains a number of fixtures called "playgrounds" that are used to test Clerk's JavaScript SDKs. To get started, run the development command:
+
+```
+npm run dev
+```
+
+##### `playgrounds/app-router`
+
+This fixture contains a Clerk / Next.js integration. Using your Clerk keys, add the following environment variables to `playgrounds/app-router/.env.local`. Refer to the [Get started with Next.js](https://clerk.com/docs/nextjs/get-started-with-nextjs) for additional information.
+
+```
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=<Your pk>
+CLERK_SECRET_KEY=<Your sk>
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
+```
+
+To start the fixture, run the following:
+
+```
+cd packages/app-router
+npm install
+npm run dev
+```
+
+Changes to the local `clerk-js`, `nextjs` and `clerk-react` packages should reflect in the running development app.
 
 ### Making changes to the hot-loaded `clerk-js`
 

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -238,12 +238,12 @@ const devConfig = ({ mode, env }) => {
         rules: [svgLoader(), typescriptLoaderDev()],
       },
       plugins: [
-        new ReactRefreshWebpackPlugin({ overlay: { sockHost: 'js.lclclerk.com' } }),
+        new ReactRefreshWebpackPlugin({ overlay: { sockHost: 'http://localhost:4000' } }),
         ...(env.serveAnalyzer ? [new BundleAnalyzerPlugin()] : []),
       ],
       devtool: 'eval-cheap-source-map',
       output: {
-        publicPath: 'https://js.lclclerk.com/npm/',
+        publicPath: 'http://localhost:4000/npm/',
         crossOriginLoading: 'anonymous',
         filename: `${variant}.js`,
         libraryTarget: 'umd',
@@ -258,7 +258,7 @@ const devConfig = ({ mode, env }) => {
         port: 4000,
         hot: true,
         liveReload: false,
-        client: { webSocketURL: 'auto://js.lclclerk.com/ws' },
+        client: { webSocketURL: 'auto://localhost:4000/ws' },
       },
     };
   };

--- a/packages/nextjs/tsup.config.ts
+++ b/packages/nextjs/tsup.config.ts
@@ -40,9 +40,9 @@ export default defineConfig(overrideOptions => {
   const copyPackageJson = (format: 'esm' | 'cjs') => `cp ./package.${format}.json ./dist/${format}/package.json`;
 
   return runAfterLast([
-    'npm run build:declarations',
     copyPackageJson('esm'),
     copyPackageJson('cjs'),
+    'npm run build:declarations',
     shouldPublish && 'npm run publish:local',
   ])(esm, cjs);
 });

--- a/playground/app-router/package.json
+++ b/playground/app-router/package.json
@@ -4,19 +4,14 @@
   "private": true,
   "scripts": {
     "dev:yalc": "npm run yalc && rm -rf .next && next dev --port 4011",
-    "yalc": "yalc add -- @clerk/nextjs @clerk/clerk-react @clerk/backend @clerk/types @clerk/shared",
     "dev": "next dev --port 4011",
     "build": "next build",
-    "build:yalc": "npm run yalc && rm -rf .next && next build",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
-    "@clerk/backend": "file:.yalc/@clerk/backend",
-    "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
-    "@clerk/nextjs": "file:.yalc/@clerk/nextjs",
-    "@clerk/shared": "file:.yalc/@clerk/shared",
-    "@clerk/types": "file:.yalc/@clerk/types",
+    "@clerk/nextjs": "file:../../packages/nextjs",
+    "@clerk/clerk-react": "file:../../packages/react",
     "@types/node": "18.16.0",
     "@types/react": "18.0.38",
     "@types/react-dom": "18.0.11",

--- a/playground/app-router/src/app/layout.tsx
+++ b/playground/app-router/src/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   // console.log(auth());
   return (
-    <ClerkProvider clerkJSUrl={'https://js.lclclerk.com/npm/clerk.browser.js'}>
+    <ClerkProvider clerkJSUrl={'http://localhost:4000/npm/clerk.browser.js'}>
       <html lang='en'>
         <body className={inter.className}>
           <Links />


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [x] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Streamlines the local dev setup for our `app-router` playground. There are two main changes that were made here to facilitate this:

### Remove reliance on the local proxy to serve the `clerk-js` bundle

This simplifies the setup without sacrificing HMR. `clerk-js` already exposes a webpack dev server at `localhost:4000`, so we can leverage that in conjunction with the `clerkJSUrl` prop.

### Remove reliance on `yalc`

This simplifies propagating updates made to the packages locally. Previously, we would need to `yalc push` any impacted packages and then pull these changes into the playground. Due to the way `yalc` works, it also requires next's development server to be restarted and its build cache to be wiped in between changes. This is a pretty big point of friction.

### Docs updates

I've also updated the `docs/CONTRIBUTING.md` file to outline how to run the `app-router` playground. This should make it easier for others to run the local development setup!

<!-- Fixes # (issue number) -->
