### PR TITLE
Deprecate clerk set session

### DIFF
--- a/.changeset/tender-cameras-yawn.md
+++ b/.changeset/tender-cameras-yawn.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Apply deprecation warnings for `@clerk/clerk-js`:
+
+- `Clerk.setSession`

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -631,10 +631,14 @@ export default class Clerk implements ClerkInterface {
     this.#resetComponentsState();
   };
 
+  /**
+   * @deprecated  Use `setActive` instead.
+   */
   public setSession = async (
     session: ActiveSessionResource | string | null,
     beforeEmit?: BeforeEmitCallback,
   ): Promise<void> => {
+    deprecated('setSession', 'Use `setActive` instead.', 'clerk:setSession');
     return this.setActive({ session, beforeEmit });
   };
 


### PR DESCRIPTION
## Description

Since we are deprecation the `setSession` hook from `@clerk/clerk-react` and there is a `@experimental` directive on `Clerk.setActive` which indicates that it's gonna replace the `Clerk.setSession`, I deprecated the `Clerk.setSession`.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
