### PR TITLE
chore(clerk-js,backend): Remove deprecated `__clerk_referrer_primary`

### DIFF
--- a/.changeset/little-grapes-compete.md
+++ b/.changeset/little-grapes-compete.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/backend': patch
+---
+
+Removing the `__clerk_referrer_primary` that was marked as deprecated. It was introduced to support the multi-domain featured, but was replaced shortly after.

--- a/packages/backend/src/tokens/interstitialRule.ts
+++ b/packages/backend/src/tokens/interstitialRule.ts
@@ -12,10 +12,6 @@ type InterstitialRule = <T extends AuthenticateRequestOptions>(
 
 const shouldRedirectToSatelliteUrl = (qp?: URLSearchParams) => !!qp?.get('__clerk_satellite_url');
 const hasJustSynced = (qp?: URLSearchParams) => qp?.get('__clerk_synced') === 'true';
-/**
- * @deprecated This will be removed in the next minor version
- */
-const isReturningFromPrimary = (qp?: URLSearchParams) => qp?.get('__clerk_referrer_primary') === 'true';
 
 const VALID_USER_AGENTS = /^Mozilla\/|(Amazon CloudFront)/;
 
@@ -86,20 +82,6 @@ export const potentialRequestAfterSignInOrOutFromClerkHostedUiInDev: Interstitia
 
   if (isDevelopmentFromApiKey(key) && crossOriginReferrer) {
     return interstitial(options, AuthErrorReason.CrossOriginReferrer);
-  }
-  return undefined;
-};
-
-/**
- * @deprecated This will be removed in the next minor version
- */
-export const satelliteInDevReturningFromPrimary: InterstitialRule = options => {
-  const { apiKey, secretKey, isSatellite, searchParams } = options;
-
-  const key = secretKey || apiKey || '';
-
-  if (isSatellite && isReturningFromPrimary(searchParams) && isDevelopmentFromApiKey(key)) {
-    return interstitial(options, AuthErrorReason.SatelliteReturnsFromPrimary);
   }
   return undefined;
 };

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -19,7 +19,6 @@ import {
   potentialFirstRequestOnProductionEnvironment,
   potentialRequestAfterSignInOrOutFromClerkHostedUiInDev,
   runInterstitialRules,
-  satelliteInDevReturningFromPrimary,
 } from './interstitialRule';
 import type { VerifyTokenOptions } from './verify';
 
@@ -161,7 +160,6 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
         crossOriginRequestWithoutHeader,
         nonBrowserRequestInDevRule,
         isSatelliteAndNeedsSyncing,
-        satelliteInDevReturningFromPrimary,
         isPrimaryInDevAndRedirectsToSatellite,
         potentialFirstRequestOnProductionEnvironment,
         potentialFirstLoadInDevWhenUATMissing,

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -76,7 +76,6 @@ import {
   noUserExists,
   pickRedirectionProp,
   removeClerkQueryParam,
-  replaceClerkQueryParam,
   requiresUserInput,
   sessionExistsAndSingleSessionModeEnabled,
   setDevBrowserJWTInURL,
@@ -85,7 +84,7 @@ import {
   windowNavigate,
 } from '../utils';
 import { memoizeListenerCallback } from '../utils/memoizeStateListenerCallback';
-import { CLERK_REFERRER_PRIMARY, CLERK_SATELLITE_URL, CLERK_SYNCED, ERROR_CODES } from './constants';
+import { CLERK_SATELLITE_URL, CLERK_SYNCED, ERROR_CODES } from './constants';
 import type { DevBrowserHandler } from './devBrowserHandler';
 import createDevBrowserHandler from './devBrowserHandler';
 import {
@@ -1141,20 +1140,6 @@ export default class Clerk implements ClerkInterface {
 
   #hasJustSynced = () => getClerkQueryParam(CLERK_SYNCED) === 'true';
   #clearJustSynced = () => removeClerkQueryParam(CLERK_SYNCED);
-  /**
-   * @deprecated This will be removed in the next minor version
-   */
-  #isReturningFromPrimary = () => getClerkQueryParam(CLERK_REFERRER_PRIMARY) === 'true';
-  /**
-   * @deprecated This will be removed in the next minor version
-   */
-  #replacePrimaryReferrerWithClerkSynced = () => {
-    if (this.#options.isInterstitial) {
-      replaceClerkQueryParam(CLERK_REFERRER_PRIMARY, CLERK_SYNCED, 'true');
-    } else {
-      removeClerkQueryParam(CLERK_REFERRER_PRIMARY);
-    }
-  };
 
   #buildSyncUrlForDevelopmentInstances = (): string => {
     const searchParams = new URLSearchParams({
@@ -1179,12 +1164,6 @@ export default class Clerk implements ClerkInterface {
   };
 
   #shouldSyncWithPrimary = (): boolean => {
-    // TODO: Remove this in the minor release
-    if (this.#isReturningFromPrimary()) {
-      this.#replacePrimaryReferrerWithClerkSynced();
-      return false;
-    }
-
     if (this.#hasJustSynced()) {
       if (!this.#options.isInterstitial) {
         this.#clearJustSynced();

--- a/packages/clerk-js/src/core/constants.ts
+++ b/packages/clerk-js/src/core/constants.ts
@@ -5,10 +5,6 @@ export const DEV_BROWSER_SSO_JWT_PARAMETER = '__dev_session';
 export const DEV_BROWSER_SSO_JWT_HTTP_HEADER = 'Clerk-Cookie';
 
 export const CLERK_MODAL_STATE = '__clerk_modal_state';
-/**
- * @deprecated This will be removed in the next minor version
- */
-export const CLERK_REFERRER_PRIMARY = '__clerk_referrer_primary';
 export const CLERK_SYNCED = '__clerk_synced';
 export const CLERK_SATELLITE_URL = '__clerk_satellite_url';
 export const ERROR_CODES = {

--- a/packages/clerk-js/src/utils/getClerkQueryParam.ts
+++ b/packages/clerk-js/src/utils/getClerkQueryParam.ts
@@ -1,4 +1,4 @@
-import { CLERK_REFERRER_PRIMARY, CLERK_SATELLITE_URL, CLERK_SYNCED } from '../core/constants';
+import { CLERK_SATELLITE_URL, CLERK_SYNCED } from '../core/constants';
 
 const ClerkQueryParams = [
   '__clerk_status',
@@ -8,7 +8,6 @@ const ClerkQueryParams = [
   '__clerk_modal_state',
   CLERK_SYNCED,
   CLERK_SATELLITE_URL,
-  CLERK_REFERRER_PRIMARY,
 ] as const;
 
 type ClerkQueryParam = (typeof ClerkQueryParams)[number];
@@ -21,7 +20,6 @@ type ClerkQueryParamsToValuesMap = {
   __clerk_modal_state: string;
   __clerk_synced: string;
   __clerk_satellite_url: string;
-  __clerk_referrer_primary: string;
 };
 
 export type VerificationStatus = 'expired' | 'failed' | 'loading' | 'verified' | 'verified_switch_tab';


### PR DESCRIPTION
## Description

This is safe to remove, as the code that was adding this query param has been removed for at least 6 releases.

To give more context `__clerk_referrer_primary` was introduced in order to identify when a primary was redirected back to a satellite app and interstitial was triggered. This was later replaced by using `__clerk_synced` and the `isInterstitial` parameter from the `load` method. 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
