### PR TITLE
feat(clerk-js): Notify admins for pending requests in OrganizationSwitcher

### DIFF
--- a/.changeset/curly-owls-marry.md
+++ b/.changeset/curly-owls-marry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Display a notification counter for admins with pending request in the active organization. The counter is it visible in OrganizationSwitcher and OrganizationProfile ("Requests" tab)

--- a/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
+++ b/packages/clerk-js/src/ui/common/NotificationCountBadge.tsx
@@ -1,0 +1,38 @@
+import { Box, NotificationBadge } from '../customizables';
+import { useDelayedVisibility, usePrefersReducedMotion } from '../hooks';
+import type { ThemableCssProp } from '../styledSystem';
+import { animations } from '../styledSystem';
+
+export const NotificationCountBadge = ({
+  notificationCount,
+  containerSx,
+}: {
+  notificationCount: number;
+  containerSx?: ThemableCssProp;
+}) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const showNotification = useDelayedVisibility(notificationCount > 0, 350) || false;
+
+  const enterExitAnimation: ThemableCssProp = t => ({
+    animation: prefersReducedMotion
+      ? 'none'
+      : `${notificationCount ? animations.notificationAnimation : animations.outAnimation} ${
+          t.transitionDuration.$textField
+        } ${t.transitionTiming.$slowBezier} 0s 1 normal forwards`,
+  });
+
+  return (
+    <Box
+      sx={[
+        t => ({
+          position: 'relative',
+          width: t.sizes.$4,
+          height: t.sizes.$4,
+        }),
+        containerSx,
+      ]}
+    >
+      {showNotification && <NotificationBadge sx={enterExitAnimation}>{notificationCount}</NotificationBadge>}
+    </Box>
+  );
+};

--- a/packages/clerk-js/src/ui/common/index.ts
+++ b/packages/clerk-js/src/ui/common/index.ts
@@ -11,6 +11,7 @@ export * from './EmailLinkStatusCard';
 export * from './Wizard';
 export * from './RemoveResourcePage';
 export * from './PrintableComponent';
+export * from './NotificationCountBadge';
 export * from './RemoveResourcePage';
 export * from './withOrganizationsEnabledGuard';
 export * from './QRCode';

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationMembers.tsx
@@ -1,3 +1,4 @@
+import { NotificationCountBadge } from '../../common';
 import { useCoreOrganization, useEnvironment, useOrganizationProfileContext } from '../../contexts';
 import { Col, descriptors, Flex, localizationKeys } from '../../customizables';
 import {
@@ -21,11 +22,13 @@ export const OrganizationMembers = withCardStateProvider(() => {
   const { organizationSettings } = useEnvironment();
   const card = useCardState();
   const { membership } = useCoreOrganization();
+  const isAdmin = membership?.role === 'admin';
+  const allowRequests = organizationSettings?.domains?.enabled && isAdmin;
+  const { membershipRequests } = useCoreOrganization({
+    membershipRequests: allowRequests || undefined,
+  });
   //@ts-expect-error
   const { __unstable_manageBillingUrl } = useOrganizationProfileContext();
-  const isAdmin = membership?.role === 'admin';
-
-  const allowRequests = organizationSettings?.domains?.enabled && isAdmin;
 
   return (
     <Col
@@ -55,7 +58,9 @@ export const OrganizationMembers = withCardStateProvider(() => {
               />
             )}
             {allowRequests && (
-              <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__requests')} />
+              <Tab localizationKey={localizationKeys('organizationProfile.membersPage.start.headerTitle__requests')}>
+                <NotificationCountBadge notificationCount={membershipRequests?.count || 0} />
+              </Tab>
             )}
           </TabsList>
           <TabPanels>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -3,6 +3,7 @@ import type { OrganizationInvitationResource, OrganizationMembershipResource } f
 import { describe, it } from '@jest/globals';
 
 import { bindCreateFixtures } from '../../../utils/test/createFixtures';
+import { runFakeTimers } from '../../../utils/test/runFakeTimers';
 import { OrganizationMembers } from '../OrganizationMembers';
 import { createFakeMember, createFakeOrganizationInvitation, createFakeOrganizationMembershipRequest } from './utils';
 
@@ -130,6 +131,31 @@ describe('OrganizationMembers', () => {
     expect(queryByText('test_user2')).toBeDefined();
     expect(queryByText('First2 Last2')).toBeDefined();
     expect(queryByText('Member')).toBeDefined();
+  });
+
+  it('displays counter in requests tab', async () => {
+    const { wrapper, fixtures } = await createFixtures(f => {
+      f.withOrganizations();
+      f.withOrganizationDomains();
+      f.withUser({
+        email_addresses: ['test@clerk.dev'],
+        organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
+      });
+    });
+
+    fixtures.clerk.organization?.getMembershipRequests.mockReturnValue(
+      Promise.resolve({
+        data: [],
+        total_count: 2,
+      }),
+    );
+
+    await runFakeTimers(async () => {
+      const { getByText } = render(<OrganizationMembers />, { wrapper });
+      await waitFor(() => {
+        expect(getByText('2')).toBeInTheDocument();
+      });
+    });
   });
 
   it.todo('removes member from organization when clicking the respective button on a user row');

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -2,11 +2,13 @@ import type { OrganizationResource } from '@clerk/types';
 import React from 'react';
 
 import { runIfFunctionOrReturn } from '../../../utils';
+import { NotificationCountBadge } from '../../common';
 import {
   useCoreClerk,
   useCoreOrganization,
   useCoreOrganizationList,
   useCoreUser,
+  useEnvironment,
   useOrganizationSwitcherContext,
 } from '../../contexts';
 import { descriptors, localizationKeys } from '../../customizables';
@@ -112,6 +114,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
         icon={CogFilled}
         label={localizationKeys('organizationSwitcher.action__manageOrganization')}
         onClick={handleManageOrganizationClicked}
+        trailing={<NotificationCountBadgeManageButton />}
       />
     );
 
@@ -167,3 +170,16 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
     );
   },
 );
+
+const NotificationCountBadgeManageButton = () => {
+  const { membership } = useCoreOrganization();
+  const { organizationSettings } = useEnvironment();
+  const isAdmin = membership?.role === 'admin';
+  const allowRequests = organizationSettings?.domains?.enabled && isAdmin;
+
+  const { membershipRequests } = useCoreOrganization({
+    membershipRequests: allowRequests || undefined,
+  });
+
+  return <NotificationCountBadge notificationCount={membershipRequests?.count || 0} />;
+};

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -71,6 +71,46 @@ describe('OrganizationSwitcher', () => {
         });
       });
     });
+
+    it('shows the counter for pending suggestions and invitations and membership requests', async () => {
+      const { wrapper, fixtures } = await createFixtures(f => {
+        f.withOrganizations();
+        f.withOrganizationDomains();
+        f.withUser({
+          email_addresses: ['test@clerk.dev'],
+          organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
+        });
+      });
+
+      fixtures.clerk.organization?.getMembershipRequests.mockReturnValue(
+        Promise.resolve({
+          data: [],
+          total_count: 2,
+        }),
+      );
+
+      fixtures.clerk.user?.getOrganizationInvitations.mockReturnValueOnce(
+        Promise.resolve({
+          data: [],
+          total_count: 2,
+        }),
+      );
+
+      fixtures.clerk.user?.getOrganizationSuggestions.mockReturnValueOnce(
+        Promise.resolve({
+          data: [],
+          total_count: 3,
+        }),
+      );
+
+      await runFakeTimers(async () => {
+        const { getByText } = render(<OrganizationSwitcher />, { wrapper });
+
+        await waitFor(() => {
+          expect(getByText('7')).toBeInTheDocument();
+        });
+      });
+    });
   });
 
   describe('OrganizationSwitcherPopover', () => {

--- a/packages/clerk-js/src/ui/elements/Actions.tsx
+++ b/packages/clerk-js/src/ui/elements/Actions.tsx
@@ -27,6 +27,7 @@ export const SecondaryActions = (props: PropsOfComponent<typeof Flex>) => {
 
 type ActionProps = Omit<PropsOfComponent<typeof Button>, 'label'> & {
   icon: React.ComponentType;
+  trailing?: React.ReactNode;
   label: LocalizationKey;
   iconBoxElementDescriptor?: ElementDescriptor;
   iconBoxElementId?: ElementId;
@@ -50,6 +51,7 @@ export const Action = (props: ActionProps) => {
     textElementId,
     iconBoxElementDescriptor,
     iconBoxElementId,
+    trailing,
     ...rest
   } = props;
 
@@ -115,6 +117,7 @@ export const Action = (props: ActionProps) => {
         variant='smallRegular'
         colorScheme='neutral'
       />
+      {trailing}
     </Button>
   );
 };

--- a/packages/clerk-js/src/ui/elements/Tabs.tsx
+++ b/packages/clerk-js/src/ui/elements/Tabs.tsx
@@ -2,7 +2,7 @@ import { createContextAndHook } from '@clerk/shared';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 
-import { Button, descriptors, Flex } from '../customizables';
+import { Button, descriptors, Flex, useLocalizations } from '../customizables';
 import type { PropsOfComponent } from '../styledSystem';
 import { getValidChildren } from '../utils';
 
@@ -87,7 +87,8 @@ export const TabsList = (props: TabsListProps) => {
 type TabProps = PropsOfComponent<typeof Button>;
 type TabPropsWithTabIndex = TabProps & { tabIndex?: number };
 export const Tab = (props: TabProps) => {
-  const { children, sx, tabIndex, isDisabled, ...rest } = props as TabPropsWithTabIndex;
+  const { t } = useLocalizations();
+  const { children, sx, tabIndex, isDisabled, localizationKey, ...rest } = props as TabPropsWithTabIndex;
 
   if (tabIndex === undefined) {
     throw new Error('Tab component must be a direct child of TabList.');
@@ -145,6 +146,7 @@ export const Tab = (props: TabProps) => {
       ]}
       {...rest}
     >
+      {t(localizationKey)}
       {children}
     </Button>
   );


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR is an improvement for the notification badge in OrganizationSwitcher
- Include the number of pending requests in the active organization in switcher (for organization admins)
- Add the same number to the "Requests" tab  in OrganizationProfile

https://github.com/clerkinc/javascript/assets/19269911/03e91fdd-2dd2-497d-9baa-96cf3ea3ce42


