### PR TITLE
fix(nextjs): Export SignInWithMetamaskButton

### DIFF
--- a/.changeset/brown-poets-hang.md
+++ b/.changeset/brown-poets-hang.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Exports SignInWithMetamaskButton for @clerk/nextjs package

--- a/.changeset/brown-poets-hang.md
+++ b/.changeset/brown-poets-hang.md
@@ -2,4 +2,4 @@
 '@clerk/nextjs': patch
 ---
 
-Exports SignInWithMetamaskButton for @clerk/nextjs package
+`SignInWithMetamaskButton` is now exported from the `@clerk/nextjs` package

--- a/packages/nextjs/src/client-boundary/uiComponents.tsx
+++ b/packages/nextjs/src/client-boundary/uiComponents.tsx
@@ -15,6 +15,7 @@ export {
   SignInButton,
   SignUpButton,
   SignOutButton,
+  SignInWithMetamaskButton,
   OrganizationList,
 } from '@clerk/clerk-react';
 

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -29,6 +29,7 @@ export {
   CreateOrganization,
   SignInButton,
   SignOutButton,
+  SignInWithMetamaskButton,
   OrganizationList,
 } from './client-boundary/uiComponents';
 


### PR DESCRIPTION
## Description

`<SignInWithMetamaskButton/>` wasn't exported from `@clerk/nextjs` package.

This PR re-exports it's from `@clerk/clerk-react`.

Fixes JS-709

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [X] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
