### PR TITLE
fix(localizations): Add missing keys for pt-BR

### DIFF
--- a/.changeset/tasty-rules-rescue.md
+++ b/.changeset/tasty-rules-rescue.md
@@ -1,0 +1,5 @@
+---
+'@clerk/localizations': minor
+---
+
+add missing localization keys for sign-in actionLink in pt-BR

--- a/packages/localizations/src/pt-BR.ts
+++ b/packages/localizations/src/pt-BR.ts
@@ -77,6 +77,10 @@ export const ptBR: LocalizationResource = {
       subtitle: 'para continuar em {{applicationName}}',
       actionText: 'Possui uma conta?',
       actionLink: 'Entrar',
+      actionLink__use_email: 'Usar email',
+      actionLink__use_phone: 'Usar telefone',
+      actionLink__use_username: 'Usar nome de usuário',
+      actionLink__use_email_username: 'Usar email ou nome de usuário',
     },
     emailLink: {
       title: 'Verifique seu e-mail',


### PR DESCRIPTION
add missing localization keys for sign-in actionLink in pt-BR

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

## Description
<!-- Please make sure: -->
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.

<!-- Description of the Pull Request -->

<!-- Fixes # (issue number) -->
