### PR TITLE
Correctly load clerk-js in clerk/chrome-extension

### DIFF
--- a/.changeset/curvy-rice-buy.md
+++ b/.changeset/curvy-rice-buy.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Experimental support for ESM and CJS for clerk-js

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -13,15 +13,18 @@
     "extension"
   ],
   "types": "./dist/types/index.d.ts",
-  "main": "./dist/index.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup --env.NODE_ENV production",
-    "clean": "rimraf ./dist",
+    "build": "tsup",
     "dev": "tsup --watch",
+    "dev:publish": "npm run dev -- --env.publish",
+    "build:declarations": "tsc -p tsconfig.declarations.json",
+    "publish:local": "npx yalc push --replace  --sig",
+    "clean": "rimraf ./dist",
     "lint": "eslint .",
     "test": "jest",
     "test:ci": "jest --maxWorkers=50%",

--- a/packages/chrome-extension/src/ClerkProvider.tsx
+++ b/packages/chrome-extension/src/ClerkProvider.tsx
@@ -1,10 +1,9 @@
-import type { ClerkProviderProps as ClerkReactProviderProps, ClerkProp } from '@clerk/clerk-react';
-import type { TokenCache } from './cache';
-
-import React from 'react';
-import { __internal__setErrorThrowerOptions, ClerkProvider as ClerkReactProvider } from '@clerk/clerk-react';
 import Clerk from '@clerk/clerk-js';
+import type { ClerkProp, ClerkProviderProps as ClerkReactProviderProps } from '@clerk/clerk-react';
+import { __internal__setErrorThrowerOptions, ClerkProvider as ClerkReactProvider } from '@clerk/clerk-react';
+import React from 'react';
 
+import type { TokenCache } from './cache';
 import { ChromeStorageCache } from './cache';
 import { buildClerk } from './singleton';
 

--- a/packages/chrome-extension/tsconfig.declarations.json
+++ b/packages/chrome-extension/tsconfig.declarations.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+    "sourceMap": false,
+    "declarationDir": "./dist/types"
+  }
+}

--- a/packages/clerk-js/package.json
+++ b/packages/clerk-js/package.json
@@ -14,7 +14,7 @@
   "author": "Clerk",
   "jsdelivr": "dist/clerk.browser.js",
   "main": "dist/clerk.js",
-  "module": "dist/clerk.js",
+  "module": "dist/clerk.mjs",
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",

--- a/playground/app-router/src/app/client/page.tsx
+++ b/playground/app-router/src/app/client/page.tsx
@@ -8,5 +8,5 @@ export default () => {
     console.log('cient/page side only component');
   });
 
-  return <div>this is a client components?</div>;
+  return <div>this is a client components</div>;
 };

--- a/playground/app-router/src/app/protected/page.tsx
+++ b/playground/app-router/src/app/protected/page.tsx
@@ -20,6 +20,7 @@ export default function Page() {
       <ClerkLoaded>
         <h2>Clerk loaded</h2>
       </ClerkLoaded>
+      <UserButton />
       <UserButton afterSignOutUrl='/' />
 
       <ClientSideWrapper>


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
This is a work in progress 
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
