### PR TITLE
fix(clerk-js,localizations,types): Add `formFieldHintText__slug` key

### DIFF
--- a/.changeset/cyan-pots-invite.md
+++ b/.changeset/cyan-pots-invite.md
@@ -1,0 +1,7 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/localizations": patch
+"@clerk/types": patch
+---
+
+Enables you to translate the tooltip hint while creating an organization through the `formFieldHintText__slug` key

--- a/packages/clerk-js/src/ui/elements/FormControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FormControl.tsx
@@ -352,7 +352,7 @@ export const FormControl = forwardRef<HTMLInputElement, PropsWithChildren<FormCo
   const Icon = icon ? (
     <Flex
       as={'span'}
-      title='A slug is a human-readable ID that must be unique.  It’s often used in URLs.'
+      title={t(localizationKeys('formFieldHintText__slug'))}
     >
       <IconCustomizable
         icon={icon}

--- a/packages/localizations/src/de-DE.ts
+++ b/packages/localizations/src/de-DE.ts
@@ -42,6 +42,8 @@ export const deDE: LocalizationResource = {
     'Der Bestätigungslink ist abgelaufen. Bitte fordern Sie einen neuen Link an.',
   formFieldAction__forgotPassword: 'Passwort vergessen?',
   formFieldHintText__optional: 'Optional',
+  formFieldHintText__slug:
+    'Der Slug ist eine für Menschen lesbare ID. Sie muss einzigartig sein und wird oft in URLs verwendet.',
   formButtonPrimary: 'Fortsetzen',
   signInEnterPasswordTitle: 'Geben Sie Ihr Passwort ein',
   backButton: 'Zurück',

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -64,6 +64,7 @@ export const enUS: LocalizationResource = {
   formFieldError__verificationLinkExpired: 'The verification link expired. Please request a new link.',
   formFieldAction__forgotPassword: 'Forgot password?',
   formFieldHintText__optional: 'Optional',
+  formFieldHintText__slug: 'A slug is a human-readable ID that must be unique. It’s often used in URLs.',
   formButtonPrimary: 'Continue',
   signInEnterPasswordTitle: 'Enter your password',
   backButton: 'Back',

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -81,6 +81,7 @@ type _LocalizationResource = {
   formFieldError__verificationLinkExpired: LocalizationValue;
   formFieldAction__forgotPassword: LocalizationValue;
   formFieldHintText__optional: LocalizationValue;
+  formFieldHintText__slug: LocalizationValue;
   formButtonPrimary: LocalizationValue;
   signInEnterPasswordTitle: LocalizationValue;
   backButton: LocalizationValue;


### PR DESCRIPTION
## Description

Enables you to translate the tooltip hint while creating an organization

Fixes https://github.com/clerkinc/javascript/issues/1795
Fixes ORG-239

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [x] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
