### PR TITLE
4️⃣ [ORG-61] Introduce OrganizationDomain and return domains from useOrganization

### DIFF
--- a/.changeset/mighty-boxes-reply.md
+++ b/.changeset/mighty-boxes-reply.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/types': patch
+---
+
+Introduces a new resource called OrganizationDomain
+
++ useOrganization has been updated in order to return a list of domain with the above type

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -85,14 +85,14 @@ export class Organization extends BaseResource implements OrganizationResource {
     getDomainParams?: GetDomainsParams,
   ): Promise<ClerkPaginatedResponse<OrganizationDomainResource>> => {
     function convertPageToOffset(pageParams: GetUserOrganizationInvitationsParams | undefined): ClerkPaginationParams {
-      const { initialPageSize, initialPage, ...restParams } = pageParams || {};
-      const _initialPageSize = initialPageSize ?? 10;
+      const { pageSize, initialPage, ...restParams } = pageParams || {};
+      const _pageSize = pageSize ?? 10;
       const _initialPage = initialPage ?? 1;
 
       return {
         ...restParams,
-        limit: initialPageSize,
-        offset: (_initialPage - 1) * _initialPageSize,
+        limit: _pageSize,
+        offset: (_initialPage - 1) * _pageSize,
       };
     }
 

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -18,9 +18,9 @@ import type {
   UpdateMembershipParams,
   UpdateOrganizationParams,
 } from '@clerk/types';
-import type { ClerkPaginationParams, GetUserOrganizationInvitationsParams } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
+import { convertPageToOffset } from '../../utils/pagesToOffset';
 import { BaseResource, OrganizationInvitation, OrganizationMembership } from './internal';
 import { OrganizationDomain } from './OrganizationDomain';
 
@@ -84,18 +84,6 @@ export class Organization extends BaseResource implements OrganizationResource {
   getDomains = async (
     getDomainParams?: GetDomainsParams,
   ): Promise<ClerkPaginatedResponse<OrganizationDomainResource>> => {
-    function convertPageToOffset(pageParams: GetUserOrganizationInvitationsParams | undefined): ClerkPaginationParams {
-      const { pageSize, initialPage, ...restParams } = pageParams || {};
-      const _pageSize = pageSize ?? 10;
-      const _initialPage = initialPage ?? 1;
-
-      return {
-        ...restParams,
-        limit: _pageSize,
-        offset: (_initialPage - 1) * _pageSize,
-      };
-    }
-
     return await BaseResource._fetch({
       path: `/organizations/${this.id}/domains`,
       method: 'GET',

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -126,40 +126,6 @@ export class Organization extends BaseResource implements OrganizationResource {
     return new OrganizationDomain(json);
   };
 
-  prepareDomainAffiliationVerification = async ({
-    domainId,
-    emailAddress,
-  }: {
-    domainId: string;
-    emailAddress: string;
-  }): Promise<OrganizationDomainResource> => {
-    const json = (
-      await BaseResource._fetch<OrganizationDomainJSON>({
-        path: `/organizations/${this.id}/domains/${domainId}/prepare_affiliation_verification`,
-        method: 'POST',
-        body: { affiliationEmailAddress: emailAddress } as any,
-      })
-    )?.response as unknown as OrganizationDomainJSON;
-    return new OrganizationDomain(json);
-  };
-
-  attemptDomainAffiliationVerification = async ({
-    domainId,
-    code,
-  }: {
-    domainId: string;
-    code: string;
-  }): Promise<OrganizationDomainResource> => {
-    const json = (
-      await BaseResource._fetch<OrganizationDomainJSON>({
-        path: `/organizations/${this.id}/domains/${domainId}/attempt_affiliation_verification`,
-        method: 'POST',
-        body: { code } as any,
-      })
-    )?.response as unknown as OrganizationDomainJSON;
-    return new OrganizationDomain(json);
-  };
-
   createDomain = async (name: string): Promise<OrganizationDomainResource> => {
     return OrganizationDomain.create(this.id, { name });
   };

--- a/packages/clerk-js/src/core/resources/OrganizationDomain.test.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationDomain.test.ts
@@ -1,0 +1,40 @@
+import { OrganizationDomain } from './internal';
+
+describe('OrganizationDomain', () => {
+  it('has the same initial properties', () => {
+    const organization = new OrganizationDomain({
+      object: 'organization_domain',
+      id: 'test_domain_id',
+      name: 'clerk.dev',
+      organization_id: 'test_org_id',
+      enrollment_mode: 'manual_invitation',
+      verification: {
+        attempts: 1,
+        expires_at: 12345,
+        strategy: 'email_code',
+        status: 'verified',
+      },
+      affiliation_email_address: 'some@clerk.dev',
+      created_at: 12345,
+      updated_at: 5678,
+    });
+
+    expect(organization).toMatchSnapshot();
+  });
+
+  it('has the same initial nullable properties', () => {
+    const organization = new OrganizationDomain({
+      object: 'organization_domain',
+      id: 'test_domain_id',
+      name: 'clerk.dev',
+      organization_id: 'test_org_id',
+      enrollment_mode: 'manual_invitation',
+      verification: null,
+      affiliation_email_address: null,
+      created_at: 12345,
+      updated_at: 5678,
+    });
+
+    expect(organization).toMatchSnapshot();
+  });
+});

--- a/packages/clerk-js/src/core/resources/OrganizationDomain.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationDomain.ts
@@ -1,0 +1,88 @@
+import type {
+  OrganizationDomainJSON,
+  OrganizationDomainResource,
+  OrganizationDomainVerification,
+  OrganizationEnrollmentMode,
+  UpdateOrganizationDomainParams,
+} from '@clerk/types';
+
+import { unixEpochToDate } from '../../utils/date';
+import { BaseResource } from './Base';
+
+export class OrganizationDomain extends BaseResource implements OrganizationDomainResource {
+  id!: string;
+  name!: string;
+  organizationId!: string;
+  enrollmentMode!: OrganizationEnrollmentMode;
+  verification!: OrganizationDomainVerification | null;
+  affiliationEmailAddress!: string | null;
+  createdAt!: Date;
+  updatedAt!: Date;
+
+  constructor(data: OrganizationDomainJSON) {
+    super();
+    this.fromJSON(data);
+  }
+
+  static async create(organizationId: string, { name }: { name: string }): Promise<OrganizationDomainResource> {
+    const json = (
+      await BaseResource._fetch<OrganizationDomainJSON>({
+        path: `/organizations/${organizationId}/domains`,
+        method: 'POST',
+        body: { name } as any,
+      })
+    )?.response as unknown as OrganizationDomainJSON;
+    return new OrganizationDomain(json);
+  }
+
+  update = (params: UpdateOrganizationDomainParams): Promise<OrganizationDomainResource> => {
+    return this._basePatch({
+      method: 'PATCH',
+      path: `/organizations/${this.organizationId}/domains/${this.id}`,
+      body: params,
+    });
+  };
+
+  delete = (): Promise<void> => {
+    return this._baseDelete({
+      path: `/organizations/${this.organizationId}/domains/${this.id}`,
+    });
+  };
+
+  // static async get({
+  //   organizationId,
+  //   domainId,
+  // }: {
+  //   organizationId: string;
+  //   domainId: string;
+  // }): Promise<OrganizationDomainResource> {
+  //   const json = (
+  //     await BaseResource._fetch<OrganizationDomainJSON>({
+  //       path: `/organizations/${organizationId}/domains/${domainId}`,
+  //       method: 'GET',
+  //     })
+  //   )?.response as unknown as OrganizationDomainJSON;
+  //   return new OrganizationDomain(json);
+  // }
+
+  protected fromJSON(data: OrganizationDomainJSON | null): this {
+    if (data) {
+      this.id = data.id;
+      this.name = data.name;
+      this.organizationId = data.organization_id;
+      this.enrollmentMode = data.enrollment_mode;
+      this.affiliationEmailAddress = data.affiliation_email_address;
+      if (data.verification) {
+        this.verification = {
+          status: data.verification.status,
+          strategy: data.verification.strategy,
+          attempts: data.verification.attempts,
+          expiresAt: unixEpochToDate(data.verification.expires_at),
+        };
+      } else {
+        this.verification = null;
+      }
+    }
+    return this;
+  }
+}

--- a/packages/clerk-js/src/core/resources/OrganizationDomain.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationDomain.ts
@@ -1,8 +1,10 @@
 import type {
+  AttemptAffiliationVerificationParams,
   OrganizationDomainJSON,
   OrganizationDomainResource,
   OrganizationDomainVerification,
   OrganizationEnrollmentMode,
+  PrepareAffiliationVerificationParams,
   UpdateOrganizationDomainParams,
 } from '@clerk/types';
 
@@ -35,6 +37,26 @@ export class OrganizationDomain extends BaseResource implements OrganizationDoma
     return new OrganizationDomain(json);
   }
 
+  prepareDomainAffiliationVerification = async (
+    params: PrepareAffiliationVerificationParams,
+  ): Promise<OrganizationDomainResource> => {
+    return this._basePost({
+      path: `/organizations/${this.organizationId}/domains/${this.id}/prepare_affiliation_verification`,
+      method: 'POST',
+      body: params as any,
+    });
+  };
+
+  attemptAffiliationVerification = async (
+    params: AttemptAffiliationVerificationParams,
+  ): Promise<OrganizationDomainResource> => {
+    return this._basePost({
+      path: `/organizations/${this.organizationId}/domains/${this.id}/attempt_affiliation_verification`,
+      method: 'POST',
+      body: params as any,
+    });
+  };
+
   update = (params: UpdateOrganizationDomainParams): Promise<OrganizationDomainResource> => {
     return this._basePatch({
       method: 'PATCH',
@@ -48,22 +70,6 @@ export class OrganizationDomain extends BaseResource implements OrganizationDoma
       path: `/organizations/${this.organizationId}/domains/${this.id}`,
     });
   };
-
-  // static async get({
-  //   organizationId,
-  //   domainId,
-  // }: {
-  //   organizationId: string;
-  //   domainId: string;
-  // }): Promise<OrganizationDomainResource> {
-  //   const json = (
-  //     await BaseResource._fetch<OrganizationDomainJSON>({
-  //       path: `/organizations/${organizationId}/domains/${domainId}`,
-  //       method: 'GET',
-  //     })
-  //   )?.response as unknown as OrganizationDomainJSON;
-  //   return new OrganizationDomain(json);
-  // }
 
   protected fromJSON(data: OrganizationDomainJSON | null): this {
     if (data) {

--- a/packages/clerk-js/src/core/resources/UserOrganizationInvitation.ts
+++ b/packages/clerk-js/src/core/resources/UserOrganizationInvitation.ts
@@ -14,13 +14,7 @@ import { BaseResource } from './internal';
 export class UserOrganizationInvitation extends BaseResource implements UserOrganizationInvitationResource {
   id!: string;
   emailAddress!: string;
-  publicOrganizationData!: {
-    hasImage: boolean;
-    imageUrl: string;
-    name: string;
-    id: string;
-    slug: string;
-  };
+  publicOrganizationData!: UserOrganizationInvitationResource['publicOrganizationData'];
   publicMetadata: OrganizationInvitationPublicMetadata = {};
   status!: OrganizationInvitationStatus;
   role!: MembershipRole;

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -4,8 +4,11 @@ exports[`Organization has the same initial properties 1`] = `
 Organization {
   "addMember": [Function],
   "adminDeleteEnabled": true,
+  "createDomain": [Function],
   "createdAt": 1970-01-01T00:00:12.345Z,
   "destroy": [Function],
+  "getDomain": [Function],
+  "getDomains": [Function],
   "getMemberships": [Function],
   "getPendingInvitations": [Function],
   "hasImage": true,

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationDomain.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationDomain.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OrganizationDomain has the same initial nullable properties 1`] = `
+OrganizationDomain {
+  "affiliationEmailAddress": null,
+  "attemptAffiliationVerification": [Function],
+  "delete": [Function],
+  "enrollmentMode": "manual_invitation",
+  "id": "test_domain_id",
+  "name": "clerk.dev",
+  "organizationId": "test_org_id",
+  "pathRoot": "",
+  "prepareDomainAffiliationVerification": [Function],
+  "update": [Function],
+  "verification": null,
+}
+`;
+
+exports[`OrganizationDomain has the same initial properties 1`] = `
+OrganizationDomain {
+  "affiliationEmailAddress": "some@clerk.dev",
+  "attemptAffiliationVerification": [Function],
+  "delete": [Function],
+  "enrollmentMode": "manual_invitation",
+  "id": "test_domain_id",
+  "name": "clerk.dev",
+  "organizationId": "test_org_id",
+  "pathRoot": "",
+  "prepareDomainAffiliationVerification": [Function],
+  "update": [Function],
+  "verification": {
+    "attempts": 1,
+    "expiresAt": 1970-01-01T00:00:12.345Z,
+    "status": "verified",
+    "strategy": "email_code",
+  },
+}
+`;

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -8,8 +8,11 @@ OrganizationMembership {
   "organization": Organization {
     "addMember": [Function],
     "adminDeleteEnabled": true,
+    "createDomain": [Function],
     "createdAt": 1970-01-01T00:00:12.345Z,
     "destroy": [Function],
+    "getDomain": [Function],
+    "getDomains": [Function],
     "getMemberships": [Function],
     "getPendingInvitations": [Function],
     "hasImage": true,

--- a/packages/clerk-js/src/core/resources/internal.ts
+++ b/packages/clerk-js/src/core/resources/internal.ts
@@ -13,6 +13,7 @@ export * from './IdentificationLink';
 export * from './Image';
 export * from './PhoneNumber';
 export * from './Organization';
+export * from './OrganizationDomain';
 export * from './OrganizationInvitation';
 export * from './OrganizationMembership';
 export * from './SamlAccount';

--- a/packages/shared/src/hooks/useOrganization.tsx
+++ b/packages/shared/src/hooks/useOrganization.tsx
@@ -1,18 +1,30 @@
 import type {
+  ClerkPaginatedResponse,
   ClerkPaginationParams,
+  GetDomainsParams,
   GetMembershipsParams,
   GetPendingInvitationsParams,
+  OrganizationDomainResource,
   OrganizationInvitationResource,
   OrganizationMembershipResource,
   OrganizationResource,
 } from '@clerk/types';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
+import useSWRInfinite from 'swr/infinite';
 
 import { useClerkInstanceContext, useOrganizationContext, useSessionContext } from './contexts';
+import type { PaginatedDataAPI, PaginatedDataAPIWithDefaults } from './useOrganizationList';
 
 type UseOrganizationParams = {
   invitationList?: GetPendingInvitationsParams;
   membershipList?: GetMembershipsParams;
+  domains?:
+    | true
+    | (GetDomainsParams & {
+        infinite?: boolean;
+        keepPreviousData?: boolean;
+      });
 };
 
 type UseOrganizationReturn =
@@ -22,6 +34,7 @@ type UseOrganizationReturn =
       invitationList: undefined;
       membershipList: undefined;
       membership: undefined;
+      domains: PaginatedDataAPIWithDefaults<OrganizationDomainResource>;
     }
   | {
       isLoaded: true;
@@ -29,6 +42,7 @@ type UseOrganizationReturn =
       invitationList: undefined;
       membershipList: undefined;
       membership: undefined;
+      domains: PaginatedDataAPIWithDefaults<OrganizationDomainResource>;
     }
   | {
       isLoaded: boolean;
@@ -36,17 +50,148 @@ type UseOrganizationReturn =
       invitationList: OrganizationInvitationResource[] | null | undefined;
       membershipList: OrganizationMembershipResource[] | null | undefined;
       membership: OrganizationMembershipResource | null | undefined;
+      domains: PaginatedDataAPI<OrganizationDomainResource> | null;
     };
+type CustomSetAction<T = unknown> = (size: T | ((_size: T) => T)) => void;
 
 type UseOrganization = (params?: UseOrganizationParams) => UseOrganizationReturn;
 
 export const useOrganization: UseOrganization = params => {
-  const { invitationList: invitationListParams, membershipList: membershipListParams } = params || {};
+  const {
+    invitationList: invitationListParams,
+    membershipList: membershipListParams,
+    domains: domainListParams,
+  } = params || {};
   const { organization, lastOrganizationMember, lastOrganizationInvitation } = useOrganizationContext();
   const session = useSessionContext();
 
+  const shouldUseDefaults = typeof domainListParams === 'boolean' && domainListParams;
+  const [paginatedPage, setPaginatedPage] = useState(shouldUseDefaults ? 1 : domainListParams?.initialPage ?? 1);
+
+  // Cache initialPage and initialPageSize until unmount
+  const initialPageRef = useRef(shouldUseDefaults ? 1 : domainListParams?.initialPage ?? 1);
+  const initialPageSizeRef = useRef(shouldUseDefaults ? 10 : domainListParams?.initialPageSize ?? 10);
+
+  const triggerInfinite = shouldUseDefaults ? false : !!domainListParams?.infinite;
+  const internalKeepPreviousData = shouldUseDefaults ? false : !!domainListParams?.keepPreviousData;
+
   const clerk = useClerkInstanceContext();
-  const shouldFetch = clerk.loaded && session && organization;
+
+  const shouldFetch = !!(clerk.loaded && session && organization);
+
+  const paginatedParams =
+    typeof domainListParams === 'undefined'
+      ? undefined
+      : {
+          initialPage: paginatedPage,
+          initialPageSize: initialPageSizeRef.current,
+        };
+
+  // Some gymnastics to adhere to the rules of hooks
+  // We need to make sure useSWR is called on every render
+  const fetchInvitations = !clerk.loaded
+    ? () => ({ data: [], total_count: 0 } as ClerkPaginatedResponse<OrganizationDomainResource>)
+    : () => organization?.getDomains(paginatedParams);
+
+  const {
+    data: userInvitationsData,
+    isValidating: userInvitationsValidating,
+    isLoading: userInvitationsLoading,
+    error: userInvitationsError,
+    mutate: userInvitationsMutate,
+  } = useSWR(
+    !triggerInfinite && shouldFetch && paginatedParams
+      ? cacheKeyDomains('domains', organization, paginatedParams)
+      : null,
+    fetchInvitations,
+    { keepPreviousData: internalKeepPreviousData },
+  );
+
+  const getInfiniteKey = (
+    pageIndex: number,
+    previousPageData: ClerkPaginatedResponse<OrganizationDomainResource> | null,
+  ) => {
+    if (!shouldFetch || !paginatedParams || !triggerInfinite) {
+      return null;
+    }
+
+    return cacheKeyDomains('domains', organization, {
+      initialPage: initialPageRef.current + pageIndex,
+      initialPageSize: initialPageSizeRef.current,
+    });
+  };
+
+  const {
+    data: userInvitationsDataInfinite,
+    isLoading: userInvitationsLoadingInfinite,
+    isValidating: userInvitationsInfiniteValidating,
+    error: userInvitationsInfiniteError,
+    size,
+    setSize,
+    mutate: userInvitationsInfiniteMutate,
+  } = useSWRInfinite(getInfiniteKey, ({ initialPage, initialPageSize }) => {
+    return !clerk.loaded || !organization
+      ? ({ data: [], total_count: 0 } as ClerkPaginatedResponse<OrganizationDomainResource>)
+      : organization.getDomains({
+          initialPage,
+          initialPageSize,
+        });
+  });
+
+  const isomorphicPage = useMemo(() => {
+    if (triggerInfinite) {
+      return size;
+    }
+    return paginatedPage;
+  }, [triggerInfinite, size, paginatedPage]);
+
+  const isomorphicSetPage: CustomSetAction<number> = useCallback(
+    numberOrgFn => {
+      if (triggerInfinite) {
+        void setSize(numberOrgFn);
+        return;
+      }
+      return setPaginatedPage(numberOrgFn);
+    },
+    [setSize],
+  );
+
+  const isomorphicData = useMemo(() => {
+    if (triggerInfinite) {
+      return userInvitationsDataInfinite?.map(a => a?.data).flat() ?? [];
+    }
+    return userInvitationsData?.data ?? [];
+  }, [triggerInfinite, userInvitationsDataInfinite, userInvitationsData]);
+
+  const isomorphicCount = useMemo(() => {
+    if (triggerInfinite) {
+      return userInvitationsDataInfinite?.[userInvitationsDataInfinite?.length - 1]?.total_count || 0;
+    }
+    return userInvitationsData?.total_count ?? 0;
+  }, [triggerInfinite, userInvitationsDataInfinite, userInvitationsData]);
+
+  const isomorphicIsLoading = triggerInfinite ? userInvitationsLoadingInfinite : userInvitationsLoading;
+  const isomorphicIsFetching = triggerInfinite ? userInvitationsInfiniteValidating : userInvitationsValidating;
+  const isomorphicIsError = !!(triggerInfinite ? userInvitationsInfiniteError : userInvitationsError);
+  /**
+   * Helpers
+   */
+  const fetchNext = useCallback(() => {
+    isomorphicSetPage(n => n + 1);
+  }, [isomorphicSetPage]);
+
+  const fetchPrevious = useCallback(() => {
+    isomorphicSetPage(n => n - 1);
+  }, [isomorphicSetPage]);
+
+  const offsetCount = (initialPageRef.current - 1) * initialPageSizeRef.current;
+
+  const pageCount = Math.ceil((isomorphicCount - offsetCount) / initialPageSizeRef.current);
+  const hasNextPage =
+    isomorphicCount - offsetCount * initialPageSizeRef.current > isomorphicPage * initialPageSizeRef.current;
+  const hasPreviousPage = (isomorphicPage - 1) * initialPageSizeRef.current > offsetCount * initialPageSizeRef.current;
+
+  const unstable__mutate = triggerInfinite ? userInvitationsInfiniteMutate : userInvitationsMutate;
 
   // Some gymnastics to adhere to the rules of hooks
   // We need to make sure useSWR is called on every render
@@ -87,6 +232,20 @@ export const useOrganization: UseOrganization = params => {
       invitationList: undefined,
       membershipList: undefined,
       membership: undefined,
+      domains: {
+        data: undefined,
+        count: undefined,
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+        page: undefined,
+        pageCount: undefined,
+        fetchPage: undefined,
+        fetchNext: undefined,
+        fetchPrevious: undefined,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
     };
   }
 
@@ -97,6 +256,7 @@ export const useOrganization: UseOrganization = params => {
       invitationList: null,
       membershipList: null,
       membership: null,
+      domains: null,
     };
   }
 
@@ -108,6 +268,20 @@ export const useOrganization: UseOrganization = params => {
       invitationList: undefined,
       membershipList: undefined,
       membership: undefined,
+      domains: {
+        data: undefined,
+        count: undefined,
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+        page: undefined,
+        pageCount: undefined,
+        fetchPage: undefined,
+        fetchNext: undefined,
+        fetchPrevious: undefined,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
     };
   }
 
@@ -120,6 +294,21 @@ export const useOrganization: UseOrganization = params => {
     unstable__mutate: () => {
       void mutateMembershipList();
       void mutateInvitationList();
+    },
+    domains: {
+      data: isomorphicData,
+      count: isomorphicCount,
+      isLoading: isomorphicIsLoading,
+      isFetching: isomorphicIsFetching,
+      isError: isomorphicIsError,
+      page: isomorphicPage,
+      pageCount,
+      fetchPage: isomorphicSetPage,
+      fetchNext,
+      fetchPrevious,
+      hasNextPage,
+      hasPreviousPage,
+      unstable__mutate,
     },
   };
 };
@@ -142,4 +331,13 @@ function cacheKey(
   return [type, organization.id, resource?.id, resource?.updatedAt, pagination.offset, pagination.limit]
     .filter(Boolean)
     .join('-');
+}
+
+function cacheKeyDomains(type: 'domains', organization: OrganizationResource, pagination: GetDomainsParams) {
+  return {
+    type,
+    organizationId: organization.id,
+    initialPage: pagination.initialPage,
+    initialPageSize: pagination.initialPageSize,
+  };
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,6 +22,7 @@ export * from './jwtv2';
 export * from './multiDomain';
 export * from './oauth';
 export * from './organization';
+export * from './organizationDomain';
 export * from './organizationInvitation';
 export * from './organizationMembership';
 export * from './organizationSettings';

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -6,6 +6,7 @@ import type { FontFamily } from './appearance';
 import type { DisplayConfigJSON } from './displayConfig';
 import type { ActJWTClaim } from './jwt';
 import type { OAuthProvider } from './oauth';
+import type { OrganizationDomainVerificationStatus, OrganizationEnrollmentMode } from './organizationDomain';
 import type { OrganizationInvitationStatus } from './organizationInvitation';
 import type { MembershipRole } from './organizationMembership';
 import type { OrganizationSettingsJSON } from './organizationSettings';
@@ -339,6 +340,25 @@ export interface OrganizationInvitationJSON extends ClerkResourceJSON {
   public_metadata: OrganizationInvitationPublicMetadata;
   status: OrganizationInvitationStatus;
   role: MembershipRole;
+  created_at: number;
+  updated_at: number;
+}
+
+interface OrganizationDomainVerificationJSON {
+  status: OrganizationDomainVerificationStatus;
+  strategy: 'email_code'; // only available value for now
+  attempts: number;
+  expires_at: number;
+}
+
+export interface OrganizationDomainJSON extends ClerkResourceJSON {
+  object: 'organization_domain';
+  id: string;
+  name: string;
+  organization_id: string;
+  enrollment_mode: OrganizationEnrollmentMode;
+  verification: OrganizationDomainVerificationJSON | null;
+  affiliation_email_address: string | null;
   created_at: number;
   updated_at: number;
 }

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -52,21 +52,6 @@ export interface OrganizationResource extends ClerkResource {
   removeMember: (userId: string) => Promise<OrganizationMembershipResource>;
   createDomain: (domainName: string) => Promise<OrganizationDomainResource>;
   getDomain: ({ domainId }: { domainId: string }) => Promise<OrganizationDomainResource>;
-  prepareDomainAffiliationVerification: ({
-    domainId,
-    emailAddress,
-  }: {
-    domainId: string;
-    emailAddress: string;
-  }) => Promise<OrganizationDomainResource>;
-
-  attemptDomainAffiliationVerification: ({
-    domainId,
-    code,
-  }: {
-    domainId: string;
-    code: string;
-  }) => Promise<OrganizationDomainResource>;
   destroy: () => Promise<void>;
   setLogo: (params: SetOrganizationLogoParams) => Promise<OrganizationResource>;
 }

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -1,4 +1,5 @@
-import type { ClerkPaginationParams } from './api';
+import type { ClerkPaginatedResponse, ClerkPaginationParams } from './api';
+import type { OrganizationDomainResource } from './organizationDomain';
 import type { OrganizationInvitationResource } from './organizationInvitation';
 import type { MembershipRole, OrganizationMembershipResource } from './organizationMembership';
 import type { ClerkResource } from './resource';
@@ -43,11 +44,29 @@ export interface OrganizationResource extends ClerkResource {
   update: (params: UpdateOrganizationParams) => Promise<OrganizationResource>;
   getMemberships: (params?: GetMembershipsParams) => Promise<OrganizationMembershipResource[]>;
   getPendingInvitations: (params?: GetPendingInvitationsParams) => Promise<OrganizationInvitationResource[]>;
+  getDomains: (params?: GetDomainsParams) => Promise<ClerkPaginatedResponse<OrganizationDomainResource>>;
   addMember: (params: AddMemberParams) => Promise<OrganizationMembershipResource>;
   inviteMember: (params: InviteMemberParams) => Promise<OrganizationInvitationResource>;
   inviteMembers: (params: InviteMembersParams) => Promise<OrganizationInvitationResource[]>;
   updateMember: (params: UpdateMembershipParams) => Promise<OrganizationMembershipResource>;
   removeMember: (userId: string) => Promise<OrganizationMembershipResource>;
+  createDomain: (domainName: string) => Promise<OrganizationDomainResource>;
+  getDomain: ({ domainId }: { domainId: string }) => Promise<OrganizationDomainResource>;
+  prepareDomainAffiliationVerification: ({
+    domainId,
+    emailAddress,
+  }: {
+    domainId: string;
+    emailAddress: string;
+  }) => Promise<OrganizationDomainResource>;
+
+  attemptDomainAffiliationVerification: ({
+    domainId,
+    code,
+  }: {
+    domainId: string;
+    code: string;
+  }) => Promise<OrganizationDomainResource>;
   destroy: () => Promise<void>;
   setLogo: (params: SetOrganizationLogoParams) => Promise<OrganizationResource>;
 }
@@ -57,6 +76,16 @@ export type GetMembershipsParams = {
 } & ClerkPaginationParams;
 
 export type GetPendingInvitationsParams = ClerkPaginationParams;
+export type GetDomainsParams = {
+  /**
+   * This the starting point for your fetched results. The initial value persists between re-renders
+   */
+  initialPage?: number;
+  /**
+   * Maximum number of items returned per request. The initial value persists between re-renders
+   */
+  initialPageSize?: number;
+};
 
 export interface AddMemberParams {
   userId: string;

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -84,7 +84,7 @@ export type GetDomainsParams = {
   /**
    * Maximum number of items returned per request. The initial value persists between re-renders
    */
-  initialPageSize?: number;
+  pageSize?: number;
 };
 
 export interface AddMemberParams {

--- a/packages/types/src/organizationDomain.ts
+++ b/packages/types/src/organizationDomain.ts
@@ -20,8 +20,21 @@ export interface OrganizationDomainResource extends ClerkResource {
   createdAt: Date;
   updatedAt: Date;
   affiliationEmailAddress: string | null;
+  prepareDomainAffiliationVerification: (
+    params: PrepareAffiliationVerificationParams,
+  ) => Promise<OrganizationDomainResource>;
+
+  attemptAffiliationVerification: (params: AttemptAffiliationVerificationParams) => Promise<OrganizationDomainResource>;
   delete: () => Promise<void>;
   update: (params: UpdateOrganizationDomainParams) => Promise<OrganizationDomainResource>;
 }
+
+export type PrepareAffiliationVerificationParams = {
+  affiliationEmailAddress: string;
+};
+
+export type AttemptAffiliationVerificationParams = {
+  emailAddress: string;
+};
 
 export type UpdateOrganizationDomainParams = Partial<Pick<OrganizationDomainResource, 'enrollmentMode'>>;

--- a/packages/types/src/organizationDomain.ts
+++ b/packages/types/src/organizationDomain.ts
@@ -34,7 +34,7 @@ export type PrepareAffiliationVerificationParams = {
 };
 
 export type AttemptAffiliationVerificationParams = {
-  emailAddress: string;
+  code: string;
 };
 
 export type UpdateOrganizationDomainParams = Partial<Pick<OrganizationDomainResource, 'enrollmentMode'>>;

--- a/packages/types/src/organizationDomain.ts
+++ b/packages/types/src/organizationDomain.ts
@@ -1,0 +1,27 @@
+import type { ClerkResource } from './resource';
+
+export interface OrganizationDomainVerification {
+  status: OrganizationDomainVerificationStatus;
+  strategy: 'email_code'; // only available value for now
+  attempts: number;
+  expiresAt: Date;
+}
+
+export type OrganizationDomainVerificationStatus = 'unverified' | 'verified';
+
+export type OrganizationEnrollmentMode = 'manual_invitation' | 'automatic_invitation';
+
+export interface OrganizationDomainResource extends ClerkResource {
+  id: string;
+  name: string;
+  organizationId: string;
+  enrollmentMode: OrganizationEnrollmentMode;
+  verification: OrganizationDomainVerification | null;
+  createdAt: Date;
+  updatedAt: Date;
+  affiliationEmailAddress: string | null;
+  delete: () => Promise<void>;
+  update: (params: UpdateOrganizationDomainParams) => Promise<OrganizationDomainResource>;
+}
+
+export type UpdateOrganizationDomainParams = Partial<Pick<OrganizationDomainResource, 'enrollmentMode'>>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR:
- Introduces a new resource called OrganizationDomain
- exposes a list of domains of the above type from the useOrganization hook

<!-- Fixes # (issue number) -->
