### PR TITLE
fix(clerk-js): Table UI issue with borders in Safari

### DIFF
--- a/.changeset/shiny-flowers-draw.md
+++ b/.changeset/shiny-flowers-draw.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Fixes a UI bug on Safari, that was causing the border of tables to be displayed incorrectly

--- a/packages/clerk-js/src/ui/primitives/Table.tsx
+++ b/packages/clerk-js/src/ui/primitives/Table.tsx
@@ -10,7 +10,8 @@ const { applyVariants, filterProps } = createVariants(theme => {
     base: {
       borderBottom: theme.borders.$normal,
       borderColor: theme.colors.$blackAlpha300,
-      borderCollapse: 'collapse',
+      borderCollapse: 'separate',
+      borderSpacing: '0',
       'td:not(:first-of-type)': {
         paddingLeft: theme.space.$2,
       },

--- a/packages/clerk-js/src/ui/primitives/Th.tsx
+++ b/packages/clerk-js/src/ui/primitives/Th.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type { PrimitiveProps, StyleVariants } from '../styledSystem';
 import { createVariants } from '../styledSystem';
+import { colors } from '../utils';
 import type { BoxProps } from './Box';
 import { Box } from './Box';
 
@@ -10,8 +11,7 @@ const { applyVariants, filterProps } = createVariants(theme => ({
     textAlign: 'left',
     fontSize: theme.fontSizes.$xs,
     fontWeight: theme.fontWeights.$normal,
-    color: theme.colors.$colorText,
-    opacity: theme.opacity.$inactive,
+    color: colors.setAlpha(theme.colors.$colorText, 0.62),
     borderBottom: theme.borders.$normal,
     borderColor: theme.colors.$blackAlpha300,
     paddingBottom: theme.space.$2,


### PR DESCRIPTION
## Description

Fixes a UI bug on Safari, that was causing the border of tables to be displayed incorrectly.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
## Chromium (same as before)

### Before
<img width="625" alt="image" src="https://github.com/clerkinc/javascript/assets/19269911/25402e06-ed04-498f-943f-f3fff40f2fd7">

### After
<img width="631" alt="image" src="https://github.com/clerkinc/javascript/assets/19269911/6bdcf4c1-d0ff-4d4e-8a78-21a2589bc433">

## Safari (fix)
### Before
<img width="630" alt="image" src="https://github.com/clerkinc/javascript/assets/19269911/b06c0b5b-5493-45db-a721-03ce522effcd">

### After
<img width="620" alt="image" src="https://github.com/clerkinc/javascript/assets/19269911/6b769f7a-9ad3-4086-aaa5-8d98d7d93f5e">

## Firefox (same as before)
### Before
<img width="621" alt="image" src="https://github.com/clerkinc/javascript/assets/19269911/6d0c83d3-ec52-4524-8324-778203371523">


### After
<img width="626" alt="image" src="https://github.com/clerkinc/javascript/assets/19269911/2577bf35-9a43-4aae-94e5-a3ce76c35981">


<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
