### PR TITLE
fix(clerk-js, clerk-react,gatsby-clerk-plugin): Cleanup subpath imports

### DIFF
--- a/.changeset/strange-lamps-knock.md
+++ b/.changeset/strange-lamps-knock.md
@@ -1,0 +1,7 @@
+---
+'gatsby-plugin-clerk': patch
+'@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+---
+
+Fix internal subpath imports by replacing them with top level imports.

--- a/packages/clerk-js/src/ui/common/SSOCallback.tsx
+++ b/packages/clerk-js/src/ui/common/SSOCallback.tsx
@@ -1,4 +1,4 @@
-import type { HandleOAuthCallbackParams, HandleSamlCallbackParams } from '@clerk/types/src';
+import type { HandleOAuthCallbackParams, HandleSamlCallbackParams } from '@clerk/types';
 import React from 'react';
 
 import { useCoreClerk } from '../contexts';

--- a/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ConnectedAccountsSection.tsx
@@ -1,5 +1,5 @@
 import type { OAuthProvider, OAuthScope, OAuthStrategy } from '@clerk/types';
-import type { ExternalAccountResource } from '@clerk/types/src';
+import type { ExternalAccountResource } from '@clerk/types';
 
 import { useRouter } from '../../../ui/router';
 import { appendModalState } from '../../../utils';

--- a/packages/clerk-js/src/ui/components/UserProfile/EnterpriseAccountsSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/EnterpriseAccountsSection.tsx
@@ -1,4 +1,4 @@
-import type { SamlAccountResource } from '@clerk/types/src';
+import type { SamlAccountResource } from '@clerk/types';
 
 import { useRouter } from '../../../ui/router';
 import { useCoreUser } from '../../contexts';

--- a/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
+++ b/packages/clerk-js/src/ui/hooks/useEnabledThirdPartyProviders.tsx
@@ -1,6 +1,6 @@
 import type { OAuthProvider, OAuthStrategy, Web3Provider, Web3Strategy } from '@clerk/types';
 // TODO: This import shouldn't be part of @clerk/types
-import { OAUTH_PROVIDERS, WEB3_PROVIDERS } from '@clerk/types/src';
+import { OAUTH_PROVIDERS, WEB3_PROVIDERS } from '@clerk/types';
 
 import { iconImageUrl } from '../common/constants';
 import { useEnvironment } from '../contexts/EnvironmentContext';

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -15,7 +15,7 @@ import type {
   UserJSON,
   UserSettingsJSON,
 } from '@clerk/types';
-import type { MembershipRole, PublicUserDataJSON } from '@clerk/types/src';
+import type { MembershipRole, PublicUserDataJSON } from '@clerk/types';
 
 import { createUser, getOrganizationId } from '../../../core/test/fixtures';
 import { createUserFixture } from './fixtures';

--- a/packages/gatsby-plugin-clerk/src/GatsbyClerkProvider.tsx
+++ b/packages/gatsby-plugin-clerk/src/GatsbyClerkProvider.tsx
@@ -1,9 +1,9 @@
+import type { IsomorphicClerkOptions } from '@clerk/clerk-react';
 import {
   __internal__setErrorThrowerOptions,
   ClerkLoaded,
   ClerkProvider as ReactClerkProvider,
 } from '@clerk/clerk-react';
-import type { IsomorphicClerkOptions } from '@clerk/clerk-react/dist/types';
 import { navigate } from 'gatsby';
 import React from 'react';
 

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -27,7 +27,7 @@ import type {
   UserProfileProps,
   UserResource,
 } from '@clerk/types';
-import type { OrganizationProfileProps, OrganizationSwitcherProps } from '@clerk/types/src';
+import type { OrganizationProfileProps, OrganizationSwitcherProps } from '@clerk/types';
 
 import { unsupportedNonBrowserDomainOrProxyUrlFunction } from './errors';
 import type {


### PR DESCRIPTION
## Description

Replace subpath imports with top level ones to avoid breaking changes upon restructuring our SDKs.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [x] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
