### PR TITLE
fix(clerk-js): Disable role toggle in <OrganizationMembers />, if last admin

### DIFF
--- a/.changeset/lucky-rockets-yawn.md
+++ b/.changeset/lucky-rockets-yawn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Disable role selection for the last admin in OrganizationProfile

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -102,6 +102,7 @@ const MemberRow = (props: {
 
   const isAdmin = currentUserMembership?.role === 'admin';
   const isCurrentUser = user.id === membership.publicUserData.userId;
+  const isLastAdmin = adminCount <= 1 && membership.role === 'admin';
 
   return (
     <RowContainer>
@@ -124,7 +125,7 @@ const MemberRow = (props: {
       <Td>
         {isAdmin ? (
           <RoleSelect
-            isDisabled={card.isLoading || !onRoleChange || (adminCount <= 1 && membership.role === 'admin')}
+            isDisabled={card.isLoading || !onRoleChange || isLastAdmin}
             value={membership.role}
             onChange={onRoleChange}
           />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -15,9 +15,13 @@ export const ActiveMembersList = () => {
     organization,
     membershipList,
     membership: currentUserMembership,
+    memberships: adminMembers,
     ...rest
   } = useCoreOrganization({
     membershipList: { offset: (page - 1) * ITEMS_PER_PAGE, limit: ITEMS_PER_PAGE },
+    memberships: {
+      role: ['admin'],
+    },
   });
   const isAdmin = currentUserMembership?.role === 'admin';
 
@@ -32,14 +36,16 @@ export const ActiveMembersList = () => {
     return null;
   }
 
-  //TODO: calculate if user is the only admin
-  const canChangeOwnAdminRole = isAdmin && organization?.membersCount > 1;
-
   const handleRoleChange = (membership: OrganizationMembershipResource) => (newRole: MembershipRole) => {
     if (!isAdmin) {
       return;
     }
-    return card.runAsync(membership.update({ role: newRole })).catch(err => handleError(err, [], card.setError));
+    return card
+      .runAsync(async () => {
+        await membership.update({ role: newRole });
+        await (adminMembers as any).unstable__mutate?.();
+      })
+      .catch(err => handleError(err, [], card.setError));
   };
 
   const handleRemove = (membership: OrganizationMembershipResource) => () => {
@@ -47,7 +53,11 @@ export const ActiveMembersList = () => {
       return;
     }
     return card
-      .runAsync(membership.destroy())
+      .runAsync(async () => {
+        const destroyedMembership = membership.destroy();
+        await (adminMembers as any).unstable__mutate?.();
+        return destroyedMembership;
+      })
       .then(mutateSwrState)
       .catch(err => handleError(err, [], card.setError));
   };
@@ -70,8 +80,9 @@ export const ActiveMembersList = () => {
         <MemberRow
           key={m.id}
           membership={m}
-          onRoleChange={canChangeOwnAdminRole ? handleRoleChange(m) : undefined}
+          onRoleChange={handleRoleChange(m)}
           onRemove={handleRemove(m)}
+          adminCount={adminMembers?.count || 0}
         />
       ))}
     />
@@ -81,9 +92,10 @@ export const ActiveMembersList = () => {
 const MemberRow = (props: {
   membership: OrganizationMembershipResource;
   onRemove: () => unknown;
+  adminCount: number;
   onRoleChange?: (role: MembershipRole) => unknown;
 }) => {
-  const { membership, onRemove, onRoleChange } = props;
+  const { membership, onRemove, onRoleChange, adminCount } = props;
   const card = useCardState();
   const { membership: currentUserMembership } = useCoreOrganization();
   const user = useCoreUser();
@@ -112,7 +124,7 @@ const MemberRow = (props: {
       <Td>
         {isAdmin ? (
           <RoleSelect
-            isDisabled={card.isLoading || !onRoleChange}
+            isDisabled={card.isLoading || !onRoleChange || (adminCount <= 1 && membership.role === 'admin')}
             value={membership.role}
             onChange={onRoleChange}
           />


### PR DESCRIPTION
## Description

Disable the admin's select menu that changes the role, if there is only one admin left.
Previously this would result in a UI error. This change improves UX
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
## Before
![image](https://github.com/clerkinc/javascript/assets/19269911/0dccce48-904d-476d-81eb-615ac9a40f83)
![image](https://github.com/clerkinc/javascript/assets/19269911/fa92d3af-9861-4b95-8a7c-a66d6e4ff3c4)

## After
![image](https://github.com/clerkinc/javascript/assets/19269911/cb812ce2-c235-4a9c-bd28-47f11b18b24d)


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
