### PR TITLE
fix(backend): Add available kid to jwk-remote-missing error

### DIFF
--- a/.changeset/cool-planes-shake.md
+++ b/.changeset/cool-planes-shake.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': patch
+---
+
+Improve the `jwk-remote-missing` error by adding the available JWK IDs to the error message. This way you can understand why the entry was not found and compare the available ones with other keys.

--- a/packages/backend/src/tokens/keys.test.ts
+++ b/packages/backend/src/tokens/keys.test.ts
@@ -189,10 +189,11 @@ export default (QUnit: QUnit) => {
     });
 
     test('throws an error when JWKS can not be fetched from Backend or Frontend API and cache updated less than 5 minutes ago', async assert => {
+      const kid = 'ins_whatever';
       try {
         await loadClerkJWKFromRemote({
           apiKey: 'deadbeef',
-          kid: 'ins_whatever',
+          kid,
         });
         assert.false(true);
       } catch (err) {
@@ -200,6 +201,9 @@ export default (QUnit: QUnit) => {
           assert.propEqual(err, {
             reason: 'jwk-remote-missing',
             action: 'Contact support@clerk.com',
+          });
+          assert.propContains(err, {
+            message: `Unable to find a signing key in JWKS that matches the kid='${kid}' of the provided session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT. The following kid are available: ${mockRsaJwkKid}, local`,
           });
         } else {
           // This should never be reached. If it does, the suite should fail
@@ -210,11 +214,12 @@ export default (QUnit: QUnit) => {
 
     test('throws an error when no JWK matches the provided kid', async assert => {
       fakeFetch.onCall(0).returns(jsonOk(mockJwks));
+      const kid = 'ins_whatever';
 
       try {
         await loadClerkJWKFromRemote({
           apiKey: 'deadbeef',
-          kid: 'ins_whatever',
+          kid,
         });
         assert.false(true);
       } catch (err) {
@@ -222,6 +227,9 @@ export default (QUnit: QUnit) => {
           assert.propEqual(err, {
             reason: 'jwk-remote-missing',
             action: 'Contact support@clerk.com',
+          });
+          assert.propContains(err, {
+            message: `Unable to find a signing key in JWKS that matches the kid='${kid}' of the provided session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT. The following kid are available: ${mockRsaJwkKid}, local`,
           });
         } else {
           // This should never be reached. If it does, the suite should fail


### PR DESCRIPTION
## Description

When the `jwk-remote-missing` error is thrown be previously printed out this:

```shell
Unable to find a signing key in JWKS that matches the kid='whatever' of the provided session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT.
```

This PR improves this message by appending the available keys:

```shell
Unable to find a signing key in JWKS that matches the kid='whatever' of the provided session token. Please make sure that the __session cookie or the HTTP authorization header contain a Clerk-generated session JWT. The following kid are available: foobar, local
```

This way a person and/or customer support can compare the kid with the available ones on the JWKS endpoint. Might help with debugging since you know what the cacheMap holds compared to the kid that was used for the request.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
