### PR TITLE
chore(fastify): Apply deprecation warnings for fastify

### DIFF
--- a/.changeset/nervous-ducks-battle.md
+++ b/.changeset/nervous-ducks-battle.md
@@ -1,0 +1,5 @@
+---
+'@clerk/fastify': patch
+---
+
+Warn about deprecated constants that will be removed in next major version

--- a/package-lock.json
+++ b/package-lock.json
@@ -33144,7 +33144,7 @@
     },
     "packages/backend": {
       "name": "@clerk/backend",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "@clerk/types": "^3.52.0",
@@ -33190,11 +33190,11 @@
     },
     "packages/chrome-extension": {
       "name": "@clerk/chrome-extension",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "^4.58.0",
-        "@clerk/clerk-react": "^4.25.0"
+        "@clerk/clerk-js": "^4.58.1",
+        "@clerk/clerk-react": "^4.25.1"
       },
       "devDependencies": {
         "@types/chrome": "*",
@@ -33210,11 +33210,11 @@
     },
     "packages/clerk-js": {
       "name": "@clerk/clerk-js",
-      "version": "4.58.0",
+      "version": "4.58.1",
       "license": "MIT",
       "dependencies": {
         "@clerk/localizations": "^1.26.0",
-        "@clerk/shared": "^0.22.1",
+        "@clerk/shared": "^0.23.0",
         "@clerk/types": "^3.52.0",
         "@emotion/cache": "11.10.5",
         "@emotion/react": "11.10.5",
@@ -33570,11 +33570,11 @@
     },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
-        "@clerk/clerk-js": "^4.58.0",
-        "@clerk/clerk-react": "^4.25.0",
+        "@clerk/clerk-js": "^4.58.1",
+        "@clerk/clerk-react": "^4.25.1",
         "base-64": "1.0.0",
         "react-native-url-polyfill": "1.3.0"
       },
@@ -33600,10 +33600,11 @@
     },
     "packages/fastify": {
       "name": "@clerk/fastify",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^0.29.1",
+        "@clerk/backend": "^0.29.2",
+        "@clerk/shared": "^0.23.0",
         "@clerk/types": "^3.52.0",
         "cookies": "0.8.0"
       },
@@ -33620,12 +33621,12 @@
       }
     },
     "packages/gatsby-plugin-clerk": {
-      "version": "4.4.8",
+      "version": "4.4.9",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^0.29.1",
-        "@clerk/clerk-react": "^4.25.0",
-        "@clerk/clerk-sdk-node": "^4.12.6",
+        "@clerk/backend": "^0.29.2",
+        "@clerk/clerk-react": "^4.25.1",
+        "@clerk/clerk-sdk-node": "^4.12.7",
         "@clerk/types": "^3.52.0",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
@@ -33668,12 +33669,12 @@
     },
     "packages/nextjs": {
       "name": "@clerk/nextjs",
-      "version": "4.24.0",
+      "version": "4.24.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^0.29.1",
-        "@clerk/clerk-react": "^4.25.0",
-        "@clerk/clerk-sdk-node": "^4.12.6",
+        "@clerk/backend": "^0.29.2",
+        "@clerk/clerk-react": "^4.25.1",
+        "@clerk/clerk-sdk-node": "^4.12.7",
         "@clerk/types": "^3.52.0",
         "path-to-regexp": "6.2.1",
         "tslib": "2.4.1"
@@ -33708,10 +33709,10 @@
     },
     "packages/react": {
       "name": "@clerk/clerk-react",
-      "version": "4.25.0",
+      "version": "4.25.1",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^0.22.1",
+        "@clerk/shared": "^0.23.0",
         "@clerk/types": "^3.52.0",
         "tslib": "2.4.1"
       },
@@ -33735,12 +33736,12 @@
     },
     "packages/remix": {
       "name": "@clerk/remix",
-      "version": "2.10.3",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^0.29.1",
-        "@clerk/clerk-react": "^4.25.0",
-        "@clerk/shared": "^0.22.1",
+        "@clerk/backend": "^0.29.2",
+        "@clerk/clerk-react": "^4.25.1",
+        "@clerk/shared": "^0.23.0",
         "@clerk/types": "^3.52.0",
         "cookie": "0.5.0",
         "tslib": "2.4.1"
@@ -33771,10 +33772,10 @@
     },
     "packages/sdk-node": {
       "name": "@clerk/clerk-sdk-node",
-      "version": "4.12.6",
+      "version": "4.12.7",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^0.29.1",
+        "@clerk/backend": "^0.29.2",
         "@clerk/types": "^3.52.0",
         "@types/cookies": "0.7.7",
         "@types/express": "4.17.14",
@@ -33813,7 +33814,7 @@
     },
     "packages/shared": {
       "name": "@clerk/shared",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "ISC",
       "dependencies": {
         "glob-to-regexp": "0.4.1",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -19,14 +19,16 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
     "build": "tsup --env.NODE_ENV production",
     "clean": "rimraf ./dist",
+    "dev": "tsup --watch",
     "lint": "eslint src/",
+    "publish:local": "npx yalc push --replace  --sig",
     "test": "jest"
   },
   "dependencies": {
     "@clerk/backend": "^0.29.2",
+    "@clerk/shared": "^0.23.0",
     "@clerk/types": "^3.52.0",
     "cookies": "0.8.0"
   },

--- a/packages/fastify/src/constants.ts
+++ b/packages/fastify/src/constants.ts
@@ -17,6 +17,9 @@ export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
  * @deprecated Use `CLERK_PUBLISHABLE_KEY` instead.
  */
 export const FRONTEND_API = process.env.CLERK_FRONTEND_API || '';
+if (FRONTEND_API) {
+  deprecated('CLERK_FRONTEND_API', 'Use `CLERK_PUBLISHABLE_KEY` environment variable instead.');
+}
 export const PUBLISHABLE_KEY = process.env.CLERK_PUBLISHABLE_KEY || '';
 export const JWT_KEY = process.env.CLERK_JWT_KEY || '';
 

--- a/packages/fastify/src/constants.ts
+++ b/packages/fastify/src/constants.ts
@@ -1,5 +1,6 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { constants } from '@clerk/backend';
+import { deprecated } from '@clerk/shared';
 
 export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
@@ -8,6 +9,9 @@ export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
  * @deprecated Use `CLERK_SECRET_KEY` instead.
  */
 export const API_KEY = process.env.CLERK_API_KEY || '';
+if (API_KEY) {
+  deprecated('CLERK_API_KEY', 'Use `CLERK_SECRET_KEY` environment variable instead.');
+}
 export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
 /**
  * @deprecated Use `CLERK_PUBLISHABLE_KEY` instead.


### PR DESCRIPTION
## Description

Warn about deprecations of the following environment variables in Clerk Fastify plugin:
- CLERK_API_KEY
- CLERK_FRONTEND_API

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [x] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
