### PR TITLE
feat(shared): Introduce deprecated/deprecatedProperty for deprecation warnings

### DIFF
--- a/.changeset/seven-rivers-greet.md
+++ b/.changeset/seven-rivers-greet.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': minor
+---
+
+Introduce `deprecated()` and `deprecatedProperty()` helper methods to report deprecation warnings once on console

--- a/packages/shared/src/utils/deprecated.test.ts
+++ b/packages/shared/src/utils/deprecated.test.ts
@@ -1,0 +1,259 @@
+jest.mock('./runtimeEnvironment', () => {
+  return { isDevelopmentEnvironment: jest.fn(() => true) };
+});
+
+import { deprecated, deprecatedProperty } from './deprecated';
+import { isDevelopmentEnvironment } from './runtimeEnvironment';
+
+describe('deprecated(fnName, warning)', () => {
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation();
+  });
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('deprecate class method shows warning', () => {
+    class Example {
+      getSomeMethod = (arg1?, arg2?) => {
+        deprecated('getSomeMethod', 'Use `getSomeMethodElse` instead.');
+        return `getSomeMethodValue:${arg1 || '-'}:${arg2 || '-'}`;
+      };
+    }
+
+    const example = new Example();
+
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(example.getSomeMethod('a', 'b')).toEqual('getSomeMethodValue:a:b');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      'DEPRECATION WARNING: "getSomeMethod" is deprecated and will be removed in the next major release.\nUse `getSomeMethodElse` instead.',
+    );
+
+    expect(example.getSomeMethod()).toEqual('getSomeMethodValue:-:-');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  test('deprecate static method shows warning', () => {
+    class Example {
+      static getSomeStaticMethod = () => {
+        deprecated('getSomeStaticMethod', 'Use `getSomeStaticMethodElse` instead.');
+        return 'getSomeStaticMethodValue';
+      };
+    }
+
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(Example.getSomeStaticMethod()).toEqual('getSomeStaticMethodValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      'DEPRECATION WARNING: "getSomeStaticMethod" is deprecated and will be removed in the next major release.\nUse `getSomeStaticMethodElse` instead.',
+    );
+
+    expect(Example.getSomeStaticMethod()).toEqual('getSomeStaticMethodValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  test('deprecate function shows warning', () => {
+    const getSomeFunction = () => {
+      deprecated('getSomeFunction', 'Use `getSomeFunctionElse` instead.');
+      return 'getSomeFunctionValue';
+    };
+
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(getSomeFunction()).toEqual('getSomeFunctionValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      'DEPRECATION WARNING: "getSomeFunction" is deprecated and will be removed in the next major release.\nUse `getSomeFunctionElse` instead.',
+    );
+
+    expect(getSomeFunction()).toEqual('getSomeFunctionValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  test('deprecate function with key shows warning', () => {
+    const getSomeFunctionWithKey = () => {
+      deprecated('getSomeFunctionWithKey', 'Use `getSomeFunctionWithKeyElse` instead.', 'getSomeFunctionWithKey:key');
+      return 'getSomeFunctionWithKeyValue';
+    };
+
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(getSomeFunctionWithKey()).toEqual('getSomeFunctionWithKeyValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      'DEPRECATION WARNING: "getSomeFunctionWithKey" is deprecated and will be removed in the next major release.\nUse `getSomeFunctionWithKeyElse` instead.',
+    );
+
+    expect(getSomeFunctionWithKey()).toEqual('getSomeFunctionWithKeyValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  test('deprecate function with the same key does not show warning', () => {
+    function V1() {
+      const getSomeFunctionWithSameKey = () => {
+        deprecated(
+          'getSomeFunctionWithSameKey',
+          'Use `getSomeFunctionWithSameKeyElse` instead.',
+          'getSomeFunctionWithSameKey:key',
+        );
+        return 'getSomeFunctionWithSameKeyValue';
+      };
+      return getSomeFunctionWithSameKey;
+    }
+
+    function V2() {
+      const getSomeFunctionWithSameKey = () => {
+        deprecated(
+          'getSomeFunctionWithSameKey',
+          'Use `getSomeFunctionWithSameKeyElse` instead.',
+          'getSomeFunctionWithSameKey:key',
+        );
+        return 'getSomeFunctionWithSameKeyValue';
+      };
+
+      return getSomeFunctionWithSameKey;
+    }
+
+    const getSomeFunctionWithSameKeyV1 = V1();
+    const getSomeFunctionWithSameKeyV2 = V2();
+
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(getSomeFunctionWithSameKeyV1()).toEqual('getSomeFunctionWithSameKeyValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+
+    expect(getSomeFunctionWithSameKeyV1()).toEqual('getSomeFunctionWithSameKeyValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+
+    // does not show warning since the consoleWarnSpy counter is 1
+    expect(getSomeFunctionWithSameKeyV2()).toEqual('getSomeFunctionWithSameKeyValue');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  describe('for non development environment', () => {
+    beforeEach(() => {
+      (isDevelopmentEnvironment as jest.Mock).mockReturnValue(false);
+    });
+    afterEach(() => {
+      (isDevelopmentEnvironment as jest.Mock).mockReturnValue(true);
+    });
+
+    test('deprecate function does not show warning', () => {
+      const getSomeFunctionInProd = () => {
+        deprecated('getSomeFunctionInProd', 'Use `getSomeFunctionInProdElse` instead.');
+        return 'getSomeFunctionInProdValue';
+      };
+
+      expect(consoleWarnSpy).not.toBeCalled();
+      // call it twice to verify that it's never called
+      expect(getSomeFunctionInProd()).toEqual('getSomeFunctionInProdValue');
+      expect(getSomeFunctionInProd()).toEqual('getSomeFunctionInProdValue');
+      expect(consoleWarnSpy).toBeCalledTimes(0);
+    });
+  });
+});
+
+describe('deprecatedProperty(cls, propName, warning, isStatic = false)', () => {
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation();
+  });
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('deprecate class property shows warning', () => {
+    class Example {
+      someProp: string;
+      constructor(someProp: string) {
+        this.someProp = someProp;
+      }
+    }
+
+    deprecatedProperty(Example, 'someProp', 'Use `somePropElse` instead.');
+
+    const example = new Example('someProp-value');
+
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(example.someProp).toEqual('someProp-value');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      'DEPRECATION WARNING: "someProp" is deprecated and will be removed in the next major release.\nUse `somePropElse` instead.',
+    );
+
+    expect(example.someProp).toEqual('someProp-value');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  test('deprecate class static property shows warning', () => {
+    class Example {
+      static someStaticProp: string;
+    }
+
+    deprecatedProperty(Example, 'someStaticProp', 'Use `someStaticPropElse` instead.', true);
+
+    Example.someStaticProp = 'someStaticProp-value';
+    expect(consoleWarnSpy).not.toBeCalled();
+
+    expect(Example.someStaticProp).toEqual('someStaticProp-value');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      'DEPRECATION WARNING: "someStaticProp" is deprecated and will be removed in the next major release.\nUse `someStaticPropElse` instead.',
+    );
+
+    expect(Example.someStaticProp).toEqual('someStaticProp-value');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  test('deprecate class readonly property shows warning', () => {
+    class Example {
+      readonly someReadOnlyProp: string;
+      constructor(someReadOnlyProp: string) {
+        this.someReadOnlyProp = someReadOnlyProp;
+      }
+    }
+
+    deprecatedProperty(Example, 'someReadOnlyProp', 'Use `someReadOnlyPropElse` instead.');
+
+    const example = new Example('someReadOnlyProp-value');
+
+    expect(consoleWarnSpy).not.toBeCalled();
+    expect(example.someReadOnlyProp).toEqual('someReadOnlyProp-value');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(consoleWarnSpy).toBeCalledWith(
+      'DEPRECATION WARNING: "someReadOnlyProp" is deprecated and will be removed in the next major release.\nUse `someReadOnlyPropElse` instead.',
+    );
+
+    expect(example.someReadOnlyProp).toEqual('someReadOnlyProp-value');
+    expect(consoleWarnSpy).toBeCalledTimes(1);
+  });
+
+  describe('for non development environment', () => {
+    beforeEach(() => {
+      (isDevelopmentEnvironment as jest.Mock).mockReturnValue(false);
+    });
+    afterEach(() => {
+      (isDevelopmentEnvironment as jest.Mock).mockReturnValue(true);
+    });
+
+    test('deprecate class readonly property does not show warning', () => {
+      class Example {
+        readonly someReadOnlyPropInProd: string;
+        constructor(someReadOnlyPropInProd: string) {
+          this.someReadOnlyPropInProd = someReadOnlyPropInProd;
+        }
+      }
+
+      deprecatedProperty(Example, 'someReadOnlyPropInProd', 'Use `someReadOnlyPropInProdElse` instead.');
+
+      const example = new Example('someReadOnlyPropInProd-value');
+
+      expect(consoleWarnSpy).not.toBeCalled();
+      // call it twice to verify that it's never called
+      expect(example.someReadOnlyPropInProd).toEqual('someReadOnlyPropInProd-value');
+      expect(example.someReadOnlyPropInProd).toEqual('someReadOnlyPropInProd-value');
+      expect(consoleWarnSpy).toBeCalledTimes(0);
+    });
+  });
+});

--- a/packages/shared/src/utils/deprecated.ts
+++ b/packages/shared/src/utils/deprecated.ts
@@ -1,0 +1,71 @@
+import { isDevelopmentEnvironment } from './runtimeEnvironment';
+/**
+ * Mark class methods or functions as deprecated.
+ *
+ * A console WARNING will be displayed when class methods
+ * or functions are invoked.
+ *
+ * Examples
+ * 1. Deprecate class method
+ * class Example {
+ *   getSomething = (arg1, arg2) => {
+ *       deprecated('Example.getSomething', 'Use `getSomethingElse` instead.');
+ *       return `getSomethingValue:${arg1 || '-'}:${arg2 || '-'}`;
+ *   };
+ * }
+ *
+ * 2. Deprecate function
+ * const getSomething = () => {
+ *   deprecated('getSomething', 'Use `getSomethingElse` instead.');
+ *   return 'getSomethingValue';
+ * };
+ */
+const displayedWarnings = new Set<string>();
+export const deprecated = (fnName: string, warning: string, key?: string): void => {
+  const messageId = key ?? fnName;
+  if (displayedWarnings.has(messageId) || !isDevelopmentEnvironment()) {
+    return;
+  }
+  displayedWarnings.add(messageId);
+
+  console.warn(
+    `DEPRECATION WARNING: "${fnName}" is deprecated and will be removed in the next major release.\n${warning}`,
+  );
+};
+/**
+ * Mark class properties as deprecated.
+ *
+ * A console WARNING will be displayed when class properties are being accessed.
+ *
+ * 1. Deprecate class property
+ * class Example {
+ *   something: string;
+ *   constructor(something: string) {
+ *     this.something = something;
+ *   }
+ * }
+ *
+ * deprecatedProperty(Example, 'something', 'Use `somethingElse` instead.');
+ *
+ * 2. Deprecate class static property
+ * class Example {
+ *   static something: string;
+ * }
+ *
+ * deprecatedProperty(Example, 'something', 'Use `somethingElse` instead.', true);
+ */
+type AnyClass = new (...args: any[]) => any;
+
+export const deprecatedProperty = (cls: AnyClass, propName: string, warning: string, isStatic = false): void => {
+  const target = isStatic ? cls : cls.prototype;
+
+  Object.defineProperty(target, propName, {
+    get() {
+      deprecated(propName, warning, `${cls.name}:${propName}`);
+      return this['_' + propName];
+    },
+    set(v: unknown) {
+      this['_' + propName] = v;
+    },
+  });
+};

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -23,3 +23,4 @@ export * from './isomorphicAtob';
 export * from './globs';
 export * from './loadScript';
 export { isDevelopmentEnvironment } from './runtimeEnvironment';
+export { deprecated, deprecatedProperty } from './deprecated';


### PR DESCRIPTION
## Description

This PR introduces `deprecated` and `deprecatedProperty` helpers that will be used to warn users when using a marked (already marked using JSDoc) class property/method or function by showing a console WARNING.
The warnings will be shown EACH the property is being accessed on the method is being called to urge the users to remove the deprecated usages.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
