### PR TITLE
fix(clerk-js,shared): Safer usage of localStorage

### DIFF
--- a/.changeset/five-swans-dream.md
+++ b/.changeset/five-swans-dream.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/shared": patch
+---
+
+Safer usage of `localStorage` by checking if `window` is available in current environment

--- a/packages/clerk-js/src/ui/hooks/useLocalStorage.ts
+++ b/packages/clerk-js/src/ui/hooks/useLocalStorage.ts
@@ -3,6 +3,10 @@ import React from 'react';
 export function useLocalStorage<T>(key: string, initialValue: T) {
   key = 'clerk:' + key;
   const [storedValue, setStoredValue] = React.useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+
     try {
       const item = window.localStorage.getItem(key);
       return item ? JSON.parse(item) : initialValue;
@@ -12,6 +16,10 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
   });
 
   const setValue = React.useCallback((value: ((stored: T) => T) | T) => {
+    if (typeof window === 'undefined') {
+      console.warn(`Tried setting localStorage key "${key}" even though environment is not a client`);
+    }
+
     try {
       const valueToStore = value instanceof Function ? value(storedValue) : value;
       setStoredValue(valueToStore);

--- a/packages/shared/src/utils/localStorageBroadcastChannel.ts
+++ b/packages/shared/src/utils/localStorageBroadcastChannel.ts
@@ -12,11 +12,16 @@ export class LocalStorageBroadcastChannel<E> {
   }
 
   public postMessage = (data: E): void => {
+    if (typeof window === 'undefined') {
+      // Silently do nothing
+      return;
+    }
+
     try {
-      localStorage.setItem(this.channelKey, JSON.stringify(data));
-      localStorage.removeItem(this.channelKey);
+      window.localStorage.setItem(this.channelKey, JSON.stringify(data));
+      window.localStorage.removeItem(this.channelKey);
     } catch (e) {
-      //
+      // Silently do nothing
     }
   };
 


### PR DESCRIPTION
## Description

Check if `window` is `undefined` and then have fallback cases for that. Since the hook seems to be modeled after https://usehooks-ts.com/react-hook/use-local-storage I applied its `window` checks that it has.

Fixes https://github.com/clerkinc/javascript/issues/1620

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
