### PR TITLE
chore(remix): Apply deprecation warnings for remix

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -27,7 +27,8 @@
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json --watch",
     "clean": "rimraf ./dist",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "publish:local": "npx yalc push --replace --sig"
   },
   "dependencies": {
     "@clerk/backend": "^0.29.1",

--- a/packages/remix/src/errors.ts
+++ b/packages/remix/src/errors.ts
@@ -23,7 +23,7 @@ function App() {
   );
 }
 
-export default ClerkApp(App, { frontendApi: '...' });
+export default ClerkApp(App, { publishableKey: '...' });
 `;
 
 export const invalidClerkStatePropError = createErrorMessage(`


### PR DESCRIPTION
## Description

We will cater the deprecated properties inside `@clerk/backend`, so we added a npm run command to the Remix package (for constancy) and we updated an option in an example of an error message.

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
