### PR TITLE
chore(types,localizations): New localization keys for max length exceeded validation

### DIFF
--- a/.changeset/mighty-days-push.md
+++ b/.changeset/mighty-days-push.md
@@ -1,0 +1,9 @@
+---
+'@clerk/localizations': patch
+'@clerk/types': patch
+---
+
+New localization keys for max length exceeded validation:
+- Organization name (form_param_max_length_exceeded__name)
+- First name (form_param_max_length_exceeded__first_name)
+- Last name (form_param_max_length_exceeded__last_name)

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -664,6 +664,9 @@ export const enUS: LocalizationResource = {
         pwned: 'If you use this password elsewhere, you should change it.',
       },
     },
+    form_param_max_length_exceeded__name: 'Name should not exceed 256 characters.',
+    form_param_max_length_exceeded__first_name: 'First name should not exceed 256 characters.',
+    form_param_max_length_exceeded__last_name: 'Last name should not exceed 256 characters.',
   },
   dates: {
     previous6Days: "Last {{ date | weekday('en-US','long') }} at {{ date | timeString('en-US') }}",

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -697,4 +697,5 @@ type UnstableErrors = WithParamName<{
       pwned: LocalizationValue;
     };
   };
+  form_param_max_length_exceeded: LocalizationValue;
 }>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
New localization keys for max length exceeded validation:
- Organization name (form_param_max_length_exceeded__name)
- First name (form_param_max_length_exceeded__first_name)
- Last name (form_param_max_length_exceeded__last_name)

<!-- Fixes # (issue number) -->
