### PR TITLE
feat(clerk-js): Allow customization of OrganizationProfile through OrganizationSwitcher

### DIFF
--- a/.changeset/chilled-parrots-pump.md
+++ b/.changeset/chilled-parrots-pump.md
@@ -1,0 +1,8 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+- Introduce organizationProfileProps as prop in `<OrganizationSwitcher/>`.
+- Introduce appearance in userProfileProps in `<UserButton/>`.
+- Deprecate the usage of `appearance.userProfile` in <UserButton/>`.

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/OrganizationSwitcherPopover.tsx
@@ -52,6 +52,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
       navigateOrganizationProfile,
       navigateAfterSelectPersonal,
       navigateAfterSelectOrganization,
+      organizationProfileProps,
     } = useOrganizationSwitcherContext();
 
     const user = useCoreUser();
@@ -93,6 +94,7 @@ export const OrganizationSwitcherPopover = React.forwardRef<HTMLDivElement, Orga
         return navigateOrganizationProfile();
       }
       return openOrganizationProfile({
+        ...organizationProfileProps,
         afterLeaveOrganizationUrl,
         //@ts-expect-error
         __unstable_manageBillingUrl,

--- a/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/useMultisessionActions.tsx
@@ -1,3 +1,4 @@
+import { deprecatedObjectProperty } from '@clerk/shared';
 import type { ActiveSessionResource, UserButtonProps, UserResource } from '@clerk/types';
 
 import { windowNavigate } from '../../../utils/windowNavigate';
@@ -44,7 +45,18 @@ export const useMultisessionActions = (opts: UseMultisessionActionsParams) => {
     }
 
     // The UserButton can also accept an appearance object for the nested UserProfile modal
-    openUserProfile({ ...opts.userProfileProps, appearance: opts.appearance?.userProfile });
+    if (opts.appearance?.userProfile) {
+      deprecatedObjectProperty(
+        opts.appearance,
+        'userProfile',
+        'Use `<UserButton userProfileProps={{appearance: {...}}} />` instead.',
+      );
+    }
+    openUserProfile({
+      appearance: opts.appearance?.userProfile,
+      // Prioritize the appearance of `userProfileProps`
+      ...opts.userProfileProps,
+    });
     return opts.actionCompleteCallback?.();
   };
 

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -795,13 +795,18 @@ export type UserButtonProps = {
    * These options serve as overrides and will be merged with the global `appearance`
    * prop of ClerkProvided (if one is provided)
    */
-  appearance?: UserButtonTheme & { userProfile?: UserProfileTheme };
+  appearance?: UserButtonTheme & {
+    /**
+     * @deprecated Use `userProfileProps.appearance` instead.
+     */
+    userProfile?: UserProfileTheme;
+  };
 
   /*
    * Specify options for the underlying <UserProfile /> component.
    * e.g. <UserButton userProfileProps={{additionalOAuthScopes: {google: ['foo', 'bar'], github: ['qux']}}} />
    */
-  userProfileProps?: Pick<UserProfileProps, 'additionalOAuthScopes'>;
+  userProfileProps?: Pick<UserProfileProps, 'additionalOAuthScopes' | 'appearance'>;
 };
 
 type PrimitiveKeys<T> = {
@@ -886,6 +891,12 @@ export type OrganizationSwitcherProps = {
    * prop of ClerkProvided (if one is provided)
    */
   appearance?: OrganizationSwitcherTheme;
+
+  /*
+   * Specify options for the underlying <OrganizationProfile /> component.
+   * e.g. <UserButton userProfileProps={{appearance: {...}}} />
+   */
+  organizationProfileProps?: Pick<OrganizationProfileProps, 'appearance'>;
 };
 
 export type OrganizationListProps = {


### PR DESCRIPTION
## Description

This PR 
-  introduces `organizatinonProfileProps` as prop of `<OrganizationSwitcher />`. This allows for the customization of OrganizationProfile when it is opened through the switcher.
- introduces `appearance` in `userProfileProps` of `<UserButton/>`.
- deprecates the usage of `appearance.userProfile` of `<UserButton/>`.


After these changes a developer can customize the Profiles like this:

```tsx
      <OrganizationSwitcher
        organizationProfileProps={{
          appearance: {
            elements: {
              formButtonPrimary: {
                background: 'black',
              },
            },
          },
        }}
      />
```

```tsx
      <UserButton
        userProfileProps={{
          appearance: {
            elements: {
              formButtonPrimary: {
                background: 'orange',
              },
            },
          },
        }}
      />
```

### Deprecated
```tsx
      <UserButton
        appearance={{
          userProfile: {
            elements: {
              formButtonPrimary: {
                background: 'black',
              },
            },
          },
        }}
      />
```
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

Fixes #1534 

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated
https://github.com/clerkinc/clerk-docs/pull/367

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
