### PR TITLE
fix(clerk-expo): Reload Clerk singleton on key change

### DIFF
--- a/.changeset/shy-ears-refuse.md
+++ b/.changeset/shy-ears-refuse.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-expo': patch
+---
+
+Allow switching the Clerk publishable key changes during runtime

--- a/packages/expo/src/cache.ts
+++ b/packages/expo/src/cache.ts
@@ -1,6 +1,7 @@
 export interface TokenCache {
   getToken: (key: string) => Promise<string | undefined | null>;
   saveToken: (key: string, token: string) => Promise<void>;
+  deleteToken: (key: string) => void;
 }
 
 const createMemoryTokenCache = (): TokenCache => {
@@ -12,6 +13,9 @@ const createMemoryTokenCache = (): TokenCache => {
     },
     getToken: key => {
       return Promise.resolve(cache[key]);
+    },
+    deleteToken: key => {
+      delete cache[key];
     },
   };
 };

--- a/packages/expo/src/singleton.ts
+++ b/packages/expo/src/singleton.ts
@@ -14,10 +14,15 @@ type BuildClerkOptions = {
 };
 
 export function buildClerk({ key, tokenCache }: BuildClerkOptions): HeadlessBrowserClerk {
-  if (!clerk) {
+  if (!clerk || key !== clerk.publishableKey) {
     const getToken = tokenCache.getToken;
     const saveToken = tokenCache.saveToken;
-    // TODO: DO NOT ACCEPT THIS
+
+    if (clerk && key !== clerk.publishableKey) {
+      // handle key change at runtime (e.g. switching from dev to staging)
+      tokenCache.deleteToken(KEY);
+    }
+
     clerk = new Clerk(key);
 
     // @ts-expect-error


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [x] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

If the Clerk publishable key changes during runtime, for example when switching between dev and staging environments, the singleton will silently fail to notice the key change. This PR detects the key change and recreates the singleton. 

Fixed #1508.