### PR TITLE
chore: Add "I haven't reached out to support already" to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -22,6 +22,7 @@ body:
           required: true
         - label: |
             I have not already reached out to Clerk support via email or Discord (if you have, no need to open an issue here)
+          required: true
         - label: |
             This issue is not a question, general help request, or anything other than a bug report directly related to Clerk. Please ask questions in our Discord community: https://clerk.com/discord.
           required: true

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -21,7 +21,7 @@ body:
             I have searched for existing issues: https://github.com/clerkinc/javascript/issues
           required: true
         - label: |
-            I have not already reached out to Clerk support via email or discord (if you have, no need to open an issue here)
+            I have not already reached out to Clerk support via email or Discord (if you have, no need to open an issue here)
         - label: |
             This issue is not a question, general help request, or anything other than a bug report directly related to Clerk. Please ask questions in our Discord community: https://clerk.com/discord.
           required: true

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -21,6 +21,8 @@ body:
             I have searched for existing issues: https://github.com/clerkinc/javascript/issues
           required: true
         - label: |
+            I have not already reached out to Clerk support via email or discord (if you have, no need to open an issue here)
+        - label: |
             This issue is not a question, general help request, or anything other than a bug report directly related to Clerk. Please ask questions in our Discord community: https://clerk.com/discord.
           required: true
   - type: input


### PR DESCRIPTION
We'd like to avoid duplicate support cases and have seen several of these recently - this PR adds an extra checkbox to confirm the issue opener hasn't already reached out to support via another channel.