### PR TITLE
USR-194 fix(clerk-js): Eliminate pre/post onBlur states for password field

### DIFF
--- a/.changeset/little-donkeys-exist.md
+++ b/.changeset/little-donkeys-exist.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Eliminate pre/post onBlur states for password field and prioritize minimum character count error message over other complexity errors.

--- a/packages/clerk-js/src/ui/components/SignIn/ResetPassword.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/ResetPassword.tsx
@@ -24,7 +24,6 @@ export const _ResetPassword = () => {
     type: 'password',
     label: localizationKeys('formFieldLabel__newPassword'),
     isRequired: true,
-    enableErrorAfterBlur: true,
     validatePassword: true,
     informationText: failedValidationsText,
     buildErrorMessage: errors => createPasswordError(errors, { t, locale, passwordSettings }),
@@ -51,7 +50,9 @@ export const _ResetPassword = () => {
   const canSubmit = isPasswordMatch;
 
   const validateForm = () => {
-    displayConfirmPasswordFeedback(confirmField.value);
+    if (passwordField.value) {
+      displayConfirmPasswordFeedback(confirmField.value);
+    }
   };
 
   const resetPassword = async () => {

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -76,7 +76,6 @@ function _SignUpContinue() {
       type: 'password',
       label: localizationKeys('formFieldLabel__password'),
       placeholder: localizationKeys('formFieldInputPlaceholder__password'),
-      enableErrorAfterBlur: true,
       validatePassword: true,
     }),
   } as const;

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -80,7 +80,6 @@ function _SignUpStart(): JSX.Element {
       type: 'password',
       label: localizationKeys('formFieldLabel__password'),
       placeholder: localizationKeys('formFieldInputPlaceholder__password'),
-      enableErrorAfterBlur: true,
       informationText: failedValidationsText,
       validatePassword: true,
       buildErrorMessage: errors => createPasswordError(errors, { t, locale, passwordSettings }),

--- a/packages/clerk-js/src/ui/hooks/__tests__/usePasswordComplexity.test.tsx
+++ b/packages/clerk-js/src/ui/hooks/__tests__/usePasswordComplexity.test.tsx
@@ -147,17 +147,21 @@ describe('usePasswordComplexity', () => {
     const { result } = renderHook(defaultRenderer, { wrapper });
 
     await act(() => {
-      result.current.getComplexity('@aP');
+      result.current.getComplexity('@apapapap');
     });
 
-    expect(result.current.failedValidationsText).toBe('Your password must contain 8 or more characters and a number.');
+    expect(result.current.failedValidationsText).toBe('Your password must contain a number and an uppercase letter.');
+
+    await act(() => {
+      result.current.getComplexity('aPaPaPaPaP');
+    });
+
+    expect(result.current.failedValidationsText).toBe('Your password must contain a special character and a number.');
 
     await act(() => {
       result.current.getComplexity('aP');
     });
 
-    expect(result.current.failedValidationsText).toBe(
-      'Your password must contain 8 or more characters, a special character, and a number.',
-    );
+    expect(result.current.failedValidationsText).toBe('Your password must contain 8 or more characters.');
   });
 });

--- a/packages/clerk-js/src/ui/hooks/usePasswordComplexity.ts
+++ b/packages/clerk-js/src/ui/hooks/usePasswordComplexity.ts
@@ -67,7 +67,11 @@ export const generateErrorTextUtil = ({
     return '';
   }
 
+  // show min length error first by itself
+  const hasMinLengthError = failedValidations?.min_length || false;
+
   const messages = Object.entries(failedValidations)
+    .filter(k => (hasMinLengthError ? k[0] === 'min_length' : true))
     .filter(([, v]) => !!v)
     .map(([k]) => {
       const localizedKey = errorMessages[k as keyof typeof errorMessages];

--- a/packages/clerk-js/src/ui/utils/passwordUtils.test.tsx
+++ b/packages/clerk-js/src/ui/utils/passwordUtils.test.tsx
@@ -30,7 +30,7 @@ describe('createPasswordError() constructs error that password', () => {
     expect(res).toBe('Your password must contain 8 or more characters.');
   });
 
-  it('is too short and needs an uppercase character', async () => {
+  it('is too short and needs an uppercase character. Shows only min_length error.', async () => {
     const { wrapper: Wrapper } = await createFixtures();
 
     const wrapperBefore = ({ children }) => (
@@ -48,7 +48,7 @@ describe('createPasswordError() constructs error that password', () => {
       ],
       createLocalizationConfig(result.current.t),
     );
-    expect(res).toBe('Your password must contain 8 or more characters and an uppercase letter.');
+    expect(res).toBe('Your password must contain 8 or more characters.');
   });
 
   it('needs an uppercase character', async () => {
@@ -63,16 +63,13 @@ describe('createPasswordError() constructs error that password', () => {
     const { result } = renderHook(() => useLocalizations(), { wrapper: wrapperBefore });
 
     const res = createPasswordError(
-      [
-        // { code: 'form_password_length_too_short', message: '' },
-        { code: 'form_password_no_uppercase', message: '' },
-      ],
+      [{ code: 'form_password_no_uppercase', message: '' }],
       createLocalizationConfig(result.current.t),
     );
     expect(res).toBe('Your password must contain an uppercase letter.');
   });
 
-  it('is too short and needs an lowercase character', async () => {
+  it('is too short and needs an lowercase character. Shows only min_length error', async () => {
     const { wrapper: Wrapper } = await createFixtures();
 
     const wrapperBefore = ({ children }) => (
@@ -90,10 +87,10 @@ describe('createPasswordError() constructs error that password', () => {
       ],
       createLocalizationConfig(result.current.t),
     );
-    expect(res).toBe('Your password must contain 8 or more characters and a lowercase letter.');
+    expect(res).toBe('Your password must contain 8 or more characters.');
   });
 
-  it('is too short and needs a lowercase and an uppercase character', async () => {
+  it('needs a lowercase and an uppercase character', async () => {
     const { wrapper: Wrapper } = await createFixtures();
 
     const wrapperBefore = ({ children }) => (
@@ -106,16 +103,15 @@ describe('createPasswordError() constructs error that password', () => {
 
     const res = createPasswordError(
       [
-        { code: 'form_password_length_too_short', message: '' },
         { code: 'form_password_no_lowercase', message: '' },
         { code: 'form_password_no_uppercase', message: '' },
       ],
       createLocalizationConfig(result.current.t),
     );
-    expect(res).toBe('Your password must contain 8 or more characters, a lowercase letter, and an uppercase letter.');
+    expect(res).toBe('Your password must contain a lowercase letter and an uppercase letter.');
   });
 
-  it('is too short and needs a lowercase, an uppercase and a number', async () => {
+  it('needs a lowercase, an uppercase and a number', async () => {
     const { wrapper: Wrapper } = await createFixtures();
 
     const wrapperBefore = ({ children }) => (
@@ -128,19 +124,16 @@ describe('createPasswordError() constructs error that password', () => {
 
     const res = createPasswordError(
       [
-        { code: 'form_password_length_too_short', message: '' },
         { code: 'form_password_no_number', message: '' },
         { code: 'form_password_no_lowercase', message: '' },
         { code: 'form_password_no_uppercase', message: '' },
       ],
       createLocalizationConfig(result.current.t),
     );
-    expect(res).toBe(
-      'Your password must contain 8 or more characters, a number, a lowercase letter, and an uppercase letter.',
-    );
+    expect(res).toBe('Your password must contain a number, a lowercase letter, and an uppercase letter.');
   });
 
-  it('is too short and needs a lowercase, an uppercase and a number', async () => {
+  it('needs a lowercase, an uppercase and a number', async () => {
     const { wrapper: Wrapper } = await createFixtures();
 
     const wrapperBefore = ({ children }) => (
@@ -153,7 +146,6 @@ describe('createPasswordError() constructs error that password', () => {
 
     const res = createPasswordError(
       [
-        { code: 'form_password_length_too_short', message: '' },
         { code: 'form_password_no_special_char', message: '' },
         { code: 'form_password_no_number', message: '' },
         { code: 'form_password_no_lowercase', message: '' },
@@ -162,7 +154,7 @@ describe('createPasswordError() constructs error that password', () => {
       createLocalizationConfig(result.current.t),
     );
     expect(res).toBe(
-      'Your password must contain 8 or more characters, a special character, a number, a lowercase letter, and an uppercase letter.',
+      'Your password must contain a special character, a number, a lowercase letter, and an uppercase letter.',
     );
   });
 

--- a/packages/clerk-js/src/ui/utils/passwordUtils.ts
+++ b/packages/clerk-js/src/ui/utils/passwordUtils.ts
@@ -47,7 +47,10 @@ export const createPasswordError = (errors: ClerkAPIError[], localizationConfig:
     return `${t(localizationKeys('unstable__errors.zxcvbn.notEnough'))} ${message}`;
   }
 
-  const message = errors.map((s: any) => {
+  // show min length error first by itself
+  const minLenErrors = errors.filter(e => e.code === 'form_password_length_too_short');
+
+  const message = (minLenErrors.length ? minLenErrors : errors).map((s: any) => {
     const localizedKey = (mapComplexityErrors(passwordSettings) as any)[s.code];
 
     if (Array.isArray(localizedKey)) {

--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -194,7 +194,6 @@ export const useFormControlFeedback = (opts: DebouncingOption): DebouncedFeedbac
     informationText = '',
     skipBlur = false,
     delayInMs = 100,
-    hasPassedComplexity = false,
   } = opts;
 
   const canDisplayFeedback = useMemo(() => {
@@ -208,7 +207,7 @@ export const useFormControlFeedback = (opts: DebouncingOption): DebouncedFeedbac
   }, [enableErrorAfterBlur, hasLostFocus, skipBlur]);
 
   const feedbackMemo = useMemo(() => {
-    const shouldDisplayErrorAsWarning = hasPassedComplexity ? errorText && !hasLostFocus : false;
+    const shouldDisplayErrorAsWarning = errorText && !skipBlur;
     const _errorText = !shouldDisplayErrorAsWarning && canDisplayFeedback ? errorText : '';
     const _warningText = shouldDisplayErrorAsWarning ? errorText : warningText;
     const _successfulText = successfulText;


### PR DESCRIPTION
fix(clerk-js): Eliminate pre/post onBlur states for password field

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Eliminate pre/post onBlur states for password field and prioritize minimum character count error message over other complexity errors.

### Before

https://github.com/clerkinc/javascript/assets/23478420/2d00071a-bb47-4430-af7a-adc7df485b91



### After
https://github.com/clerkinc/javascript/assets/23478420/37f13b56-29b1-4c1e-9aa7-2a9c9a88e58a


https://github.com/clerkinc/javascript/assets/23478420/ed264166-97a1-4229-9f48-e7dcef812781


<!-- Fixes # (issue number) -->
