### PR TITLE
feat(clerk-js): Implement resend OTP functionality for Organization Domain

### DIFF
--- a/.changeset/pink-keys-shake.md
+++ b/.changeset/pink-keys-shake.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Implement Resend OTP functionality as part of the Organization Domain verification flow

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/VerifyDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/VerifyDomainPage.tsx
@@ -84,6 +84,9 @@ export const VerifyDomainPage = withCardStateProvider(() => {
   }
   const handleResend = () => {
     codeControl.reset();
+    domain?.prepareAffiliationVerification({ affiliationEmailAddress: emailField.value }).catch(err => {
+      handleError(err, [emailField], card.setError);
+    });
   };
 
   const dataChanged = organization.name !== emailField.value;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This commit implements the Resend OTP functionality on the Organization Domain page, that tries to send again the email that contains the OTP code in order to complete the verification flow

<!-- Fixes # (issue number) -->
