### PR TITLE
chore(clerk-js): Use URLs for appearance layout unit tests for improved readability

### DIFF
--- a/.changeset/breezy-horses-raise.md
+++ b/.changeset/breezy-horses-raise.md
@@ -1,5 +1,2 @@
 ---
-'@clerk/clerk-js': patch
 ---
-
-Removed dummy `test` text from appearance layout unit tests, with valid URLs for improved readbility.

--- a/.changeset/breezy-horses-raise.md
+++ b/.changeset/breezy-horses-raise.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Removed dummy `test` text from appearance layout unit test, with valid URLs for improved readbility.

--- a/.changeset/breezy-horses-raise.md
+++ b/.changeset/breezy-horses-raise.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Removed dummy `test` text from appearance layout unit test, with valid URLs for improved readbility.
+Removed dummy `test` text from appearance layout unit tests, with valid URLs for improved readbility.

--- a/packages/clerk-js/src/ui/customizables/__tests__/parseAppearance.test.tsx
+++ b/packages/clerk-js/src/ui/customizables/__tests__/parseAppearance.test.tsx
@@ -231,11 +231,11 @@ describe('AppearanceProvider layout flows', () => {
         appearanceKey='signIn'
         globalAppearance={{
           layout: {
-            helpPageUrl: 'test',
-            logoImageUrl: 'test',
-            logoLinkUrl: 'test',
-            privacyPageUrl: 'test',
-            termsPageUrl: 'test',
+            helpPageUrl: 'https://example.com/help',
+            logoImageUrl: 'https://placehold.co/64x64.png',
+            logoLinkUrl: 'https://example.com/',
+            privacyPageUrl: 'https://example.com/privacy',
+            termsPageUrl: 'https://example.com/terms',
             logoPlacement: 'inside',
             showOptionalFields: false,
             socialButtonsPlacement: 'bottom',
@@ -248,11 +248,11 @@ describe('AppearanceProvider layout flows', () => {
     );
 
     const { result } = renderHook(() => useAppearance(), { wrapper });
-    expect(result.current.parsedLayout.helpPageUrl).toBe('test');
-    expect(result.current.parsedLayout.logoImageUrl).toBe('test');
-    expect(result.current.parsedLayout.logoLinkUrl).toBe('test');
-    expect(result.current.parsedLayout.privacyPageUrl).toBe('test');
-    expect(result.current.parsedLayout.termsPageUrl).toBe('test');
+    expect(result.current.parsedLayout.helpPageUrl).toBe('https://example.com/help');
+    expect(result.current.parsedLayout.logoImageUrl).toBe('https://placehold.co/64x64.png');
+    expect(result.current.parsedLayout.logoLinkUrl).toBe('https://example.com/');
+    expect(result.current.parsedLayout.privacyPageUrl).toBe('https://example.com/privacy');
+    expect(result.current.parsedLayout.termsPageUrl).toBe('https://example.com/terms');
     expect(result.current.parsedLayout.logoPlacement).toBe('inside');
     expect(result.current.parsedLayout.showOptionalFields).toBe(false);
     expect(result.current.parsedLayout.socialButtonsPlacement).toBe('bottom');
@@ -265,11 +265,11 @@ describe('AppearanceProvider layout flows', () => {
         appearanceKey='signIn'
         appearance={{
           layout: {
-            helpPageUrl: 'test2',
-            logoImageUrl: 'test2',
-            logoLinkUrl: 'test2',
-            privacyPageUrl: 'test2',
-            termsPageUrl: 'test2',
+            helpPageUrl: 'https://example.com/help',
+            logoImageUrl: 'https://placehold.co/64x64.png',
+            logoLinkUrl: 'https://example.com/',
+            privacyPageUrl: 'https://example.com/privacy',
+            termsPageUrl: 'https://example.com/terms',
             logoPlacement: 'outside',
             showOptionalFields: true,
             socialButtonsPlacement: 'top',
@@ -282,11 +282,11 @@ describe('AppearanceProvider layout flows', () => {
     );
 
     const { result } = renderHook(() => useAppearance(), { wrapper });
-    expect(result.current.parsedLayout.helpPageUrl).toBe('test2');
-    expect(result.current.parsedLayout.logoImageUrl).toBe('test2');
-    expect(result.current.parsedLayout.logoLinkUrl).toBe('test2');
-    expect(result.current.parsedLayout.privacyPageUrl).toBe('test2');
-    expect(result.current.parsedLayout.termsPageUrl).toBe('test2');
+    expect(result.current.parsedLayout.helpPageUrl).toBe('https://example.com/help');
+    expect(result.current.parsedLayout.logoImageUrl).toBe('https://placehold.co/64x64.png');
+    expect(result.current.parsedLayout.logoLinkUrl).toBe('https://example.com/');
+    expect(result.current.parsedLayout.privacyPageUrl).toBe('https://example.com/privacy');
+    expect(result.current.parsedLayout.termsPageUrl).toBe('https://example.com/terms');
     expect(result.current.parsedLayout.logoPlacement).toBe('outside');
     expect(result.current.parsedLayout.showOptionalFields).toBe(true);
     expect(result.current.parsedLayout.socialButtonsPlacement).toBe('top');
@@ -299,11 +299,11 @@ describe('AppearanceProvider layout flows', () => {
         appearanceKey='signIn'
         globalAppearance={{
           layout: {
-            helpPageUrl: 'test',
-            logoImageUrl: 'test',
-            logoLinkUrl: 'test',
-            privacyPageUrl: 'test',
-            termsPageUrl: 'test',
+            helpPageUrl: 'https://example.com/help',
+            logoImageUrl: 'https://placehold.co/64x64.png',
+            logoLinkUrl: 'https://example.com/',
+            privacyPageUrl: 'https://example.com/privacy',
+            termsPageUrl: 'https://example.com/terms',
             logoPlacement: 'inside',
             showOptionalFields: false,
             socialButtonsPlacement: 'bottom',
@@ -312,11 +312,11 @@ describe('AppearanceProvider layout flows', () => {
         }}
         appearance={{
           layout: {
-            helpPageUrl: 'test2',
-            logoImageUrl: 'test2',
-            logoLinkUrl: 'test2',
-            privacyPageUrl: 'test2',
-            termsPageUrl: 'test2',
+            helpPageUrl: 'https://second.example.com/help',
+            logoImageUrl: 'https://placehold.co/32x32@2.png',
+            logoLinkUrl: 'https://second.example.com/',
+            privacyPageUrl: 'https://second.example.com/privacy',
+            termsPageUrl: 'https://second.example.com/terms',
             logoPlacement: 'outside',
             showOptionalFields: true,
             socialButtonsPlacement: 'top',
@@ -329,11 +329,11 @@ describe('AppearanceProvider layout flows', () => {
     );
 
     const { result } = renderHook(() => useAppearance(), { wrapper });
-    expect(result.current.parsedLayout.helpPageUrl).toBe('test2');
-    expect(result.current.parsedLayout.logoImageUrl).toBe('test2');
-    expect(result.current.parsedLayout.logoLinkUrl).toBe('test2');
-    expect(result.current.parsedLayout.privacyPageUrl).toBe('test2');
-    expect(result.current.parsedLayout.termsPageUrl).toBe('test2');
+    expect(result.current.parsedLayout.helpPageUrl).toBe('https://second.example.com/help');
+    expect(result.current.parsedLayout.logoImageUrl).toBe('https://placehold.co/32x32@2.png');
+    expect(result.current.parsedLayout.logoLinkUrl).toBe('https://second.example.com/');
+    expect(result.current.parsedLayout.privacyPageUrl).toBe('https://second.example.com/privacy');
+    expect(result.current.parsedLayout.termsPageUrl).toBe('https://second.example.com/terms');
     expect(result.current.parsedLayout.logoPlacement).toBe('outside');
     expect(result.current.parsedLayout.showOptionalFields).toBe(true);
     expect(result.current.parsedLayout.socialButtonsPlacement).toBe('top');


### PR DESCRIPTION
## Description

This PR removes dummy `test` text from appearance layout unit tests with valid URLs for improved readbility.

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [X] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
