### PR TITLE
Update lock-threads.yml

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -26,6 +26,7 @@ jobs:
           days-before-pr-stale: 45
           days-before-issue-close: 10
           days-before-pr-close: 10
+          exempt-issue-labels: 'needs-triage,prioritized'
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'


### PR DESCRIPTION
Make `needs-triage` and `prioritized` labels exempt from the stale labeler

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Description

For issues that we have not yet triaged, or actively prioritized, we do not need the stale labeler to keep running. This change makes that so ✨