### PR TITLE
chore(clerk-react): Mark `setSession` as deprecated

### DIFF
--- a/.changeset/tame-tomatoes-develop.md
+++ b/.changeset/tame-tomatoes-develop.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-react': patch
+---
+
+Mark setSession as deprecated when it is re-exported within hooks

--- a/packages/react/src/hooks/useSessionList.ts
+++ b/packages/react/src/hooks/useSessionList.ts
@@ -1,11 +1,34 @@
-import type { SetActive, SessionResource, SetSession } from '@clerk/types';
+import type { SessionResource, SetActive, SetSession } from '@clerk/types';
 
 import { useClientContext } from '../contexts/ClientContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 
 type UseSessionListReturn =
-  | { isLoaded: false; sessions: undefined; setSession: undefined; setActive: undefined }
-  | { isLoaded: true; sessions: SessionResource[]; setSession: SetSession; setActive: SetActive };
+  | {
+      isLoaded: false;
+      sessions: undefined;
+      /**
+       * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
+       * Set the current session explicitly. Setting the session to `null` unsets the active session and signs out the user.
+       * @param session Passed session resource object, session id (string version) or null
+       * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
+       */
+      setSession: undefined;
+      setActive: undefined;
+    }
+  | {
+      isLoaded: true;
+      sessions: SessionResource[];
+
+      /**
+       * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
+       * Set the current session explicitly. Setting the session to `null` unsets the active session and signs out the user.
+       * @param session Passed session resource object, session id (string version) or null
+       * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
+       */
+      setSession: SetSession;
+      setActive: SetActive;
+    };
 
 type UseSessionList = () => UseSessionListReturn;
 

--- a/packages/react/src/hooks/useSignIn.ts
+++ b/packages/react/src/hooks/useSignIn.ts
@@ -4,8 +4,30 @@ import { useClientContext } from '../contexts/ClientContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 
 type UseSignInReturn =
-  | { isLoaded: false; signIn: undefined; setSession: undefined; setActive: undefined }
-  | { isLoaded: true; signIn: SignInResource; setSession: SetSession; setActive: SetActive };
+  | {
+      isLoaded: false;
+      signIn: undefined;
+      /**
+       * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
+       * Set the current session explicitly. Setting the session to `null` unsets the active session and signs out the user.
+       * @param session Passed session resource object, session id (string version) or null
+       * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
+       */
+      setSession: undefined;
+      setActive: undefined;
+    }
+  | {
+      isLoaded: true;
+      signIn: SignInResource;
+      /**
+       * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
+       * Set the current session explicitly. Setting the session to `null` unsets the active session and signs out the user.
+       * @param session Passed session resource object, session id (string version) or null
+       * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
+       */
+      setSession: SetSession;
+      setActive: SetActive;
+    };
 
 type UseSignIn = () => UseSignInReturn;
 

--- a/packages/react/src/hooks/useSignUp.ts
+++ b/packages/react/src/hooks/useSignUp.ts
@@ -4,8 +4,30 @@ import { useClientContext } from '../contexts/ClientContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 
 type UseSignUpReturn =
-  | { isLoaded: false; signUp: undefined; setSession: undefined; setActive: undefined }
-  | { isLoaded: true; signUp: SignUpResource; setSession: SetSession; setActive: SetActive };
+  | {
+      isLoaded: false;
+      signUp: undefined;
+      /**
+       * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
+       * Set the current session explicitly. Setting the session to `null` unsets the active session and signs out the user.
+       * @param session Passed session resource object, session id (string version) or null
+       * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
+       */
+      setSession: undefined;
+      setActive: undefined;
+    }
+  | {
+      isLoaded: true;
+      signUp: SignUpResource;
+      /**
+       * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
+       * Set the current session explicitly. Setting the session to `null` unsets the active session and signs out the user.
+       * @param session Passed session resource object, session id (string version) or null
+       * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
+       */
+      setSession: SetSession;
+      setActive: SetActive;
+    };
 
 type UseSignUp = () => UseSignUpReturn;
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -278,7 +278,7 @@ export interface Clerk {
 
   /**
    * @deprecated This method is deprecated and will be removed in the future. Use {@link Clerk.setActive} instead
-   * Set the current session explicitly. Setting the session to `null` deletes the active session.
+   * Set the current session explicitly. Setting the session to `null` unsets the active session and signs out the user.
    * @param session Passed session resource object, session id (string version) or null
    * @param beforeEmit Callback run just before the active session is set to the passed object. Can be used to hook up for pre-navigation actions.
    */


### PR DESCRIPTION
This function was already deprecated but was not marked as such when re-exported from the hooks

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
