### PR TITLE
chore(types): Drop `password` property from UserJSON

### DIFF
--- a/.changeset/friendly-gorillas-smash.md
+++ b/.changeset/friendly-gorillas-smash.md
@@ -1,0 +1,5 @@
+---
+"@clerk/types": patch
+---
+
+Drop `password` property from `UserJSON` since it's not being returned by the Frontend API

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -204,10 +204,6 @@ export interface UserJSON extends ClerkResourceJSON {
 
   organization_memberships: OrganizationMembershipJSON[];
   password_enabled: boolean;
-  /**
-   * @deprecated This will be removed in the next major version
-   */
-  password: string;
   profile_image_id: string;
   first_name: string;
   last_name: string;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -140,7 +140,6 @@ export type VerifyTOTPParams = { code: string };
 type UpdateUserJSON = Pick<
   UserJSON,
   | 'username'
-  | 'password'
   | 'first_name'
   | 'last_name'
   | 'primary_email_address_id'


### PR DESCRIPTION
## Description

There is no reference in our FAPI responses (`/v1/me`) about `password` field. 
The password is only used as part of the `UpdateUserParams` type, so i moved it from UserJSON to that type.
Also there is no reference in our Frontend API docs: https://reference.clerk.dev/reference/frontend-api-reference/users/user

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
