### PR TITLE
New `getInvitations` in clerk-js  and `invitations` from useOrganization

### DIFF
--- a/.changeset/fast-books-kiss.md
+++ b/.changeset/fast-books-kiss.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': patch
+---
+
+Introduce `invitations` in useOrganization, which enables to fetch invitations as paginated lists.
+Deprecate `invitationList` in favor of the above introduction.

--- a/.changeset/three-carrots-remain.md
+++ b/.changeset/three-carrots-remain.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Introduces a new method for fetching organization invitations called `Organization.getInvitations`.
+Deprecate `Organization.getPendingInvitations`

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -4,6 +4,7 @@ import type {
   ClerkResourceReloadParams,
   CreateOrganizationParams,
   GetDomainsParams,
+  GetInvitationsParams,
   GetMembershipRequestParams,
   GetMemberships,
   GetPendingInvitationsParams,
@@ -12,6 +13,7 @@ import type {
   OrganizationDomainJSON,
   OrganizationDomainResource,
   OrganizationInvitationJSON,
+  OrganizationInvitationResource,
   OrganizationJSON,
   OrganizationMembershipJSON,
   OrganizationMembershipRequestJSON,
@@ -203,6 +205,29 @@ export class Organization extends BaseResource implements OrganizationResource {
         return pendingInvitations.map(pendingInvitation => new OrganizationInvitation(pendingInvitation));
       })
       .catch(() => []);
+  };
+
+  getInvitations = async (
+    getInvitationsParams?: GetInvitationsParams,
+  ): Promise<ClerkPaginatedResponse<OrganizationInvitationResource>> => {
+    return await BaseResource._fetch({
+      path: `/organizations/${this.id}/invitations`,
+      method: 'GET',
+      search: convertPageToOffset(getInvitationsParams) as any,
+    })
+      .then(res => {
+        const { data: requests, total_count } =
+          res?.response as unknown as ClerkPaginatedResponse<OrganizationInvitationJSON>;
+
+        return {
+          total_count,
+          data: requests.map(request => new OrganizationInvitation(request)),
+        };
+      })
+      .catch(() => ({
+        total_count: 0,
+        data: [],
+      }));
   };
 
   addMember = async ({ userId, role }: AddMemberParams) => {

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -1,3 +1,4 @@
+import { deprecated } from '@clerk/shared';
 import type {
   AddMemberParams,
   ClerkPaginatedResponse,
@@ -195,6 +196,7 @@ export class Organization extends BaseResource implements OrganizationResource {
   getPendingInvitations = async (
     getPendingInvitationsParams?: GetPendingInvitationsParams,
   ): Promise<OrganizationInvitation[]> => {
+    deprecated('getPendingInvitations', 'Use the `getInvitations` method instead.');
     return await BaseResource._fetch({
       path: `/organizations/${this.id}/invitations/pending`,
       method: 'GET',

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -9,6 +9,7 @@ Organization {
   "destroy": [Function],
   "getDomain": [Function],
   "getDomains": [Function],
+  "getInvitations": [Function],
   "getMembershipRequests": [Function],
   "getMemberships": [Function],
   "getPendingInvitations": [Function],

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -13,6 +13,7 @@ OrganizationMembership {
     "destroy": [Function],
     "getDomain": [Function],
     "getDomains": [Function],
+    "getInvitations": [Function],
     "getMembershipRequests": [Function],
     "getMemberships": [Function],
     "getPendingInvitations": [Function],

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InvitedMembersList.tsx
@@ -2,25 +2,15 @@ import type { OrganizationInvitationResource } from '@clerk/types';
 
 import { useCoreOrganization } from '../../contexts';
 import { localizationKeys, Td, Text } from '../../customizables';
-import { ThreeDotsMenu, useCardState, usePagination, UserPreview } from '../../elements';
+import { ThreeDotsMenu, useCardState, UserPreview } from '../../elements';
 import { handleError, roleLocalizationKey } from '../../utils';
 import { DataTable, RowContainer } from './MemberListTable';
 
-const ITEMS_PER_PAGE = 10;
-
 export const InvitedMembersList = () => {
   const card = useCardState();
-  const { page, changePage } = usePagination();
-  const { organization, invitationList, ...rest } = useCoreOrganization({
-    invitationList: { offset: (page - 1) * ITEMS_PER_PAGE, limit: ITEMS_PER_PAGE },
+  const { organization, invitations } = useCoreOrganization({
+    invitations: true,
   });
-
-  const mutateSwrState = () => {
-    const unstable__mutate = (rest as any).unstable__mutate;
-    if (unstable__mutate && typeof unstable__mutate === 'function') {
-      unstable__mutate();
-    }
-  };
 
   if (!organization) {
     return null;
@@ -28,19 +18,20 @@ export const InvitedMembersList = () => {
 
   const revoke = (invitation: OrganizationInvitationResource) => () => {
     return card
-      .runAsync(invitation.revoke)
-      .then(mutateSwrState)
-      .then(() => changePage(1))
+      .runAsync(async () => {
+        await invitation.revoke();
+        await (invitations as any).unstable__mutate?.();
+      })
       .catch(err => handleError(err, [], card.setError));
   };
 
   return (
     <DataTable
-      page={page}
-      onPageChange={changePage}
-      itemCount={organization.pendingInvitationsCount}
-      itemsPerPage={ITEMS_PER_PAGE}
-      isLoading={!invitationList}
+      page={invitations?.page || 1}
+      onPageChange={invitations?.fetchPage || (() => null)}
+      itemCount={invitations?.count || 0}
+      pageCount={invitations?.pageCount || 0}
+      isLoading={invitations?.isLoading}
       emptyStateLocalizationKey={localizationKeys('organizationProfile.membersPage.invitationsTab.table__emptyRow')}
       headers={[
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__user'),
@@ -48,7 +39,7 @@ export const InvitedMembersList = () => {
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__role'),
         localizationKeys('organizationProfile.membersPage.activeMembersTab.tableHeader__actions'),
       ]}
-      rows={(invitationList || []).map(i => (
+      rows={(invitations?.data || []).map(i => (
         <InvitationRow
           key={i.id}
           invitation={i}

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -147,7 +147,7 @@ describe('OrganizationMembers', () => {
 
     await waitFor(() => {
       expect(fixtures.clerk.organization?.getMemberships).toHaveBeenCalled();
-      expect(fixtures.clerk.organization?.getPendingInvitations).not.toHaveBeenCalled();
+      expect(fixtures.clerk.organization?.getInvitations).not.toHaveBeenCalled();
       expect(fixtures.clerk.organization?.getMembershipRequests).not.toHaveBeenCalled();
       expect(queryByText('test_user1')).toBeInTheDocument();
       expect(queryByText('First1 Last1')).toBeInTheDocument();
@@ -258,14 +258,19 @@ describe('OrganizationMembers', () => {
       });
     });
 
-    fixtures.clerk.organization?.getPendingInvitations.mockReturnValue(Promise.resolve(invitationList));
+    fixtures.clerk.organization?.getInvitations.mockReturnValue(
+      Promise.resolve({
+        data: invitationList,
+        total_count: 2,
+      }),
+    );
     const { queryByText, getByRole } = render(<OrganizationMembers />, { wrapper });
     await userEvent.click(getByRole('tab', { name: 'Invitations' }));
-    expect(fixtures.clerk.organization?.getPendingInvitations).toHaveBeenCalled();
-    expect(queryByText('admin1@clerk.dev')).toBeDefined();
-    expect(queryByText('Admin')).toBeDefined();
-    expect(queryByText('member2@clerk.dev')).toBeDefined();
-    expect(queryByText('Member')).toBeDefined();
+    expect(fixtures.clerk.organization?.getInvitations).toHaveBeenCalled();
+    expect(queryByText('admin1@clerk.dev')).toBeInTheDocument();
+    expect(queryByText('Admin')).toBeInTheDocument();
+    expect(queryByText('member2@clerk.dev')).toBeInTheDocument();
+    expect(queryByText('Member')).toBeInTheDocument();
   });
 
   it('changes tab and renders pending requests', async () => {
@@ -342,6 +347,6 @@ describe('OrganizationMembers', () => {
     );
     const { findByText } = render(<OrganizationMembers />, { wrapper });
     await waitFor(() => expect(fixtures.clerk.organization?.getMemberships).toHaveBeenCalled());
-    expect(await findByText('You')).toBeDefined();
+    expect(await findByText('You')).toBeInTheDocument();
   });
 });

--- a/packages/shared/src/hooks/useOrganization.tsx
+++ b/packages/shared/src/hooks/useOrganization.tsx
@@ -21,6 +21,9 @@ import type { PaginatedResources, PaginatedResourcesWithDefault } from './types'
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
 
 type UseOrganizationParams = {
+  /**
+   * @deprecated Use invitations instead
+   */
   invitationList?: GetPendingInvitationsParams;
   /**
    * @deprecated Use `memberships` instead
@@ -39,6 +42,13 @@ type UseOrganizationParams = {
         keepPreviousData?: boolean;
       });
   memberships?:
+    | true
+    | (GetMembersParams & {
+        infinite?: boolean;
+        keepPreviousData?: boolean;
+      });
+
+  invitations?:
     | true
     | (GetMembersParams & {
         infinite?: boolean;

--- a/packages/shared/src/hooks/useOrganization.tsx
+++ b/packages/shared/src/hooks/useOrganization.tsx
@@ -21,6 +21,7 @@ import { useSWR } from './clerk-swr';
 import { useClerkInstanceContext, useOrganizationContext, useSessionContext } from './contexts';
 import type { PaginatedResources, PaginatedResourcesWithDefault } from './types';
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
+import { deprecated } from '../utils';
 
 type UseOrganizationParams = {
   /**
@@ -290,6 +291,10 @@ export const useOrganization: UseOrganization = params => {
     ? () => [] as OrganizationMembershipResource[]
     : () => clerk.organization?.getMemberships(membershipListParams);
 
+  if (invitationListParams) {
+    deprecated('invitationList in useOrganization', 'Use the `invitations` property and return value instead.');
+  }
+
   const {
     data: invitationList,
     isValidating: isInvitationsLoading,
@@ -300,6 +305,10 @@ export const useOrganization: UseOrganization = params => {
       : null,
     pendingInvitations,
   );
+
+  if (membershipListParams) {
+    deprecated('membershipList in useOrganization', 'Use the `memberships` property and return value instead.');
+  }
 
   const {
     data: membershipList,

--- a/packages/types/src/organization.ts
+++ b/packages/types/src/organization.ts
@@ -44,7 +44,11 @@ export interface OrganizationResource extends ClerkResource {
   updatedAt: Date;
   update: (params: UpdateOrganizationParams) => Promise<OrganizationResource>;
   getMemberships: GetMemberships;
+  /**
+   * @deprecated Use `getInvitations` instead
+   */
   getPendingInvitations: (params?: GetPendingInvitationsParams) => Promise<OrganizationInvitationResource[]>;
+  getInvitations: (params?: GetInvitationsParams) => Promise<ClerkPaginatedResponse<OrganizationInvitationResource>>;
   getDomains: (params?: GetDomainsParams) => Promise<ClerkPaginatedResponse<OrganizationDomainResource>>;
   getMembershipRequests: (
     params?: GetMembershipRequestParams,
@@ -80,6 +84,9 @@ export type GetMembersParams = {
   role?: MembershipRole[];
 };
 
+/**
+ * @deprecated use `getInvitations` instead
+ */
 export type GetPendingInvitationsParams = ClerkPaginationParams;
 export type GetDomainsParams = {
   /**
@@ -92,6 +99,19 @@ export type GetDomainsParams = {
   pageSize?: number;
 
   enrollmentMode?: OrganizationEnrollmentMode;
+};
+
+export type GetInvitationsParams = {
+  /**
+   * This is the starting point for your fetched results. The initial value persists between re-renders
+   */
+  initialPage?: number;
+  /**
+   * Maximum number of items returned per request. The initial value persists between re-renders
+   */
+  pageSize?: number;
+
+  status?: OrganizationInvitationStatus[];
 };
 
 export type GetMembershipRequestParams = {


### PR DESCRIPTION
## Description

This PR
- deprecates `getPendingInvitations` which did not allow for filtering by status
- introduces `getInvitations` which support the new pagination params and filtering
- deprecates `invitationList` as params and return value of useOrganization
- introduces `invitations` which support paginated responces, build-in pagination, and infinite loading.

It was the missing part that brings our organization hooks in harmony between their APIs

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
