### PR TITLE
fix(fastify): Correct fastify options type

### DIFF
--- a/.changeset/smooth-avocados-compete.md
+++ b/.changeset/smooth-avocados-compete.md
@@ -1,0 +1,5 @@
+---
+"@clerk/fastify": patch
+---
+
+Pass the `ClerkFastifyOptions` to the exported fastify plugin

--- a/packages/fastify/src/clerkPlugin.test.ts
+++ b/packages/fastify/src/clerkPlugin.test.ts
@@ -6,6 +6,7 @@ jest.mock('./withClerkMiddleware', () => {
 
 import { clerkPlugin } from './clerkPlugin';
 import { createFastifyInstanceMock } from './test/utils';
+import type { ALLOWED_HOOKS } from './types';
 
 describe('clerkPlugin()', () => {
   test('adds withClerkMiddleware as preHandler by default', () => {
@@ -35,7 +36,13 @@ describe('clerkPlugin()', () => {
       const fastify = createFastifyInstanceMock();
 
       expect(() => {
-        clerkPlugin(fastify, { hookName }, doneFn);
+        clerkPlugin(
+          fastify,
+          {
+            hookName: hookName as (typeof ALLOWED_HOOKS)[number],
+          },
+          doneFn,
+        );
       }).toThrowError(`Unsupported hookName: ${hookName}`);
     },
   );

--- a/packages/fastify/src/clerkPlugin.ts
+++ b/packages/fastify/src/clerkPlugin.ts
@@ -5,7 +5,11 @@ import type { ClerkFastifyOptions } from './types';
 import { ALLOWED_HOOKS } from './types';
 import { withClerkMiddleware } from './withClerkMiddleware';
 
-const plugin: FastifyPluginCallback = (instance: FastifyInstance, opts: ClerkFastifyOptions, done) => {
+const plugin: FastifyPluginCallback<ClerkFastifyOptions> = (
+  instance: FastifyInstance,
+  opts: ClerkFastifyOptions,
+  done,
+) => {
   instance.decorateRequest('auth', null);
   // run clerk as a middleware to all scoped routes
   const hookName = opts.hookName || 'preHandler';


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [x] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected. (There was an error, not related to my work.)
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
The `ClerkFastifyOptions` type wasn't being passed through to the client, so typescript was complaining. :)

<!-- Fixes # (issue number) -->
