### PR TITLE
fix(clerk-js): Disable chunking for clerk headless build

### DIFF
--- a/.changeset/thick-timers-wave.md
+++ b/.changeset/thick-timers-wave.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Disable chunking for `@clerk/clerk-js/headless` to ensure the library doesn't attempt to dynamically load chunks in a non-browser environment.

--- a/packages/clerk-js/jest.config.js
+++ b/packages/clerk-js/jest.config.js
@@ -8,7 +8,7 @@ const config = {
   setupFiles: ['./setupJest.ts'],
   setupFilesAfterEnv: ['./setupJestAfterEnv.ts'],
   testRegex: [
-    '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
+    '/__tests__/(.+/)*.*.test.[jt]sx?$',
     '/ui/.*/__tests__/.*.test.[jt]sx?$',
     '/(core|utils)/.*.test.[jt]sx?$',
   ],

--- a/packages/clerk-js/jest.config.js
+++ b/packages/clerk-js/jest.config.js
@@ -7,7 +7,11 @@ const config = {
   roots: ['<rootDir>/src'],
   setupFiles: ['./setupJest.ts'],
   setupFilesAfterEnv: ['./setupJestAfterEnv.ts'],
-  testRegex: ['/ui/.*/__tests__/.*.test.[jt]sx?$', '/(core|utils)/.*.test.[jt]sx?$'],
+  testRegex: [
+    '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
+    '/ui/.*/__tests__/.*.test.[jt]sx?$',
+    '/(core|utils)/.*.test.[jt]sx?$',
+  ],
   testPathIgnorePatterns: ['/node_modules/'],
 
   collectCoverage: false,

--- a/packages/clerk-js/setupJest.ts
+++ b/packages/clerk-js/setupJest.ts
@@ -1,48 +1,50 @@
 import { jest } from '@jest/globals';
 
-window.ResizeObserver =
-  window.ResizeObserver ||
-  jest.fn().mockImplementation(() => ({
-    disconnect: jest.fn(),
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-  }));
+if (typeof window !== 'undefined') {
+  window.ResizeObserver =
+    window.ResizeObserver ||
+    jest.fn().mockImplementation(() => ({
+      disconnect: jest.fn(),
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+    }));
 
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // deprecated
-    removeListener: jest.fn(), // deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // deprecated
+      removeListener: jest.fn(), // deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
 
-global.__PKG_NAME__ = '';
-global.__PKG_VERSION__ = '';
+  global.__PKG_NAME__ = '';
+  global.__PKG_VERSION__ = '';
 
-//@ts-expect-error
-global.IntersectionObserver = class IntersectionObserver {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor() {}
+  //@ts-expect-error
+  global.IntersectionObserver = class IntersectionObserver {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor() {}
 
-  disconnect() {
-    return null;
-  }
+    disconnect() {
+      return null;
+    }
 
-  observe() {
-    return null;
-  }
+    observe() {
+      return null;
+    }
 
-  takeRecords() {
-    return null;
-  }
+    takeRecords() {
+      return null;
+    }
 
-  unobserve() {
-    return null;
-  }
-};
+    unobserve() {
+      return null;
+    }
+  };
+}

--- a/packages/clerk-js/src/__tests__/headless.test.ts
+++ b/packages/clerk-js/src/__tests__/headless.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+
+describe('clerk/headless', () => {
+  it('JS-689: should not error when loading headless', () => {
+    expect(() => {
+      require('../../headless/index.js');
+    }).not.toThrow();
+  });
+});

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -183,6 +183,14 @@ const prodConfig = ({ mode, env }) => {
     entryForVariant(variants.clerkHeadless),
     common({ mode }),
     commonForProd(),
+    // Disable chunking for the headless variant, since it's meant to be used in a non-browser environment and
+    // attempting to load chunks causes issues due to usage of a dynamic publicPath. We generally are only concerned with
+    // chunking in our browser bundles.
+    {
+      optimization: {
+        splitChunks: false,
+      },
+    },
     // externalsForHeadless(),
   );
 

--- a/packages/clerk-js/webpack.config.js
+++ b/packages/clerk-js/webpack.config.js
@@ -187,6 +187,9 @@ const prodConfig = ({ mode, env }) => {
     // attempting to load chunks causes issues due to usage of a dynamic publicPath. We generally are only concerned with
     // chunking in our browser bundles.
     {
+      output: {
+        publicPath: '',
+      },
       optimization: {
         splitChunks: false,
       },


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
Updates the `clerk/headless` build configuration to disable chunking. This ensures we don't attempt to load chunks at runtime, causing issues with public path resolution.

<!-- Fixes # (issue number) -->
fixes JS-689, fixes #1644 
