### PR TITLE
chore(repo): Only allow snapshot releases for Clerk org members

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -17,6 +17,22 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
+      - name: Limit action to Clerk members
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          retries: 3
+          retry-exempt-status-codes: 400,401
+          github-token: ${{ secrets.CLERK_COOKIE_PAT }}
+          script: |
+            const isMember = await github.rest.orgs.checkMembershipForUser({
+              org: 'clerkinc',
+              username: context.actor
+            });
+            if (!isMember) {
+              core.setFailed(`@${actor} is not a member of the Clerk organization`);
+            }
+
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
@@ -61,7 +77,7 @@ jobs:
                 return { name, version };
               })
               .filter(({ version }) => version.includes("-${{ steps.extract-snapshot-name.outputs.name }}"));
-            
+
             let table = `| Package | Version |\n| --- | --- |\n`;
             descriptors.forEach(({ name, version }) => {
               table += `| ${name} | ${version} |\n`;
@@ -74,7 +90,7 @@ jobs:
               .join("\n");
             core.setOutput("table", table);
             core.setOutput("snippets", snippets);
-          
+
 
       - name: Update Comment
         if: steps.version-packages.outputs.success == '1'


### PR DESCRIPTION
## Description
This limits the `!snapshot` command to Clerk org members only, preventing malicious 3rd-party users from opening a PR and releasing a `snapshot` test version with unverified code.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
