### PR TITLE
fix(shared): Hide warnings on test/production environments

### DIFF
--- a/.changeset/silver-onions-look.md
+++ b/.changeset/silver-onions-look.md
@@ -1,0 +1,6 @@
+---
+"@clerk/shared": patch
+---
+
+`deprecated()` & `deprecatedProperty` warnings will be hidden in test/production
+environments and when there is no NODE_ENV environment variable defined.

--- a/packages/shared/src/utils/deprecated.ts
+++ b/packages/shared/src/utils/deprecated.ts
@@ -1,4 +1,4 @@
-import { isDevelopmentEnvironment } from './runtimeEnvironment';
+import { isProductionEnvironment, isTestEnvironment } from './runtimeEnvironment';
 /**
  * Mark class methods or functions as deprecated.
  *
@@ -22,8 +22,9 @@ import { isDevelopmentEnvironment } from './runtimeEnvironment';
  */
 const displayedWarnings = new Set<string>();
 export const deprecated = (fnName: string, warning: string, key?: string): void => {
+  const hideWarning = isTestEnvironment() || isProductionEnvironment();
   const messageId = key ?? fnName;
-  if (displayedWarnings.has(messageId) || !isDevelopmentEnvironment()) {
+  if (displayedWarnings.has(messageId) || hideWarning) {
     return;
   }
   displayedWarnings.add(messageId);

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -22,5 +22,5 @@ export * from './runWithExponentialBackOff';
 export * from './isomorphicAtob';
 export * from './globs';
 export * from './loadScript';
-export { isDevelopmentEnvironment } from './runtimeEnvironment';
+export * from './runtimeEnvironment';
 export { deprecated, deprecatedProperty } from './deprecated';

--- a/packages/shared/src/utils/runtimeEnvironment.ts
+++ b/packages/shared/src/utils/runtimeEnvironment.ts
@@ -12,3 +12,23 @@ export const isDevelopmentEnvironment = (): boolean => {
 
   return false;
 };
+
+export const isTestEnvironment = (): boolean => {
+  try {
+    return process.env.NODE_ENV === 'test';
+    // eslint-disable-next-line no-empty
+  } catch (err) {}
+
+  // TODO: add support for import.meta.env.DEV that is being used by vite
+  return false;
+};
+
+export const isProductionEnvironment = (): boolean => {
+  try {
+    return process.env.NODE_ENV === 'production';
+    // eslint-disable-next-line no-empty
+  } catch (err) {}
+
+  // TODO: add support for import.meta.env.DEV that is being used by vite
+  return false;
+};


### PR DESCRIPTION
## Description

Introduce 2 helpers (`isTestEnvironment()` / `isProductionEnvironment()`) in `@clerk/shared` package to be used for identifying the current environment and change the deprecations warnings condition from visible only on the development environment to hidden only on production and test environment.

After this change, the deprecation warning will be visible to applications without `process.env.NODE_ENV` defined.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
