### PR TITLE
feat(clerk-js,shared,types): Add ClerkRuntimeError class

### DIFF
--- a/.changeset/curly-scissors-buy.md
+++ b/.changeset/curly-scissors-buy.md
@@ -1,0 +1,8 @@
+---
+'@clerk/localizations': patch
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/types': patch
+---
+
+Introduce ClerkRuntimeError class for localizing error messages in ClerkJS components

--- a/packages/clerk-js/src/core/resources/Error.ts
+++ b/packages/clerk-js/src/core/resources/Error.ts
@@ -8,5 +8,6 @@ export {
   parseErrors,
   MagicLinkError,
   ClerkAPIResponseError,
+  isClerkRuntimeError,
 } from '@clerk/shared';
 export type { MetamaskError } from '@clerk/shared';

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -1,4 +1,4 @@
-import { Poller } from '@clerk/shared';
+import { ClerkRuntimeError, Poller } from '@clerk/shared';
 import type {
   AttemptEmailAddressVerificationParams,
   AttemptPhoneNumberVerificationParams,
@@ -80,7 +80,7 @@ export class SignUp extends BaseResource implements SignUpResource {
         if (e.captchaError) {
           paramsWithCaptcha.captchaError = e.captchaError;
         } else {
-          throw e;
+          throw new ClerkRuntimeError(e.message, { code: 'captcha_unavailable' });
         }
       }
     }

--- a/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
@@ -1,5 +1,5 @@
 import { createContextAndHook } from '@clerk/shared';
-import type { ClerkAPIError } from '@clerk/types';
+import type { ClerkAPIError, ClerkRuntimeError } from '@clerk/types';
 import React from 'react';
 
 import { useLocalizations } from '../../customizables';
@@ -31,7 +31,8 @@ const useCardState = () => {
   const { translateError } = useLocalizations();
 
   const setIdle = (metadata?: Metadata) => setState(s => ({ ...s, status: 'idle', metadata }));
-  const setError = (metadata: ClerkAPIError | Metadata) => setState(s => ({ ...s, error: translateError(metadata) }));
+  const setError = (metadata: ClerkRuntimeError | ClerkAPIError | Metadata) =>
+    setState(s => ({ ...s, error: translateError(metadata) }));
   const setLoading = (metadata?: Metadata) => setState(s => ({ ...s, status: 'loading', metadata }));
   const runAsync = async <T = unknown,>(cb: Promise<T> | (() => Promise<T>), metadata?: Metadata) => {
     setLoading(metadata);

--- a/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
+++ b/packages/clerk-js/src/ui/localization/makeLocalizable.tsx
@@ -1,4 +1,5 @@
-import type { ClerkAPIError, LocalizationResource } from '@clerk/types';
+import { isClerkRuntimeError } from '@clerk/shared';
+import type { ClerkAPIError, ClerkRuntimeError, LocalizationResource } from '@clerk/types';
 import React from 'react';
 
 import { useOptions } from '../contexts';
@@ -70,11 +71,16 @@ export const useLocalizations = () => {
     return localizedStringFromKey(localizationKey, parsedResource, globalTokens);
   };
 
-  const translateError = (error: ClerkAPIError | string | undefined) => {
+  const translateError = (error: ClerkRuntimeError | ClerkAPIError | string | undefined) => {
     if (!error || typeof error === 'string') {
       return t(error);
     }
-    const { code, message, longMessage, meta } = error || {};
+
+    if (isClerkRuntimeError(error)) {
+      return t(localizationKeys(`unstable__errors.${error.code}` as any)) || error.message;
+    }
+
+    const { code, message, longMessage, meta } = (error || {}) as ClerkAPIError;
     const { paramName = '' } = meta || {};
 
     if (!code) {

--- a/packages/localizations/src/en-US.ts
+++ b/packages/localizations/src/en-US.ts
@@ -716,6 +716,8 @@ export const enUS: LocalizationResource = {
     identification_deletion_failed: 'You cannot delete your last identification.',
     phone_number_exists: 'This phone number is taken. Please try another.',
     form_identifier_not_found: '',
+    captcha_unavailable:
+      'Sign up unsuccessful due to failed bot validation. Please refresh the page to try again or reach out to support for more assistance.',
     captcha_invalid:
       'Sign up unsuccessful due to failed security validations. Please refresh the page to try again or reach out to support for more assistance.',
     form_password_pwned:

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -18,6 +18,11 @@ export interface ClerkAPIError {
   };
 }
 
+export interface ClerkRuntimeError {
+  code: string;
+  message: string;
+}
+
 /**
  * Pagination params
  */

--- a/packages/types/src/localization.ts
+++ b/packages/types/src/localization.ts
@@ -749,6 +749,7 @@ type UnstableErrors = WithParamName<{
   identification_deletion_failed: LocalizationValue;
   phone_number_exists: LocalizationValue;
   form_identifier_not_found: LocalizationValue;
+  captcha_unavailable: LocalizationValue;
   captcha_invalid: LocalizationValue;
   form_password_pwned: LocalizationValue;
   form_username_invalid_length: LocalizationValue;


### PR DESCRIPTION
## Description


With the introduction of ClerkRuntimeError class, we can localize error messages and display them in ClerkJS components. This functionality existed for FAPI errors, and we are now adding support for runtime errors.


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
### Example
Displays an error message caused when lazy loading a 3rd party library. In this case, the sign up process cannot continue and we need to provided the end user with some feedback.
<img width="432" alt="Screenshot 2023-10-02 at 2 12 53 PM" src="https://github.com/clerkinc/javascript/assets/19269911/9e7e1bcd-5bce-45fa-9e5d-10331c752737">


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
