### PR TITLE
Construct urls based on Organization or User <OrganizationSwitcher/>

### DIFF
--- a/.changeset/strange-owls-behave.md
+++ b/.changeset/strange-owls-behave.md
@@ -1,0 +1,19 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Construct urls based on context in <OrganizationSwitcher/>
+- Deprecate `afterSwitchOrganizationUrl`
+- Introduce `afterSelectOrganizationUrl` & `afterSelectPersonalUrl`
+
+`afterSelectOrganizationUrl` accepts
+- Full URL -> 'https://clerk.com/'
+- relative path -> '/organizations'
+- relative path -> with param '/organizations/:id'
+- function that returns a string -> (org) => `/org/${org.slug}`
+`afterSelectPersonalUrl` accepts
+- Full URL -> 'https://clerk.com/'
+- relative path -> '/users'
+- relative path -> with param '/users/:username'
+- function that returns a string -> (user) => `/users/${user.id}`

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationPage.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationPage.tsx
@@ -1,3 +1,4 @@
+import type { OrganizationResource } from '@clerk/types';
 import React from 'react';
 
 import { QuestionMark } from '../../../ui/icons';
@@ -27,6 +28,7 @@ export const CreateOrganizationPage = withCardStateProvider(() => {
   const { setActive, closeCreateOrganization } = useCoreClerk();
   const { mode, navigateAfterCreateOrganization, skipInvitationScreen } = useCreateOrganizationContext();
   const { organization } = useCoreOrganization();
+  const lastCreatedOrganizationRef = React.useRef<OrganizationResource | null>(null);
 
   const wizard = useWizard({ onNextStep: () => card.setError(undefined) });
 
@@ -61,6 +63,7 @@ export const CreateOrganizationPage = withCardStateProvider(() => {
         await organization.setLogo({ file });
       }
 
+      lastCreatedOrganizationRef.current = organization;
       await setActive({ organization });
 
       if (skipInvitationScreen ?? organization.maxAllowedMemberships === 1) {
@@ -74,7 +77,9 @@ export const CreateOrganizationPage = withCardStateProvider(() => {
   };
 
   const completeFlow = () => {
-    void navigateAfterCreateOrganization();
+    // We are confident that lastCreatedOrganizationRef.current will never be null
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    void navigateAfterCreateOrganization(lastCreatedOrganizationRef.current!);
     if (mode === 'modal') {
       closeCreateOrganization();
     }

--- a/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
@@ -158,4 +158,54 @@ describe('CreateOrganization', () => {
       expect(queryByText(/Invite members/i)).not.toBeInTheDocument();
     });
   });
+
+  describe('navigation', () => {
+    it('constructs afterCreateOrganizationUrl from function', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.dev'],
+        });
+      });
+
+      const createdOrg = getCreatedOrg({
+        maxAllowedMemberships: 1,
+      });
+
+      fixtures.clerk.createOrganization.mockReturnValue(Promise.resolve(createdOrg));
+
+      props.setProps({ afterCreateOrganizationUrl: org => `/org/${org.id}` });
+      const { getByRole, userEvent, getByLabelText } = render(<CreateOrganization />, {
+        wrapper,
+      });
+      await userEvent.type(getByLabelText(/Organization name/i), 'new org');
+      await userEvent.click(getByRole('button', { name: /create organization/i }));
+
+      expect(fixtures.router.navigate).toHaveBeenCalledWith(`/org/${createdOrg.id}`);
+    });
+
+    it('constructs afterCreateOrganizationUrl from `:slug` ', async () => {
+      const { wrapper, fixtures, props } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.dev'],
+        });
+      });
+
+      const createdOrg = getCreatedOrg({
+        maxAllowedMemberships: 1,
+      });
+
+      fixtures.clerk.createOrganization.mockReturnValue(Promise.resolve(createdOrg));
+
+      props.setProps({ afterCreateOrganizationUrl: '/org/:slug' });
+      const { getByRole, userEvent, getByLabelText } = render(<CreateOrganization />, {
+        wrapper,
+      });
+      await userEvent.type(getByLabelText(/Organization name/i), 'new org');
+      await userEvent.click(getByRole('button', { name: /create organization/i }));
+
+      expect(fixtures.router.navigate).toHaveBeenCalledWith(`/org/${createdOrg.slug}`);
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -48,7 +48,8 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
       afterCreateOrganizationUrl,
       navigateCreateOrganization,
       navigateOrganizationProfile,
-      navigateAfterSwitchOrganization,
+      navigateAfterSelectPersonal,
+      navigateAfterSelectOrganization,
     } = useOrganizationSwitcherContext();
 
     const user = useCoreUser();
@@ -60,12 +61,19 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
     }
 
     const handleOrganizationClicked = (organization: OrganizationResource) => {
-      return card.runAsync(() => setActive({ organization, beforeEmit: navigateAfterSwitchOrganization })).then(close);
+      return card
+        .runAsync(() =>
+          setActive({
+            organization,
+            beforeEmit: () => navigateAfterSelectOrganization(organization),
+          }),
+        )
+        .then(close);
     };
 
     const handlePersonalWorkspaceClicked = () => {
       return card
-        .runAsync(() => setActive({ organization: null, beforeEmit: navigateAfterSwitchOrganization }))
+        .runAsync(() => setActive({ organization: null, beforeEmit: () => navigateAfterSelectPersonal(user) }))
         .then(close);
     };
 

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -131,6 +131,56 @@ describe('OrganizationSwitcher', () => {
       expect(queryByRole('button', { name: 'Create Organization' })).not.toBeInTheDocument();
     });
 
-    it.todo('switches between active organizations when one is clicked');
+    it("switches between active organizations when one is clicked'", async () => {
+      const { wrapper, props, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.dev'],
+          organization_memberships: [
+            { name: 'Org1', role: 'basic_member' },
+            { name: 'Org2', role: 'admin' },
+          ],
+          create_organization_enabled: false,
+        });
+      });
+      fixtures.clerk.setActive.mockReturnValueOnce(Promise.resolve());
+
+      props.setProps({ hidePersonal: true });
+      const { getByRole, getByText, userEvent } = render(<OrganizationSwitcher />, { wrapper });
+      await userEvent.click(getByRole('button'));
+      await userEvent.click(getByText('Org2'));
+
+      expect(fixtures.clerk.setActive).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: expect.objectContaining({
+            name: 'Org2',
+          }),
+        }),
+      );
+    });
+
+    it("switches to personal workspace when clicked'", async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withUser({
+          email_addresses: ['test@clerk.dev'],
+          organization_memberships: [
+            { name: 'Org1', role: 'basic_member' },
+            { name: 'Org2', role: 'admin' },
+          ],
+        });
+      });
+
+      fixtures.clerk.setActive.mockReturnValueOnce(Promise.resolve());
+      const { getByRole, getByText, userEvent } = render(<OrganizationSwitcher />, { wrapper });
+      await userEvent.click(getByRole('button'));
+      await userEvent.click(getByText(/Personal workspace/i));
+
+      expect(fixtures.clerk.setActive).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: null,
+        }),
+      );
+    });
   });
 });

--- a/packages/clerk-js/src/utils/__tests__/dynamicParamParser.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/dynamicParamParser.test.ts
@@ -1,0 +1,29 @@
+import { describe } from '@jest/globals';
+
+import { createDynamicParamParser } from '../dynamicParamParser';
+
+const entity = {
+  foo: 'foo_string',
+  bar: 'bar_string',
+};
+
+describe('createDynamicParamParser', () => {
+  const testCases = [
+    [':foo', entity, 'foo_string'],
+    ['/:foo', entity, '/foo_string'],
+    ['/some/:bar/any', entity, '/some/bar_string/any'],
+    ['/:notValid', entity, '/:notValid'],
+  ] as const;
+
+  it.each(testCases)(
+    'replaces the dynamic param with the value assigned to the key inside the object. Url=(%s), Object=(%s), result=(%s)',
+    (urlWithParam, obj, result) => {
+      expect(
+        createDynamicParamParser({ regex: /:(\w+)/ })({
+          urlWithParam,
+          entity: obj,
+        }),
+      ).toEqual(result);
+    },
+  );
+});

--- a/packages/clerk-js/src/utils/dynamicParamParser.ts
+++ b/packages/clerk-js/src/utils/dynamicParamParser.ts
@@ -1,0 +1,14 @@
+export const createDynamicParamParser =
+  ({ regex }: { regex: RegExp }) =>
+  <T extends Record<any, any>>({ urlWithParam, entity }: { urlWithParam: string; entity: T }) => {
+    const match = regex.exec(urlWithParam);
+
+    if (match) {
+      const key = match[1];
+      if (key in entity) {
+        const value = entity[key] as string;
+        return urlWithParam.replace(match[0], value);
+      }
+    }
+    return urlWithParam;
+  };

--- a/packages/clerk-js/src/utils/index.ts
+++ b/packages/clerk-js/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './beforeUnloadTracker';
 export * from './componentGuards';
 export * from './cookies';
+export * from './dynamicParamParser';
 export * from './devBrowser';
 export * from './email';
 export * from './encoders';

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -661,7 +661,9 @@ export type CreateOrganizationProps = {
    * Full URL or path to navigate after creating a new organization.
    * @default undefined
    */
-  afterCreateOrganizationUrl?: string;
+  afterCreateOrganizationUrl?:
+    | ((organization: OrganizationResource) => string)
+    | LooseExtractedParams<PrimitiveKeys<OrganizationResource>>;
   /**
    * Hides the screen for sending invitations after an organization is created.
    * @default undefined When left undefined Clerk will automatically hide the screen if
@@ -730,6 +732,12 @@ export type UserButtonProps = {
   userProfileProps?: Pick<UserProfileProps, 'additionalOAuthScopes'>;
 };
 
+type PrimitiveKeys<T> = {
+  [K in keyof T]: T[K] extends string | boolean | number | null ? K : never;
+}[keyof T];
+
+type LooseExtractedParams<T extends string> = `:${T}` | (string & NonNullable<unknown>);
+
 export type OrganizationSwitcherProps = {
   /**
    Controls the default state of the OrganizationSwitcher
@@ -746,13 +754,31 @@ export type OrganizationSwitcherProps = {
   /**
    * Full URL or path to navigate after a successful organization switch.
    * @default undefined
+   * @deprecated use `afterSelectOrganizationUrl` or `afterSelectPersonalUrl`
    */
   afterSwitchOrganizationUrl?: string;
   /**
    * Full URL or path to navigate after creating a new organization.
    * @default undefined
    */
-  afterCreateOrganizationUrl?: string;
+  afterCreateOrganizationUrl?:
+    | ((organization: OrganizationResource) => string)
+    | LooseExtractedParams<PrimitiveKeys<OrganizationResource>>;
+  /**
+   * Full URL or path to navigate after a successful organization selection.
+   * Accepts a function that returns URL or path
+   * @default undefined`
+   */
+  afterSelectOrganizationUrl?:
+    | ((organization: OrganizationResource) => string)
+    | LooseExtractedParams<PrimitiveKeys<OrganizationResource>>;
+
+  /**
+   * Full URL or path to navigate after a successful selection of personal workspace.
+   * Accepts a function that returns URL or path
+   * @default undefined`
+   */
+  afterSelectPersonalUrl?: ((user: UserResource) => string) | LooseExtractedParams<PrimitiveKeys<UserResource>>;
   /**
    * Full URL or path to navigate to after the user leaves the currently active organization.
    * @default undefined


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

### Demo for this PR

You can test the changes of this PR in [this app](https://b2b-saas-starter.clerkpreview.com/)
- Url changes when switching between organizations
- after creation of an organization we are navigated to it's profile with the constructed url

<!-- Fixes # (issue number) -->
