### PR TITLE
feat(clerk-js,types): Add appearance keys for pagination and table head

### DIFF
--- a/.changeset/clean-bears-fold.md
+++ b/.changeset/clean-bears-fold.md
@@ -1,0 +1,11 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/themes': minor
+'@clerk/types': minor
+---
+
+Introduces three new element appearence descriptors:
+
+- `tableHead` let's you customize the tables head styles.
+- `paginationButton` let's you customize the pagination buttons.
+- `paginationRowText` let's you customize the pagination text.

--- a/.changeset/clean-bears-fold.md
+++ b/.changeset/clean-bears-fold.md
@@ -1,6 +1,6 @@
 ---
 '@clerk/clerk-js': minor
-'@clerk/themes': minor
+'@clerk/themes': patch
 '@clerk/types': minor
 ---
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/MemberListTable.tsx
@@ -2,7 +2,20 @@ import type { MembershipRole } from '@clerk/types';
 import React from 'react';
 
 import type { LocalizationKey } from '../../customizables';
-import { Col, Flex, Spinner, Table, Tbody, Td, Text, Th, Thead, Tr, useLocalizations } from '../../customizables';
+import {
+  Col,
+  descriptors,
+  Flex,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useLocalizations,
+} from '../../customizables';
 import { Pagination, Select, SelectButton, SelectOptionList } from '../../elements';
 import type { PropsOfComponent } from '../../styledSystem';
 import { roleLocalizationKey } from '../../utils';
@@ -54,6 +67,7 @@ export const DataTable = (props: MembersListTableProps) => {
             <Tr>
               {headers.map((h, index) => (
                 <Th
+                  elementDescriptor={descriptors.tableHead}
                   key={index}
                   localizationKey={h}
                 />

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -190,6 +190,11 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'tabButton',
   'tabListContainer',
 
+  'tableHead',
+
+  'paginationPageButton',
+  'paginationInfoText',
+
   'selectButton',
   'selectSearchInput',
   'selectButtonIcon',

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -192,8 +192,8 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
 
   'tableHead',
 
-  'paginationPageButton',
-  'paginationInfoText',
+  'paginationButton',
+  'paginationRowText',
 
   'selectButton',
   'selectSearchInput',

--- a/packages/clerk-js/src/ui/elements/Pagination.tsx
+++ b/packages/clerk-js/src/ui/elements/Pagination.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Button, Flex, localizationKeys, Text } from '../customizables';
+import { Button, descriptors, Flex, localizationKeys, Text } from '../customizables';
 import type { PropsOfComponent } from '../styledSystem';
 import { mqu } from '../styledSystem';
 import { range } from '../utils';
@@ -31,6 +31,7 @@ const PageButton = (props: PropsOfComponent<typeof Button> & { isActive?: boolea
         },
         sx,
       ]}
+      elementDescriptor={descriptors.paginationPageButton}
       {...rest}
     />
   );
@@ -52,32 +53,27 @@ const RowInformation = (props: RowInfoProps) => {
   } = props;
 
   return (
-    <Text>
+    <Text elementDescriptor={descriptors.paginationInfoText}>
       <Text
         as='span'
-        sx={t => ({
-          color: t.colors.$blackAlpha700,
-        })}
+        colorScheme='inherit'
         localizationKey={localizationKeys('paginationRowText__displaying')}
       />{' '}
       <Text
         as='span'
+        colorScheme='inherit'
         sx={t => ({ fontWeight: t.fontWeights.$medium })}
       >
         {startingRow === endingRow && [0, 1].includes(startingRow) ? startingRow : `${startingRow} – ${endingRow}`}
       </Text>{' '}
       <Text
         as='span'
-        sx={t => ({
-          color: t.colors.$blackAlpha700,
-        })}
+        colorScheme='inherit'
         localizationKey={localizationKeys('paginationRowText__of')}
       />{' '}
       <Text
         as='span'
-        sx={t => ({
-          color: t.colors.$blackAlpha700,
-        })}
+        colorScheme='inherit'
       >
         {allRowsCount}
       </Text>

--- a/packages/clerk-js/src/ui/elements/Pagination.tsx
+++ b/packages/clerk-js/src/ui/elements/Pagination.tsx
@@ -31,7 +31,7 @@ const PageButton = (props: PropsOfComponent<typeof Button> & { isActive?: boolea
         },
         sx,
       ]}
-      elementDescriptor={descriptors.paginationPageButton}
+      elementDescriptor={descriptors.paginationButton}
       {...rest}
     />
   );
@@ -53,7 +53,7 @@ const RowInformation = (props: RowInfoProps) => {
   } = props;
 
   return (
-    <Text elementDescriptor={descriptors.paginationInfoText}>
+    <Text elementDescriptor={descriptors.paginationRowText}>
       <Text
         as='span'
         colorScheme='inherit'

--- a/packages/clerk-js/src/ui/elements/Pagination.tsx
+++ b/packages/clerk-js/src/ui/elements/Pagination.tsx
@@ -53,27 +53,33 @@ const RowInformation = (props: RowInfoProps) => {
   } = props;
 
   return (
-    <Text elementDescriptor={descriptors.paginationRowText}>
+    <Text>
       <Text
         as='span'
-        colorScheme='inherit'
+        elementDescriptor={descriptors.paginationRowText}
+        elementId={descriptors.paginationRowText?.setId('displaying')}
+        sx={t => ({ opacity: t.opacity.$inactive })}
         localizationKey={localizationKeys('paginationRowText__displaying')}
       />{' '}
       <Text
         as='span'
-        colorScheme='inherit'
+        elementDescriptor={descriptors.paginationRowText}
+        elementId={descriptors.paginationRowText?.setId('rowsCount')}
         sx={t => ({ fontWeight: t.fontWeights.$medium })}
       >
         {startingRow === endingRow && [0, 1].includes(startingRow) ? startingRow : `${startingRow} – ${endingRow}`}
       </Text>{' '}
       <Text
         as='span'
-        colorScheme='inherit'
+        elementDescriptor={descriptors.paginationRowText}
+        elementId={descriptors.paginationRowText?.setId('displaying')}
+        sx={t => ({ opacity: t.opacity.$inactive })}
         localizationKey={localizationKeys('paginationRowText__of')}
       />{' '}
       <Text
         as='span'
-        colorScheme='inherit'
+        elementDescriptor={descriptors.paginationRowText}
+        elementId={descriptors.paginationRowText?.setId('allRowsCount')}
       >
         {allRowsCount}
       </Text>

--- a/packages/themes/src/createTheme.ts
+++ b/packages/themes/src/createTheme.ts
@@ -4,12 +4,12 @@ import type { Appearance, BaseTheme, DeepPartial, Elements, Theme } from '@clerk
 
 import type { InternalTheme } from '../../clerk-js/src/ui/foundations';
 
-type CreateClerkThemeParams = DeepPartial<Theme> & {
+interface CreateClerkThemeParams extends DeepPartial<Theme> {
   /**
    * {@link Theme.elements}
    */
   elements?: Elements | ((params: { theme: InternalTheme }) => Elements);
-};
+}
 
 export const unstable_createTheme = (appearance: Appearance<CreateClerkThemeParams>): BaseTheme => {
   // Placeholder method that might hande more transformations in the future

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -346,8 +346,8 @@ export type ElementsConfig = {
 
   tableHead: WithOptions<never, never, never>;
 
-  paginationPageButton: WithOptions<never, never, never>;
-  paginationInfoText: WithOptions<never, never, never>;
+  paginationButton: WithOptions<never, never, never>;
+  paginationRowText: WithOptions<never, never, never>;
 
   selectButton: WithOptions<SelectId, never, never>;
   selectSearchInput: WithOptions<SelectId, never, never>;

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -344,6 +344,11 @@ export type ElementsConfig = {
   tabButton: WithOptions<never, never, never>;
   tabListContainer: WithOptions<never, never, never>;
 
+  tableHead: WithOptions<never, never, never>;
+
+  paginationPageButton: WithOptions<never, never, never>;
+  paginationInfoText: WithOptions<never, never, never>;
+
   selectButton: WithOptions<SelectId, never, never>;
   selectSearchInput: WithOptions<SelectId, never, never>;
   selectButtonIcon: WithOptions<SelectId, never, never>;

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -347,7 +347,7 @@ export type ElementsConfig = {
   tableHead: WithOptions<never, never, never>;
 
   paginationButton: WithOptions<never, never, never>;
-  paginationRowText: WithOptions<never, never, never>;
+  paginationRowText: WithOptions<'allRowsCount' | 'rowsCount' | 'displaying', never, never>;
 
   selectButton: WithOptions<SelectId, never, never>;
   selectSearchInput: WithOptions<SelectId, never, never>;


### PR DESCRIPTION
## Description

Add missing appearance keys for Pagination text and buttons and Table head.

### Before

![Before](https://github.com/clerkinc/javascript/assets/6823226/58d72754-7040-465c-ad9a-40ce5c959d6b)

### After

![After](https://github.com/clerkinc/javascript/assets/6823226/e0ffbcee-464e-4b19-a049-9ce9d614c96d)


<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [X] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [X] `@clerk/types`
- [x] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
