### PR TITLE
feat(clerk-js): Update `personalWorkspace` to display Personal account

### DIFF
--- a/.changeset/little-cobras-wash.md
+++ b/.changeset/little-cobras-wash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': patch
+---
+
+Update "personal workspace" label to "personal account"

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -26,7 +26,7 @@ describe('OrganizationSwitcher', () => {
       });
       props.setProps({ hidePersonal: false });
       const { getByText } = render(<OrganizationSwitcher />, { wrapper });
-      expect(getByText('Personal Workspace')).toBeDefined();
+      expect(getByText('Personal account')).toBeDefined();
     });
 
     it('does not show the personal workspace when disabled', async () => {
@@ -94,7 +94,7 @@ describe('OrganizationSwitcher', () => {
       const { getAllByText, getByText, getByRole, userEvent } = render(<OrganizationSwitcher />, { wrapper });
       await userEvent.click(getByRole('button'));
       expect(getAllByText('Org1')).not.toBeNull();
-      expect(getByText('Personal Workspace')).toBeDefined();
+      expect(getByText('Personal account')).toBeDefined();
       expect(getByText('Org2')).toBeDefined();
     });
 
@@ -293,7 +293,7 @@ describe('OrganizationSwitcher', () => {
       fixtures.clerk.setActive.mockReturnValueOnce(Promise.resolve());
       const { getByRole, getByText, userEvent } = render(<OrganizationSwitcher />, { wrapper });
       await userEvent.click(getByRole('button'));
-      await userEvent.click(getByText(/Personal workspace/i));
+      await userEvent.click(getByText(/Personal account/i));
 
       expect(fixtures.clerk.setActive).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -528,7 +528,7 @@ export const enUS: LocalizationResource = {
     action__addAccount: 'Add account',
   },
   organizationSwitcher: {
-    personalWorkspace: 'Personal Workspace',
+    personalWorkspace: 'Personal account',
     notSelected: 'No organization selected',
     action__createOrganization: 'Create Organization',
     action__manageOrganization: 'Manage Organization',


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This is the first PR that brings some UI updates to organization switcher.
- It updates the label from "Personal workspace" to "Personal account"


![image](https://github.com/clerkinc/javascript/assets/19269911/a824de17-2000-48b8-a3b5-486ccf503e4f)


<!-- Fixes # (issue number) -->
