### PR TITLE
feat(clerk-js): Add factor-one support for account transfer flow

### DIFF
--- a/.changeset/hot-crabs-applaud.md
+++ b/.changeset/hot-crabs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Add support for redirecting to "factor-one" during account transfer flow.

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -1230,7 +1230,7 @@ describe('Clerk singleton', () => {
       });
     });
 
-    it('redirects user to first-factor if the email is claimed but the external account has an unverified email', async () => {
+    it('redirects user to factor-one, if the email is claimed, but the external account has an unverified email', async () => {
       mockEnvironmentFetch.mockReturnValue(
         Promise.resolve({
           authConfig: {},
@@ -1256,6 +1256,56 @@ describe('Clerk singleton', () => {
       await sut.load({
         navigate: mockNavigate,
       });
+
+      await sut.handleRedirectCallback();
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/sign-in#/factor-one');
+      });
+    });
+
+    it('redirects user to factor-one, if we are doing a account transfer and the external account has an unverified email', async () => {
+      mockEnvironmentFetch.mockReturnValue(
+        Promise.resolve({
+          authConfig: {},
+          userSettings: mockUserSettings,
+          displayConfig: mockDisplayConfig,
+          isSingleSession: () => false,
+          isProduction: () => false,
+          isDevelopmentOrStaging: () => true,
+        }),
+      );
+
+      mockClientFetch.mockReturnValue(
+        Promise.resolve({
+          activeSessions: [],
+          signIn: new SignIn(null),
+          signUp: new SignUp({
+            status: 'missing_requirements',
+            missing_fields: [],
+            unverified_fields: ['email_address'],
+            verifications: {
+              external_account: {
+                status: 'transferable',
+                error: {
+                  code: 'external_account_exists',
+                },
+              },
+            },
+          } as unknown as SignUpJSON),
+        }),
+      );
+
+      const mockSignInCreate = jest.fn().mockReturnValue(Promise.resolve({ status: 'needs_first_factor' }));
+
+      const sut = new Clerk(frontendApi);
+      await sut.load({
+        navigate: mockNavigate,
+      });
+      if (!sut.client) {
+        fail('we should always have a client');
+      }
+      sut.client.signIn.create = mockSignInCreate;
 
       await sut.handleRedirectCallback();
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -915,6 +915,8 @@ export default class Clerk implements ClerkInterface {
             session: res.createdSessionId,
             beforeEmit: navigateAfterSignIn,
           });
+        case 'needs_first_factor':
+          return navigateToFactorOne();
         case 'needs_second_factor':
           return navigateToFactorTwo();
         default:


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This change adds support for redirecting to "factor-one" step during the account transfer flow (from sign-up to sign-in).


https://github.com/clerkinc/javascript/assets/684680/18e0fded-0cbb-4970-875e-1e1fe010c105



<!-- Fixes # (issue number) -->
