### PR TITLE
chore(shared): Remove patch for swr-devtools

### DIFF
--- a/.changeset/three-tigers-tell.md
+++ b/.changeset/three-tigers-tell.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Removes the patch for disabling swr-devtools causing apps with swr and broswers with the devtools extention to break.

--- a/packages/shared/src/hooks/clerk-swr.ts
+++ b/packages/shared/src/hooks/clerk-swr.ts
@@ -1,10 +1,3 @@
-export const disableSWRDevtools = () => {
-  if (typeof window !== 'undefined') {
-    // @ts-ignore
-    window.__SWR_DEVTOOLS_USE__ = undefined;
-  }
-};
-
 export * from 'swr';
 export { default as useSWR } from 'swr';
 export { default as useSWRInfinite } from 'swr/infinite';

--- a/packages/shared/src/hooks/contexts.tsx
+++ b/packages/shared/src/hooks/contexts.tsx
@@ -11,8 +11,6 @@ import type { PropsWithChildren } from 'react';
 import React from 'react';
 
 import { deprecated } from '../utils';
-import { disableSWRDevtools } from './clerk-swr';
-disableSWRDevtools();
 import { SWRConfig } from './clerk-swr';
 import { createContextAndHook } from './createContextAndHook';
 

--- a/packages/shared/src/hooks/useOrganization.tsx
+++ b/packages/shared/src/hooks/useOrganization.tsx
@@ -14,14 +14,11 @@ import type {
 import type { ClerkPaginatedResponse } from '@clerk/types';
 import type { GetMembersParams } from '@clerk/types';
 
-import { disableSWRDevtools } from './clerk-swr';
-
-disableSWRDevtools();
+import { deprecated } from '../utils';
 import { useSWR } from './clerk-swr';
 import { useClerkInstanceContext, useOrganizationContext, useSessionContext } from './contexts';
 import type { PaginatedResources, PaginatedResourcesWithDefault } from './types';
 import { usePagesOrInfinite, useWithSafeValues } from './usePagesOrInfinite';
-import { deprecated } from '../utils';
 
 type UseOrganizationParams = {
   /**

--- a/packages/shared/src/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/hooks/usePagesOrInfinite.ts
@@ -1,7 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
-import { disableSWRDevtools } from './clerk-swr';
-disableSWRDevtools();
 import { useSWR, useSWRInfinite } from './clerk-swr';
 import type { ValueOrSetter } from './types';
 import type { PaginatedResources } from './types';


### PR DESCRIPTION
## Description
Our patch was preventing swr-devtools from running with the react version the clerkjs components use, causing the hosting app to break.

This has now been [patched from the maintainer of swr-devtools ](https://github.com/koba04/swr-devtools/pull/126) and in a setup where both patches run the devtools will alway be disabled.

This PR removes our patch and allows swr-devtools to run only for the hosting app (not hotloaded clerkjs components)

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
