### PR TITLE
Pre fill form fields in <SignIn/> and <SignUp/>

### DIFF
--- a/.changeset/fresh-papayas-cheat.md
+++ b/.changeset/fresh-papayas-cheat.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+---
+
+`<SignIn/>` and `<SignUp/>` input fields can now be prefilled with the `initialValues` prop.

--- a/.changeset/fresh-papayas-cheat.md
+++ b/.changeset/fresh-papayas-cheat.md
@@ -4,4 +4,4 @@
 '@clerk/types': minor
 ---
 
-`<SignIn/>` and `<SignUp/>` input fields can now be prefilled with the `initialValues` prop.
+`<SignIn/>`, `<SignUp/>`, `<RedirectToSignin/>`, `<RedirectToSignUp/>`, `clerk.redirectToSignIn()` and `clerk.redirectToSignUp()` now accept the `initialValues` option, which will prefill the appropriate form fields with the values provided.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -41,12 +41,14 @@ import type {
   Resources,
   SetActiveParams,
   SignInProps,
+  SignInRedirectOptions,
   SignInResource,
   SignOut,
   SignOutCallback,
   SignOutOptions,
   SignUpField,
   SignUpProps,
+  SignUpRedirectOptions,
   SignUpResource,
   UnsubscribeCallback,
   UserButtonProps,
@@ -58,6 +60,7 @@ import type { MountComponentRenderer } from '../ui/Components';
 import { completeSignUpFlow } from '../ui/components/SignUp/util';
 import {
   appendAsQueryParams,
+  appendUrlsAsQueryParams,
   buildURL,
   createBeforeUnloadTracker,
   createCookieHandler,
@@ -694,11 +697,11 @@ export default class Clerk implements ClerkInterface {
     return setDevBrowserJWTInURL(toURL, devBrowserJwt, asQueryParam).href;
   }
 
-  public buildSignInUrl(options?: RedirectOptions): string {
+  public buildSignInUrl(options?: SignInRedirectOptions): string {
     return this.#buildUrl('signInUrl', options);
   }
 
-  public buildSignUpUrl(options?: RedirectOptions): string {
+  public buildSignUpUrl(options?: SignUpRedirectOptions): string {
     return this.#buildUrl('signUpUrl', options);
   }
 
@@ -757,14 +760,14 @@ export default class Clerk implements ClerkInterface {
     return;
   };
 
-  public redirectToSignIn = async (options?: RedirectOptions): Promise<unknown> => {
+  public redirectToSignIn = async (options?: SignInRedirectOptions): Promise<unknown> => {
     if (inBrowser()) {
       return this.navigate(this.buildSignInUrl(options));
     }
     return;
   };
 
-  public redirectToSignUp = async (options?: RedirectOptions): Promise<unknown> => {
+  public redirectToSignUp = async (options?: SignUpRedirectOptions): Promise<unknown> => {
     if (inBrowser()) {
       return this.navigate(this.buildSignUpUrl(options));
     }
@@ -1456,7 +1459,7 @@ export default class Clerk implements ClerkInterface {
     });
   };
 
-  #buildUrl = (key: 'signInUrl' | 'signUpUrl', options?: RedirectOptions): string => {
+  #buildUrl = (key: 'signInUrl' | 'signUpUrl', options?: SignInRedirectOptions | SignUpRedirectOptions): string => {
     if (!this.#isReady || !this.#environment || !this.#environment.displayConfig) {
       return '';
     }
@@ -1472,7 +1475,10 @@ export default class Clerk implements ClerkInterface {
       { options: this.#options, displayConfig: this.#environment.displayConfig },
       false,
     );
-    return this.buildUrlWithAuth(appendAsQueryParams(signInOrUpUrl, opts));
+
+    return this.buildUrlWithAuth(
+      appendUrlsAsQueryParams(appendAsQueryParams(signInOrUpUrl, options?.initialValues || {}), opts),
+    );
   };
 
   assertComponentsReady(controls: unknown): asserts controls is ReturnType<MountComponentRenderer> {

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -17,3 +17,6 @@ export const ERROR_CODES = {
   NOT_ALLOWED_ACCESS: 'not_allowed_access',
   SAML_USER_ATTRIBUTE_MISSING: 'saml_user_attribute_missing',
 };
+
+export const SIGN_IN_INITIAL_VALUE_KEYS = ['email_address', 'phone_number', 'username'];
+export const SIGN_UP_INITIAL_VALUE_KEYS = ['email_address', 'phone_number', 'username', 'first_name', 'last_name'];

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -222,4 +222,36 @@ describe('SignInStart', () => {
       expect(screen.getByRole('textbox', { name: /phone number/i })).toHaveAttribute('type', 'tel');
     });
   });
+
+  describe('initialValues', () => {
+    it('prefills the emailAddress field with the correct initial value', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      props.setProps({ initialValues: { emailAddress: 'foo@clerk.com' } });
+
+      render(<SignInStart />, { wrapper });
+      screen.getByDisplayValue(/foo@clerk.com/i);
+    });
+
+    it('prefills the phoneNumber field with the correct initial value', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withPhoneNumber();
+      });
+      props.setProps({ initialValues: { phoneNumber: '+306911111111' } });
+
+      render(<SignInStart />, { wrapper });
+      screen.getByDisplayValue(/691 1111111/i);
+    });
+
+    it('prefills the username field with the correct initial value', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withUsername();
+      });
+
+      props.setProps({ initialValues: { username: 'foo' } });
+      render(<SignInStart />, { wrapper });
+      screen.getByDisplayValue(/foo/i);
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -32,7 +32,7 @@ function _SignUpContinue() {
   const { navigate } = useRouter();
   const { displayConfig, userSettings } = useEnvironment();
   const { attributes } = userSettings;
-  const { navigateAfterSignUp, signInUrl, unsafeMetadata } = useSignUpContext();
+  const { navigateAfterSignUp, signInUrl, unsafeMetadata, initialValues = {} } = useSignUpContext();
   const signUp = useCoreSignUp();
   const isProgressiveSignUp = userSettings.signUp.progressive;
   const [activeCommIdentifierType, setActiveCommIdentifierType] = React.useState<ActiveIdentifier>(
@@ -47,27 +47,27 @@ function _SignUpContinue() {
 
   // TODO: This form should be shared between SignUpStart and SignUpContinue
   const formState = {
-    firstName: useFormControl('firstName', '', {
+    firstName: useFormControl('firstName', initialValues.firstName || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__firstName'),
       placeholder: localizationKeys('formFieldInputPlaceholder__firstName'),
     }),
-    lastName: useFormControl('lastName', '', {
+    lastName: useFormControl('lastName', initialValues.lastName || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__lastName'),
       placeholder: localizationKeys('formFieldInputPlaceholder__lastName'),
     }),
-    emailAddress: useFormControl('emailAddress', '', {
+    emailAddress: useFormControl('emailAddress', initialValues.emailAddress || '', {
       type: 'email',
       label: localizationKeys('formFieldLabel__emailAddress'),
       placeholder: localizationKeys('formFieldInputPlaceholder__emailAddress'),
     }),
-    username: useFormControl('username', '', {
+    username: useFormControl('username', initialValues.username || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__username'),
       placeholder: localizationKeys('formFieldInputPlaceholder__username'),
     }),
-    phoneNumber: useFormControl('phoneNumber', '', {
+    phoneNumber: useFormControl('phoneNumber', initialValues.phoneNumber || '', {
       type: 'tel',
       label: localizationKeys('formFieldLabel__phoneNumber'),
       placeholder: localizationKeys('formFieldInputPlaceholder__phoneNumber'),

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpStart.tsx
@@ -42,6 +42,7 @@ function _SignUpStart(): JSX.Element {
     getInitialActiveIdentifier(attributes, userSettings.signUp.progressive),
   );
   const { t, locale } = useLocalizations();
+  const initialValues = ctx.initialValues || {};
 
   const [missingRequirementsWithTicket, setMissingRequirementsWithTicket] = React.useState(false);
 
@@ -51,27 +52,27 @@ function _SignUpStart(): JSX.Element {
   const { failedValidationsText } = usePasswordComplexity(passwordSettings);
 
   const formState = {
-    firstName: useFormControl('firstName', signUp.firstName || '', {
+    firstName: useFormControl('firstName', signUp.firstName || initialValues.firstName || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__firstName'),
       placeholder: localizationKeys('formFieldInputPlaceholder__firstName'),
     }),
-    lastName: useFormControl('lastName', signUp.lastName || '', {
+    lastName: useFormControl('lastName', signUp.lastName || initialValues.lastName || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__lastName'),
       placeholder: localizationKeys('formFieldInputPlaceholder__lastName'),
     }),
-    emailAddress: useFormControl('emailAddress', signUp.emailAddress || '', {
+    emailAddress: useFormControl('emailAddress', signUp.emailAddress || initialValues.emailAddress || '', {
       type: 'email',
       label: localizationKeys('formFieldLabel__emailAddress'),
       placeholder: localizationKeys('formFieldInputPlaceholder__emailAddress'),
     }),
-    username: useFormControl('username', signUp.username || '', {
+    username: useFormControl('username', signUp.username || initialValues.username || '', {
       type: 'text',
       label: localizationKeys('formFieldLabel__username'),
       placeholder: localizationKeys('formFieldInputPlaceholder__username'),
     }),
-    phoneNumber: useFormControl('phoneNumber', signUp.phoneNumber || '', {
+    phoneNumber: useFormControl('phoneNumber', signUp.phoneNumber || initialValues.phoneNumber || '', {
       type: 'tel',
       label: localizationKeys('formFieldLabel__phoneNumber'),
       placeholder: localizationKeys('formFieldInputPlaceholder__phoneNumber'),

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -167,4 +167,36 @@ describe('SignUpStart', () => {
       expect(screen.getByRole('textbox', { name: 'Phone number' })).toHaveValue('(123) 456-789');
     });
   });
+
+  describe('initialValues', () => {
+    it('prefills the emailAddress field with the correct initial value', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withEmailAddress();
+      });
+      props.setProps({ initialValues: { emailAddress: 'foo@clerk.com' } });
+
+      render(<SignUpStart />, { wrapper });
+      screen.getByDisplayValue(/foo@clerk.com/i);
+    });
+
+    it('prefills the phoneNumber field with the correct initial value', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withPhoneNumber();
+      });
+      props.setProps({ initialValues: { phoneNumber: '+306911111111' } });
+
+      render(<SignUpStart />, { wrapper });
+      screen.getByDisplayValue(/691 1111111/i);
+    });
+
+    it('prefills the username field with the correct initial value', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withUsername();
+      });
+
+      props.setProps({ initialValues: { username: 'foo' } });
+      render(<SignUpStart />, { wrapper });
+      screen.getByDisplayValue(/foo/i);
+    });
+  });
 });

--- a/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/clerk-js/src/ui/elements/PhoneInput/PhoneInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useLayoutEffect, useState } from 'react';
+import { forwardRef, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useCoreClerk } from '../../contexts';
 import { descriptors, Flex, Input, Text } from '../../customizables';
@@ -24,7 +24,7 @@ type PhoneInputProps = PropsOfComponent<typeof Input> & { locationBasedCountryIs
 
 const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps>((props, ref) => {
   const { onChange: onChangeProp, value, locationBasedCountryIso, sx, ...rest } = props;
-  const phoneInputRef = React.useRef<HTMLInputElement>(null);
+  const phoneInputRef = useRef<HTMLInputElement>(null);
   const { setNumber, setIso, setNumberAndIso, numberWithCode, iso, formattedNumber } = useFormattedPhoneNumber({
     initPhoneWithCode: value as string,
     locationBasedCountryIso,
@@ -37,11 +37,11 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps>((props, ref
     onChangeProp?.({ target: { value: numberWithCode } } as any);
   };
 
-  const selectedCountryOption = React.useMemo(() => {
+  const selectedCountryOption = useMemo(() => {
     return countryOptions.find(o => o.country.iso === iso) || countryOptions[0];
   }, [iso]);
 
-  React.useEffect(callOnChangeProp, [numberWithCode]);
+  useEffect(callOnChangeProp, [numberWithCode]);
 
   const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
@@ -153,7 +153,7 @@ const PhoneInputBase = forwardRef<HTMLInputElement, PhoneInputProps>((props, ref
 type CountryCodeListItemProps = PropsOfComponent<typeof Flex> & {
   country: CountryEntry;
 };
-const CountryCodeListItem = React.memo((props: CountryCodeListItemProps) => {
+const CountryCodeListItem = memo((props: CountryCodeListItemProps) => {
   const { country, sx, ...rest } = props;
   return (
     <Flex

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -1,7 +1,7 @@
 import type { SignUpResource } from '@clerk/types';
 
 import {
-  appendAsQueryParams,
+  appendUrlsAsQueryParams,
   buildURL,
   getAllETLDs,
   getETLDPlusOneFromFrontendApi,
@@ -242,28 +242,28 @@ describe('trimTrailingSlash(string)', () => {
 describe('appendQueryParams(base,url)', () => {
   it('returns the same url if no params provided', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base);
+    const res = appendUrlsAsQueryParams(base);
     expect(res).toBe('https://dashboard.clerk.com/');
   });
 
   it('handles URL objects', () => {
     const base = new URL('https://dashboard.clerk.com');
     const url = new URL('https://dashboard.clerk.com/applications/appid/instances/');
-    const res = appendAsQueryParams(base, { redirect_url: url });
+    const res = appendUrlsAsQueryParams(base, { redirect_url: url });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F');
   });
 
   it('handles plain strings', () => {
     const base = 'https://dashboard.clerk.com';
     const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendAsQueryParams(base, { redirect_url: url });
+    const res = appendUrlsAsQueryParams(base, { redirect_url: url });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F');
   });
 
   it('handles multiple params', () => {
     const base = 'https://dashboard.clerk.com';
     const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendAsQueryParams(base, {
+    const res = appendUrlsAsQueryParams(base, {
       redirect_url: url,
       after_sign_in_url: url,
     });
@@ -274,26 +274,26 @@ describe('appendQueryParams(base,url)', () => {
 
   it('skips falsy values', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { redirect_url: undefined });
+    const res = appendUrlsAsQueryParams(base, { redirect_url: undefined });
     expect(res).toBe('https://dashboard.clerk.com/');
   });
 
   it('converts relative to absolute urls', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { redirect_url: '/test' });
+    const res = appendUrlsAsQueryParams(base, { redirect_url: '/test' });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
   });
 
   it('converts keys from camel to snake case', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { redirectUrl: '/test' });
+    const res = appendUrlsAsQueryParams(base, { redirectUrl: '/test' });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
   });
 
   it('keeps origin before appending if base and url have different origin', () => {
     const base = new URL('https://dashboard.clerk.com');
     const url = new URL('https://www.google.com/something');
-    const res = appendAsQueryParams(base, { redirect_url: url });
+    const res = appendUrlsAsQueryParams(base, { redirect_url: url });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fwww.google.com%2Fsomething');
   });
 });

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -210,7 +210,7 @@ export const trimTrailingSlash = (path: string): string => {
   return (path || '').replace(/\/+$/, '');
 };
 
-export const appendAsQueryParams = (
+export const appendUrlsAsQueryParams = (
   baseUrl: string | URL,
   urls: Record<string, string | URL | null | undefined> = {},
 ): string => {
@@ -229,6 +229,21 @@ export const appendAsQueryParams = (
   // This is required for ClerkJS Components Hash router to work as expected
   // as it treats the hash as sub-path with its nested querystring parameters.
   return `${base}${params.toString() ? '#/?' + params.toString() : ''}`;
+};
+
+export const appendAsQueryParams = (
+  baseUrl: string | URL,
+  values: Record<string, string | null | undefined> = {},
+): string => {
+  const base = toURL(baseUrl);
+  for (const [key, val] of Object.entries(values)) {
+    if (!val) {
+      continue;
+    }
+    base.searchParams.append(camelToSnake(key), val);
+  }
+
+  return baseUrl.toString() + base.search;
 };
 
 export const hasExternalAccountSignUpError = (signUp: SignUpResource): boolean => {

--- a/packages/react/src/components/controlComponents.tsx
+++ b/packages/react/src/components/controlComponents.tsx
@@ -5,7 +5,7 @@ import { useAuthContext } from '../contexts/AuthContext';
 import { useIsomorphicClerkContext } from '../contexts/IsomorphicClerkContext';
 import { useSessionContext } from '../contexts/SessionContext';
 import { LoadedGuarantee } from '../contexts/StructureContext';
-import type { RedirectToProps, WithClerkProp } from '../types';
+import type { RedirectToSignInProps, RedirectToSignUpProps, WithClerkProp } from '../types';
 import { withClerk } from './withClerk';
 
 export const SignedIn = ({ children }: React.PropsWithChildren<unknown>): JSX.Element | null => {
@@ -40,7 +40,7 @@ export const ClerkLoading = ({ children }: React.PropsWithChildren<unknown>): JS
   return <>{children}</>;
 };
 
-export const RedirectToSignIn = withClerk(({ clerk, ...props }: WithClerkProp<RedirectToProps>) => {
+export const RedirectToSignIn = withClerk(({ clerk, ...props }: WithClerkProp<RedirectToSignInProps>) => {
   const { client, session } = clerk;
   // TODO: Remove temp use of __unstable__environment
   const { __unstable__environment } = clerk as any;
@@ -59,7 +59,7 @@ export const RedirectToSignIn = withClerk(({ clerk, ...props }: WithClerkProp<Re
   return null;
 }, 'RedirectToSignIn');
 
-export const RedirectToSignUp = withClerk(({ clerk, ...props }: WithClerkProp<RedirectToProps>) => {
+export const RedirectToSignUp = withClerk(({ clerk, ...props }: WithClerkProp<RedirectToSignUpProps>) => {
   React.useEffect(() => {
     void clerk.redirectToSignUp(props);
   }, []);

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -14,13 +14,14 @@ import type {
   OrganizationListProps,
   OrganizationMembershipResource,
   OrganizationResource,
-  RedirectOptions,
   SetActiveParams,
   SignInProps,
+  SignInRedirectOptions,
   SignOut,
   SignOutCallback,
   SignOutOptions,
   SignUpProps,
+  SignUpRedirectOptions,
   UnsubscribeCallback,
   UserButtonProps,
   UserProfileProps,
@@ -596,7 +597,7 @@ export default class IsomorphicClerk {
     }
   };
 
-  redirectToSignIn = (opts: RedirectOptions): void => {
+  redirectToSignIn = (opts: SignInRedirectOptions): void => {
     const callback = () => this.clerkjs?.redirectToSignIn(opts as any);
     if (this.clerkjs && this.#loaded) {
       void callback();
@@ -605,7 +606,7 @@ export default class IsomorphicClerk {
     }
   };
 
-  redirectToSignUp = (opts: RedirectOptions): void => {
+  redirectToSignUp = (opts: SignUpRedirectOptions): void => {
     const callback = () => this.clerkjs?.redirectToSignUp(opts as any);
     if (this.clerkjs && this.#loaded) {
       void callback();

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -6,8 +6,9 @@ import type {
   LoadedClerk,
   MultiDomainAndOrProxy,
   PublishableKeyOrFrontendApi,
-  RedirectOptions,
   SessionResource,
+  SignInRedirectOptions,
+  SignUpRedirectOptions,
   UserResource,
 } from '@clerk/types';
 
@@ -83,4 +84,5 @@ export interface SignUpButtonProps extends ButtonProps {
 
 export type SignInWithMetamaskButtonProps = Pick<ButtonProps, 'redirectUrl' | 'children'>;
 
-export type RedirectToProps = RedirectOptions;
+export type RedirectToSignInProps = SignInRedirectOptions;
+export type RedirectToSignUpProps = SignUpRedirectOptions;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -358,14 +358,14 @@ export interface Clerk {
    *
    * @param opts A {@link RedirectOptions} object
    */
-  redirectToSignIn(opts?: RedirectOptions): Promise<unknown>;
+  redirectToSignIn(opts?: SignInRedirectOptions): Promise<unknown>;
 
   /**
    * Redirects to the configured URL where <SignUp/> is mounted.
    *
    * @param opts A {@link RedirectOptions} object
    */
-  redirectToSignUp(opts?: RedirectOptions): Promise<unknown>;
+  redirectToSignUp(opts?: SignUpRedirectOptions): Promise<unknown>;
 
   /**
    * Redirects to the configured URL where <UserProfile/> is mounted.
@@ -559,7 +559,6 @@ export type SignUpInitialValues = {
   firstName?: string;
   lastName?: string;
   username?: string;
-  web3WalletAddress?: string;
 };
 
 export type RedirectOptions = {
@@ -582,6 +581,20 @@ export type RedirectOptions = {
    * to the same value.
    */
   redirectUrl?: string | null;
+};
+
+export type SignInRedirectOptions = RedirectOptions & {
+  /**
+   * Initial values that are used to prefill the sign in form.
+   */
+  initialValues?: SignInInitialValues;
+};
+
+export type SignUpRedirectOptions = RedirectOptions & {
+  /**
+   * Initial values that are used to prefill the sign up form.
+   */
+  initialValues?: SignUpInitialValues;
 };
 
 export type SetActiveParams = {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -547,6 +547,21 @@ export interface Resources {
 
 export type RoutingStrategy = 'path' | 'hash' | 'virtual';
 
+export type SignInInitialValues = {
+  emailAddress?: string;
+  phoneNumber?: string;
+  username?: string;
+};
+
+export type SignUpInitialValues = {
+  emailAddress?: string;
+  phoneNumber?: string;
+  firstName?: string;
+  lastName?: string;
+  username?: string;
+  web3WalletAddress?: string;
+};
+
 export type RedirectOptions = {
   /**
    * Full URL or path to navigate after successful sign in.
@@ -611,6 +626,10 @@ export type SignInProps = {
    * prop of ClerkProvided (if one is provided)
    */
   appearance?: SignInTheme;
+  /**
+   * Initial values that are used to prefill the sign in form.
+   */
+  initialValues?: SignInInitialValues;
 } & RedirectOptions;
 
 export type SignUpProps = {
@@ -638,6 +657,10 @@ export type SignUpProps = {
    * Additional arbitrary metadata to be stored alongside the User object
    */
   unsafeMetadata?: SignUpUnsafeMetadata;
+  /**
+   * Initial values that are used to prefill the sign up form.
+   */
+  initialValues?: SignUpInitialValues;
 } & RedirectOptions;
 
 export type UserProfileProps = {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.

<!-- Description of the Pull Request -->
This PR implements the functionality of prefilling specific input fields of `<SignIn/>` and `<SignUp/>` with the `initialValues` prop. 
The switching mechanism in `<SignIn/>` is smart, meaning that if you switch from email to phone, the phone number will be prefilled with the `initialValues.phoneNumber` value initially.

https://github.com/clerkinc/javascript/assets/73396808/3503dff3-ac36-4cbd-bf0e-9d0a06e36766


https://github.com/clerkinc/javascript/assets/73396808/1f437e46-b903-416c-a2b8-ff9644f448de


https://github.com/clerkinc/javascript/assets/73396808/5ebabcc7-0d02-4f07-be47-63f3e1744a29
<!-- Fixes # (issue number



) -->
