### PR TITLE
fix(clerk-js): Added padding for ArrowBlockButton to prevent layout shift

### DIFF
--- a/.changeset/large-baboons-hope.md
+++ b/.changeset/large-baboons-hope.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Added some padding when the ArrowBlockButton is in loading state and has a left icon to prevent layout shift.

--- a/.changeset/large-baboons-hope.md
+++ b/.changeset/large-baboons-hope.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Added some padding when the ArrowBlockButton is in loading state and has a left icon to prevent layout shift.
+Updated the OAuth buttons in the SignIn and SignUp components to prevent layout shifts while loading.

--- a/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
+++ b/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
@@ -73,21 +73,18 @@ export const ArrowBlockButton = (props: ArrowBlockButtonProps) => {
         <Flex
           as='span'
           center
-          sx={[
-            theme => ({
-              flex: `0 0 ${theme.space.$4}`,
-            }),
-            theme =>
-              isLoading && {
-                padding: theme.space.$0x5,
-              },
-          ]}
+          sx={theme => ({ flex: `0 0 ${theme.space.$4}` })}
         >
           {isLoading ? (
             <Spinner
               elementDescriptor={spinnerElementDescriptor}
               elementId={spinnerElementId}
               size={'md'}
+              sx={theme => [
+                {
+                  padding: theme.space.$2,
+                },
+              ]}
             />
           ) : !isIconElement && leftIcon ? (
             <Icon

--- a/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
+++ b/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
@@ -73,14 +73,21 @@ export const ArrowBlockButton = (props: ArrowBlockButtonProps) => {
         <Flex
           as='span'
           center
-          sx={theme => ({ flex: `0 0 ${theme.space.$4}` })}
+          sx={[
+            theme => ({
+              flex: `0 0 ${theme.space.$4}`,
+            }),
+            theme =>
+              isLoading && {
+                padding: theme.space.$0x5,
+              },
+          ]}
         >
           {isLoading ? (
             <Spinner
               elementDescriptor={spinnerElementDescriptor}
               elementId={spinnerElementId}
-              sx={{ position: 'absolute' }}
-              size={'sm'}
+              size={'md'}
             />
           ) : !isIconElement && leftIcon ? (
             <Icon


### PR DESCRIPTION
## Description

Added some padding when the `ArrowBlockButton` is in loading state and has a left icon to prevent layout shift.

fixes JS-723

### Before

https://github.com/clerkinc/javascript/assets/6823226/d801173e-757c-42d8-9d6b-cfefaa357723

### After

https://github.com/clerkinc/javascript/assets/6823226/064d9f7f-26ce-4920-a04f-3176d2e03041

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
