### PR TITLE
chore(clerk-js): Apply deprecation warnings

### DIFF
--- a/.changeset/forty-crews-fetch.md
+++ b/.changeset/forty-crews-fetch.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Use our deprecate utility to log warnings about deprecated usage of Organization.getMemberships

--- a/.changeset/four-chairs-lay.md
+++ b/.changeset/four-chairs-lay.md
@@ -1,0 +1,10 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Apply deprecation warnings clerk-js package for:
+-  Organization.create() using string parameter
+-  Organization.retrieve() `limit` & `offset`
+-  Clerk.getOrganizationMemberships()
+- `svgUrl`
+- `avatarUrl`/`logoUrl`/`faviconUrl`/`profileImageUrl`

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1,6 +1,7 @@
 import type { LocalStorageBroadcastChannel } from '@clerk/shared';
 import {
   addClerkPrefix,
+  deprecated,
   handleValueOrFn,
   inClientSide,
   is4xxError,
@@ -1080,6 +1081,7 @@ export default class Clerk implements ClerkInterface {
    * @deprecated use User.getOrganizationMemberships
    */
   public getOrganizationMemberships = async (): Promise<OrganizationMembership[]> => {
+    deprecated('getOrganizationMemberships', 'Use User.getOrganizationMemberships');
     return await OrganizationMembership.retrieve();
   };
 

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -1,3 +1,4 @@
+import { deprecatedProperty } from '@clerk/shared';
 import type { DisplayConfigJSON, DisplayConfigResource, DisplayThemeJSON, PreferredSignInStrategy } from '@clerk/types';
 
 import { BaseResource } from './internal';
@@ -18,9 +19,13 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
   instanceEnvironmentType!: string;
   faviconImageUrl!: string;
   logoImageUrl!: string;
-  // TODO: Remove
+  /**
+   * @deprecated  Use `logoImageUrl` instead.
+   */
   logoUrl!: string;
-  // TODO: Remove
+  /**
+   * @deprecated  Use `faviconImageUrl` instead.
+   */
   faviconUrl!: string;
   preferredSignInStrategy!: PreferredSignInStrategy;
   signInUrl!: string;
@@ -52,9 +57,7 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.preferredSignInStrategy = data.preferred_sign_in_strategy;
     this.logoImageUrl = data.logo_image_url;
     this.faviconImageUrl = data.favicon_image_url;
-    // TODO: Remove
     this.logoUrl = data.logo_url;
-    // TODO: Remove
     this.faviconUrl = data.favicon_url;
     this.homeUrl = data.home_url;
     this.signInUrl = data.sign_in_url;
@@ -77,3 +80,6 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     return this;
   }
 }
+
+deprecatedProperty(DisplayConfig, 'logoUrl', 'Use `logoImageUrl` instead.');
+deprecatedProperty(DisplayConfig, 'faviconUrl', 'Use `faviconImageUrl` instead.');

--- a/packages/clerk-js/src/core/resources/ExternalAccount.ts
+++ b/packages/clerk-js/src/core/resources/ExternalAccount.ts
@@ -1,4 +1,4 @@
-import { titleize } from '@clerk/shared';
+import { deprecatedProperty, titleize } from '@clerk/shared';
 import type {
   ExternalAccountJSON,
   ExternalAccountResource,
@@ -84,3 +84,5 @@ export class ExternalAccount extends BaseResource implements ExternalAccountReso
     return this.username || this.emailAddress || this.label;
   }
 }
+
+deprecatedProperty(ExternalAccount, 'avatarUrl', 'Use `imageUrl` instead.');

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -67,6 +67,11 @@ export class Organization extends BaseResource implements OrganizationResource {
     if (typeof paramsOrName === 'string') {
       // DX: Deprecated v3.5.2
       name = paramsOrName;
+      deprecated(
+        'create',
+        'Calling `create` with a string is deprecated. Use an object of type CreateOrganizationParams instead.',
+        'organization:create',
+      );
     } else {
       name = paramsOrName.name;
       slug = paramsOrName.slug;

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -1,4 +1,4 @@
-import { deprecated } from '@clerk/shared';
+import { deprecated, deprecatedProperty } from '@clerk/shared';
 import type {
   AddMemberParams,
   ClerkPaginatedResponse,
@@ -343,3 +343,5 @@ export class Organization extends BaseResource implements OrganizationResource {
     return this.fromJSON(currentOrganization?.organization as OrganizationJSON);
   }
 }
+
+deprecatedProperty(Organization, 'logoUrl', 'Use `imageUrl` instead.');

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -24,6 +24,7 @@ import type {
   UpdateMembershipParams,
   UpdateOrganizationParams,
 } from '@clerk/types';
+import type { GetMembershipsParams } from '@clerk/types';
 
 import { unixEpochToDate } from '../../utils/date';
 import { convertPageToOffset } from '../../utils/pagesToOffset';
@@ -166,6 +167,18 @@ export class Organization extends BaseResource implements OrganizationResource {
 
   getMemberships: GetMemberships = async getMembershipsParams => {
     const isDeprecatedParams = typeof getMembershipsParams === 'undefined' || !getMembershipsParams?.paginated;
+
+    if (!(getMembershipsParams as GetMembershipsParams)?.limit) {
+      deprecated(
+        'limit',
+        'Use `pageSize` instead in Organization.getMemberships.',
+        'organization:getMemberships:limit',
+      );
+    }
+    if (!(getMembershipsParams as GetMembershipsParams)?.offset) {
+      deprecated('offset', 'Use `initialPage` instead in Organization.limit.', 'organization:getMemberships:offset');
+    }
+
     return await BaseResource._fetch({
       path: `/organizations/${this.id}/memberships`,
       method: 'GET',

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -138,6 +138,9 @@ export class OrganizationMembership extends BaseResource implements Organization
   }
 }
 
+// TODO(@dimkl): deprecate nested property
+// deprecatedProperty(OrganizationMembership, 'publicUserData.profileImageUrl', 'Use `imageUrl` instead.');
+
 export type UpdateOrganizationMembershipParams = {
   role: MembershipRole;
 };

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -1,3 +1,4 @@
+import { deprecated } from '@clerk/shared';
 import type {
   ClerkPaginatedResponse,
   ClerkResourceReloadParams,
@@ -29,6 +30,22 @@ export class OrganizationMembership extends BaseResource implements Organization
   static retrieve: GetOrganizationMembershipsClass = async retrieveMembershipsParams => {
     const isDeprecatedParams =
       typeof retrieveMembershipsParams === 'undefined' || !retrieveMembershipsParams?.paginated;
+
+    if (!(retrieveMembershipsParams as RetrieveMembershipsParams)?.limit) {
+      deprecated(
+        'limit',
+        'Use `pageSize` instead in OrganizationMembership.retrieve.',
+        'organization-membership:limit',
+      );
+    }
+    if (!(retrieveMembershipsParams as RetrieveMembershipsParams)?.offset) {
+      deprecated(
+        'offset',
+        'Use `initialPage` instead in OrganizationMembership.retrieve.',
+        'organization-membership:offset',
+      );
+    }
+
     return await BaseResource._fetch({
       path: '/me/organization_memberships',
       method: 'GET',

--- a/packages/clerk-js/src/core/resources/OrganizationMembershipRequest.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembershipRequest.ts
@@ -51,3 +51,6 @@ export class OrganizationMembershipRequest extends BaseResource implements Organ
     return this;
   }
 }
+
+// TODO(@dimkl): deprecate nested property
+// deprecatedProperty(OrganizationMembershipRequest, 'publicUserData.profileImageUrl', 'Use `imageUrl` instead.');

--- a/packages/clerk-js/src/core/resources/User.ts
+++ b/packages/clerk-js/src/core/resources/User.ts
@@ -1,3 +1,4 @@
+import { deprecatedProperty } from '@clerk/shared';
 import type {
   BackupCodeJSON,
   BackupCodeResource,
@@ -347,3 +348,5 @@ export class User extends BaseResource implements UserResource {
     return this;
   }
 }
+
+deprecatedProperty(User, 'profileImageUrl', 'Use `imageUrl` instead.');

--- a/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/Organization.test.ts.snap
@@ -18,7 +18,6 @@ Organization {
   "imageUrl": "https://clerk.com",
   "inviteMember": [Function],
   "inviteMembers": [Function],
-  "logoUrl": "https://url-for-logo.png",
   "maxAllowedMemberships": 3,
   "membersCount": 1,
   "name": "test_name",

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationMembership.test.ts.snap
@@ -22,7 +22,6 @@ OrganizationMembership {
     "imageUrl": "https://clerk.com",
     "inviteMember": [Function],
     "inviteMembers": [Function],
-    "logoUrl": "https://path-to-logo.png",
     "maxAllowedMemberships": 3,
     "membersCount": 1,
     "name": "test_name",

--- a/packages/clerk-js/src/ui/common/constants.ts
+++ b/packages/clerk-js/src/ui/common/constants.ts
@@ -1,3 +1,4 @@
+import { deprecated } from '@clerk/shared';
 import type { Attribute, Web3Provider } from '@clerk/types';
 
 import type { LocalizationKey } from '../localization/localizationKeys';
@@ -102,6 +103,7 @@ export function getWeb3ProviderData(name: Web3Provider): Web3ProviderData | unde
  * @deprecated In favor of iconImageUrl
  */
 export function svgUrl(id: string): string {
+  deprecated('svgUrl', 'Use `iconImageUrl` instead');
   return `https://images.clerk.com/static/${id}.svg`;
 }
 


### PR DESCRIPTION
## Description

**Review it per commit**

Deprecation warnings added in `@clerk/clerk-js`:
-  `Organization.create()` using string parameter
-  `Organization.retrieve()` `limit` & `offset`
-  `Clerk.getOrganizationMemberships()`
- `svgUrl`
- `avatarUrl`/`logoUrl`/`faviconUrl`/`profileImageUrl`

Notes: We cannot show deprecation warnings in console for deprecated type properties (eg `UserJSON.profile_image_url`)

TODO:
- [x] support deprecation warnings for nested props in separate PR
  

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
