### PR TITLE
feat(clerk-js): Introduce Clerk.client.clearCache()

### DIFF
--- a/.changeset/swift-rivers-behave.md
+++ b/.changeset/swift-rivers-behave.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/types': patch
+---
+
+Introduce Clerk.client.clearCache() method

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -60,6 +60,10 @@ export class Client extends BaseResource implements ClientResource {
     });
   }
 
+  clearCache(): void {
+    return this.sessions.forEach(s => s.clearCache());
+  }
+
   fromJSON(data: ClientJSON | null): this {
     if (data) {
       this.id = data.id;

--- a/packages/clerk-js/src/core/resources/Session.ts
+++ b/packages/clerk-js/src/core/resources/Session.ts
@@ -65,6 +65,10 @@ export class Session extends BaseResource implements SessionResource {
     });
   };
 
+  clearCache = (): void => {
+    return SessionTokenCache.clear();
+  };
+
   getToken: GetToken = async (options?: GetTokenOptions): Promise<string | null> => {
     return runWithExponentialBackOff(() => this._getToken(options), {
       shouldRetry: (error: unknown, currentIteration: number) => !is4xxError(error) && currentIteration < 4,

--- a/packages/clerk-js/src/core/tokenCache.ts
+++ b/packages/clerk-js/src/core/tokenCache.ts
@@ -87,6 +87,12 @@ const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
         // Mutate cached value and set expirations
         value.expiresIn = expiresIn;
         timer = setTimeout(deleteKey, expiresIn * 1000);
+
+        // Teach ClerkJS not to block the exit of the event loop when used in Node environments.
+        // More info at https://nodejs.org/api/timers.html#timeoutunref
+        if (typeof timer.unref === 'function') {
+          timer.unref();
+        }
       })
       .catch(() => {
         deleteKey();

--- a/packages/clerk-js/src/core/tokenCache.ts
+++ b/packages/clerk-js/src/core/tokenCache.ts
@@ -50,11 +50,14 @@ export class TokenCacheKey {
 const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
   const cache = new Map<string, TokenCacheValue>();
 
+  let timer: ReturnType<typeof setTimeout>;
+
   const size = () => {
     return cache.size;
   };
 
   const clear = () => {
+    clearTimeout(timer);
     cache.clear();
   };
 
@@ -83,7 +86,7 @@ const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
 
         // Mutate cached value and set expirations
         value.expiresIn = expiresIn;
-        setTimeout(deleteKey, expiresIn * 1000);
+        timer = setTimeout(deleteKey, expiresIn * 1000);
       })
       .catch(() => {
         deleteKey();

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -11,6 +11,7 @@ export interface ClientResource extends ClerkResource {
   isNew: () => boolean;
   create: () => Promise<ClientResource>;
   destroy: () => Promise<void>;
+  clearCache: () => void;
   lastActiveSessionId: string | null;
   createdAt: Date | null;
   updatedAt: Date | null;

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -18,6 +18,7 @@ export interface SessionResource extends ClerkResource {
   remove: () => Promise<SessionResource>;
   touch: () => Promise<SessionResource>;
   getToken: GetToken;
+  clearCache: () => void;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

The `Clerk.client.clearCache` method clears the internal token cache for each session of the current client.

Fixes https://github.com/clerkinc/javascript/issues/1525