### PR TITLE
feat(shared): Organization hooks with `setData` and `revalidate`

### DIFF
--- a/.changeset/blue-ghosts-float.md
+++ b/.changeset/blue-ghosts-float.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+---
+
+Expose mutate for paginated lists of data in organization hooks.
+`const {userMemberships:{mutate}} = useOrganizationList({userMemberships:true})`

--- a/.changeset/blue-ghosts-float.md
+++ b/.changeset/blue-ghosts-float.md
@@ -1,6 +1,6 @@
 ---
-'@clerk/shared': patch
+'@clerk/shared': minor
 ---
 
-Expose mutate for paginated lists of data in organization hooks.
-`const {userMemberships:{mutate}} = useOrganizationList({userMemberships:true})`
+Expose `revalidate` and `setData` for paginated lists of data in organization hooks.
+`const {userMemberships:{revalidate, setData}} = useOrganizationList({userMemberships:true})`

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
@@ -39,12 +39,7 @@ export const InvitationPreview = withCardStateProvider((props: UserOrganizationI
       })
       .then(([updatedItem, organization]) => {
         // Update cache in case another listener depends on it
-        userInvitations?.mutate?.(pages => populateCacheUpdateItem(updatedItem, pages), {
-          // Since `accept` gives back the updated information,
-          // we don't need to revalidate here.
-          revalidate: false,
-        });
-
+        void userInvitations?.setCache?.(cachedPages => populateCacheUpdateItem(updatedItem, cachedPages));
         setAcceptedOrganization(organization);
       })
       .catch(err => handleError(err, [], card.setError));

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
@@ -5,7 +5,7 @@ import { useCoreClerk, useCoreOrganizationList } from '../../contexts';
 import { localizationKeys } from '../../customizables';
 import { useCardState, withCardStateProvider } from '../../elements';
 import { handleError } from '../../utils';
-import { updateCacheInPlace } from '../OrganizationSwitcher/utils';
+import { populateCacheUpdateItem } from '../OrganizationSwitcher/utils';
 import { PreviewListItem, PreviewListItemButton } from './shared';
 import { MembershipPreview } from './UserMembershipList';
 import { organizationListParams } from './utils';
@@ -39,7 +39,12 @@ export const InvitationPreview = withCardStateProvider((props: UserOrganizationI
       })
       .then(([updatedItem, organization]) => {
         // Update cache in case another listener depends on it
-        updateCacheInPlace(userInvitations)(updatedItem);
+        userInvitations?.mutate?.(pages => populateCacheUpdateItem(updatedItem, pages), {
+          // Since `accept` gives back the updated information,
+          // we don't need to revalidate here.
+          revalidate: false,
+        });
+
         setAcceptedOrganization(organization);
       })
       .catch(err => handleError(err, [], card.setError));

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
@@ -39,7 +39,7 @@ export const InvitationPreview = withCardStateProvider((props: UserOrganizationI
       })
       .then(([updatedItem, organization]) => {
         // Update cache in case another listener depends on it
-        void userInvitations?.setCache?.(cachedPages => populateCacheUpdateItem(updatedItem, cachedPages));
+        void userInvitations?.setData?.(cachedPages => populateCacheUpdateItem(updatedItem, cachedPages));
         setAcceptedOrganization(organization);
       })
       .catch(err => handleError(err, [], card.setError));

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
@@ -17,13 +17,7 @@ export const AcceptRejectInvitationButtons = (props: OrganizationSuggestionResou
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updatedItem => {
-        userSuggestions?.mutate?.(pages => populateCacheUpdateItem(updatedItem, pages), {
-          // Since `accept` gives back the updated information,
-          // we don't need to revalidate here.
-          revalidate: false,
-        });
-      })
+      .then(updatedItem => userSuggestions?.setCache?.(pages => populateCacheUpdateItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
@@ -17,7 +17,7 @@ export const AcceptRejectInvitationButtons = (props: OrganizationSuggestionResou
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updatedItem => userSuggestions?.setCache?.(pages => populateCacheUpdateItem(updatedItem, pages)))
+      .then(updatedItem => userSuggestions?.setData?.(pages => populateCacheUpdateItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
@@ -4,7 +4,7 @@ import { useCoreOrganizationList } from '../../contexts';
 import { localizationKeys, Text } from '../../customizables';
 import { useCardState, withCardStateProvider } from '../../elements';
 import { handleError } from '../../utils';
-import { updateCacheInPlace } from '../OrganizationSwitcher/utils';
+import { populateCacheUpdateItem } from '../OrganizationSwitcher/utils';
 import { PreviewListItem, PreviewListItemButton } from './shared';
 import { organizationListParams } from './utils';
 
@@ -17,7 +17,13 @@ export const AcceptRejectInvitationButtons = (props: OrganizationSuggestionResou
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updateCacheInPlace(userSuggestions))
+      .then(updatedItem => {
+        userSuggestions?.mutate?.(pages => populateCacheUpdateItem(updatedItem, pages), {
+          // Since `accept` gives back the updated information,
+          // we don't need to revalidate here.
+          revalidate: false,
+        });
+      })
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -9,7 +9,7 @@ import { DataTable, RoleSelect, RowContainer } from './MemberListTable';
 
 export const ActiveMembersList = () => {
   const card = useCardState();
-  const { organization, memberships, ...rest } = useCoreOrganization({
+  const { organization, memberships } = useCoreOrganization({
     memberships: true,
   });
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -27,7 +27,7 @@ export const ActiveMembersList = () => {
   const handleRoleChange = (membership: OrganizationMembershipResource) => (newRole: MembershipRole) => {
     return card
       .runAsync(async () => {
-        await membership.update({ role: newRole });
+        return await membership.update({ role: newRole });
       })
       .catch(err => handleError(err, [], card.setError));
   };
@@ -35,8 +35,7 @@ export const ActiveMembersList = () => {
   const handleRemove = (membership: OrganizationMembershipResource) => () => {
     return card
       .runAsync(async () => {
-        const destroyedMembership = await membership.destroy();
-        return destroyedMembership;
+        return await membership.destroy();
       })
       .then(mutateSwrState)
       .catch(err => handleError(err, [], card.setError));

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -13,13 +13,6 @@ export const ActiveMembersList = () => {
     memberships: true,
   });
 
-  const mutateSwrState = () => {
-    const unstable__mutate = (rest as any).unstable__mutate;
-    if (unstable__mutate && typeof unstable__mutate === 'function') {
-      unstable__mutate();
-    }
-  };
-
   if (!organization) {
     return null;
   }
@@ -35,9 +28,10 @@ export const ActiveMembersList = () => {
   const handleRemove = (membership: OrganizationMembershipResource) => () => {
     return card
       .runAsync(async () => {
-        return await membership.destroy();
+        const destroyedMembership = await membership.destroy();
+        await memberships?.revalidate?.();
+        return destroyedMembership;
       })
-      .then(mutateSwrState)
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainPage.tsx
@@ -66,7 +66,7 @@ export const RemoveDomainPage = () => {
       successMessage={localizationKeys('organizationProfile.removeDomainPage.successMessage', {
         domain: ref.current?.name,
       })}
-      deleteResource={() => domain?.delete().then(() => (domains as any).unstable__mutate())}
+      deleteResource={() => domain?.delete().then(() => domains?.mutate?.())}
       breadcrumbTitle={localizationKeys('organizationProfile.profilePage.domainSection.title')}
       Breadcrumbs={OrganizationProfileBreadcrumbs}
     />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainPage.tsx
@@ -66,7 +66,7 @@ export const RemoveDomainPage = () => {
       successMessage={localizationKeys('organizationProfile.removeDomainPage.successMessage', {
         domain: ref.current?.name,
       })}
-      deleteResource={() => domain?.delete().then(() => domains?.mutate?.())}
+      deleteResource={() => domain?.delete().then(() => domains?.revalidate?.())}
       breadcrumbTitle={localizationKeys('organizationProfile.profilePage.domainSection.title')}
       Breadcrumbs={OrganizationProfileBreadcrumbs}
     />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
@@ -60,7 +60,7 @@ const RequestRow = withCardStateProvider(
       return card
         .runAsync(async () => {
           await request.accept();
-          await membershipRequests.mutate();
+          await membershipRequests.revalidate();
         }, 'accept')
         .catch(err => handleError(err, [], onError));
     };
@@ -71,7 +71,7 @@ const RequestRow = withCardStateProvider(
       return card
         .runAsync(async () => {
           await request.reject();
-          await membershipRequests.mutate();
+          await membershipRequests.revalidate();
         }, 'reject')
         .catch(err => handleError(err, [], onError));
     };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
@@ -49,23 +49,29 @@ const RequestRow = withCardStateProvider(
   (props: { request: OrganizationMembershipRequestResource; onError: ReturnType<typeof useCardState>['setError'] }) => {
     const { request, onError } = props;
     const card = useCardState();
-    const { membershipRequests } = useCoreOrganization({
+    const { membership, membershipRequests } = useCoreOrganization({
       membershipRequests: membershipRequestsParams,
     });
 
     const onAccept = () => {
+      if (!membership || !membershipRequests) {
+        return;
+      }
       return card
         .runAsync(async () => {
           await request.accept();
-          await (membershipRequests as any).unstable__mutate?.();
+          await membershipRequests.mutate();
         }, 'accept')
         .catch(err => handleError(err, [], onError));
     };
     const onReject = () => {
+      if (!membership || !membershipRequests) {
+        return;
+      }
       return card
         .runAsync(async () => {
           await request.reject();
-          await (membershipRequests as any).unstable__mutate?.();
+          await membershipRequests.mutate();
         }, 'reject')
         .catch(err => handleError(err, [], onError));
     };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainPage.tsx
@@ -157,7 +157,7 @@ export const VerifiedDomainPage = withCardStateProvider(() => {
         deletePending: deletePending.checked,
       });
 
-      await domains.mutate();
+      await domains.revalidate();
 
       await navigate('../../');
     } catch (e) {

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainPage.tsx
@@ -55,7 +55,7 @@ export const VerifiedDomainPage = withCardStateProvider(() => {
   const card = useCardState();
   const { organizationSettings } = useEnvironment();
 
-  const { organization, domains } = useCoreOrganization({
+  const { membership, organization, domains } = useCoreOrganization({
     domains: {
       infinite: true,
     },
@@ -147,7 +147,7 @@ export const VerifiedDomainPage = withCardStateProvider(() => {
   });
 
   const updateEnrollmentMode = async () => {
-    if (!domain || !organization) {
+    if (!domain || !organization || !membership || !domains) {
       return;
     }
 
@@ -157,7 +157,7 @@ export const VerifiedDomainPage = withCardStateProvider(() => {
         deletePending: deletePending.checked,
       });
 
-      await (domains as any).unstable__mutate();
+      await domains.mutate();
 
       await navigate('../../');
     } catch (e) {

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
@@ -44,13 +44,7 @@ const AcceptRejectSuggestionButtons = (props: OrganizationSuggestionResource) =>
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updatedItem => {
-        userSuggestions?.mutate?.(pages => populateCacheUpdateItem(updatedItem, pages), {
-          // Since `accept` gives back the updated information,
-          // we don't need to revalidate here.
-          revalidate: false,
-        });
-      })
+      .then(updatedItem => userSuggestions?.setCache?.(pages => populateCacheUpdateItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 
@@ -87,13 +81,7 @@ const AcceptRejectInvitationButtons = (props: UserOrganizationInvitationResource
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updatedItem => {
-        userInvitations?.mutate?.(pages => populateCacheRemoveItem(updatedItem, pages), {
-          // Since `accept` gives back the updated information,
-          // we don't need to revalidate here.
-          revalidate: false,
-        });
-      })
+      .then(updatedItem => userInvitations?.setCache?.(pages => populateCacheRemoveItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
@@ -44,7 +44,7 @@ const AcceptRejectSuggestionButtons = (props: OrganizationSuggestionResource) =>
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updatedItem => userSuggestions?.setCache?.(pages => populateCacheUpdateItem(updatedItem, pages)))
+      .then(updatedItem => userSuggestions?.setData?.(pages => populateCacheUpdateItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 
@@ -81,7 +81,7 @@ const AcceptRejectInvitationButtons = (props: UserOrganizationInvitationResource
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updatedItem => userInvitations?.setCache?.(pages => populateCacheRemoveItem(updatedItem, pages)))
+      .then(updatedItem => userInvitations?.setData?.(pages => populateCacheRemoveItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
@@ -9,7 +9,7 @@ import { useInView } from '../../hooks';
 import type { PropsOfComponent } from '../../styledSystem';
 import { common } from '../../styledSystem';
 import { handleError } from '../../utils';
-import { organizationListParams, removeItemFromPaginatedCache, updateCacheInPlace } from './utils';
+import { organizationListParams, populateCacheRemoveItem, populateCacheUpdateItem } from './utils';
 
 const useFetchInvitations = () => {
   const { userInvitations, userSuggestions } = useCoreOrganizationList(organizationListParams);
@@ -44,7 +44,13 @@ const AcceptRejectSuggestionButtons = (props: OrganizationSuggestionResource) =>
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updateCacheInPlace(userSuggestions))
+      .then(updatedItem => {
+        userSuggestions?.mutate?.(pages => populateCacheUpdateItem(updatedItem, pages), {
+          // Since `accept` gives back the updated information,
+          // we don't need to revalidate here.
+          revalidate: false,
+        });
+      })
       .catch(err => handleError(err, [], card.setError));
   };
 
@@ -81,7 +87,13 @@ const AcceptRejectInvitationButtons = (props: UserOrganizationInvitationResource
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(removeItemFromPaginatedCache(userInvitations))
+      .then(updatedItem => {
+        userInvitations?.mutate?.(pages => populateCacheRemoveItem(updatedItem, pages), {
+          // Since `accept` gives back the updated information,
+          // we don't need to revalidate here.
+          revalidate: false,
+        });
+      })
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/utils.ts
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/utils.ts
@@ -17,9 +17,16 @@ export const organizationListParams = {
 
 export const populateCacheUpdateItem = <T extends { id: string }>(
   updatedItem: T,
-  itemsInfinitePages: ClerkPaginatedResponse<T>[],
+  itemsInfinitePages: (ClerkPaginatedResponse<T> | undefined)[] | undefined,
 ) => {
+  if (typeof itemsInfinitePages === 'undefined') {
+    return [{ data: [updatedItem], total_count: 1 }];
+  }
+
   return itemsInfinitePages.map(item => {
+    if (typeof item === 'undefined') {
+      return item;
+    }
     const newData = item.data.map(obj => {
       if (obj.id === updatedItem.id) {
         return {
@@ -33,38 +40,23 @@ export const populateCacheUpdateItem = <T extends { id: string }>(
   });
 };
 
-export const updateCacheInPlace =
-  (userSuggestions: any) =>
-  <T extends { id: string }>(result: T): any => {
-    userSuggestions?.unstable__mutate?.(result, {
-      populateCache: populateCacheUpdateItem,
-      // Since `accept` gives back the updated information,
-      // we don't need to revalidate here.
-      revalidate: false,
-    });
-  };
-
 export const populateCacheRemoveItem = <T extends { id: string }>(
   updatedItem: T,
-  itemsInfinitePages: ClerkPaginatedResponse<T>[],
+  itemsInfinitePages: (ClerkPaginatedResponse<T> | undefined)[] | undefined,
 ) => {
-  const prevTotalCount = itemsInfinitePages[itemsInfinitePages.length - 1].total_count;
+  const prevTotalCount = itemsInfinitePages?.[itemsInfinitePages.length - 1]?.total_count;
 
-  return itemsInfinitePages.map(item => {
+  if (!prevTotalCount) {
+    return undefined;
+  }
+
+  return itemsInfinitePages?.map(item => {
+    if (typeof item === 'undefined') {
+      return item;
+    }
     const newData = item.data.filter(obj => {
       return obj.id !== updatedItem.id;
     });
     return { ...item, data: newData, total_count: prevTotalCount - 1 };
   });
 };
-
-export const removeItemFromPaginatedCache =
-  (userInvitations: any) =>
-  <T extends { id: string }>(result: T): any => {
-    userInvitations?.unstable__mutate?.(result, {
-      populateCache: populateCacheRemoveItem,
-      // Since `accept` gives back the updated information,
-      // we don't need to revalidate here.
-      revalidate: false,
-    });
-  };

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/utils.ts
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/utils.ts
@@ -23,6 +23,10 @@ export const populateCacheUpdateItem = <T extends { id: string }>(
     return [{ data: [updatedItem], total_count: 1 }];
   }
 
+  /**
+   * We should "preserve" an undefined page if one is found. For example if swr triggers 2 requests, page 1 & page2, and the request for page2 resolves first, at that point in memory itemsInfinitePages would look like this [undefined, {....}]
+   * if SWR says that has fetched 2 pages but the first result of is undefined, we should not return back an array with 1 item as this will end up having cacheKeys that point nowhere.
+   */
   return itemsInfinitePages.map(item => {
     if (typeof item === 'undefined') {
       return item;
@@ -50,6 +54,10 @@ export const populateCacheRemoveItem = <T extends { id: string }>(
     return undefined;
   }
 
+  /**
+   * We should "preserve" an undefined page if one is found. For example if swr triggers 2 requests, page 1 & page2, and the request for page2 resolves first, at that point in memory itemsInfinitePages would look like this [undefined, {....}]
+   * if SWR says that has fetched 2 pages but the first result of is undefined, we should not return back an array with 1 item as this will end up having cacheKeys that point nowhere.
+   */
   return itemsInfinitePages?.map(item => {
     if (typeof item === 'undefined') {
       return item;

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -107,31 +107,19 @@ type UseOrganization = <T extends UseOrganizationParams>(
       membership: OrganizationMembershipResource | null | undefined;
       domains: PaginatedResources<
         OrganizationDomainResource,
-        T['membershipRequests'] extends { infinite: true } ? true : false,
-        T['membershipRequests'] extends { infinite: true }
-          ? ClerkPaginatedResponse<OrganizationDomainResource>
-          : OrganizationDomainResource[]
+        T['membershipRequests'] extends { infinite: true } ? true : false
       > | null;
       membershipRequests: PaginatedResources<
         OrganizationMembershipRequestResource,
-        T['membershipRequests'] extends { infinite: true } ? true : false,
-        T['membershipRequests'] extends { infinite: true }
-          ? ClerkPaginatedResponse<OrganizationMembershipRequestResource>
-          : OrganizationMembershipRequestResource[]
+        T['membershipRequests'] extends { infinite: true } ? true : false
       > | null;
       memberships: PaginatedResources<
         OrganizationMembershipResource,
-        T['memberships'] extends { infinite: true } ? true : false,
-        T['memberships'] extends { infinite: true }
-          ? ClerkPaginatedResponse<OrganizationMembershipResource>
-          : OrganizationMembershipResource[]
+        T['memberships'] extends { infinite: true } ? true : false
       > | null;
       invitations: PaginatedResources<
         OrganizationInvitationResource,
-        T['invitations'] extends { infinite: true } ? true : false,
-        T['invitations'] extends { infinite: true }
-          ? ClerkPaginatedResponse<OrganizationInvitationResource>
-          : OrganizationInvitationResource[]
+        T['invitations'] extends { infinite: true } ? true : false
       > | null;
     };
 
@@ -397,13 +385,10 @@ export const useOrganization: UseOrganization = params => {
       void mutateMembershipList();
       void mutateInvitationList();
     },
-    // Let the hook return type define this type
-    domains: domains as any,
-    // Let the hook return type define this type
-    membershipRequests: membershipRequests as any,
-    // Let the hook return type define this type
-    memberships: memberships as any,
-    invitations: invitations as any,
+    domains,
+    membershipRequests,
+    memberships,
+    invitations,
   };
 };
 

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -149,7 +149,7 @@ const undefinedPaginatedResource = {
   hasNextPage: false,
   hasPreviousPage: false,
   revalidate: undefined,
-  setCache: undefined,
+  setData: undefined,
 } as const;
 
 export const useOrganization: UseOrganization = params => {

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -148,7 +148,8 @@ const undefinedPaginatedResource = {
   fetchPrevious: undefined,
   hasNextPage: false,
   hasPreviousPage: false,
-  mutate: undefined,
+  revalidate: undefined,
+  setCache: undefined,
 } as const;
 
 export const useOrganization: UseOrganization = params => {

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -56,7 +56,9 @@ type UseOrganizationParams = {
       });
 };
 
-type UseOrganizationReturn =
+type UseOrganization = <T extends UseOrganizationParams>(
+  params?: T,
+) =>
   | {
       isLoaded: false;
       organization: undefined;
@@ -103,13 +105,35 @@ type UseOrganizationReturn =
        */
       membershipList: OrganizationMembershipResource[] | null | undefined;
       membership: OrganizationMembershipResource | null | undefined;
-      domains: PaginatedResources<OrganizationDomainResource> | null;
-      membershipRequests: PaginatedResources<OrganizationMembershipRequestResource> | null;
-      memberships: PaginatedResources<OrganizationMembershipResource> | null;
-      invitations: PaginatedResources<OrganizationInvitationResource> | null;
+      domains: PaginatedResources<
+        OrganizationDomainResource,
+        T['membershipRequests'] extends { infinite: true } ? true : false,
+        T['membershipRequests'] extends { infinite: true }
+          ? ClerkPaginatedResponse<OrganizationDomainResource>
+          : OrganizationDomainResource[]
+      > | null;
+      membershipRequests: PaginatedResources<
+        OrganizationMembershipRequestResource,
+        T['membershipRequests'] extends { infinite: true } ? true : false,
+        T['membershipRequests'] extends { infinite: true }
+          ? ClerkPaginatedResponse<OrganizationMembershipRequestResource>
+          : OrganizationMembershipRequestResource[]
+      > | null;
+      memberships: PaginatedResources<
+        OrganizationMembershipResource,
+        T['memberships'] extends { infinite: true } ? true : false,
+        T['memberships'] extends { infinite: true }
+          ? ClerkPaginatedResponse<OrganizationMembershipResource>
+          : OrganizationMembershipResource[]
+      > | null;
+      invitations: PaginatedResources<
+        OrganizationInvitationResource,
+        T['invitations'] extends { infinite: true } ? true : false,
+        T['invitations'] extends { infinite: true }
+          ? ClerkPaginatedResponse<OrganizationInvitationResource>
+          : OrganizationInvitationResource[]
+      > | null;
     };
-
-type UseOrganization = (params?: UseOrganizationParams) => UseOrganizationReturn;
 
 const undefinedPaginatedResource = {
   data: undefined,
@@ -124,6 +148,7 @@ const undefinedPaginatedResource = {
   fetchPrevious: undefined,
   hasNextPage: false,
   hasPreviousPage: false,
+  mutate: undefined,
 } as const;
 
 export const useOrganization: UseOrganization = params => {
@@ -371,10 +396,13 @@ export const useOrganization: UseOrganization = params => {
       void mutateMembershipList();
       void mutateInvitationList();
     },
-    domains,
-    membershipRequests,
-    memberships,
-    invitations,
+    // Let the hook return type define this type
+    domains: domains as any,
+    // Let the hook return type define this type
+    membershipRequests: membershipRequests as any,
+    // Let the hook return type define this type
+    memberships: memberships as any,
+    invitations: invitations as any,
   };
 };
 

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -80,24 +80,15 @@ type UseOrganizationList = <T extends UseOrganizationListParams>(
       setActive: SetActive;
       userMemberships: PaginatedResources<
         OrganizationMembershipResource,
-        T['userMemberships'] extends { infinite: true } ? true : false,
-        T['userMemberships'] extends { infinite: true }
-          ? ClerkPaginatedResponse<OrganizationMembershipResource>
-          : OrganizationMembershipResource[]
+        T['userMemberships'] extends { infinite: true } ? true : false
       >;
       userInvitations: PaginatedResources<
         UserOrganizationInvitationResource,
-        T['userInvitations'] extends { infinite: true } ? true : false,
-        T['userInvitations'] extends { infinite: true }
-          ? ClerkPaginatedResponse<UserOrganizationInvitationResource>
-          : UserOrganizationInvitationResource[]
+        T['userInvitations'] extends { infinite: true } ? true : false
       >;
       userSuggestions: PaginatedResources<
         OrganizationSuggestionResource,
-        T['userSuggestions'] extends { infinite: true } ? true : false,
-        T['userSuggestions'] extends { infinite: true }
-          ? ClerkPaginatedResponse<OrganizationSuggestionResource>
-          : OrganizationSuggestionResource[]
+        T['userSuggestions'] extends { infinite: true } ? true : false
       >;
     };
 
@@ -234,12 +225,9 @@ export const useOrganizationList: UseOrganizationList = params => {
     organizationList: createOrganizationList(user.organizationMemberships),
     setActive: clerk.setActive,
     createOrganization: clerk.createOrganization,
-    // Let the hook return type define this type
-    userMemberships: memberships as any,
-    // Let the hook return type define this type
-    userInvitations: invitations as any,
-    // Let the hook return type define this type
-    userSuggestions: suggestions as any,
+    userMemberships: memberships,
+    userInvitations: invitations,
+    userSuggestions: suggestions,
   };
   deprecatedObjectProperty(result, 'organizationList', 'Use `userMemberships` instead.');
 

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -52,7 +52,7 @@ const undefinedPaginatedResource = {
   hasNextPage: false,
   hasPreviousPage: false,
   revalidate: undefined,
-  setCache: undefined,
+  setData: undefined,
 } as const;
 
 type UseOrganizationList = <T extends UseOrganizationListParams>(

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -51,7 +51,8 @@ const undefinedPaginatedResource = {
   fetchPrevious: undefined,
   hasNextPage: false,
   hasPreviousPage: false,
-  mutate: undefined,
+  revalidate: undefined,
+  setCache: undefined,
 } as const;
 
 type UseOrganizationList = <T extends UseOrganizationListParams>(

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -38,8 +38,25 @@ type UseOrganizationListParams = {
 };
 
 type OrganizationList = ReturnType<typeof createOrganizationList>;
+const undefinedPaginatedResource = {
+  data: undefined,
+  count: undefined,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  page: undefined,
+  pageCount: undefined,
+  fetchPage: undefined,
+  fetchNext: undefined,
+  fetchPrevious: undefined,
+  hasNextPage: false,
+  hasPreviousPage: false,
+  mutate: undefined,
+} as const;
 
-type UseOrganizationListReturn =
+type UseOrganizationList = <T extends UseOrganizationListParams>(
+  params?: T,
+) =>
   | {
       isLoaded: false;
       /**
@@ -60,28 +77,28 @@ type UseOrganizationListReturn =
       organizationList: OrganizationList;
       createOrganization: (params: CreateOrganizationParams) => Promise<OrganizationResource>;
       setActive: SetActive;
-      userMemberships: PaginatedResources<OrganizationMembershipResource>;
-      userInvitations: PaginatedResources<UserOrganizationInvitationResource>;
-      userSuggestions: PaginatedResources<OrganizationSuggestionResource>;
+      userMemberships: PaginatedResources<
+        OrganizationMembershipResource,
+        T['userMemberships'] extends { infinite: true } ? true : false,
+        T['userMemberships'] extends { infinite: true }
+          ? ClerkPaginatedResponse<OrganizationMembershipResource>
+          : OrganizationMembershipResource[]
+      >;
+      userInvitations: PaginatedResources<
+        UserOrganizationInvitationResource,
+        T['userInvitations'] extends { infinite: true } ? true : false,
+        T['userInvitations'] extends { infinite: true }
+          ? ClerkPaginatedResponse<UserOrganizationInvitationResource>
+          : UserOrganizationInvitationResource[]
+      >;
+      userSuggestions: PaginatedResources<
+        OrganizationSuggestionResource,
+        T['userSuggestions'] extends { infinite: true } ? true : false,
+        T['userSuggestions'] extends { infinite: true }
+          ? ClerkPaginatedResponse<OrganizationSuggestionResource>
+          : OrganizationSuggestionResource[]
+      >;
     };
-
-const undefinedPaginatedResource = {
-  data: undefined,
-  count: undefined,
-  isLoading: false,
-  isFetching: false,
-  isError: false,
-  page: undefined,
-  pageCount: undefined,
-  fetchPage: undefined,
-  fetchNext: undefined,
-  fetchPrevious: undefined,
-  hasNextPage: false,
-  hasPreviousPage: false,
-  unstable__mutate: undefined,
-} as const;
-
-type UseOrganizationList = (params?: UseOrganizationListParams) => UseOrganizationListReturn;
 
 export const useOrganizationList: UseOrganizationList = params => {
   const { userMemberships, userInvitations, userSuggestions } = params || {};
@@ -216,9 +233,12 @@ export const useOrganizationList: UseOrganizationList = params => {
     organizationList: createOrganizationList(user.organizationMemberships),
     setActive: clerk.setActive,
     createOrganization: clerk.createOrganization,
-    userMemberships: memberships,
-    userInvitations: invitations,
-    userSuggestions: suggestions,
+    // Let the hook return type define this type
+    userMemberships: memberships as any,
+    // Let the hook return type define this type
+    userInvitations: invitations as any,
+    // Let the hook return type define this type
+    userSuggestions: suggestions as any,
   };
   deprecatedObjectProperty(result, 'organizationList', 'Use `userMemberships` instead.');
 

--- a/packages/shared/src/react/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/react/hooks/usePagesOrInfinite.ts
@@ -206,7 +206,7 @@ export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, options,
   const hasNextPage = count - offsetCount * pageSizeRef.current > page * pageSizeRef.current;
   const hasPreviousPage = (page - 1) * pageSizeRef.current > offsetCount * pageSizeRef.current;
 
-  const setCache: CacheSetter = triggerInfinite
+  const setData: CacheSetter = triggerInfinite
     ? value =>
         swrInfiniteMutate(value, {
           revalidate: false,
@@ -234,6 +234,6 @@ export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, options,
     // Let the hook return type define this type
     revalidate: revalidate as any,
     // Let the hook return type define this type
-    setCache: setCache as any,
+    setData: setData as any,
   };
 };

--- a/packages/shared/src/react/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/react/hooks/usePagesOrInfinite.ts
@@ -88,7 +88,7 @@ type UsePagesOrInfinite = <
    */
   options: TOptions,
   cacheKeys: CacheKeys,
-) => PaginatedResources<ExtractData<FetcherReturnData>, TOptions['infinite'], FetcherReturnData>;
+) => PaginatedResources<ExtractData<FetcherReturnData>, TOptions['infinite']>;
 
 export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, options, cacheKeys) => {
   const [paginatedPage, setPaginatedPage] = useState(params.initialPage ?? 1);

--- a/packages/shared/src/react/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/react/hooks/usePagesOrInfinite.ts
@@ -2,8 +2,8 @@
 
 import { useCallback, useMemo, useRef, useState } from 'react';
 
-import { useSWR, useSWRInfinite } from './clerk-swr';
-import type { CacheSetter, PaginatedResources, ValueOrSetter } from './types';
+import { useSWR, useSWRInfinite } from '../clerk-swr';
+import type { CacheSetter, PaginatedResources, ValueOrSetter } from '../types';
 
 function getDifferentKeys(obj1: Record<string, unknown>, obj2: Record<string, unknown>): Record<string, unknown> {
   const keysSet = new Set(Object.keys(obj2));

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -1,10 +1,12 @@
+import type { ClerkPaginatedResponse } from '@clerk/types';
+
 export type ValueOrSetter<T = unknown> = (size: T | ((_size: T) => T)) => void;
 
 export type CacheSetter<CData = any> = (
   data?: CData | ((currentData?: CData) => Promise<undefined | CData> | undefined | CData),
 ) => Promise<CData | undefined>;
 
-export type PaginatedResources<T = unknown, Infinite = false, ArrayOrPaginated = unknown> = {
+export type PaginatedResources<T = unknown, Infinite = false> = {
   data: T[];
   count: number;
   isLoading: boolean;
@@ -20,9 +22,9 @@ export type PaginatedResources<T = unknown, Infinite = false, ArrayOrPaginated =
   revalidate: () => Promise<void>;
   setData: Infinite extends true
     ? // Array of pages of data
-      CacheSetter<(ArrayOrPaginated | undefined)[]>
+      CacheSetter<(ClerkPaginatedResponse<T> | undefined)[]>
     : // Array of data
-      CacheSetter<ArrayOrPaginated | undefined>;
+      CacheSetter<ClerkPaginatedResponse<T> | undefined>;
 };
 
 // Utility type to convert PaginatedDataAPI to properties as undefined, except booleans set to false

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -1,6 +1,9 @@
-import type { KeyedMutator } from './clerk-swr';
-
 export type ValueOrSetter<T = unknown> = (size: T | ((_size: T) => T)) => void;
+
+export type CacheSetter<CData = any> = (
+  data?: CData | ((currentData?: CData) => Promise<undefined | CData> | undefined | CData),
+) => Promise<CData | undefined>;
+
 export type PaginatedResources<T = unknown, Infinite = false, ArrayOrPaginated = unknown> = {
   data: T[];
   count: number;
@@ -14,11 +17,12 @@ export type PaginatedResources<T = unknown, Infinite = false, ArrayOrPaginated =
   fetchNext: () => void;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
-  mutate: Infinite extends true
+  revalidate: () => Promise<void>;
+  setCache: Infinite extends true
     ? // Array of pages of data
-      KeyedMutator<(ArrayOrPaginated | undefined)[]>
+      CacheSetter<(ArrayOrPaginated | undefined)[]>
     : // Array of data
-      KeyedMutator<ArrayOrPaginated | undefined>;
+      CacheSetter<ArrayOrPaginated | undefined>;
 };
 
 // Utility type to convert PaginatedDataAPI to properties as undefined, except booleans set to false

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -1,5 +1,7 @@
+import type { KeyedMutator } from './clerk-swr';
+
 export type ValueOrSetter<T = unknown> = (size: T | ((_size: T) => T)) => void;
-export type PaginatedResources<T = unknown> = {
+export type PaginatedResources<T = unknown, Infinite = false, ArrayOrPaginated = unknown> = {
   data: T[];
   count: number;
   isLoading: boolean;
@@ -12,11 +14,14 @@ export type PaginatedResources<T = unknown> = {
   fetchNext: () => void;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
+  mutate: Infinite extends true
+    ? // Array of pages of data
+      KeyedMutator<(ArrayOrPaginated | undefined)[]>
+    : // Array of data
+      KeyedMutator<ArrayOrPaginated | undefined>;
 };
 
 // Utility type to convert PaginatedDataAPI to properties as undefined, except booleans set to false
 export type PaginatedResourcesWithDefault<T> = {
-  [K in keyof PaginatedResources<T>]: PaginatedResources<T>[K] extends boolean
-    ? false
-    : PaginatedResources<T>[K] | undefined;
+  [K in keyof PaginatedResources<T>]: PaginatedResources<T>[K] extends boolean ? false : undefined;
 };

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -18,7 +18,7 @@ export type PaginatedResources<T = unknown, Infinite = false, ArrayOrPaginated =
   hasNextPage: boolean;
   hasPreviousPage: boolean;
   revalidate: () => Promise<void>;
-  setCache: Infinite extends true
+  setData: Infinite extends true
     ? // Array of pages of data
       CacheSetter<(ArrayOrPaginated | undefined)[]>
     : // Array of data


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

**Issue:** 
So far our organization hooks did not officially support mutations. Developers did not have a way to alternate the cache or simply revalidate on demand.

**Background:** 
For `invitationList` (from useOrganization) we didn't encounter such issues, because we are forcing an update under the hood when `lastOrganizationMember` changes. In the case of deleted resource, the hook would refetch and the deleted items would disappear from the cache. In the new flows we introduce with <OrganizationList/> we need to update the cache in place and avoid refetching, in order to avoid layout shifts.

We want developers to explicitly call either `revalidate` or `setData` after a resource is updated and let them decide which method best suits their use-case.


This PR exposes the mutate function for both useSWR and useSWR infinite based on the parameters a developer provided.
- ✅ Wrapper for swr mutate, allows us to have a consistent API without relying on swr not to break our customers.
- ✅ Wrapper for swr mutate, allows us to move to other internal implementation with ease.
- ✅ Can alternate local cache with `setData`
- ✅ Revalidate on demand with `revalidate`. (for example after creating an organization or accepting an invite)
- ❌ `mutate` is what swr describes as [Bound Mutate](https://swr.vercel.app/docs/mutation#bound-mutate) and does not use useSWRMutation under the hood.

As part of the PR, we replaced all usages of unstable__mutate from our update useOrganization and useOrganizationList hooks within ClerkJS Components
- `setData` will not trigger a revalidation, it will simply replace the passed data with data already in cache
- `revalidate` does not accept any parameter and will perform a revalidation causing a request to fire. 
    -  For infinite pagination it will refetch all the cached pages.  
    
Note: I attempted to optimize the revalidation of all pages with infinite by traversing the cache that  is only affected by the updated resource. 
There is also the case where this approach would result in duplicate keys when rendering lists.
This seems to be quite complicated as swr keeps n+1 records for infinite. That means the if 2 pages are fetched, 3 cache are created. 2 keys directly match the pages data and the 3rd is a "parent" record with its own key and it contains copies of the data of the 2 pages. Manually updating any of them, means we need to update the other as well.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated
This will be merged after the PR goes to production https://github.com/clerkinc/clerk-docs/pull/310

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
