### PR TITLE
fix(shared): Force disable swr devtools for organization hooks

### DIFF
--- a/.changeset/green-snails-tickle.md
+++ b/.changeset/green-snails-tickle.md
@@ -1,0 +1,7 @@
+---
+'@clerk/shared': patch
+---
+
+Fix: swr devtools breaks applications with clerk
+- Force disable swr devtools for organization hooks
+- Let the swr devtool to pick the correct react version

--- a/packages/shared/src/hooks/clerk-swr.ts
+++ b/packages/shared/src/hooks/clerk-swr.ts
@@ -1,0 +1,10 @@
+export const disableSWRDevtools = () => {
+  if (typeof window !== 'undefined') {
+    // @ts-ignore
+    window.__SWR_DEVTOOLS_USE__ = undefined;
+  }
+};
+
+export * from 'swr';
+export { default as useSWR } from 'swr';
+export { default as useSWRInfinite } from 'swr/infinite';

--- a/packages/shared/src/hooks/contexts.tsx
+++ b/packages/shared/src/hooks/contexts.tsx
@@ -9,8 +9,10 @@ import type {
 } from '@clerk/types';
 import type { PropsWithChildren } from 'react';
 import React from 'react';
-import { SWRConfig } from 'swr';
 
+import { disableSWRDevtools } from './clerk-swr';
+disableSWRDevtools();
+import { SWRConfig } from './clerk-swr';
 import { createContextAndHook } from './createContextAndHook';
 
 const [ClerkInstanceContext, useClerkInstanceContext] = createContextAndHook<LoadedClerk>('ClerkInstanceContext');

--- a/packages/shared/src/hooks/useOrganization.tsx
+++ b/packages/shared/src/hooks/useOrganization.tsx
@@ -11,8 +11,10 @@ import type {
   OrganizationResource,
 } from '@clerk/types';
 import type { ClerkPaginatedResponse } from '@clerk/types';
-import useSWR from 'swr';
 
+import { disableSWRDevtools } from './clerk-swr';
+disableSWRDevtools();
+import { useSWR } from './clerk-swr';
 import { useClerkInstanceContext, useOrganizationContext, useSessionContext } from './contexts';
 import type { PaginatedResources, PaginatedResourcesWithDefault } from './types';
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';

--- a/packages/shared/src/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/hooks/usePagesOrInfinite.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import useSWR from 'swr';
-import useSWRInfinite from 'swr/infinite';
 
+import { disableSWRDevtools } from './clerk-swr';
+disableSWRDevtools();
+import { useSWR, useSWRInfinite } from './clerk-swr';
 import type { ValueOrSetter } from './types';
 import type { PaginatedResources } from './types';
 


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

This PR fixes a bug where the application would break if the SWR Devtools extention was enabled in the broswer.

See 👉  [SWR Devtool Issue](https://github.com/koba04/swr-devtools/issues/125)

By overriding the window.__SWR_DEVTOOLS_USE__ with a false value before importing swr, enables us to [disable swr from "hinting"](https://github.com/vercel/swr/blob/4d20bff6759d4478380963654a560a1cf9ae7be1/_internal/src/utils/devtools.ts#L12) to swr-devtools which react version to use.

# Clerk Dashboard 
## Before

https://github.com/clerkinc/javascript/assets/19269911/ad4cd3f0-51d5-4ea1-abaa-dca0d2a54315
## After 

https://github.com/clerkinc/javascript/assets/19269911/8393132b-a56f-41df-a16a-45950609c7bb





<!-- Fixes # (issue number) -->
