### PR TITLE
fix(clerk-js): Correctly display all badges email/phone

### DIFF
--- a/.changeset/breezy-countries-play.md
+++ b/.changeset/breezy-countries-play.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixed a bug where the "Unverified" badge was missing on email or phone number fields when those where marked as "Primary"

--- a/packages/clerk-js/src/ui/components/UserProfile/EmailSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EmailSection.tsx
@@ -49,18 +49,21 @@ const EmailAccordion = ({ email }: { email: EmailAddressResource }) => {
     <UserProfileAccordion
       title={email.emailAddress}
       badge={
-        isPrimary ? (
-          <Badge
-            localizationKey={localizationKeys('badge__primary')}
-            textVariant={'extraSmallMedium'}
-          />
-        ) : !isVerified ? (
-          <Badge
-            localizationKey={localizationKeys('badge__unverified')}
-            colorScheme='danger'
-            textVariant={'extraSmallMedium'}
-          />
-        ) : undefined
+        <>
+          {isPrimary && (
+            <Badge
+              localizationKey={localizationKeys('badge__primary')}
+              textVariant={'extraSmallMedium'}
+            />
+          )}
+          {!isVerified && (
+            <Badge
+              localizationKey={localizationKeys('badge__unverified')}
+              colorScheme='danger'
+              textVariant={'extraSmallMedium'}
+            />
+          )}
+        </>
       }
     >
       <Col gap={4}>

--- a/packages/clerk-js/src/ui/components/UserProfile/PhoneSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/PhoneSection.tsx
@@ -60,18 +60,21 @@ const PhoneAccordion = ({ phone }: { phone: PhoneNumberResource }) => {
       }
       title={formattedPhone}
       badge={
-        isPrimary ? (
-          <Badge
-            localizationKey={localizationKeys('badge__primary')}
-            textVariant={'extraSmallMedium'}
-          />
-        ) : !isVerified ? (
-          <Badge
-            localizationKey={localizationKeys('badge__unverified')}
-            colorScheme='danger'
-            textVariant={'extraSmallMedium'}
-          />
-        ) : undefined
+        <>
+          {isPrimary && (
+            <Badge
+              localizationKey={localizationKeys('badge__primary')}
+              textVariant={'extraSmallMedium'}
+            />
+          )}
+          {!isVerified && (
+            <Badge
+              localizationKey={localizationKeys('badge__unverified')}
+              colorScheme='danger'
+              textVariant={'extraSmallMedium'}
+            />
+          )}
+        </>
       }
     >
       <Col gap={4}>


### PR DESCRIPTION

## Description

This bug was introduced when we moved the "unverified" badges from the body of the expandable to the trigger. Previously the "primary" badge always had priority over the "unverified". We decided to display both. 

This PR displays both badges when needed.

### Before
![image](https://github.com/clerkinc/javascript/assets/19269911/de68c8dd-02c4-4ea5-bc40-79bc4c69c53b)
![image](https://github.com/clerkinc/javascript/assets/19269911/1a987f6d-3120-4630-8be6-6a17fe188fbd)


### After
![image](https://github.com/clerkinc/javascript/assets/19269911/25c77164-49c2-41f2-9522-ff339489a519)
![image](https://github.com/clerkinc/javascript/assets/19269911/c78da910-b6ea-42cb-9aad-4b3e26411b08)


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
