### PR TITLE
fix(clerk-sdk-node): Cleanup clerk-sdk-node request url generation

### DIFF
--- a/.changeset/shy-jeans-share.md
+++ b/.changeset/shy-jeans-share.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Refactor the internal generation of request URLs to use a shared helper from `@clerk/backend`

--- a/packages/backend/src/util/IsomorphicRequest.ts
+++ b/packages/backend/src/util/IsomorphicRequest.ts
@@ -1,10 +1,14 @@
 import { parse } from 'cookie';
 
 import runtime from '../runtime';
+import { buildRequestUrl } from '../utils';
 
 type IsomorphicRequestOptions = (Request: typeof runtime.Request, Headers: typeof runtime.Headers) => Request;
 export const createIsomorphicRequest = (cb: IsomorphicRequestOptions): Request => {
-  return cb(runtime.Request, runtime.Headers);
+  const req = cb(runtime.Request, runtime.Headers);
+  // Used to fix request.url using the x-forwarded-* headers
+  const headersGeneratedURL = buildRequestUrl(req);
+  return new runtime.Request(headersGeneratedURL, req);
 };
 
 export const buildRequest = (req?: Request) => {

--- a/packages/fastify/src/withClerkMiddleware.ts
+++ b/packages/fastify/src/withClerkMiddleware.ts
@@ -21,13 +21,12 @@ export const withClerkMiddleware = (options: ClerkFastifyOptions) => {
           (acc, key) => Object.assign(acc, { [key]: req?.headers[key] }),
           {},
         );
-        // Making some manual tests it seems that FastifyRequest populates the req protocol / hostname
-        // based on the forwarded headers. With that in mind we can use those attributes instead
-        // of using the headers to calculate them by our own.
-        const reqUrl = new URL(req.url, `${req.protocol}://${req.hostname}`);
         const headers = new Headers(requestHeaders);
-
-        return new Request(reqUrl, {
+        // Making some manual tests it seems that FastifyRequest populates the req protocol / hostname
+        // based on the forwarded headers. Nevertheless, we are gonna use a dummy base and the request
+        // will be fixed by the createIsomorphicRequest.
+        const dummyOriginReqUrl = new URL(req.url || '', `${req.protocol}://clerk-dummy`);
+        return new Request(dummyOriginReqUrl, {
           method: req.method,
           headers,
         });

--- a/packages/sdk-node/src/__tests__/middleware.test.ts
+++ b/packages/sdk-node/src/__tests__/middleware.test.ts
@@ -7,7 +7,7 @@ import type { WithAuthProp } from '../types';
 
 const mockNext = jest.fn();
 
-const createRequest = () => ({ url: '/path', cookies: {}, headers: {} } as Request);
+const createRequest = () => ({ url: '/path', cookies: {}, headers: { host: 'example.com' } } as Request);
 
 afterEach(() => {
   mockNext.mockReset();


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Refactor clerk-sdk-node to build the request origin in order to centralize the way we construct the origin for all of our JS backend packages.
Those changes may make the code more complex or may not provide much value, that's why the we should evaluate if centralizing the origin construction by using a function from the `clerk/backend` package is worth it.
<!-- Fixes # (issue number) -->
