### PR TITLE
fix(backend): Populate members_count of an Organization

### DIFF
--- a/.changeset/nice-games-rule.md
+++ b/.changeset/nice-games-rule.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix missing members_count property for an Organization

--- a/packages/backend/src/api/resources/JSON.ts
+++ b/packages/backend/src/api/resources/JSON.ts
@@ -146,6 +146,7 @@ export interface OrganizationJSON extends ClerkResourceJSON {
   updated_at: number;
   max_allowed_memberships: number;
   admin_delete_enabled: boolean;
+  members_count?: number;
 }
 
 export interface OrganizationInvitationJSON extends ClerkResourceJSON {

--- a/packages/backend/src/api/resources/Organization.ts
+++ b/packages/backend/src/api/resources/Organization.ts
@@ -18,6 +18,7 @@ export class Organization {
     readonly privateMetadata: OrganizationPrivateMetadata = {},
     readonly maxAllowedMemberships: number,
     readonly adminDeleteEnabled: boolean,
+    readonly members_count?: number,
   ) {}
 
   static fromJSON(data: OrganizationJSON): Organization {
@@ -35,6 +36,7 @@ export class Organization {
       data.private_metadata,
       data.max_allowed_memberships,
       data.admin_delete_enabled,
+      data.members_count,
     );
   }
 }


### PR DESCRIPTION
## Description

`members_count` was not populated even if users would explicitly ask to be returned.
`clerkClient.organizations.getOrganizationList({ includeMembersCount: true, });`

Turns out the property has never populated in the first place

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
