### PR TITLE
fix(clerk-js): Set SameSite=Lax for db cookie, so that it can be read…

### DIFF
--- a/.changeset/cool-lamps-cry.md
+++ b/.changeset/cool-lamps-cry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Set SameSite=Lax for dev browser cookie, instead of Strict, so that it can be read from the server after redirects

--- a/packages/clerk-js/src/core/devBrowserHandler.ts
+++ b/packages/clerk-js/src/core/devBrowserHandler.ts
@@ -146,6 +146,14 @@ export default function createDevBrowserHandler({
     const devOrStgApi = isDevOrStagingUrl(frontendApi);
     const devOrStgHost = isDevOrStagingUrl(window.location.host);
 
+    // If a cookie already exists, it might have SameSite=Strict
+    // Re-set it to make sure it has SameSite=Lax
+    const existingDevBrowserCookie = cookieHandler.getDevBrowserCookie();
+    if (existingDevBrowserCookie) {
+      cookieHandler.removeDevBrowserCookie();
+      cookieHandler.setDevBrowserCookie(existingDevBrowserCookie);
+    }
+
     if (devOrStgApi) {
       fapiClient.onBeforeRequest(request => {
         const devBrowserJWT = getDevBrowserJWT();

--- a/packages/clerk-js/src/utils/cookies/handler.ts
+++ b/packages/clerk-js/src/utils/cookies/handler.ts
@@ -67,7 +67,7 @@ export const createCookieHandler = () => {
 
   const setDevBrowserCookie = (jwt: string) => {
     const expires = addYears(Date.now(), 1);
-    const sameSite = 'Strict';
+    const sameSite = DEFAULT_SAME_SITE;
     const secure = false;
 
     return devBrowserCookie.set(jwt, {
@@ -75,6 +75,10 @@ export const createCookieHandler = () => {
       sameSite,
       secure,
     });
+  };
+
+  const getDevBrowserCookie = () => {
+    return devBrowserCookie.get();
   };
 
   const removeDevBrowserCookie = () => devBrowserCookie.remove();
@@ -97,6 +101,7 @@ export const createCookieHandler = () => {
     removeSessionCookie,
     removeAllDevBrowserCookies,
     setDevBrowserCookie,
+    getDevBrowserCookie,
     removeDevBrowserCookie,
   };
 };


### PR DESCRIPTION
… from SSR after redirects

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

WIP, works for new flows

Need to figure out the following:
* Best point to change already set Strict db cookies to Lax
* See if there is potential for duplicate cookies to be set
