### PR TITLE
chore(nextjs): Apply deprecation warnings

### DIFF
--- a/.changeset/spicy-toys-change.md
+++ b/.changeset/spicy-toys-change.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Warn about deprecations that will be dropped in next major version

--- a/packages/nextjs/src/server/clerkClient.ts
+++ b/packages/nextjs/src/server/clerkClient.ts
@@ -1,23 +1,7 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { Clerk } from '@clerk/backend';
 
-/**
- * @deprecated
- */
-export const JS_VERSION = process.env.CLERK_JS_VERSION || '';
-export const CLERK_JS_VERSION = process.env.NEXT_PUBLIC_CLERK_JS_VERSION || '';
-export const CLERK_JS_URL = process.env.NEXT_PUBLIC_CLERK_JS || '';
-export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
-export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
-export const API_KEY = process.env.CLERK_API_KEY || '';
-export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
-export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
-export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
-export const DOMAIN = process.env.NEXT_PUBLIC_CLERK_DOMAIN || '';
-export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';
-export const IS_SATELLITE = process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true' || false;
-export const SIGN_IN_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '';
-export const SIGN_UP_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '';
+import { API_KEY, API_URL, API_VERSION, DOMAIN, IS_SATELLITE, PROXY_URL, SECRET_KEY } from './constants';
 
 const clerkClient = Clerk({
   apiKey: API_KEY,
@@ -36,3 +20,8 @@ const createClerkClient = Clerk;
 export { clerkClient, createClerkClient, Clerk };
 
 export * from '@clerk/backend';
+
+/**
+ * @deprecated Don't export the constants. Should be marked as internal
+ */
+export * from './constants';

--- a/packages/nextjs/src/server/constants.ts
+++ b/packages/nextjs/src/server/constants.ts
@@ -19,7 +19,13 @@ if (API_KEY) {
   deprecated('CLERK_API_KEY', 'Use `CLERK_SECRET_KEY` environment variable instead.');
 }
 export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
+/**
+ * @deprecated Use `PUBLISHABLE_KEY` instead.
+ */
 export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
+if (FRONTEND_API) {
+  deprecated('NEXT_PUBLIC_CLERK_FRONTEND_API', 'Use `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` environment variable instead.');
+}
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
 export const DOMAIN = process.env.NEXT_PUBLIC_CLERK_DOMAIN || '';
 export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';

--- a/packages/nextjs/src/server/constants.ts
+++ b/packages/nextjs/src/server/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * @deprecated
+ */
+export const JS_VERSION = process.env.CLERK_JS_VERSION || '';
+export const CLERK_JS_VERSION = process.env.NEXT_PUBLIC_CLERK_JS_VERSION || '';
+export const CLERK_JS_URL = process.env.NEXT_PUBLIC_CLERK_JS || '';
+export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
+export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
+export const API_KEY = process.env.CLERK_API_KEY || '';
+export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
+export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
+export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
+export const DOMAIN = process.env.NEXT_PUBLIC_CLERK_DOMAIN || '';
+export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';
+export const IS_SATELLITE = process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true' || false;
+export const SIGN_IN_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '';
+export const SIGN_UP_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '';

--- a/packages/nextjs/src/server/constants.ts
+++ b/packages/nextjs/src/server/constants.ts
@@ -1,7 +1,12 @@
+import { deprecated } from '@clerk/shared';
+
 /**
- * @deprecated
+ * @deprecated Use `CLERK_JS_VERSION` instead.
  */
 export const JS_VERSION = process.env.CLERK_JS_VERSION || '';
+if (JS_VERSION) {
+  deprecated('CLERK_JS_VERSION', 'Use `NEXT_PUBLIC_CLERK_JS_VERSION` environment variable instead.');
+}
 export const CLERK_JS_VERSION = process.env.NEXT_PUBLIC_CLERK_JS_VERSION || '';
 export const CLERK_JS_URL = process.env.NEXT_PUBLIC_CLERK_JS || '';
 export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';

--- a/packages/nextjs/src/server/constants.ts
+++ b/packages/nextjs/src/server/constants.ts
@@ -11,7 +11,13 @@ export const CLERK_JS_VERSION = process.env.NEXT_PUBLIC_CLERK_JS_VERSION || '';
 export const CLERK_JS_URL = process.env.NEXT_PUBLIC_CLERK_JS || '';
 export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
+/**
+ * @deprecated Use `CLERK_SECRET_KEY` instead.
+ */
 export const API_KEY = process.env.CLERK_API_KEY || '';
+if (API_KEY) {
+  deprecated('CLERK_API_KEY', 'Use `CLERK_SECRET_KEY` environment variable instead.');
+}
 export const SECRET_KEY = process.env.CLERK_SECRET_KEY || '';
 export const FRONTEND_API = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';

--- a/packages/nextjs/src/server/withClerkMiddleware.ts
+++ b/packages/nextjs/src/server/withClerkMiddleware.ts
@@ -1,5 +1,6 @@
 import type { RequestState } from '@clerk/backend';
 import { constants, debugRequestState } from '@clerk/backend';
+import { deprecated } from '@clerk/shared';
 import type { NextFetchEvent, NextMiddleware, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
@@ -35,6 +36,11 @@ export const decorateResponseWithObservabilityHeaders = (res: NextResponse, requ
 export const withClerkMiddleware: WithClerkMiddleware = (...args: unknown[]) => {
   const noop = () => undefined;
   const [handler = noop, opts = {}] = args as [NextMiddleware, WithAuthOptions] | [];
+
+  deprecated(
+    'withClerkMiddleware',
+    'Use `authMiddleware` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+  );
 
   return async (req: NextRequest, event: NextFetchEvent) => {
     const { isSatellite, domain, signInUrl, proxyUrl } = handleMultiDomainAndProxy(req, opts);

--- a/packages/nextjs/src/ssr/withServerSideAuth.ts
+++ b/packages/nextjs/src/ssr/withServerSideAuth.ts
@@ -1,5 +1,6 @@
 import type { RequestState } from '@clerk/backend';
 import { constants, debugRequestState } from '@clerk/backend';
+import { deprecated } from '@clerk/shared';
 import type { ServerResponse } from 'http';
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
@@ -43,6 +44,10 @@ const decorateResponseWithObservabilityHeaders = (res: ServerResponse, requestSt
 export const withServerSideAuth: WithServerSideAuth = (cbOrOptions: any, options?: any): any => {
   const cb = typeof cbOrOptions === 'function' ? cbOrOptions : undefined;
   const opts = (options ? options : typeof cbOrOptions !== 'function' ? cbOrOptions : {}) || {};
+  deprecated(
+    'withServerSideAuth',
+    'Use `authMiddleware` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+  );
 
   // Support both loadOrganization and the older loadOrg option without breaking changes
   // TODO: Remove pre v5

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,26 @@
     "tsconfig.json",
     "tsconfig.*.json"
   ],
-  "globalEnv": ["NODE_VERSION", "NPM_VERSION", "NODE_ENV", "VERCEL"],
+  "globalEnv": [
+    "NODE_VERSION",
+    "NPM_VERSION",
+    "NODE_ENV",
+    "VERCEL",
+    "CLERK_JS_VERSION",
+    "CLERK_API_URL",
+    "CLERK_API_VERSION",
+    "CLERK_API_KEY",
+    "CLERK_SECRET_KEY",
+    "NEXT_PUBLIC_CLERK_JS_VERSION",
+    "NEXT_PUBLIC_CLERK_JS",
+    "NEXT_PUBLIC_CLERK_FRONTEND_API",
+    "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    "NEXT_PUBLIC_CLERK_DOMAIN",
+    "NEXT_PUBLIC_CLERK_PROXY_URL",
+    "NEXT_PUBLIC_CLERK_IS_SATELLITE",
+    "NEXT_PUBLIC_CLERK_SIGN_IN_URL",
+    "NEXT_PUBLIC_CLERK_SIGN_UP_URL"
+  ],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Description

** REVIEW IT PER COMMIT **

Warn about deprecations of the following in Clerk Nextjs:

- `withClerkMiddleware`
- `withServerSideAuth`
- `CLERK_JS_VERSION` environment variable
- `CLERK_API_KEY` environment variable
- `NEXT_PUBLIC_FRONTEND_API` environment variable

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
