### PR TITLE
fix(clerk-react): Remove nested `package.json` files

### DIFF
--- a/.changeset/smart-poems-film.md
+++ b/.changeset/smart-poems-film.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-react": patch
+---
+
+Remove nested `package.json` files inside `dist/cjs` and `dist/esm` and move `sideEffects` property to top-level `package.json` file. This change won't change behavior.

--- a/packages/react/package.cjs.json
+++ b/packages/react/package.cjs.json
@@ -1,3 +1,0 @@
-{
-  "sideEffects": ["./index.js", "./polyfills.js"]
-}

--- a/packages/react/package.esm.json
+++ b/packages/react/package.esm.json
@@ -1,3 +1,0 @@
-{
-  "sideEffects": ["./index.js", "./polyfills.js"]
-}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,8 +27,10 @@
     "dist"
   ],
   "sideEffects": [
-    "./dist/**/index.js",
-    "./dist/**/polyfills.js"
+    "./dist/cjs/index.js",
+    "./dist/cjs/polyfills.js",
+    "./dist/esm/index.js",
+    "./dist/esm/polyfills.js"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,6 +26,10 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "./dist/**/index.js",
+    "./dist/**/polyfills.js"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -2,7 +2,6 @@ import type { Options } from 'tsup';
 import { defineConfig } from 'tsup';
 
 import { runAfterLast } from '../../scripts/utils';
-// @ts-ignore
 import { name, version } from './package.json';
 
 export default defineConfig(overrideOptions => {
@@ -23,21 +22,15 @@ export default defineConfig(overrideOptions => {
     },
   };
 
-  const onSuccess = (format: 'esm' | 'cjs') => {
-    return `cp ./package.${format}.json ./dist/${format}/package.json`;
-  };
-
   const esm: Options = {
     ...common,
     format: 'esm',
-    onSuccess: onSuccess('esm'),
   };
 
   const cjs: Options = {
     ...common,
     format: 'cjs',
     outDir: './dist/cjs',
-    onSuccess: onSuccess('cjs'),
   };
 
   return runAfterLast(['npm run build:declarations', shouldPublish && 'npm run publish:local'])(esm, cjs);


### PR DESCRIPTION
## Description

A customer is using webpack Module federation and shared this error with us:

```shell
"WARNING in shared module @clerk/clerk-react -> C:\path\to\project\node_modules@clerk\clerk-react\dist\esm\index.js No version specified and unable to automatically determine one. No version in description file (usually package.json). Add version to description file C:\path\to\project\node_modules@clerk\clerk-react\dist\esm\package.json, or manually specify version in shared config."
```

And yes, previously the nested `package.json` files inside `dist/cjs` and `dist/esm` only had `sideEffects` in there. But we don't need those files because `sideEffects` can also just be in the top-level package.json with the paths to it.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
