### PR TITLE
chore(types,backend): Remove experimental jsdoc tags from multi-domain types

### DIFF
--- a/.changeset/light-spoons-poke.md
+++ b/.changeset/light-spoons-poke.md
@@ -1,0 +1,6 @@
+---
+'@clerk/backend': patch
+'@clerk/types': patch
+---
+
+Remove experimenta jsdoc tags from multi-domain types.

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -79,25 +79,10 @@ export type AuthenticateRequestOptions = OptionalVerifyTokenOptions &
     referrer?: string;
     /* Request user-agent value */
     userAgent?: string;
-    /**
-     * @experimental
-     */
     domain?: string;
-    /**
-     * @experimental
-     */
     isSatellite?: boolean;
-    /**
-     * @experimental
-     */
     proxyUrl?: string;
-    /**
-     * @experimental
-     */
     searchParams?: URLSearchParams;
-    /**
-     * @experimental
-     */
     signInUrl?: string;
     signUpUrl?: string;
     afterSignInUrl?: string;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -529,10 +529,6 @@ export interface ClerkOptions {
    * Defaults to false
    */
   isInterstitial?: boolean;
-
-  /**
-   * @experimental
-   */
   isSatellite?: boolean | ((url: URL) => boolean);
 }
 


### PR DESCRIPTION
## Description


We can safely remove the experimental tags, as the feature has gone through 2 iterations already and we consider it stable.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

// TODO: create one once this is approved

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
