### PR TITLE
USR-165 fix(backend): Add filter by status support for getInvitationList() method

### DIFF
--- a/.changeset/sixty-eyes-attend.md
+++ b/.changeset/sixty-eyes-attend.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Add filter by status(pending, accepted, revoked) support for getInvitationList method

--- a/packages/backend/src/api/endpoints/InvitationApi.ts
+++ b/packages/backend/src/api/endpoints/InvitationApi.ts
@@ -10,11 +10,26 @@ type CreateParams = {
   publicMetadata?: UserPublicMetadata;
 };
 
+type GetInvitationListParams = {
+  /**
+   * Filters invitations based on their status(accepted, pending, revoked).
+   *
+   * @example
+   * get all revoked invitations
+   *
+   * import { invitations } from '@clerk/clerk-sdk-node';
+   * await invitations.getInvitationList({ status: 'revoked })
+   *
+   */
+  status?: 'accepted' | 'pending' | 'revoked';
+};
+
 export class InvitationAPI extends AbstractAPI {
-  public async getInvitationList() {
+  public async getInvitationList(params: GetInvitationListParams = {}) {
     return this.request<Invitation[]>({
       method: 'GET',
       path: basePath,
+      queryParams: params,
     });
   }
 


### PR DESCRIPTION

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Add filter by status(pending, accepted, revoked) support for getInvitationList method since it is supported by our [BE](https://clerk.com/docs/reference/backend-api/tag/Invitations#operation/ListInvitations)
<!-- Fixes # (issue number) -->
