### PR TITLE
fix(shared): Fix SyntaxError on non-module imports by dropping support for import.meta used in vite

### DIFF
--- a/.changeset/giant-needles-exercise.md
+++ b/.changeset/giant-needles-exercise.md
@@ -1,0 +1,5 @@
+---
+"@clerk/shared": patch
+---
+
+Fix SyntaxError on non-module imports by dropping support for import.meta (used in vite)

--- a/packages/shared/src/utils/runtimeEnvironment.ts
+++ b/packages/shared/src/utils/runtimeEnvironment.ts
@@ -4,11 +4,7 @@ export const isDevelopmentEnvironment = (): boolean => {
     // eslint-disable-next-line no-empty
   } catch (err) {}
 
-  try {
-    // @ts-ignore
-    return import.meta.env.DEV || import.meta.env.MODE === 'development';
-    // eslint-disable-next-line no-empty
-  } catch (err) {}
+  // TODO: add support for import.meta.env.DEV that is being used by vite
 
   return false;
 };


### PR DESCRIPTION
## Description

Trying to support vite `import.meta.env.DEV` to detect the environment as fallback is causing an Error:
```
Uncaught SyntaxError: Cannot use 'import.meta' outside a module ...
```
when it's being imported as script tag or used with CommonJS.

We will drop the support for now since vite supports `process.env.NODE_ENV`.

ref: https://vitejs.dev/guide/env-and-mode.html
<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
