### PR TITLE
fix(backend): Use fakeTimers() in tests to resolve test flakiness

### DIFF
--- a/.changeset/shiny-meals-marry.md
+++ b/.changeset/shiny-meals-marry.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Fix 1 second flakiness in assertions tests

--- a/packages/backend/src/tokens/jwt/assertions.test.ts
+++ b/packages/backend/src/tokens/jwt/assertions.test.ts
@@ -14,7 +14,7 @@ import {
 } from './assertions';
 
 export default (QUnit: QUnit) => {
-  const { module, test, hooks } = QUnit;
+  const { module, test } = QUnit;
 
   function formatToUTCString(ts: number) {
     const tsDate = new Date(0);
@@ -259,7 +259,16 @@ export default (QUnit: QUnit) => {
     });
   });
 
-  module('assertExpirationClaim(exp, clockSkewInMs)', () => {
+  module('assertExpirationClaim(exp, clockSkewInMs)', hooks => {
+    let fakeClock;
+    hooks.beforeEach(() => {
+      fakeClock = sinon.useFakeTimers();
+    });
+    hooks.afterEach(() => {
+      fakeClock.restore();
+      sinon.restore();
+    });
+
     test('throws err if exp is in the past', assert => {
       const nowInSeconds = Date.now() / 1000;
       const exp = nowInSeconds - 5;
@@ -300,7 +309,16 @@ export default (QUnit: QUnit) => {
     });
   });
 
-  module('assertActivationClaim(nbf, clockSkewInMs)', () => {
+  module('assertActivationClaim(nbf, clockSkewInMs)', hooks => {
+    let fakeClock;
+    hooks.beforeEach(() => {
+      fakeClock = sinon.useFakeTimers();
+    });
+    hooks.afterEach(() => {
+      fakeClock.restore();
+      sinon.restore();
+    });
+
     test('does not throw error if nbf is undefined', assert => {
       assert.equal(undefined, assertActivationClaim(undefined, 0));
     });
@@ -343,7 +361,16 @@ export default (QUnit: QUnit) => {
     });
   });
 
-  module('assertIssuedAtClaim(iat, clockSkewInMs)', () => {
+  module('assertIssuedAtClaim(iat, clockSkewInMs)', hooks => {
+    let fakeClock;
+    hooks.beforeEach(() => {
+      fakeClock = sinon.useFakeTimers();
+    });
+    hooks.afterEach(() => {
+      fakeClock.restore();
+      sinon.restore();
+    });
+
     test('does not throw error if iat is undefined', assert => {
       assert.equal(undefined, assertIssuedAtClaim(undefined, 0));
     });


### PR DESCRIPTION
## Description

The tests were failing from time to time due to differences in the dates in the error messages asserted in the assertions test files. The difference was 1 second.

<img width="1602" alt="Screenshot 2023-09-21 at 14 57 52" src="https://github.com/clerkinc/javascript/assets/3936408/dfe77cc8-94ac-4f8e-a333-0795c9d0d19a">

Example of failed run: https://github.com/clerkinc/javascript/actions/runs/6260901259/job/16999859243?pr=1743

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
