### PR TITLE
feat(clerk-js): Support Paginated response in OrganizationMembership.retrieve & `userMemberships` in useOrganizationList

### DIFF
--- a/.changeset/gold-jeans-turn.md
+++ b/.changeset/gold-jeans-turn.md
@@ -1,0 +1,9 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/types': patch
+---
+
+Updates signature of OrganizationMembership.retrieve to support backwards compatibility while allowing using the new paginated responses.
+
++ userMemberships is now also part of the returned values of useOrganizationList

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1009,6 +1009,9 @@ export default class Clerk implements ClerkInterface {
     return Organization.create({ name, slug });
   };
 
+  /**
+   * @deprecated use User.getOrganizationMemberships
+   */
   public getOrganizationMemberships = async (): Promise<OrganizationMembership[]> => {
     return await OrganizationMembership.retrieve();
   };

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -129,7 +129,13 @@ export type UpdateOrganizationMembershipParams = {
  * @deprecated
  */
 export type RetrieveMembershipsParams = {
+  /**
+   * @deprecated Use pageSize instead
+   */
   limit?: number;
+  /**
+   * @deprecated Use initialPage instead
+   */
   offset?: number;
 };
 

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -10,6 +10,7 @@ import type {
   EmailAddressResource,
   ExternalAccountJSON,
   ExternalAccountResource,
+  GetOrganizationMemberships,
   GetUserOrganizationInvitationsParams,
   GetUserOrganizationSuggestionsParams,
   ImageResource,
@@ -32,7 +33,6 @@ import { unixEpochToDate } from '../../utils/date';
 import { normalizeUnsafeMetadata } from '../../utils/resourceParams';
 import { getFullName } from '../../utils/user';
 import { BackupCode } from './BackupCode';
-import type { RetrieveMembershipsParams } from './internal';
 import {
   BaseResource,
   DeletedObject,
@@ -266,11 +266,8 @@ export class User extends BaseResource implements UserResource {
     return OrganizationSuggestion.retrieve(params);
   };
 
-  getOrganizationMemberships = async (
-    retrieveMembership: RetrieveMembershipsParams,
-  ): Promise<OrganizationMembership[]> => {
-    return await OrganizationMembership.retrieve(retrieveMembership);
-  };
+  getOrganizationMemberships: GetOrganizationMemberships = retrieveMembership =>
+    OrganizationMembership.retrieve(retrieveMembership);
 
   get verifiedExternalAccounts() {
     return this.externalAccounts.filter(externalAccount => externalAccount.verification?.status == 'verified');

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/utils.ts
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/utils.ts
@@ -1,6 +1,9 @@
 import type { useCoreOrganizationList } from '../../contexts';
 
 export const organizationListParams = {
+  userMemberships: {
+    infinite: true,
+  },
   userInvitations: {
     infinite: true,
   },

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -101,6 +101,7 @@ export interface UserResource extends ClerkResource {
   getSessions: () => Promise<SessionWithActivitiesResource[]>;
   setProfileImage: (params: SetProfileImageParams) => Promise<ImageResource>;
   createExternalAccount: (params: CreateExternalAccountParams) => Promise<ExternalAccountResource>;
+  getOrganizationMemberships: GetOrganizationMemberships;
   getOrganizationInvitations: (
     params?: GetUserOrganizationInvitationsParams,
   ) => Promise<ClerkPaginatedResponse<UserOrganizationInvitationResource>>;
@@ -190,3 +191,29 @@ export type GetUserOrganizationSuggestionsParams = {
 
   status?: OrganizationSuggestionStatus | OrganizationSuggestionStatus[];
 };
+
+type GetUserOrganizationMembershipOldParams = {
+  limit?: number;
+  offset?: number;
+};
+
+export type GetUserOrganizationMembershipParams = {
+  /**
+   * This the starting point for your fetched results. The initial value persists between re-renders
+   */
+  initialPage?: number;
+  /**
+   * Maximum number of items returned per request. The initial value persists between re-renders
+   */
+  pageSize?: number;
+};
+
+type MembershipParams = (GetUserOrganizationMembershipOldParams | GetUserOrganizationMembershipParams) & {
+  paginated?: boolean;
+};
+
+export type GetOrganizationMemberships = <T extends MembershipParams>(
+  params?: T,
+) => T['paginated'] extends true
+  ? Promise<ClerkPaginatedResponse<OrganizationMembershipResource>>
+  : Promise<OrganizationMembershipResource[]>;


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR 
- marks as `deprecated` the `Clerk.getOrganizationMemberships` method
- updates the signature of `User.getOrganizationMemberships` method and `OrganizationMembership.retrieve`

This PR aims to support backwards compatibility at the type level but also at runtime by adding a new supported parameter to `OrganizationMembership.retrieve` the `paginated:true`

Examples: 
```ts

// Works as before and does not accept parameters (now marked as deprecated)
const memberships = await clerk.getOrganizationMemberships()
// ^ this will be of type OrganizationMemberships[]


// Works as before and accepts parameters
const memberships = await user.getOrganizationMemberships()
// ^ this will be of type OrganizationMembershipResource[]


const memberships = await user.getOrganizationMemberships({limit:10, offset:0})
// ^ this will be of type OrganizationMembershipResource[]


const memberships = await user.getOrganizationMemberships({initialPage:1, pageSize:10, paginated: true})
// ^ this will be of type ClerkPaginatedResponse<OrganizationMembershipResource>

// The hooks only accepts the new paginated params `initialPage & pageSize` (internally uses paginated: true)
const {userMemberships} = useOrganizationList({userMemberships:true})

userMemberships.data
// ^ this will always be of type OrganizationMembershipResource[]


```


<!-- Fixes # (issue number) -->
