### PR TITLE
Custom Pages for `<UserProfile />` and `<OrganizationProfile />` components

### DIFF
--- a/.changeset/proud-ways-lie.md
+++ b/.changeset/proud-ways-lie.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': minor
+'@clerk/clerk-react': minor
+'@clerk/types': minor
+---
+
+Introduce Custom Pages in UserProfile

--- a/.changeset/proud-ways-lie.md
+++ b/.changeset/proud-ways-lie.md
@@ -4,4 +4,4 @@
 '@clerk/types': minor
 ---
 
-Introduce Custom Pages in UserProfile
+Introduce Custom Pages in UserProfile and OrganizationProfile

--- a/.changeset/proud-ways-lie.md
+++ b/.changeset/proud-ways-lie.md
@@ -4,4 +4,36 @@
 '@clerk/types': minor
 ---
 
-Introduce Custom Pages in UserProfile and OrganizationProfile
+Introduce customization in `UserProfile` and `OrganizationProfile`
+
+The `<UserProfile />` component now allows the addition of custom pages and external links to the navigation sidebar. Custom pages can be created using the `<UserProfile.Page>` component, and external links can be added using the `<UserProfile.Link>` component. The default routes, such as `Account` and `Security`, can be reordered.
+
+Example React API usage:
+
+```tsx
+<UserProfile>
+  <UserProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
+    <MyCustomPageContent />
+  </UserProfile.Page>
+  <UserProfile.Link label="External" url="/home" labelIcon={<Icon />} />
+  <UserProfile.Page label="account" />
+  <UserProfile.Page label="security" />
+</UserProfile>
+```
+Custom pages and links should be provided as children using the `<UserButton.UserProfilePage>` and `<UserButton.UserProfileLink>` components when using the `UserButton` component.
+
+The `<OrganizationProfile />` component now supports the addition of custom pages and external links to the navigation sidebar. Custom pages can be created using the `<OrganizationProfile.Page>` component, and external links can be added using the `<OrganizationProfile.Link>` component. The default routes, such as `Members` and `Settings`, can be reordered.
+
+Example React API usage:
+
+```tsx
+<OrganizationProfile>
+  <OrganizationProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
+    <MyCustomPageContent />
+  </OrganizationProfile.Page>
+  <OrganizationProfile.Link label="External" url="/home" labelIcon={<Icon />} />
+  <OrganizationProfile.Page label="members" />
+  <OrganizationProfile.Page label="settings" />
+</OrganizationProfile>
+```
+Custom pages and links should be provided as children using the `<OrganizationSwitcher.OrganizationProfilePage>` and `<OrganizationSwitcher.OrganizationProfileLink>` components when using the `OrganizationSwitcher` component.

--- a/packages/clerk-js/bundlewatch.config.json
+++ b/packages/clerk-js/bundlewatch.config.json
@@ -2,7 +2,7 @@
   "files": [
     { "path": "./dist/clerk.browser.js", "maxSize": "62kB" },
     { "path": "./dist/clerk.headless.js", "maxSize": "43kB" },
-    { "path": "./dist/ui-common*.js", "maxSize": "75KB" },
+    { "path": "./dist/ui-common*.js", "maxSize": "76KB" },
     { "path": "./dist/vendors*.js", "maxSize": "70KB" },
     { "path": "./dist/createorganization*.js", "maxSize": "5KB" },
     { "path": "./dist/impersonationfab*.js", "maxSize": "5KB" },

--- a/packages/clerk-js/src/ui/common/CustomPageContentContainer.tsx
+++ b/packages/clerk-js/src/ui/common/CustomPageContentContainer.tsx
@@ -1,0 +1,28 @@
+import { Col, descriptors } from '../customizables';
+import { CardAlert, NavbarMenuButtonRow, useCardState, withCardStateProvider } from '../elements';
+import type { CustomPageContent } from '../utils';
+import { ExternalElementMounter } from '../utils';
+
+export const CustomPageContentContainer = withCardStateProvider(
+  ({ mount, unmount }: Omit<CustomPageContent, 'url'>) => {
+    const card = useCardState();
+    return (
+      <Col
+        elementDescriptor={descriptors.page}
+        gap={8}
+      >
+        <CardAlert>{card.error}</CardAlert>
+        <NavbarMenuButtonRow />
+        <Col
+          elementDescriptor={descriptors.profilePage}
+          gap={8}
+        >
+          <ExternalElementMounter
+            mount={mount}
+            unmount={unmount}
+          />
+        </Col>
+      </Col>
+    );
+  },
+);

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileNavbar.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileNavbar.tsx
@@ -1,31 +1,14 @@
 import React from 'react';
 
-import { useCoreOrganization } from '../../contexts';
-import type { NavbarRoute } from '../../elements';
+import { useCoreOrganization, useOrganizationProfileContext } from '../../contexts';
 import { Breadcrumbs, NavBar, NavbarContextProvider, OrganizationPreview } from '../../elements';
-import { CogFilled, User } from '../../icons';
-import { localizationKeys } from '../../localization';
 import type { PropsOfComponent } from '../../styledSystem';
-
-const organizationProfileRoutes: NavbarRoute[] = [
-  {
-    name: localizationKeys('organizationProfile.start.headerTitle__members'),
-    id: 'members',
-    icon: User,
-    path: '/',
-  },
-  {
-    name: localizationKeys('organizationProfile.start.headerTitle__settings'),
-    id: 'settings',
-    icon: CogFilled,
-    path: 'organization-settings',
-  },
-];
 
 export const OrganizationProfileNavbar = (
   props: React.PropsWithChildren<Pick<PropsOfComponent<typeof NavBar>, 'contentRef'>>,
 ) => {
   const { organization } = useCoreOrganization();
+  const { pages } = useOrganizationProfileContext();
 
   if (!organization) {
     return null;
@@ -41,7 +24,7 @@ export const OrganizationProfileNavbar = (
             sx={t => ({ margin: `0 0 ${t.space.$4} ${t.space.$2}` })}
           />
         }
-        routes={organizationProfileRoutes}
+        routes={pages.routes}
         contentRef={props.contentRef}
       />
       {props.children}
@@ -49,19 +32,12 @@ export const OrganizationProfileNavbar = (
   );
 };
 
-const pageToRootNavbarRouteMap = {
-  'invite-members': organizationProfileRoutes.find(r => r.id === 'members'),
-  domain: organizationProfileRoutes.find(r => r.id === 'settings'),
-  profile: organizationProfileRoutes.find(r => r.id === 'settings'),
-  leave: organizationProfileRoutes.find(r => r.id === 'settings'),
-  delete: organizationProfileRoutes.find(r => r.id === 'settings'),
-};
-
 export const OrganizationProfileBreadcrumbs = (props: Pick<PropsOfComponent<typeof Breadcrumbs>, 'title'>) => {
+  const { pages } = useOrganizationProfileContext();
   return (
     <Breadcrumbs
       {...props}
-      pageToRootNavbarRoute={pageToRootNavbarRouteMap}
+      pageToRootNavbarRoute={pages.pageToRootNavbarRouteMap}
     />
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -1,9 +1,9 @@
+import { CustomPageContentContainer } from '../../common/CustomPageContentContainer';
 import { Gate } from '../../common/Gate';
 import { useOrganizationProfileContext } from '../../contexts';
 import { ProfileCardContent } from '../../elements';
 import { Route, Switch } from '../../router';
 import type { PropsOfComponent } from '../../styledSystem';
-import { ExternalElementMounter } from '../../utils';
 import { DeleteOrganizationPage, LeaveOrganizationPage } from './ActionConfirmationPage';
 import { AddDomainPage } from './AddDomainPage';
 import { InviteMembersPage } from './InviteMembersPage';
@@ -30,7 +30,7 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
             path={!isPredefinedPageRoot && index === 0 ? undefined : customPage.url}
             key={`custom-page-${customPage.url}`}
           >
-            <ExternalElementMounter
+            <CustomPageContentContainer
               mount={customPage.mount}
               unmount={customPage.unmount}
             />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -1,7 +1,9 @@
 import { Gate } from '../../common/Gate';
+import { useOrganizationProfileContext } from '../../contexts';
 import { ProfileCardContent } from '../../elements';
 import { Route, Switch } from '../../router';
 import type { PropsOfComponent } from '../../styledSystem';
+import { ExternalElementMounter } from '../../utils';
 import { DeleteOrganizationPage, LeaveOrganizationPage } from './ActionConfirmationPage';
 import { AddDomainPage } from './AddDomainPage';
 import { InviteMembersPage } from './InviteMembersPage';
@@ -13,100 +15,122 @@ import { VerifiedDomainPage } from './VerifiedDomainPage';
 import { VerifyDomainPage } from './VerifyDomainPage';
 
 export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof ProfileCardContent>) => {
+  const { pages } = useOrganizationProfileContext();
+  const isMembersPageRoot = pages.routes[0].id === 'members';
+  const isSettingsPageRoot = pages.routes[0].id === 'settings';
+  const isPredefinedPageRoot = isSettingsPageRoot || isMembersPageRoot;
+
   return (
     <ProfileCardContent contentRef={props.contentRef}>
-      <Route path='organization-settings'>
-        <Switch>
+      <Switch>
+        {/* Custom Pages */}
+        {pages.contents?.map((customPage, index) => (
           <Route
-            path='profile'
-            flowStart
+            index={!isPredefinedPageRoot && index === 0}
+            path={!isPredefinedPageRoot && index === 0 ? undefined : customPage.url}
+            key={`custom-page-${customPage.url}`}
           >
-            <Gate
+            <ExternalElementMounter
+              mount={customPage.mount}
+              unmount={customPage.unmount}
+            />
+          </Route>
+        ))}
+        <Route>
+          <Route path={isSettingsPageRoot ? undefined : 'organization-settings'}>
+            <Switch>
+              <Route
+                path='profile'
+                flowStart
+              >
+                <Gate
               permission={'org:sys_profile:manage'}
               redirectTo='../'
             >
               <ProfileSettingsPage />
             </Gate>
-          </Route>
-          <Route
-            path='domain'
-            flowStart
-          >
-            <Switch>
-              <Route path=':id/verify'>
-                <Gate
+              </Route>
+              <Route
+                path='domain'
+                flowStart
+              >
+                <Switch>
+                  <Route path=':id/verify'>
+                    <Gate
                   permission={'org:sys_domains:manage'}
                   redirectTo='../../'
                 >
                   <VerifyDomainPage />
-                </Gate>
+                  </Gate>
               </Route>
-              <Route path=':id/remove'>
-                <Gate
+                  <Route path=':id/remove'>
+                    <Gate
                   permission={'org:sys_domains:delete'}
                   redirectTo='../../'
                 >
                   <RemoveDomainPage />
-                </Gate>
+                  </Gate>
               </Route>
-              <Route path=':id'>
-                <Gate
+                  <Route path=':id'>
+                    <Gate
                   permission={'org:sys_domains:manage'}
                   redirectTo='../../'
                 >
                   <VerifiedDomainPage />
-                </Gate>
+                  </Gate>
               </Route>
-              <Route index>
-                <Gate
+                  <Route index>
+                    <Gate
                   permission={'org:sys_domains:manage'}
                   redirectTo='../'
                 >
                   <AddDomainPage />
                 </Gate>
+                  </Route>
+                </Switch>
               </Route>
-            </Switch>
-          </Route>
-          <Route
-            path='leave'
-            flowStart
-          >
-            <LeaveOrganizationPage />
-          </Route>
-          <Route
-            path='delete'
-            flowStart
-          >
-            <Gate
+              <Route
+                path='leave'
+                flowStart
+              >
+                <LeaveOrganizationPage />
+              </Route>
+              <Route
+                path='delete'
+                flowStart
+              >
+                <Gate
               permission={'org:sys_profile:delete'}
               redirectTo='../'
             >
               <DeleteOrganizationPage />
-            </Gate>
+              </Gate>
           </Route>
-          <Route index>
-            <OrganizationSettings />
+              <Route index>
+                <OrganizationSettings />
+              </Route>
+            </Switch>
           </Route>
-        </Switch>
-      </Route>
-      <Route>
-        <Switch>
-          <Route
-            path='invite-members'
-            flowStart
-          >
-            <Gate
+          <Route path={isMembersPageRoot ? undefined : 'organization-members'}>
+            <Switch>
+              <Route
+                path='invite-members'
+                flowStart
+              >
+                <Gate
               permission={'org:sys_memberships:manage'}
               redirectTo='../'
             >
               <InviteMembersPage />
             </Gate>
+              </Route>
+              <Route index>
+                <OrganizationMembers />
+              </Route>
+            </Switch>
           </Route>
-          <Route index>
-            <OrganizationMembers />
-          </Route>
-        </Switch>
-      </Route>
+        </Route>
+      </Switch>
     </ProfileCardContent>
   );
 };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -1,6 +1,6 @@
+import { Gate } from '../../common';
 import { CustomPageContentContainer } from '../../common/CustomPageContentContainer';
 import { ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID } from '../../constants';
-import { Gate } from '../../common/Gate';
 import { useOrganizationProfileContext } from '../../contexts';
 import { ProfileCardContent } from '../../elements';
 import { Route, Switch } from '../../router';
@@ -48,11 +48,11 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
                 flowStart
               >
                 <Gate
-              permission={'org:sys_profile:manage'}
-              redirectTo='../'
-            >
-              <ProfileSettingsPage />
-            </Gate>
+                  permission={'org:sys_profile:manage'}
+                  redirectTo='../'
+                >
+                  <ProfileSettingsPage />
+                </Gate>
               </Route>
               <Route
                 path='domain'
@@ -61,35 +61,35 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
                 <Switch>
                   <Route path=':id/verify'>
                     <Gate
-                  permission={'org:sys_domains:manage'}
-                  redirectTo='../../'
-                >
-                  <VerifyDomainPage />
-                  </Gate>
-              </Route>
+                      permission={'org:sys_domains:manage'}
+                      redirectTo='../../'
+                    >
+                      <VerifyDomainPage />
+                    </Gate>
+                  </Route>
                   <Route path=':id/remove'>
                     <Gate
-                  permission={'org:sys_domains:delete'}
-                  redirectTo='../../'
-                >
-                  <RemoveDomainPage />
-                  </Gate>
-              </Route>
+                      permission={'org:sys_domains:delete'}
+                      redirectTo='../../'
+                    >
+                      <RemoveDomainPage />
+                    </Gate>
+                  </Route>
                   <Route path=':id'>
                     <Gate
-                  permission={'org:sys_domains:manage'}
-                  redirectTo='../../'
-                >
-                  <VerifiedDomainPage />
-                  </Gate>
-              </Route>
+                      permission={'org:sys_domains:manage'}
+                      redirectTo='../../'
+                    >
+                      <VerifiedDomainPage />
+                    </Gate>
+                  </Route>
                   <Route index>
                     <Gate
-                  permission={'org:sys_domains:manage'}
-                  redirectTo='../'
-                >
-                  <AddDomainPage />
-                </Gate>
+                      permission={'org:sys_domains:manage'}
+                      redirectTo='../'
+                    >
+                      <AddDomainPage />
+                    </Gate>
                   </Route>
                 </Switch>
               </Route>
@@ -104,12 +104,12 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
                 flowStart
               >
                 <Gate
-              permission={'org:sys_profile:delete'}
-              redirectTo='../'
-            >
-              <DeleteOrganizationPage />
-              </Gate>
-          </Route>
+                  permission={'org:sys_profile:delete'}
+                  redirectTo='../'
+                >
+                  <DeleteOrganizationPage />
+                </Gate>
+              </Route>
               <Route index>
                 <OrganizationSettings />
               </Route>
@@ -122,11 +122,11 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
                 flowStart
               >
                 <Gate
-              permission={'org:sys_memberships:manage'}
-              redirectTo='../'
-            >
-              <InviteMembersPage />
-            </Gate>
+                  permission={'org:sys_memberships:manage'}
+                  redirectTo='../'
+                >
+                  <InviteMembersPage />
+                </Gate>
               </Route>
               <Route index>
                 <OrganizationMembers />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -18,24 +18,27 @@ export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof Profile
   const { pages } = useOrganizationProfileContext();
   const isMembersPageRoot = pages.routes[0].id === 'members';
   const isSettingsPageRoot = pages.routes[0].id === 'settings';
-  const isPredefinedPageRoot = isSettingsPageRoot || isMembersPageRoot;
+
+  const customPageRoutesWithContents = pages.contents?.map((customPage, index) => {
+    const shouldFirstCustomItemBeOnRoot = !isSettingsPageRoot && !isMembersPageRoot && index === 0;
+    return (
+      <Route
+        index={shouldFirstCustomItemBeOnRoot}
+        path={shouldFirstCustomItemBeOnRoot ? undefined : customPage.url}
+        key={`custom-page-${customPage.url}`}
+      >
+        <CustomPageContentContainer
+          mount={customPage.mount}
+          unmount={customPage.unmount}
+        />
+      </Route>
+    );
+  });
 
   return (
     <ProfileCardContent contentRef={props.contentRef}>
       <Switch>
-        {/* Custom Pages */}
-        {pages.contents?.map((customPage, index) => (
-          <Route
-            index={!isPredefinedPageRoot && index === 0}
-            path={!isPredefinedPageRoot && index === 0 ? undefined : customPage.url}
-            key={`custom-page-${customPage.url}`}
-          >
-            <CustomPageContentContainer
-              mount={customPage.mount}
-              unmount={customPage.unmount}
-            />
-          </Route>
-        ))}
+        {customPageRoutesWithContents}
         <Route>
           <Route path={isSettingsPageRoot ? undefined : 'organization-settings'}>
             <Switch>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/OrganizationProfileRoutes.tsx
@@ -1,4 +1,5 @@
 import { CustomPageContentContainer } from '../../common/CustomPageContentContainer';
+import { ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID } from '../../constants';
 import { Gate } from '../../common/Gate';
 import { useOrganizationProfileContext } from '../../contexts';
 import { ProfileCardContent } from '../../elements';
@@ -16,8 +17,8 @@ import { VerifyDomainPage } from './VerifyDomainPage';
 
 export const OrganizationProfileRoutes = (props: PropsOfComponent<typeof ProfileCardContent>) => {
   const { pages } = useOrganizationProfileContext();
-  const isMembersPageRoot = pages.routes[0].id === 'members';
-  const isSettingsPageRoot = pages.routes[0].id === 'settings';
+  const isMembersPageRoot = pages.routes[0].id === ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.MEMBERS;
+  const isSettingsPageRoot = pages.routes[0].id === ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.SETTINGS;
 
   const customPageRoutesWithContents = pages.contents?.map((customPage, index) => {
     const shouldFirstCustomItemBeOnRoot = !isSettingsPageRoot && !isMembersPageRoot && index === 0;

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationProfile.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationProfile.test.tsx
@@ -1,3 +1,4 @@
+import type { CustomPage } from '@clerk/types';
 import { describe, it } from '@jest/globals';
 import React from 'react';
 
@@ -18,5 +19,38 @@ describe('OrganizationProfile', () => {
     expect(getByText('Org1')).toBeDefined();
     expect(getByText('Members')).toBeDefined();
     expect(getByText('Settings')).toBeDefined();
+  });
+
+  it('includes custom nav items', async () => {
+    const { wrapper, props } = await createFixtures(f => {
+      f.withOrganizations();
+      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: ['Org1'] });
+    });
+
+    const customPages: CustomPage[] = [
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      {
+        label: 'ExternalLink',
+        url: '/link',
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+
+    props.setProps({ customPages });
+
+    const { getByText } = render(<OrganizationProfile />, { wrapper });
+    expect(getByText('Org1')).toBeDefined();
+    expect(getByText('Members')).toBeDefined();
+    expect(getByText('Settings')).toBeDefined();
+    expect(getByText('Custom1')).toBeDefined();
+    expect(getByText('ExternalLink')).toBeDefined();
   });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileNavbar.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileNavbar.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useUserProfileContext } from '../../contexts';
 import { Breadcrumbs, NavBar, NavbarContextProvider } from '../../elements';
 import type { PropsOfComponent } from '../../styledSystem';
-import { pageToRootNavbarRouteMap } from '../../utils';
 
 export const UserProfileNavbar = (
   props: React.PropsWithChildren<Pick<PropsOfComponent<typeof NavBar>, 'contentRef'>>,
@@ -21,10 +20,11 @@ export const UserProfileNavbar = (
 };
 
 export const UserProfileBreadcrumbs = (props: Pick<PropsOfComponent<typeof Breadcrumbs>, 'title'>) => {
+  const { pages } = useUserProfileContext();
   return (
     <Breadcrumbs
       {...props}
-      pageToRootNavbarRoute={pageToRootNavbarRouteMap}
+      pageToRootNavbarRoute={pages.pageToRootNavbarRouteMap}
     />
   );
 };

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileNavbar.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileNavbar.tsx
@@ -1,49 +1,23 @@
 import React from 'react';
 
-import type { NavbarRoute } from '../../elements';
+import { useUserProfileContext } from '../../contexts';
 import { Breadcrumbs, NavBar, NavbarContextProvider } from '../../elements';
-import { TickShield, User } from '../../icons';
-import { localizationKeys } from '../../localization';
 import type { PropsOfComponent } from '../../styledSystem';
-
-const userProfileRoutes: NavbarRoute[] = [
-  {
-    name: localizationKeys('userProfile.start.headerTitle__account'),
-    id: 'account',
-    icon: User,
-    path: '/',
-  },
-  {
-    name: localizationKeys('userProfile.start.headerTitle__security'),
-    id: 'security',
-    icon: TickShield,
-    path: '',
-  },
-];
+import { pageToRootNavbarRouteMap } from '../../utils';
 
 export const UserProfileNavbar = (
   props: React.PropsWithChildren<Pick<PropsOfComponent<typeof NavBar>, 'contentRef'>>,
 ) => {
+  const { pages } = useUserProfileContext();
   return (
     <NavbarContextProvider>
       <NavBar
-        routes={userProfileRoutes}
+        routes={pages.routes}
         contentRef={props.contentRef}
       />
       {props.children}
     </NavbarContextProvider>
   );
-};
-
-const pageToRootNavbarRouteMap = {
-  profile: userProfileRoutes.find(r => r.id === 'account'),
-  'email-address': userProfileRoutes.find(r => r.id === 'account'),
-  'phone-number': userProfileRoutes.find(r => r.id === 'account'),
-  'connected-account': userProfileRoutes.find(r => r.id === 'account'),
-  'web3-wallet': userProfileRoutes.find(r => r.id === 'account'),
-  username: userProfileRoutes.find(r => r.id === 'account'),
-  'multi-factor': userProfileRoutes.find(r => r.id === 'security'),
-  password: userProfileRoutes.find(r => r.id === 'security'),
 };
 
 export const UserProfileBreadcrumbs = (props: Pick<PropsOfComponent<typeof Breadcrumbs>, 'title'>) => {

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -1,8 +1,8 @@
+import { CustomPageContentContainer } from '../../common/CustomPageContentContainer';
 import { useUserProfileContext } from '../../contexts';
 import { ProfileCardContent } from '../../elements';
 import { Route, Switch } from '../../router';
 import type { PropsOfComponent } from '../../styledSystem';
-import { ExternalElementMounter } from '../../utils';
 import { ConnectedAccountsPage } from './ConnectedAccountsPage';
 import { DeletePage } from './DeletePage';
 import { EmailPage } from './EmailPage';
@@ -36,7 +36,7 @@ export const UserProfileRoutes = (props: PropsOfComponent<typeof ProfileCardCont
             path={!isAccountPageRoot && index === 0 ? undefined : customPage.url}
             key={`custom-page-${customPage.url}`}
           >
-            <ExternalElementMounter
+            <CustomPageContentContainer
               mount={customPage.mount}
               unmount={customPage.unmount}
             />

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -25,15 +25,16 @@ import { Web3Page } from './Web3Page';
 
 export const UserProfileRoutes = (props: PropsOfComponent<typeof ProfileCardContent>) => {
   const { pages } = useUserProfileContext();
+  const isAccountPageRoot = pages.routes[0].id === 'account' || pages.routes[0].id === 'security';
   return (
     <ProfileCardContent contentRef={props.contentRef}>
       <Switch>
         {/* Custom Pages */}
         {pages.contents?.map((customPage, index) => (
           <Route
-            index={!pages.isAccountPageRoot && index === 0}
-            path={!pages.isAccountPageRoot && index === 0 ? undefined : customPage.url}
-            key={`custom-page-${index}`}
+            index={!isAccountPageRoot && index === 0}
+            path={!isAccountPageRoot && index === 0 ? undefined : customPage.url}
+            key={`custom-page-${customPage.url}`}
           >
             <ExternalElementMounter
               mount={customPage.mount}
@@ -41,7 +42,7 @@ export const UserProfileRoutes = (props: PropsOfComponent<typeof ProfileCardCont
             />
           </Route>
         ))}
-        <Route path={pages.isAccountPageRoot ? undefined : 'account'}>
+        <Route path={isAccountPageRoot ? undefined : 'account'}>
           <Route
             path='profile'
             flowStart

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -1,6 +1,8 @@
+import { useUserProfileContext } from '../../contexts';
 import { ProfileCardContent } from '../../elements';
 import { Route, Switch } from '../../router';
 import type { PropsOfComponent } from '../../styledSystem';
+import { ExternalElementMounter } from '../../utils';
 import { ConnectedAccountsPage } from './ConnectedAccountsPage';
 import { DeletePage } from './DeletePage';
 import { EmailPage } from './EmailPage';
@@ -22,90 +24,134 @@ import { UsernamePage } from './UsernamePage';
 import { Web3Page } from './Web3Page';
 
 export const UserProfileRoutes = (props: PropsOfComponent<typeof ProfileCardContent>) => {
+  const { pages } = useUserProfileContext();
   return (
     <ProfileCardContent contentRef={props.contentRef}>
-      <Route index>
-        <RootPage />
-      </Route>
-      <Route path='profile'>
-        <ProfilePage />
-      </Route>
-      <Route path='email-address'>
-        <Switch>
-          <Route path=':id/remove'>
-            <RemoveEmailPage />
+      <Switch>
+        {/* Custom Pages */}
+        {pages.contents?.map((customPage, index) => (
+          <Route
+            index={!pages.isAccountPageRoot && index === 0}
+            path={!pages.isAccountPageRoot && index === 0 ? undefined : customPage.url}
+            key={`custom-page-${index}`}
+          >
+            <ExternalElementMounter
+              mount={customPage.mount}
+              unmount={customPage.unmount}
+            />
           </Route>
-          <Route path=':id'>
-            <EmailPage />
+        ))}
+        <Route path={pages.isAccountPageRoot ? undefined : 'account'}>
+          <Route
+            path='profile'
+            flowStart
+          >
+            <ProfilePage />
+          </Route>
+          <Route
+            path='email-address'
+            flowStart
+          >
+            <Switch>
+              <Route path=':id/remove'>
+                <RemoveEmailPage />
+              </Route>
+              <Route path=':id'>
+                <EmailPage />
+              </Route>
+              <Route index>
+                <EmailPage />
+              </Route>
+            </Switch>
+          </Route>
+          <Route
+            path='phone-number'
+            flowStart
+          >
+            <Switch>
+              <Route path=':id/remove'>
+                <RemovePhonePage />
+              </Route>
+              <Route path=':id'>
+                <PhonePage />
+              </Route>
+              <Route index>
+                <PhonePage />
+              </Route>
+            </Switch>
+          </Route>
+          <Route
+            path='multi-factor'
+            flowStart
+          >
+            <Switch>
+              <Route path='totp/remove'>
+                <RemoveMfaTOTPPage />
+              </Route>
+              <Route path='backup_code/add'>
+                <MfaBackupCodeCreatePage />
+              </Route>
+              <Route path=':id/remove'>
+                <RemoveMfaPhoneCodePage />
+              </Route>
+              <Route path=':id'>
+                <MfaPage />
+              </Route>
+              <Route index>
+                <MfaPage />
+              </Route>
+            </Switch>
+          </Route>
+          <Route
+            path='connected-account'
+            flowStart
+          >
+            <Switch>
+              <Route path=':id/remove'>
+                <RemoveConnectedAccountPage />
+              </Route>
+              <Route index>
+                <ConnectedAccountsPage />
+              </Route>
+            </Switch>
+          </Route>
+          <Route
+            path='web3-wallet'
+            flowStart
+          >
+            <Switch>
+              <Route path=':id/remove'>
+                <RemoveWeb3WalletPage />
+              </Route>
+              <Route index>
+                <Web3Page />
+              </Route>
+            </Switch>
+          </Route>
+          <Route
+            path='username'
+            flowStart
+          >
+            <UsernamePage />
+          </Route>
+          {/*<Route path='security'>*/}
+          <Route
+            path='password'
+            flowStart
+          >
+            <PasswordPage />
+          </Route>
+          <Route
+            path='delete'
+            flowStart
+          >
+            <DeletePage />
           </Route>
           <Route index>
-            <EmailPage />
+            <RootPage />
           </Route>
-        </Switch>
-      </Route>
-      <Route path='phone-number'>
-        <Switch>
-          <Route path=':id/remove'>
-            <RemovePhonePage />
-          </Route>
-          <Route path=':id'>
-            <PhonePage />
-          </Route>
-          <Route index>
-            <PhonePage />
-          </Route>
-        </Switch>
-      </Route>
-      <Route path='multi-factor'>
-        <Switch>
-          <Route path='totp/remove'>
-            <RemoveMfaTOTPPage />
-          </Route>
-          <Route path='backup_code/add'>
-            <MfaBackupCodeCreatePage />
-          </Route>
-          <Route path=':id/remove'>
-            <RemoveMfaPhoneCodePage />
-          </Route>
-          <Route path=':id'>
-            <MfaPage />
-          </Route>
-          <Route index>
-            <MfaPage />
-          </Route>
-        </Switch>
-      </Route>
-      <Route path='connected-account'>
-        <Switch>
-          <Route path=':id/remove'>
-            <RemoveConnectedAccountPage />
-          </Route>
-          <Route index>
-            <ConnectedAccountsPage />
-          </Route>
-        </Switch>
-      </Route>
-      <Route path='web3-wallet'>
-        <Switch>
-          <Route path=':id/remove'>
-            <RemoveWeb3WalletPage />
-          </Route>
-          <Route index>
-            <Web3Page />
-          </Route>
-        </Switch>
-      </Route>
-      <Route path='username'>
-        <UsernamePage />
-      </Route>
-      {/*<Route path='security'>*/}
-      <Route path='password'>
-        <PasswordPage />
-      </Route>
-      {/*</Route>*/}
-      <Route path='delete'>
-        <DeletePage />
-      </Route>
+        </Route>
+      </Switch>
     </ProfileCardContent>
   );
 };

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -1,4 +1,5 @@
 import { CustomPageContentContainer } from '../../common/CustomPageContentContainer';
+import { USER_PROFILE_NAVBAR_ROUTE_ID } from '../../constants';
 import { useUserProfileContext } from '../../contexts';
 import { ProfileCardContent } from '../../elements';
 import { Route, Switch } from '../../router';
@@ -25,7 +26,9 @@ import { Web3Page } from './Web3Page';
 
 export const UserProfileRoutes = (props: PropsOfComponent<typeof ProfileCardContent>) => {
   const { pages } = useUserProfileContext();
-  const isAccountPageRoot = pages.routes[0].id === 'account' || pages.routes[0].id === 'security';
+  const isAccountPageRoot =
+    pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT ||
+    pages.routes[0].id === USER_PROFILE_NAVBAR_ROUTE_ID.SECURITY;
 
   const customPageRoutesWithContents = pages.contents?.map((customPage, index) => {
     const shouldFirstCustomItemBeOnRoot = !isAccountPageRoot && index === 0;

--- a/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UserProfileRoutes.tsx
@@ -26,22 +26,27 @@ import { Web3Page } from './Web3Page';
 export const UserProfileRoutes = (props: PropsOfComponent<typeof ProfileCardContent>) => {
   const { pages } = useUserProfileContext();
   const isAccountPageRoot = pages.routes[0].id === 'account' || pages.routes[0].id === 'security';
+
+  const customPageRoutesWithContents = pages.contents?.map((customPage, index) => {
+    const shouldFirstCustomItemBeOnRoot = !isAccountPageRoot && index === 0;
+    return (
+      <Route
+        index={shouldFirstCustomItemBeOnRoot}
+        path={shouldFirstCustomItemBeOnRoot ? undefined : customPage.url}
+        key={`custom-page-${customPage.url}`}
+      >
+        <CustomPageContentContainer
+          mount={customPage.mount}
+          unmount={customPage.unmount}
+        />
+      </Route>
+    );
+  });
+
   return (
     <ProfileCardContent contentRef={props.contentRef}>
       <Switch>
-        {/* Custom Pages */}
-        {pages.contents?.map((customPage, index) => (
-          <Route
-            index={!isAccountPageRoot && index === 0}
-            path={!isAccountPageRoot && index === 0 ? undefined : customPage.url}
-            key={`custom-page-${customPage.url}`}
-          >
-            <CustomPageContentContainer
-              mount={customPage.mount}
-              unmount={customPage.unmount}
-            />
-          </Route>
-        ))}
+        {customPageRoutesWithContents}
         <Route path={isAccountPageRoot ? undefined : 'account'}>
           <Route
             path='profile'

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
@@ -2,9 +2,10 @@ import { describe, it } from '@jest/globals';
 import React from 'react';
 
 import { bindCreateFixtures, render, screen } from '../../../../testUtils';
+import type { CustomPage } from '../../../utils';
 import { UserProfile } from '../UserProfile';
 
-const { createFixtures } = bindCreateFixtures('SignIn');
+const { createFixtures } = bindCreateFixtures('UserProfile');
 
 describe('UserProfile', () => {
   describe('Navigation', () => {
@@ -18,6 +19,40 @@ describe('UserProfile', () => {
       expect(accountElements.some(el => el.tagName.toUpperCase() === 'BUTTON')).toBe(true);
       const securityElements = screen.getAllByText(/Security/i);
       expect(securityElements.some(el => el.tagName.toUpperCase() === 'BUTTON')).toBe(true);
+    });
+
+    it('includes custom nav items', async () => {
+      const { wrapper, props } = await createFixtures(f => {
+        f.withUser({ email_addresses: ['test@clerk.dev'] });
+      });
+
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'ExternalLink',
+          url: '/link',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+
+      props.setProps({ customPages });
+      render(<UserProfile />, { wrapper });
+      const accountElements = screen.getAllByText(/Account/i);
+      expect(accountElements.some(el => el.tagName.toUpperCase() === 'BUTTON')).toBe(true);
+      const securityElements = screen.getAllByText(/Security/i);
+      expect(securityElements.some(el => el.tagName.toUpperCase() === 'BUTTON')).toBe(true);
+      const customElements = screen.getAllByText(/Custom1/i);
+      expect(customElements.some(el => el.tagName.toUpperCase() === 'BUTTON')).toBe(true);
+      const externalElements = screen.getAllByText(/ExternalLink/i);
+      expect(externalElements.some(el => el.tagName.toUpperCase() === 'BUTTON')).toBe(true);
     });
   });
 });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
@@ -1,8 +1,8 @@
+import type { CustomPage } from '@clerk/types';
 import { describe, it } from '@jest/globals';
 import React from 'react';
 
 import { bindCreateFixtures, render, screen } from '../../../../testUtils';
-import type { CustomPage } from '../../../utils';
 import { UserProfile } from '../UserProfile';
 
 const { createFixtures } = bindCreateFixtures('UserProfile');

--- a/packages/clerk-js/src/ui/constants.ts
+++ b/packages/clerk-js/src/ui/constants.ts
@@ -1,0 +1,9 @@
+export const USER_PROFILE_NAVBAR_ROUTE_ID = {
+  ACCOUNT: 'account',
+  SECURITY: 'security',
+};
+
+export const ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID = {
+  MEMBERS: 'members',
+  SETTINGS: 'settings',
+};

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from 'react';
 import { SIGN_IN_INITIAL_VALUE_KEYS, SIGN_UP_INITIAL_VALUE_KEYS } from '../../core/constants';
 import { buildAuthQueryString, buildURL, createDynamicParamParser, pickRedirectionProp } from '../../utils';
 import { useCoreClerk, useEnvironment, useOptions } from '../contexts';
+import type { NavbarRoute } from '../elements';
 import type { ParsedQs } from '../router';
 import { useRouter } from '../router';
 import type {
@@ -18,6 +19,8 @@ import type {
   UserButtonCtx,
   UserProfileCtx,
 } from '../types';
+import type { CustomPageContent } from '../utils';
+import { createCustomPages } from '../utils';
 
 const populateParamFromObject = createDynamicParamParser({ regex: /:(\w+)/ });
 
@@ -184,24 +187,31 @@ export const useSignInContext = (): SignInContextType => {
   };
 };
 
+type PagesType = {
+  routes: NavbarRoute[];
+  contents: CustomPageContent[];
+  isAccountPageRoot: boolean;
+};
+
 export type UserProfileContextType = UserProfileCtx & {
   queryParams: ParsedQs;
   authQueryString: string | null;
+  pages: PagesType;
 };
 
-// UserProfile does not accept any props except for
-// `routing` and `path`
-// TODO: remove if not needed during the components v2 overhaul
 export const useUserProfileContext = (): UserProfileContextType => {
-  const { componentName, ...ctx } = (React.useContext(ComponentContext) || {}) as UserProfileCtx;
+  const { componentName, customPages, ...ctx } = (React.useContext(ComponentContext) || {}) as UserProfileCtx;
   const { queryParams } = useRouter();
 
   if (componentName !== 'UserProfile') {
     throw new Error('Clerk: useUserProfileContext called outside of the mounted UserProfile component.');
   }
 
+  const pages = useMemo(() => createCustomPages(customPages || []), [customPages]);
+
   return {
     ...ctx,
+    pages,
     componentName,
     queryParams,
     authQueryString: '',

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -191,6 +191,7 @@ type PagesType = {
   routes: NavbarRoute[];
   contents: CustomPageContent[];
   isAccountPageRoot: boolean;
+  pageToRootNavbarRouteMap: Record<string, NavbarRoute>;
 };
 
 export type UserProfileContextType = UserProfileCtx & {

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -20,7 +20,7 @@ import type {
   UserProfileCtx,
 } from '../types';
 import type { CustomPageContent } from '../utils';
-import { createCustomPages } from '../utils';
+import { createOrganizationProfileCustomPages, createUserProfileCustomPages } from '../utils';
 
 const populateParamFromObject = createDynamicParamParser({ regex: /:(\w+)/ });
 
@@ -190,7 +190,6 @@ export const useSignInContext = (): SignInContextType => {
 type PagesType = {
   routes: NavbarRoute[];
   contents: CustomPageContent[];
-  isAccountPageRoot: boolean;
   pageToRootNavbarRouteMap: Record<string, NavbarRoute>;
 };
 
@@ -208,7 +207,7 @@ export const useUserProfileContext = (): UserProfileContextType => {
     throw new Error('Clerk: useUserProfileContext called outside of the mounted UserProfile component.');
   }
 
-  const pages = useMemo(() => createCustomPages(customPages || []), [customPages]);
+  const pages = useMemo(() => createUserProfileCustomPages(customPages || []), [customPages]);
 
   return {
     ...ctx,
@@ -409,8 +408,13 @@ export const useOrganizationListContext = () => {
   };
 };
 
-export const useOrganizationProfileContext = () => {
-  const { componentName, ...ctx } = (React.useContext(ComponentContext) || {}) as OrganizationProfileCtx;
+export type OrganizationProfileContextType = OrganizationProfileCtx & {
+  pages: PagesType;
+  navigateAfterLeaveOrganization: () => Promise<unknown>;
+};
+
+export const useOrganizationProfileContext = (): OrganizationProfileContextType => {
+  const { componentName, customPages, ...ctx } = (React.useContext(ComponentContext) || {}) as OrganizationProfileCtx;
   const { navigate } = useRouter();
   const { displayConfig } = useEnvironment();
 
@@ -418,11 +422,14 @@ export const useOrganizationProfileContext = () => {
     throw new Error('Clerk: useOrganizationProfileContext called outside OrganizationProfile.');
   }
 
+  const pages = useMemo(() => createOrganizationProfileCustomPages(customPages || []), [customPages]);
+
   const navigateAfterLeaveOrganization = () =>
     navigate(ctx.afterLeaveOrganizationUrl || displayConfig.afterLeaveOrganizationUrl);
 
   return {
     ...ctx,
+    pages,
     navigateAfterLeaveOrganization,
     componentName,
   };

--- a/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
+++ b/packages/clerk-js/src/ui/contexts/ClerkUIComponentsContext.tsx
@@ -207,7 +207,7 @@ export const useUserProfileContext = (): UserProfileContextType => {
     throw new Error('Clerk: useUserProfileContext called outside of the mounted UserProfile component.');
   }
 
-  const pages = useMemo(() => createUserProfileCustomPages(customPages || []), [customPages]);
+  const pages = createUserProfileCustomPages(customPages || []);
 
   return {
     ...ctx,
@@ -422,7 +422,7 @@ export const useOrganizationProfileContext = (): OrganizationProfileContextType 
     throw new Error('Clerk: useOrganizationProfileContext called outside OrganizationProfile.');
   }
 
-  const pages = useMemo(() => createOrganizationProfileCustomPages(customPages || []), [customPages]);
+  const pages = createOrganizationProfileCustomPages(customPages || []);
 
   const navigateAfterLeaveOrganization = () =>
     navigate(ctx.afterLeaveOrganizationUrl || displayConfig.afterLeaveOrganizationUrl);

--- a/packages/clerk-js/src/ui/elements/Navbar.tsx
+++ b/packages/clerk-js/src/ui/elements/Navbar.tsx
@@ -1,5 +1,4 @@
 import { createContextAndHook, useSafeLayoutEffect } from '@clerk/shared/react';
-import type { NavbarItemId } from '@clerk/types';
 import React, { useEffect } from 'react';
 
 import type { LocalizationKey } from '../customizables';
@@ -27,10 +26,11 @@ export const NavbarContextProvider = (props: React.PropsWithChildren<Record<neve
 };
 
 export type NavbarRoute = {
-  name: LocalizationKey;
-  id: NavbarItemId;
+  name: LocalizationKey | string;
+  id: string;
   icon: React.ComponentType;
   path: string;
+  external?: boolean;
 };
 type RouteId = NavbarRoute['id'];
 type NavBarProps = {
@@ -43,12 +43,20 @@ const getSectionId = (id: RouteId) => `#cl-section-${id}`;
 
 export const NavBar = (props: NavBarProps) => {
   const { contentRef, routes, header } = props;
-  const [activeId, setActiveId] = React.useState<RouteId>(routes[0]['id']);
+  const [activeId, setActiveId] = React.useState<RouteId>('');
   const { close } = useNavbarContext();
   const { navigate } = useRouter();
   const { navigateToFlowStart } = useNavigateToFlowStart();
   const { t } = useLocalizations();
   const router = useRouter();
+
+  const handleNavigate = (route: NavbarRoute) => {
+    if (route?.external) {
+      return () => navigate(route.path);
+    } else {
+      return () => navigateAndScroll(route);
+    }
+  };
 
   const navigateAndScroll = async (route: NavbarRoute) => {
     if (contentRef.current) {
@@ -74,7 +82,7 @@ export const NavBar = (props: NavBarProps) => {
         for (const entry of entries) {
           const id = entry.target?.id?.split('section-')[1];
           if (entry.isIntersecting && id) {
-            return setActiveId(id as NavbarItemId);
+            return setActiveId(id);
           }
         }
       };
@@ -114,8 +122,9 @@ export const NavBar = (props: NavBarProps) => {
       const matchesPath = router.matches(route.path);
       if (isRoot || matchesPath) {
         setActiveId(route.id);
+        return false;
       }
-      return false;
+      return true;
     });
   }, [router.currentPath]);
 
@@ -128,7 +137,7 @@ export const NavBar = (props: NavBarProps) => {
           elementId={descriptors.navbarButton.setId(r.id as any)}
           iconElementDescriptor={descriptors.navbarButtonIcon}
           iconElementId={descriptors.navbarButtonIcon.setId(r.id) as any}
-          onClick={() => navigateAndScroll(r)}
+          onClick={handleNavigate(r)}
           icon={r.icon}
           isActive={activeId === r.id}
         >

--- a/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
+++ b/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+type ExternalElementMounterProps = {
+  mount: (el: HTMLDivElement) => void;
+  unmount: (el?: HTMLDivElement) => void;
+};
+
+export const ExternalElementMounter = ({ mount, unmount }: ExternalElementMounterProps) => {
+  const nodeRef = useRef(null);
+  useEffect(() => {
+    let elRef: HTMLDivElement | undefined;
+    if (nodeRef.current) {
+      elRef = nodeRef.current;
+      mount(nodeRef.current);
+    }
+    return () => {
+      unmount(elRef);
+    };
+  }, [nodeRef.current]);
+  return (
+    <>
+      <div ref={nodeRef}></div>
+    </>
+  );
+};

--- a/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
+++ b/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
@@ -7,6 +7,7 @@ type ExternalElementMounterProps = {
 
 export const ExternalElementMounter = ({ mount, unmount }: ExternalElementMounterProps) => {
   const nodeRef = useRef(null);
+
   useEffect(() => {
     let elRef: HTMLDivElement | undefined;
     if (nodeRef.current) {
@@ -17,9 +18,6 @@ export const ExternalElementMounter = ({ mount, unmount }: ExternalElementMounte
       unmount(elRef);
     };
   }, [nodeRef.current]);
-  return (
-    <>
-      <div ref={nodeRef}></div>
-    </>
-  );
+
+  return <div ref={nodeRef}></div>;
 };

--- a/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
+++ b/packages/clerk-js/src/ui/utils/ExternalElementMounter.tsx
@@ -5,7 +5,7 @@ type ExternalElementMounterProps = {
   unmount: (el?: HTMLDivElement) => void;
 };
 
-export const ExternalElementMounter = ({ mount, unmount }: ExternalElementMounterProps) => {
+export const ExternalElementMounter = ({ mount, unmount, ...rest }: ExternalElementMounterProps) => {
   const nodeRef = useRef(null);
 
   useEffect(() => {
@@ -19,5 +19,10 @@ export const ExternalElementMounter = ({ mount, unmount }: ExternalElementMounte
     };
   }, [nodeRef.current]);
 
-  return <div ref={nodeRef}></div>;
+  return (
+    <div
+      ref={nodeRef}
+      {...rest}
+    ></div>
+  );
 };

--- a/packages/clerk-js/src/ui/utils/__tests__/createCustomPages.test.ts
+++ b/packages/clerk-js/src/ui/utils/__tests__/createCustomPages.test.ts
@@ -1,0 +1,312 @@
+import type { CustomPage } from '../createCustomPages';
+import { createCustomPages } from '../createCustomPages';
+
+describe('createCustomPages', () => {
+  it('should return the default pages if no custom pages are passed', () => {
+    const { routes, contents, isAccountPageRoot } = createCustomPages([]);
+    expect(routes.length).toEqual(2);
+    expect(routes[0].id).toEqual('account');
+    expect(routes[1].id).toEqual('security');
+    expect(contents.length).toEqual(0);
+    expect(isAccountPageRoot).toEqual(true);
+  });
+
+  it('should return the custom pages after the default pages', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      {
+        label: 'Custom2',
+        url: 'custom2',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes, contents, isAccountPageRoot } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[0].id).toEqual('account');
+    expect(routes[1].id).toEqual('security');
+    expect(routes[2].name).toEqual('Custom1');
+    expect(routes[3].name).toEqual('Custom2');
+    expect(contents.length).toEqual(2);
+    expect(contents[0].url).toEqual('custom1');
+    expect(contents[1].url).toEqual('custom2');
+    expect(isAccountPageRoot).toEqual(true);
+  });
+
+  it('should reorder the default pages when their label is used to target them', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      { label: 'account' },
+      { label: 'security' },
+      {
+        label: 'Custom2',
+        url: 'custom2',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes, contents, isAccountPageRoot } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[0].name).toEqual('Custom1');
+    expect(routes[1].id).toEqual('account');
+    expect(routes[2].id).toEqual('security');
+    expect(routes[3].name).toEqual('Custom2');
+    expect(contents.length).toEqual(2);
+    expect(contents[0].url).toEqual('custom1');
+    expect(contents[1].url).toEqual('custom2');
+    expect(isAccountPageRoot).toEqual(false);
+  });
+
+  it('ignores invalid entries', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      { label: 'account' },
+      { label: 'security' },
+      { label: 'Aaaaaa' },
+      { label: 'account', mount: () => undefined },
+      {
+        label: 'Custom2',
+        url: 'custom2',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[0].name).toEqual('Custom1');
+    expect(routes[1].id).toEqual('account');
+    expect(routes[2].id).toEqual('security');
+    expect(routes[3].name).toEqual('Custom2');
+  });
+
+  it('sets the path of the first page to be the root (/)', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      { label: 'account' },
+      { label: 'security' },
+      {
+        label: 'Custom2',
+        url: 'custom2',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[0].path).toEqual('/');
+    expect(routes[1].path).toEqual('account');
+    expect(routes[2].path).toEqual('account');
+    expect(routes[3].path).toEqual('custom2');
+  });
+
+  it('sets the path of both account and security pages to root (/) if account is first', () => {
+    const customPages: CustomPage[] = [
+      { label: 'account' },
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      { label: 'security' },
+      {
+        label: 'Custom2',
+        url: 'custom2',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[0].path).toEqual('/');
+    expect(routes[1].path).toEqual('custom1');
+    expect(routes[2].path).toEqual('/');
+    expect(routes[3].path).toEqual('custom2');
+  });
+
+  it('sets the path of both account and security pages to root (/) if security is first', () => {
+    const customPages: CustomPage[] = [
+      { label: 'security' },
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      { label: 'account' },
+      {
+        label: 'Custom2',
+        url: 'custom2',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[0].path).toEqual('/');
+    expect(routes[1].path).toEqual('custom1');
+    expect(routes[2].path).toEqual('/');
+    expect(routes[3].path).toEqual('custom2');
+  });
+
+  it('throws if the first item in the navbar is an external link', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Link1',
+        url: '/link1',
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      { label: 'account' },
+      { label: 'security' },
+      {
+        label: 'Custom2',
+        url: 'custom2',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    expect(() => createCustomPages(customPages)).toThrow();
+  });
+
+  it('adds an external link to the navbar routes', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Custom1',
+        url: 'custom1',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      {
+        label: 'Link1',
+        url: '/link1',
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes, contents, isAccountPageRoot } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[0].id).toEqual('account');
+    expect(routes[1].id).toEqual('security');
+    expect(routes[2].name).toEqual('Custom1');
+    expect(routes[3].name).toEqual('Link1');
+    expect(contents.length).toEqual(1);
+    expect(contents[0].url).toEqual('custom1');
+    expect(isAccountPageRoot).toEqual(true);
+  });
+
+  it('sanitizes the path for external links', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Link1',
+        url: 'https://www.fullurl.com',
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      {
+        label: 'Link2',
+        url: '/url-with-slash',
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      {
+        label: 'Link3',
+        url: 'url-without-slash',
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes } = createCustomPages(customPages);
+    expect(routes.length).toEqual(5);
+    expect(routes[2].path).toEqual('https://www.fullurl.com');
+    expect(routes[3].path).toEqual('/url-with-slash');
+    expect(routes[4].path).toEqual('/url-without-slash');
+  });
+
+  it('sanitizes the path for custom pages', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Page1',
+        url: '/url-with-slash',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+      {
+        label: 'Page2',
+        url: 'url-without-slash',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    const { routes } = createCustomPages(customPages);
+    expect(routes.length).toEqual(4);
+    expect(routes[2].path).toEqual('url-with-slash');
+    expect(routes[3].path).toEqual('url-without-slash');
+  });
+
+  it('throws when a custom page has an absolute URL', () => {
+    const customPages: CustomPage[] = [
+      {
+        label: 'Page1',
+        url: 'https://www.fullurl.com',
+        mount: () => undefined,
+        unmount: () => undefined,
+        mountIcon: () => undefined,
+        unmountIcon: () => undefined,
+      },
+    ];
+    expect(() => createCustomPages(customPages)).toThrow();
+  });
+});

--- a/packages/clerk-js/src/ui/utils/__tests__/createCustomPages.test.ts
+++ b/packages/clerk-js/src/ui/utils/__tests__/createCustomPages.test.ts
@@ -1,14 +1,14 @@
-import type { CustomPage } from '../createCustomPages';
-import { createCustomPages } from '../createCustomPages';
+import type { CustomPage } from '@clerk/types';
 
-describe('createCustomPages', () => {
+import { createUserProfileCustomPages } from '../createCustomPages';
+
+describe('createUserProfileCustomPages', () => {
   it('should return the default pages if no custom pages are passed', () => {
-    const { routes, contents, isAccountPageRoot } = createCustomPages([]);
+    const { routes, contents } = createUserProfileCustomPages([]);
     expect(routes.length).toEqual(2);
     expect(routes[0].id).toEqual('account');
     expect(routes[1].id).toEqual('security');
     expect(contents.length).toEqual(0);
-    expect(isAccountPageRoot).toEqual(true);
   });
 
   it('should return the custom pages after the default pages', () => {
@@ -30,7 +30,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes, contents, isAccountPageRoot } = createCustomPages(customPages);
+    const { routes, contents } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[0].id).toEqual('account');
     expect(routes[1].id).toEqual('security');
@@ -39,7 +39,6 @@ describe('createCustomPages', () => {
     expect(contents.length).toEqual(2);
     expect(contents[0].url).toEqual('custom1');
     expect(contents[1].url).toEqual('custom2');
-    expect(isAccountPageRoot).toEqual(true);
   });
 
   it('should reorder the default pages when their label is used to target them', () => {
@@ -63,7 +62,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes, contents, isAccountPageRoot } = createCustomPages(customPages);
+    const { routes, contents } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[0].name).toEqual('Custom1');
     expect(routes[1].id).toEqual('account');
@@ -72,7 +71,6 @@ describe('createCustomPages', () => {
     expect(contents.length).toEqual(2);
     expect(contents[0].url).toEqual('custom1');
     expect(contents[1].url).toEqual('custom2');
-    expect(isAccountPageRoot).toEqual(false);
   });
 
   it('ignores invalid entries', () => {
@@ -98,7 +96,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes } = createCustomPages(customPages);
+    const { routes } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[0].name).toEqual('Custom1');
     expect(routes[1].id).toEqual('account');
@@ -127,7 +125,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes } = createCustomPages(customPages);
+    const { routes } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[0].path).toEqual('/');
     expect(routes[1].path).toEqual('account');
@@ -156,7 +154,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes } = createCustomPages(customPages);
+    const { routes } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[0].path).toEqual('/');
     expect(routes[1].path).toEqual('custom1');
@@ -185,7 +183,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes } = createCustomPages(customPages);
+    const { routes } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[0].path).toEqual('/');
     expect(routes[1].path).toEqual('custom1');
@@ -212,7 +210,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    expect(() => createCustomPages(customPages)).toThrow();
+    expect(() => createUserProfileCustomPages(customPages)).toThrow();
   });
 
   it('adds an external link to the navbar routes', () => {
@@ -232,7 +230,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes, contents, isAccountPageRoot } = createCustomPages(customPages);
+    const { routes, contents } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[0].id).toEqual('account');
     expect(routes[1].id).toEqual('security');
@@ -240,7 +238,6 @@ describe('createCustomPages', () => {
     expect(routes[3].name).toEqual('Link1');
     expect(contents.length).toEqual(1);
     expect(contents[0].url).toEqual('custom1');
-    expect(isAccountPageRoot).toEqual(true);
   });
 
   it('sanitizes the path for external links', () => {
@@ -264,7 +261,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes } = createCustomPages(customPages);
+    const { routes } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(5);
     expect(routes[2].path).toEqual('https://www.fullurl.com');
     expect(routes[3].path).toEqual('/url-with-slash');
@@ -290,7 +287,7 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    const { routes } = createCustomPages(customPages);
+    const { routes } = createUserProfileCustomPages(customPages);
     expect(routes.length).toEqual(4);
     expect(routes[2].path).toEqual('url-with-slash');
     expect(routes[3].path).toEqual('url-without-slash');
@@ -307,6 +304,6 @@ describe('createCustomPages', () => {
         unmountIcon: () => undefined,
       },
     ];
-    expect(() => createCustomPages(customPages)).toThrow();
+    expect(() => createUserProfileCustomPages(customPages)).toThrow();
   });
 });

--- a/packages/clerk-js/src/ui/utils/__tests__/createCustomPages.test.ts
+++ b/packages/clerk-js/src/ui/utils/__tests__/createCustomPages.test.ts
@@ -1,309 +1,616 @@
 import type { CustomPage } from '@clerk/types';
 
-import { createUserProfileCustomPages } from '../createCustomPages';
+import { createOrganizationProfileCustomPages, createUserProfileCustomPages } from '../createCustomPages';
 
-describe('createUserProfileCustomPages', () => {
-  it('should return the default pages if no custom pages are passed', () => {
-    const { routes, contents } = createUserProfileCustomPages([]);
-    expect(routes.length).toEqual(2);
-    expect(routes[0].id).toEqual('account');
-    expect(routes[1].id).toEqual('security');
-    expect(contents.length).toEqual(0);
+describe('createCustomPages', () => {
+  describe('createUserProfileCustomPages', () => {
+    it('should return the default pages if no custom pages are passed', () => {
+      const { routes, contents } = createUserProfileCustomPages([]);
+      expect(routes.length).toEqual(2);
+      expect(routes[0].id).toEqual('account');
+      expect(routes[1].id).toEqual('security');
+      expect(contents.length).toEqual(0);
+    });
+
+    it('should return the custom pages after the default pages', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes, contents } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].id).toEqual('account');
+      expect(routes[1].id).toEqual('security');
+      expect(routes[2].name).toEqual('Custom1');
+      expect(routes[3].name).toEqual('Custom2');
+      expect(contents.length).toEqual(2);
+      expect(contents[0].url).toEqual('custom1');
+      expect(contents[1].url).toEqual('custom2');
+    });
+
+    it('should reorder the default pages when their label is used to target them', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'account' },
+        { label: 'security' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes, contents } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].name).toEqual('Custom1');
+      expect(routes[1].id).toEqual('account');
+      expect(routes[2].id).toEqual('security');
+      expect(routes[3].name).toEqual('Custom2');
+      expect(contents.length).toEqual(2);
+      expect(contents[0].url).toEqual('custom1');
+      expect(contents[1].url).toEqual('custom2');
+    });
+
+    it('ignores invalid entries', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'account' },
+        { label: 'security' },
+        { label: 'Aaaaaa' },
+        { label: 'account', mount: () => undefined },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].name).toEqual('Custom1');
+      expect(routes[1].id).toEqual('account');
+      expect(routes[2].id).toEqual('security');
+      expect(routes[3].name).toEqual('Custom2');
+    });
+
+    it('sets the path of the first page to be the root (/)', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'account' },
+        { label: 'security' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].path).toEqual('/');
+      expect(routes[1].path).toEqual('account');
+      expect(routes[2].path).toEqual('account');
+      expect(routes[3].path).toEqual('custom2');
+    });
+
+    it('sets the path of both account and security pages to root (/) if account is first', () => {
+      const customPages: CustomPage[] = [
+        { label: 'account' },
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'security' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].path).toEqual('/');
+      expect(routes[1].path).toEqual('custom1');
+      expect(routes[2].path).toEqual('/');
+      expect(routes[3].path).toEqual('custom2');
+    });
+
+    it('sets the path of both account and security pages to root (/) if security is first', () => {
+      const customPages: CustomPage[] = [
+        { label: 'security' },
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'account' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].path).toEqual('/');
+      expect(routes[1].path).toEqual('custom1');
+      expect(routes[2].path).toEqual('/');
+      expect(routes[3].path).toEqual('custom2');
+    });
+
+    it('throws if the first item in the navbar is an external link', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Link1',
+          url: '/link1',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'account' },
+        { label: 'security' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      expect(() => createUserProfileCustomPages(customPages)).toThrow();
+    });
+
+    it('adds an external link to the navbar routes', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Link1',
+          url: '/link1',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes, contents } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].id).toEqual('account');
+      expect(routes[1].id).toEqual('security');
+      expect(routes[2].name).toEqual('Custom1');
+      expect(routes[3].name).toEqual('Link1');
+      expect(contents.length).toEqual(1);
+      expect(contents[0].url).toEqual('custom1');
+    });
+
+    it('sanitizes the path for external links', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Link1',
+          url: 'https://www.fullurl.com',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Link2',
+          url: '/url-with-slash',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Link3',
+          url: 'url-without-slash',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(5);
+      expect(routes[2].path).toEqual('https://www.fullurl.com');
+      expect(routes[3].path).toEqual('/url-with-slash');
+      expect(routes[4].path).toEqual('/url-without-slash');
+    });
+
+    it('sanitizes the path for custom pages', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Page1',
+          url: '/url-with-slash',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Page2',
+          url: 'url-without-slash',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createUserProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[2].path).toEqual('url-with-slash');
+      expect(routes[3].path).toEqual('url-without-slash');
+    });
+
+    it('throws when a custom page has an absolute URL', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Page1',
+          url: 'https://www.fullurl.com',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      expect(() => createUserProfileCustomPages(customPages)).toThrow();
+    });
   });
 
-  it('should return the custom pages after the default pages', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Custom1',
-        url: 'custom1',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      {
-        label: 'Custom2',
-        url: 'custom2',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes, contents } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[0].id).toEqual('account');
-    expect(routes[1].id).toEqual('security');
-    expect(routes[2].name).toEqual('Custom1');
-    expect(routes[3].name).toEqual('Custom2');
-    expect(contents.length).toEqual(2);
-    expect(contents[0].url).toEqual('custom1');
-    expect(contents[1].url).toEqual('custom2');
-  });
+  describe('createOrganizationProfileCustomPages', () => {
+    it('should return the default pages if no custom pages are passed', () => {
+      const { routes, contents } = createOrganizationProfileCustomPages([]);
+      expect(routes.length).toEqual(2);
+      expect(routes[0].id).toEqual('members');
+      expect(routes[1].id).toEqual('settings');
+      expect(contents.length).toEqual(0);
+    });
 
-  it('should reorder the default pages when their label is used to target them', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Custom1',
-        url: 'custom1',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      { label: 'account' },
-      { label: 'security' },
-      {
-        label: 'Custom2',
-        url: 'custom2',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes, contents } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[0].name).toEqual('Custom1');
-    expect(routes[1].id).toEqual('account');
-    expect(routes[2].id).toEqual('security');
-    expect(routes[3].name).toEqual('Custom2');
-    expect(contents.length).toEqual(2);
-    expect(contents[0].url).toEqual('custom1');
-    expect(contents[1].url).toEqual('custom2');
-  });
+    it('should return the custom pages after the default pages', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes, contents } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].id).toEqual('members');
+      expect(routes[1].id).toEqual('settings');
+      expect(routes[2].name).toEqual('Custom1');
+      expect(routes[3].name).toEqual('Custom2');
+      expect(contents.length).toEqual(2);
+      expect(contents[0].url).toEqual('custom1');
+      expect(contents[1].url).toEqual('custom2');
+    });
 
-  it('ignores invalid entries', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Custom1',
-        url: 'custom1',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      { label: 'account' },
-      { label: 'security' },
-      { label: 'Aaaaaa' },
-      { label: 'account', mount: () => undefined },
-      {
-        label: 'Custom2',
-        url: 'custom2',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[0].name).toEqual('Custom1');
-    expect(routes[1].id).toEqual('account');
-    expect(routes[2].id).toEqual('security');
-    expect(routes[3].name).toEqual('Custom2');
-  });
+    it('should reorder the default pages when their label is used to target them', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'members' },
+        { label: 'settings' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes, contents } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].name).toEqual('Custom1');
+      expect(routes[1].id).toEqual('members');
+      expect(routes[2].id).toEqual('settings');
+      expect(routes[3].name).toEqual('Custom2');
+      expect(contents.length).toEqual(2);
+      expect(contents[0].url).toEqual('custom1');
+      expect(contents[1].url).toEqual('custom2');
+    });
 
-  it('sets the path of the first page to be the root (/)', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Custom1',
-        url: 'custom1',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      { label: 'account' },
-      { label: 'security' },
-      {
-        label: 'Custom2',
-        url: 'custom2',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[0].path).toEqual('/');
-    expect(routes[1].path).toEqual('account');
-    expect(routes[2].path).toEqual('account');
-    expect(routes[3].path).toEqual('custom2');
-  });
+    it('ignores invalid entries', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'members' },
+        { label: 'settings' },
+        { label: 'Aaaaaa' },
+        { label: 'members', mount: () => undefined },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].name).toEqual('Custom1');
+      expect(routes[1].id).toEqual('members');
+      expect(routes[2].id).toEqual('settings');
+      expect(routes[3].name).toEqual('Custom2');
+    });
 
-  it('sets the path of both account and security pages to root (/) if account is first', () => {
-    const customPages: CustomPage[] = [
-      { label: 'account' },
-      {
-        label: 'Custom1',
-        url: 'custom1',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      { label: 'security' },
-      {
-        label: 'Custom2',
-        url: 'custom2',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[0].path).toEqual('/');
-    expect(routes[1].path).toEqual('custom1');
-    expect(routes[2].path).toEqual('/');
-    expect(routes[3].path).toEqual('custom2');
-  });
+    it('sets the path of the first page to be the root (/)', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'members' },
+        { label: 'settings' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].path).toEqual('/');
+      expect(routes[1].path).toEqual('organization-members');
+      expect(routes[2].path).toEqual('organization-settings');
+      expect(routes[3].path).toEqual('custom2');
+    });
 
-  it('sets the path of both account and security pages to root (/) if security is first', () => {
-    const customPages: CustomPage[] = [
-      { label: 'security' },
-      {
-        label: 'Custom1',
-        url: 'custom1',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      { label: 'account' },
-      {
-        label: 'Custom2',
-        url: 'custom2',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[0].path).toEqual('/');
-    expect(routes[1].path).toEqual('custom1');
-    expect(routes[2].path).toEqual('/');
-    expect(routes[3].path).toEqual('custom2');
-  });
+    it('sets the path of members pages to root (/) if it is first', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'settings' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].path).toEqual('/');
+      expect(routes[1].path).toEqual('custom1');
+      expect(routes[2].path).toEqual('organization-settings');
+      expect(routes[3].path).toEqual('custom2');
+    });
 
-  it('throws if the first item in the navbar is an external link', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Link1',
-        url: '/link1',
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      { label: 'account' },
-      { label: 'security' },
-      {
-        label: 'Custom2',
-        url: 'custom2',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    expect(() => createUserProfileCustomPages(customPages)).toThrow();
-  });
+    it('sets the path of settings pages to root (/) if it is first', () => {
+      const customPages: CustomPage[] = [
+        { label: 'settings' },
+        { label: 'members' },
 
-  it('adds an external link to the navbar routes', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Custom1',
-        url: 'custom1',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      {
-        label: 'Link1',
-        url: '/link1',
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes, contents } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[0].id).toEqual('account');
-    expect(routes[1].id).toEqual('security');
-    expect(routes[2].name).toEqual('Custom1');
-    expect(routes[3].name).toEqual('Link1');
-    expect(contents.length).toEqual(1);
-    expect(contents[0].url).toEqual('custom1');
-  });
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].path).toEqual('/');
+      expect(routes[1].path).toEqual('organization-members');
+      expect(routes[3].path).toEqual('custom2');
+    });
 
-  it('sanitizes the path for external links', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Link1',
-        url: 'https://www.fullurl.com',
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      {
-        label: 'Link2',
-        url: '/url-with-slash',
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      {
-        label: 'Link3',
-        url: 'url-without-slash',
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(5);
-    expect(routes[2].path).toEqual('https://www.fullurl.com');
-    expect(routes[3].path).toEqual('/url-with-slash');
-    expect(routes[4].path).toEqual('/url-without-slash');
-  });
+    it('throws if the first item in the navbar is an external link', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Link1',
+          url: '/link1',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        { label: 'members' },
+        { label: 'settings' },
+        {
+          label: 'Custom2',
+          url: 'custom2',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      expect(() => createOrganizationProfileCustomPages(customPages)).toThrow();
+    });
 
-  it('sanitizes the path for custom pages', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Page1',
-        url: '/url-with-slash',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-      {
-        label: 'Page2',
-        url: 'url-without-slash',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    const { routes } = createUserProfileCustomPages(customPages);
-    expect(routes.length).toEqual(4);
-    expect(routes[2].path).toEqual('url-with-slash');
-    expect(routes[3].path).toEqual('url-without-slash');
-  });
+    it('adds an external link to the navbar routes', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Custom1',
+          url: 'custom1',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Link1',
+          url: '/link1',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes, contents } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[0].id).toEqual('members');
+      expect(routes[1].id).toEqual('settings');
+      expect(routes[2].name).toEqual('Custom1');
+      expect(routes[3].name).toEqual('Link1');
+      expect(contents.length).toEqual(1);
+      expect(contents[0].url).toEqual('custom1');
+    });
 
-  it('throws when a custom page has an absolute URL', () => {
-    const customPages: CustomPage[] = [
-      {
-        label: 'Page1',
-        url: 'https://www.fullurl.com',
-        mount: () => undefined,
-        unmount: () => undefined,
-        mountIcon: () => undefined,
-        unmountIcon: () => undefined,
-      },
-    ];
-    expect(() => createUserProfileCustomPages(customPages)).toThrow();
+    it('sanitizes the path for external links', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Link1',
+          url: 'https://www.fullurl.com',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Link2',
+          url: '/url-with-slash',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Link3',
+          url: 'url-without-slash',
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(5);
+      expect(routes[2].path).toEqual('https://www.fullurl.com');
+      expect(routes[3].path).toEqual('/url-with-slash');
+      expect(routes[4].path).toEqual('/url-without-slash');
+    });
+
+    it('sanitizes the path for custom pages', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Page1',
+          url: '/url-with-slash',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+        {
+          label: 'Page2',
+          url: 'url-without-slash',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      const { routes } = createOrganizationProfileCustomPages(customPages);
+      expect(routes.length).toEqual(4);
+      expect(routes[2].path).toEqual('url-with-slash');
+      expect(routes[3].path).toEqual('url-without-slash');
+    });
+
+    it('throws when a custom page has an absolute URL', () => {
+      const customPages: CustomPage[] = [
+        {
+          label: 'Page1',
+          url: 'https://www.fullurl.com',
+          mount: () => undefined,
+          unmount: () => undefined,
+          mountIcon: () => undefined,
+          unmountIcon: () => undefined,
+        },
+      ];
+      expect(() => createOrganizationProfileCustomPages(customPages)).toThrow();
+    });
   });
 });

--- a/packages/clerk-js/src/ui/utils/createCustomPages.tsx
+++ b/packages/clerk-js/src/ui/utils/createCustomPages.tsx
@@ -1,0 +1,217 @@
+import { isDevelopmentEnvironment } from '@clerk/shared';
+import type { CustomPage } from '@clerk/types';
+
+import { isValidUrl } from '../../utils';
+import type { NavbarRoute } from '../elements';
+import { TickShield, User } from '../icons';
+import { localizationKeys } from '../localization';
+import { ExternalElementMounter } from './ExternalElementMounter';
+
+const CLERK_ACCOUNT_ROUTE: NavbarRoute = {
+  name: localizationKeys('userProfile.start.headerTitle__account'),
+  id: 'account',
+  icon: User,
+  path: 'account',
+};
+
+const CLERK_SECURITY_ROUTE: NavbarRoute = {
+  name: localizationKeys('userProfile.start.headerTitle__security'),
+  id: 'security',
+  icon: TickShield,
+  path: 'account',
+};
+
+export const pageToRootNavbarRouteMap = {
+  profile: CLERK_ACCOUNT_ROUTE,
+  'email-address': CLERK_ACCOUNT_ROUTE,
+  'phone-number': CLERK_ACCOUNT_ROUTE,
+  'connected-account': CLERK_ACCOUNT_ROUTE,
+  'web3-wallet': CLERK_ACCOUNT_ROUTE,
+  username: CLERK_ACCOUNT_ROUTE,
+  'multi-factor': CLERK_SECURITY_ROUTE,
+  password: CLERK_SECURITY_ROUTE,
+};
+
+export type CustomPageContent = {
+  url: string;
+  mount: (el: HTMLDivElement) => void;
+  unmount: (el?: HTMLDivElement) => void;
+};
+
+type UserProfileReorderItem = {
+  label: 'account' | 'security';
+};
+
+type UserProfileCustomPage = {
+  label: string;
+  url: string;
+  mountIcon: (el: HTMLDivElement) => void;
+  unmountIcon: (el?: HTMLDivElement) => void;
+  mount: (el: HTMLDivElement) => void;
+  unmount: (el?: HTMLDivElement) => void;
+};
+
+type UserProfileCustomLink = {
+  label: string;
+  url: string;
+  mountIcon: (el: HTMLDivElement) => void;
+  unmountIcon: (el?: HTMLDivElement) => void;
+};
+
+export const createCustomPages = (customPages: CustomPage[]) => {
+  if (isDevelopmentEnvironment()) {
+    checkForDuplicateUsageOfReorderingItems(customPages);
+  }
+
+  const validCustomPages = customPages.filter(cp => {
+    if (!isValidPageItem(cp)) {
+      if (isDevelopmentEnvironment()) {
+        console.error('Invalid custom page data: ', cp);
+      }
+      return false;
+    }
+    return true;
+  });
+
+  const { allRoutes, contents } = getRoutesAndContents(validCustomPages);
+
+  assertExternalLinkAsRoot(allRoutes);
+
+  const routes = setFirstPathToRoot(allRoutes);
+
+  if (isDevelopmentEnvironment()) {
+    warnForDuplicatePaths(routes);
+  }
+
+  return { routes, contents, isAccountPageRoot: routes[0].id === 'account' || routes[0].id === 'security' };
+};
+
+const getRoutesAndContents = (customPages: CustomPage[]) => {
+  let clerkDefaultRoutes: NavbarRoute[] = [{ ...CLERK_ACCOUNT_ROUTE }, { ...CLERK_SECURITY_ROUTE }];
+  const CLERK_ROUTES = {
+    account: CLERK_ACCOUNT_ROUTE,
+    security: CLERK_SECURITY_ROUTE,
+  };
+  const contents: CustomPageContent[] = [];
+
+  const routesWithoutDefaults: NavbarRoute[] = customPages.map((cp, index) => {
+    if (isCustomLink(cp)) {
+      return {
+        name: cp.label,
+        id: `custom-page-${index}`,
+        icon: () => (
+          <ExternalElementMounter
+            mount={cp.mountIcon}
+            unmount={cp.unmountIcon}
+          />
+        ),
+        path: sanitizeCustomLinkURL(cp.url),
+        external: true,
+      };
+    }
+    if (isCustomPage(cp)) {
+      const pageURL = sanitizeCustomPageURL(cp.url);
+      contents.push({ url: pageURL, mount: cp.mount, unmount: cp.unmount });
+      return {
+        name: cp.label,
+        id: `custom-page-${index}`,
+        icon: () => (
+          <ExternalElementMounter
+            mount={cp.mountIcon}
+            unmount={cp.unmountIcon}
+          />
+        ),
+        path: pageURL,
+      };
+    }
+    const reorderItem = CLERK_ROUTES[cp.label as 'account' | 'security'];
+    clerkDefaultRoutes = clerkDefaultRoutes.filter(({ id }) => id !== cp.label);
+    return { ...reorderItem };
+  });
+
+  const allRoutes = [...clerkDefaultRoutes, ...routesWithoutDefaults];
+
+  return { allRoutes, contents };
+};
+
+// Set the path of the first route to '/' or if the first route is account or security, set the path of both account and security to '/'
+const setFirstPathToRoot = (routes: NavbarRoute[]) => {
+  if (routes[0].id === 'account' || routes[0].id === 'security') {
+    return routes.map(r => {
+      if (r.id === 'account' || r.id === 'security') {
+        return { ...r, path: '/' };
+      }
+      return r;
+    });
+  } else {
+    return routes.map((r, index) => (index === 0 ? { ...r, path: '/' } : r));
+  }
+};
+
+const checkForDuplicateUsageOfReorderingItems = (customPages: CustomPage[]) => {
+  const reorderItems = customPages.filter(cp => isAccountReorderItem(cp) || isSecurityReorderItem(cp));
+  reorderItems.reduce((acc, cp) => {
+    if (acc.includes(cp.label)) {
+      console.error(
+        `The "${cp.label}" item is used more than once when reordering UserProfile pages. This may cause unexpected behavior.`,
+      );
+    }
+    return [...acc, cp.label];
+  }, [] as string[]);
+};
+
+const warnForDuplicatePaths = (routes: NavbarRoute[]) => {
+  const paths = routes
+    .filter(({ external, path }) => !external && path !== '/' && path !== 'account')
+    .map(({ path }) => path);
+  const duplicatePaths = paths.filter((p, index) => paths.indexOf(p) !== index);
+  duplicatePaths.forEach(p => {
+    console.error(`Duplicate path "${p}" found in custom pages. This may cause unexpected behavior.`);
+  });
+};
+
+const isValidPageItem = (cp: CustomPage): cp is CustomPage => {
+  return isCustomPage(cp) || isCustomLink(cp) || isAccountReorderItem(cp) || isSecurityReorderItem(cp);
+};
+
+const isCustomPage = (cp: CustomPage): cp is UserProfileCustomPage => {
+  return !!cp.url && !!cp.label && !!cp.mount && !!cp.unmount && !!cp.mountIcon && !!cp.unmountIcon;
+};
+
+const isCustomLink = (cp: CustomPage): cp is UserProfileCustomLink => {
+  return !!cp.url && !!cp.label && !cp.mount && !cp.unmount && !!cp.mountIcon && !!cp.unmountIcon;
+};
+
+const isAccountReorderItem = (cp: CustomPage): cp is UserProfileReorderItem => {
+  return !cp.url && !cp.mount && !cp.unmount && !cp.mountIcon && !cp.unmountIcon && cp.label === 'account';
+};
+
+const isSecurityReorderItem = (cp: CustomPage): cp is UserProfileReorderItem => {
+  return !cp.url && !cp.mount && !cp.unmount && !cp.mountIcon && !cp.unmountIcon && cp.label === 'security';
+};
+
+const sanitizeCustomPageURL = (url: string): string => {
+  if (!url) {
+    throw new Error('URL is required for custom pages');
+  }
+  if (isValidUrl(url)) {
+    throw new Error('Absolute URLs are not supported for custom pages');
+  }
+  return (url as string).charAt(0) === '/' && (url as string).length > 1 ? (url as string).substring(1) : url;
+};
+
+const sanitizeCustomLinkURL = (url: string): string => {
+  if (!url) {
+    throw new Error('URL is required for custom links');
+  }
+  if (isValidUrl(url)) {
+    return url;
+  }
+  return (url as string).charAt(0) === '/' ? url : `/${url}`;
+};
+
+const assertExternalLinkAsRoot = (routes: NavbarRoute[]) => {
+  if (routes[0].external) {
+    throw new Error('The first route cannot be a <UserProfile.Link /> component');
+  }
+};

--- a/packages/clerk-js/src/ui/utils/createCustomPages.tsx
+++ b/packages/clerk-js/src/ui/utils/createCustomPages.tsx
@@ -79,7 +79,7 @@ const createCustomPages = ({
   const validCustomPages = customPages.filter(cp => {
     if (!isValidPageItem(cp, validReorderItemLabels)) {
       if (isDevelopmentEnvironment()) {
-        console.error('Invalid custom page data: ', cp);
+        console.error('Clerk: Invalid custom page data: ', cp);
       }
       return false;
     }
@@ -112,7 +112,7 @@ type GetRoutesAndContentsParams = {
 };
 
 const getRoutesAndContents = ({ customPages, defaultRoutes }: GetRoutesAndContentsParams) => {
-  let remainingDefaultRoutes: NavbarRoute[] = defaultRoutes.map(r => ({ ...r }));
+  let remainingDefaultRoutes: NavbarRoute[] = defaultRoutes.map(r => r);
   const contents: CustomPageContent[] = [];
 
   const routesWithoutDefaults: NavbarRoute[] = customPages.map((cp, index) => {
@@ -178,7 +178,7 @@ const checkForDuplicateUsageOfReorderingItems = (customPages: CustomPage[], vali
   reorderItems.reduce((acc, cp) => {
     if (acc.includes(cp.label)) {
       console.error(
-        `The "${cp.label}" item is used more than once when reordering UserProfile pages. This may cause unexpected behavior.`,
+        `Clerk: The "${cp.label}" item is used more than once when reordering UserProfile pages. This may cause unexpected behavior.`,
       );
     }
     return [...acc, cp.label];
@@ -191,7 +191,7 @@ const warnForDuplicatePaths = (routes: NavbarRoute[], pathsToFilter: string[]) =
     .map(({ path }) => path);
   const duplicatePaths = paths.filter((p, index) => paths.indexOf(p) !== index);
   duplicatePaths.forEach(p => {
-    console.error(`Duplicate path "${p}" found in custom pages. This may cause unexpected behavior.`);
+    console.error(`Clerk: Duplicate path "${p}" found in custom pages. This may cause unexpected behavior.`);
   });
 };
 
@@ -215,17 +215,17 @@ const isReorderItem = (cp: CustomPage, validItems: string[]): cp is UserProfileR
 
 const sanitizeCustomPageURL = (url: string): string => {
   if (!url) {
-    throw new Error('URL is required for custom pages');
+    throw new Error('Clerk: URL is required for custom pages');
   }
   if (isValidUrl(url)) {
-    throw new Error('Absolute URLs are not supported for custom pages');
+    throw new Error('Clerk: Absolute URLs are not supported for custom pages');
   }
   return (url as string).charAt(0) === '/' && (url as string).length > 1 ? (url as string).substring(1) : url;
 };
 
 const sanitizeCustomLinkURL = (url: string): string => {
   if (!url) {
-    throw new Error('URL is required for custom links');
+    throw new Error('Clerk: URL is required for custom links');
   }
   if (isValidUrl(url)) {
     return url;
@@ -235,7 +235,7 @@ const sanitizeCustomLinkURL = (url: string): string => {
 
 const assertExternalLinkAsRoot = (routes: NavbarRoute[]) => {
   if (routes[0].external) {
-    throw new Error('The first route cannot be a custom external link component');
+    throw new Error('Clerk: The first route cannot be a custom external link component');
   }
 };
 

--- a/packages/clerk-js/src/ui/utils/createCustomPages.tsx
+++ b/packages/clerk-js/src/ui/utils/createCustomPages.tsx
@@ -2,6 +2,7 @@ import { isDevelopmentEnvironment } from '@clerk/shared';
 import type { CustomPage } from '@clerk/types';
 
 import { isValidUrl } from '../../utils';
+import { ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID, USER_PROFILE_NAVBAR_ROUTE_ID } from '../constants';
 import type { NavbarRoute } from '../elements';
 import { CogFilled, TickShield, User } from '../icons';
 import { localizationKeys } from '../localization';
@@ -14,7 +15,7 @@ export type CustomPageContent = {
 };
 
 type ProfileReorderItem = {
-  label: 'account' | 'security';
+  label: 'account' | 'security' | 'members' | 'settings';
 };
 
 type ProfileCustomPage = {
@@ -184,6 +185,7 @@ const checkForDuplicateUsageOfReorderingItems = (customPages: CustomPage[], vali
     return [...acc, cp.label];
   }, [] as string[]);
 };
+
 //path !== '/' && path !== 'account'
 const warnForDuplicatePaths = (routes: NavbarRoute[], pathsToFilter: string[]) => {
   const paths = routes
@@ -243,27 +245,27 @@ const getUserProfileDefaultRoutes = (): GetDefaultRoutesReturnType => {
   const INITIAL_ROUTES: NavbarRoute[] = [
     {
       name: localizationKeys('userProfile.start.headerTitle__account'),
-      id: 'account',
+      id: USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT,
       icon: User,
       path: 'account',
     },
     {
       name: localizationKeys('userProfile.start.headerTitle__security'),
-      id: 'security',
+      id: USER_PROFILE_NAVBAR_ROUTE_ID.SECURITY,
       icon: TickShield,
       path: 'account',
     },
   ];
 
   const pageToRootNavbarRouteMap: Record<string, NavbarRoute> = {
-    profile: INITIAL_ROUTES.find(r => r.id === 'account') as NavbarRoute,
-    'email-address': INITIAL_ROUTES.find(r => r.id === 'account') as NavbarRoute,
-    'phone-number': INITIAL_ROUTES.find(r => r.id === 'account') as NavbarRoute,
-    'connected-account': INITIAL_ROUTES.find(r => r.id === 'account') as NavbarRoute,
-    'web3-wallet': INITIAL_ROUTES.find(r => r.id === 'account') as NavbarRoute,
-    username: INITIAL_ROUTES.find(r => r.id === 'account') as NavbarRoute,
-    'multi-factor': INITIAL_ROUTES.find(r => r.id === 'security') as NavbarRoute,
-    password: INITIAL_ROUTES.find(r => r.id === 'security') as NavbarRoute,
+    profile: INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT) as NavbarRoute,
+    'email-address': INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT) as NavbarRoute,
+    'phone-number': INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT) as NavbarRoute,
+    'connected-account': INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT) as NavbarRoute,
+    'web3-wallet': INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT) as NavbarRoute,
+    username: INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.ACCOUNT) as NavbarRoute,
+    'multi-factor': INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.SECURITY) as NavbarRoute,
+    password: INITIAL_ROUTES.find(r => r.id === USER_PROFILE_NAVBAR_ROUTE_ID.SECURITY) as NavbarRoute,
   };
 
   const validReorderItemLabels: string[] = INITIAL_ROUTES.map(r => r.id);
@@ -275,24 +277,24 @@ const getOrganizationProfileDefaultRoutes = (): GetDefaultRoutesReturnType => {
   const INITIAL_ROUTES: NavbarRoute[] = [
     {
       name: localizationKeys('organizationProfile.start.headerTitle__members'),
-      id: 'members',
+      id: ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.MEMBERS,
       icon: User,
       path: 'organization-members',
     },
     {
       name: localizationKeys('organizationProfile.start.headerTitle__settings'),
-      id: 'settings',
+      id: ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.SETTINGS,
       icon: CogFilled,
       path: 'organization-settings',
     },
   ];
 
   const pageToRootNavbarRouteMap: Record<string, NavbarRoute> = {
-    'invite-members': INITIAL_ROUTES.find(r => r.id === 'members') as NavbarRoute,
-    domain: INITIAL_ROUTES.find(r => r.id === 'settings') as NavbarRoute,
-    profile: INITIAL_ROUTES.find(r => r.id === 'settings') as NavbarRoute,
-    leave: INITIAL_ROUTES.find(r => r.id === 'settings') as NavbarRoute,
-    delete: INITIAL_ROUTES.find(r => r.id === 'settings') as NavbarRoute,
+    'invite-members': INITIAL_ROUTES.find(r => r.id === ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.MEMBERS) as NavbarRoute,
+    domain: INITIAL_ROUTES.find(r => r.id === ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.SETTINGS) as NavbarRoute,
+    profile: INITIAL_ROUTES.find(r => r.id === ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.SETTINGS) as NavbarRoute,
+    leave: INITIAL_ROUTES.find(r => r.id === ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.SETTINGS) as NavbarRoute,
+    delete: INITIAL_ROUTES.find(r => r.id === ORGANIZATION_PROFILE_NAVBAR_ROUTE_ID.SETTINGS) as NavbarRoute,
   };
 
   const validReorderItemLabels: string[] = INITIAL_ROUTES.map(r => r.id);

--- a/packages/clerk-js/src/ui/utils/createCustomPages.tsx
+++ b/packages/clerk-js/src/ui/utils/createCustomPages.tsx
@@ -13,11 +13,11 @@ export type CustomPageContent = {
   unmount: (el?: HTMLDivElement) => void;
 };
 
-type UserProfileReorderItem = {
+type ProfileReorderItem = {
   label: 'account' | 'security';
 };
 
-type UserProfileCustomPage = {
+type ProfileCustomPage = {
   label: string;
   url: string;
   mountIcon: (el: HTMLDivElement) => void;
@@ -26,7 +26,7 @@ type UserProfileCustomPage = {
   unmount: (el?: HTMLDivElement) => void;
 };
 
-type UserProfileCustomLink = {
+type ProfileCustomLink = {
   label: string;
   url: string;
   mountIcon: (el: HTMLDivElement) => void;
@@ -178,7 +178,7 @@ const checkForDuplicateUsageOfReorderingItems = (customPages: CustomPage[], vali
   reorderItems.reduce((acc, cp) => {
     if (acc.includes(cp.label)) {
       console.error(
-        `Clerk: The "${cp.label}" item is used more than once when reordering UserProfile pages. This may cause unexpected behavior.`,
+        `Clerk: The "${cp.label}" item is used more than once when reordering pages. This may cause unexpected behavior.`,
       );
     }
     return [...acc, cp.label];
@@ -199,15 +199,15 @@ const isValidPageItem = (cp: CustomPage, validReorderItems: string[]): cp is Cus
   return isCustomPage(cp) || isCustomLink(cp) || isReorderItem(cp, validReorderItems);
 };
 
-const isCustomPage = (cp: CustomPage): cp is UserProfileCustomPage => {
+const isCustomPage = (cp: CustomPage): cp is ProfileCustomPage => {
   return !!cp.url && !!cp.label && !!cp.mount && !!cp.unmount && !!cp.mountIcon && !!cp.unmountIcon;
 };
 
-const isCustomLink = (cp: CustomPage): cp is UserProfileCustomLink => {
+const isCustomLink = (cp: CustomPage): cp is ProfileCustomLink => {
   return !!cp.url && !!cp.label && !cp.mount && !cp.unmount && !!cp.mountIcon && !!cp.unmountIcon;
 };
 
-const isReorderItem = (cp: CustomPage, validItems: string[]): cp is UserProfileReorderItem => {
+const isReorderItem = (cp: CustomPage, validItems: string[]): cp is ProfileReorderItem => {
   return (
     !cp.url && !cp.mount && !cp.unmount && !cp.mountIcon && !cp.unmountIcon && validItems.some(v => v === cp.label)
   );

--- a/packages/clerk-js/src/ui/utils/createCustomPages.tsx
+++ b/packages/clerk-js/src/ui/utils/createCustomPages.tsx
@@ -121,10 +121,11 @@ const getRoutesAndContents = ({ customPages, defaultRoutes }: GetRoutesAndConten
       return {
         name: cp.label,
         id: `custom-page-${index}`,
-        icon: () => (
+        icon: props => (
           <ExternalElementMounter
             mount={cp.mountIcon}
             unmount={cp.unmountIcon}
+            {...props}
           />
         ),
         path: sanitizeCustomLinkURL(cp.url),
@@ -137,10 +138,11 @@ const getRoutesAndContents = ({ customPages, defaultRoutes }: GetRoutesAndConten
       return {
         name: cp.label,
         id: `custom-page-${index}`,
-        icon: () => (
+        icon: props => (
           <ExternalElementMounter
             mount={cp.mountIcon}
             unmount={cp.unmountIcon}
+            {...props}
           />
         ),
         path: pageURL,

--- a/packages/clerk-js/src/ui/utils/index.ts
+++ b/packages/clerk-js/src/ui/utils/index.ts
@@ -21,3 +21,5 @@ export * from './getRelativeToNowDateKey';
 export * from './mergeRefs';
 export * from './createSlug';
 export * from './passwordUtils';
+export * from './createCustomPages';
+export * from './ExternalElementMounter';

--- a/packages/nextjs/src/app-beta/client/ui-components.tsx
+++ b/packages/nextjs/src/app-beta/client/ui-components.tsx
@@ -1,11 +1,4 @@
 'use client';
-import { deprecated } from '@clerk/shared/deprecated';
-
-deprecated(
-  '@clerk/nextjs/app-beta',
-  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
-);
-
 import {
   CreateOrganization as _CreateOrganization,
   OrganizationProfile as _OrganizationProfile,
@@ -15,6 +8,12 @@ import {
   UserButton as _UserButton,
   UserProfile as _UserProfile,
 } from '@clerk/clerk-react';
+import { deprecated } from '@clerk/shared/deprecated';
+
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
 
 /**
  * @deprecated Use imports from `@clerk/nextjs` instead.
@@ -25,12 +24,12 @@ export const CreateOrganization = _CreateOrganization;
  * @deprecated Use imports from `@clerk/nextjs` instead.
  * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
  */
-export const OrganizationProfile = _OrganizationProfile;
+export const OrganizationProfile: typeof _OrganizationProfile = _OrganizationProfile;
 /**
  * @deprecated Use imports from `@clerk/nextjs` instead.
  * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
  */
-export const OrganizationSwitcher = _OrganizationSwitcher;
+export const OrganizationSwitcher: typeof _OrganizationSwitcher = _OrganizationSwitcher;
 /**
  * @deprecated Use imports from `@clerk/nextjs` instead.
  * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
@@ -45,9 +44,9 @@ export const SignUp = _SignUp;
  * @deprecated Use imports from `@clerk/nextjs` instead.
  * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
  */
-export const UserButton = _UserButton;
+export const UserButton: typeof _UserButton = _UserButton;
 /**
  * @deprecated Use imports from `@clerk/nextjs` instead.
  * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
  */
-export const UserProfile = _UserProfile;
+export const UserProfile: typeof _UserProfile = _UserProfile;

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -12,9 +12,21 @@ import type {
 import type { PropsWithChildren } from 'react';
 import React, { createElement } from 'react';
 
-import { userProfileLinkRenderedError, userProfilePageRenderedError } from '../errors';
-import type { MountProps, UserProfileLinkProps, UserProfilePageProps, WithClerkProp } from '../types';
-import { useCustomPages } from '../utils/useCustomPages';
+import {
+  organizationProfileLinkRenderedError,
+  organizationProfilePageRenderedError,
+  userProfileLinkRenderedError,
+  userProfilePageRenderedError,
+} from '../errors';
+import type {
+  MountProps,
+  OrganizationProfileLinkProps,
+  OrganizationProfilePageProps,
+  UserProfileLinkProps,
+  UserProfilePageProps,
+  WithClerkProp,
+} from '../types';
+import { useOrganizationProfileCustomPages, useUserProfileCustomPages } from '../utils';
 import { withClerk } from './withClerk';
 
 // README: <Portal/> should be a class pure component in order for mount and unmount
@@ -116,7 +128,7 @@ export function UserProfileLink({ children }: PropsWithChildren<UserProfileLinkP
 }
 
 const _UserProfile = withClerk(({ clerk, ...props }: WithClerkProp<PropsWithChildren<UserProfileProps>>) => {
-  const { customPages, customPagesPortals } = useCustomPages(props.children);
+  const { customPages, customPagesPortals } = useUserProfileCustomPages(props.children);
   return (
     <Portal
       mount={clerk.mountUserProfile}
@@ -138,7 +150,7 @@ export const UserProfile: UserProfileExportType = Object.assign(_UserProfile, {
 });
 
 const _UserButton = withClerk(({ clerk, ...props }: WithClerkProp<PropsWithChildren<UserButtonProps>>) => {
-  const { customPages, customPagesPortals } = useCustomPages(props.children);
+  const { customPages, customPagesPortals } = useUserProfileCustomPages(props.children);
   const userProfileProps = Object.assign(props.userProfileProps || {}, { customPages });
   return (
     <Portal
@@ -160,16 +172,44 @@ export const UserButton: UserButtonExportType = Object.assign(_UserButton, {
   UserProfileLink: UserProfileLink,
 });
 
-export const OrganizationProfile = withClerk(({ clerk, ...props }: WithClerkProp<OrganizationProfileProps>) => {
-  return (
-    <Portal
-      mount={clerk.mountOrganizationProfile}
-      unmount={clerk.unmountOrganizationProfile}
-      updateProps={(clerk as any).__unstable__updateProps}
-      props={props}
-    />
-  );
-}, 'OrganizationProfile');
+export function OrganizationProfilePage({ children }: PropsWithChildren<OrganizationProfilePageProps>) {
+  if (isDevelopmentEnvironment()) {
+    console.error(organizationProfilePageRenderedError);
+  }
+  return <div>{children}</div>;
+}
+
+export function OrganizationProfileLink({ children }: PropsWithChildren<OrganizationProfileLinkProps>) {
+  if (isDevelopmentEnvironment()) {
+    console.error(organizationProfileLinkRenderedError);
+  }
+  return <div>{children}</div>;
+}
+
+const _OrganizationProfile = withClerk(
+  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<OrganizationProfileProps>>) => {
+    const { customPages, customPagesPortals } = useOrganizationProfileCustomPages(props.children);
+    return (
+      <Portal
+        mount={clerk.mountOrganizationProfile}
+        unmount={clerk.unmountOrganizationProfile}
+        updateProps={(clerk as any).__unstable__updateProps}
+        props={{ ...props, customPages }}
+        customPagesPortals={customPagesPortals}
+      />
+    );
+  },
+  'OrganizationProfile',
+);
+
+type OrganizationProfileExportType = typeof _OrganizationProfile & {
+  Page: ({ children }: PropsWithChildren<OrganizationProfilePageProps>) => React.JSX.Element;
+  Link: ({ children }: PropsWithChildren<OrganizationProfileLinkProps>) => React.JSX.Element;
+};
+export const OrganizationProfile: OrganizationProfileExportType = Object.assign(_OrganizationProfile, {
+  Page: OrganizationProfilePage,
+  Link: OrganizationProfileLink,
+});
 
 export const CreateOrganization = withClerk(({ clerk, ...props }: WithClerkProp<CreateOrganizationProps>) => {
   return (
@@ -182,16 +222,31 @@ export const CreateOrganization = withClerk(({ clerk, ...props }: WithClerkProp<
   );
 }, 'CreateOrganization');
 
-export const OrganizationSwitcher = withClerk(({ clerk, ...props }: WithClerkProp<OrganizationSwitcherProps>) => {
-  return (
-    <Portal
-      mount={clerk.mountOrganizationSwitcher}
-      unmount={clerk.unmountOrganizationSwitcher}
-      updateProps={(clerk as any).__unstable__updateProps}
-      props={props}
-    />
-  );
-}, 'OrganizationSwitcher');
+const _OrganizationSwitcher = withClerk(
+  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<OrganizationSwitcherProps>>) => {
+    const { customPages, customPagesPortals } = useOrganizationProfileCustomPages(props.children);
+    const organizationProfileProps = Object.assign(props.organizationProfileProps || {}, { customPages });
+    return (
+      <Portal
+        mount={clerk.mountOrganizationSwitcher}
+        unmount={clerk.unmountOrganizationSwitcher}
+        updateProps={(clerk as any).__unstable__updateProps}
+        props={{ ...props, organizationProfileProps }}
+        customPagesPortals={customPagesPortals}
+      />
+    );
+  },
+  'OrganizationSwitcher',
+);
+
+type OrganizationSwitcherExportType = typeof _OrganizationSwitcher & {
+  OrganizationProfilePage: ({ children }: PropsWithChildren<OrganizationProfilePageProps>) => React.JSX.Element;
+  OrganizationProfileLink: ({ children }: PropsWithChildren<OrganizationProfileLinkProps>) => React.JSX.Element;
+};
+export const OrganizationSwitcher: OrganizationSwitcherExportType = Object.assign(_OrganizationSwitcher, {
+  OrganizationProfilePage: OrganizationProfilePage,
+  OrganizationProfileLink: OrganizationProfileLink,
+});
 
 export const OrganizationList = withClerk(({ clerk, ...props }: WithClerkProp<OrganizationListProps>) => {
   return (

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -1,4 +1,3 @@
-import { isDevelopmentEnvironment } from '@clerk/shared';
 import type {
   CreateOrganizationProps,
   OrganizationListProps,
@@ -26,8 +25,28 @@ import type {
   UserProfilePageProps,
   WithClerkProp,
 } from '../types';
-import { useOrganizationProfileCustomPages, useUserProfileCustomPages } from '../utils';
+import { errorInDevMode, useOrganizationProfileCustomPages, useUserProfileCustomPages } from '../utils';
 import { withClerk } from './withClerk';
+
+type UserProfileExportType = typeof _UserProfile & {
+  Page: typeof UserProfilePage;
+  Link: typeof UserProfileLink;
+};
+
+type UserButtonExportType = typeof _UserButton & {
+  UserProfilePage: typeof UserProfilePage;
+  UserProfileLink: typeof UserProfileLink;
+};
+
+type OrganizationProfileExportType = typeof _OrganizationProfile & {
+  Page: typeof OrganizationProfilePage;
+  Link: typeof OrganizationProfileLink;
+};
+
+type OrganizationSwitcherExportType = typeof _OrganizationSwitcher & {
+  OrganizationProfilePage: typeof OrganizationProfilePage;
+  OrganizationProfileLink: typeof OrganizationProfileLink;
+};
 
 // README: <Portal/> should be a class pure component in order for mount and unmount
 // lifecycle props to be invoked correctly. Replacing the class component with a
@@ -114,16 +133,12 @@ export const SignUp = withClerk(({ clerk, ...props }: WithClerkProp<SignUpProps>
 }, 'SignUp');
 
 export function UserProfilePage({ children }: PropsWithChildren<UserProfilePageProps>) {
-  if (isDevelopmentEnvironment()) {
-    console.error(userProfilePageRenderedError);
-  }
+  errorInDevMode(userProfilePageRenderedError);
   return <div>{children}</div>;
 }
 
 export function UserProfileLink({ children }: PropsWithChildren<UserProfileLinkProps>) {
-  if (isDevelopmentEnvironment()) {
-    console.error(userProfileLinkRenderedError);
-  }
+  errorInDevMode(userProfileLinkRenderedError);
   return <div>{children}</div>;
 }
 
@@ -140,10 +155,6 @@ const _UserProfile = withClerk(({ clerk, ...props }: WithClerkProp<PropsWithChil
   );
 }, 'UserProfile');
 
-type UserProfileExportType = typeof _UserProfile & {
-  Page: ({ children }: PropsWithChildren<UserProfilePageProps>) => React.JSX.Element;
-  Link: ({ children }: PropsWithChildren<UserProfileLinkProps>) => React.JSX.Element;
-};
 export const UserProfile: UserProfileExportType = Object.assign(_UserProfile, {
   Page: UserProfilePage,
   Link: UserProfileLink,
@@ -163,26 +174,18 @@ const _UserButton = withClerk(({ clerk, ...props }: WithClerkProp<PropsWithChild
   );
 }, 'UserButton');
 
-type UserButtonExportType = typeof _UserButton & {
-  UserProfilePage: ({ children }: PropsWithChildren<UserProfilePageProps>) => React.JSX.Element;
-  UserProfileLink: ({ children }: PropsWithChildren<UserProfileLinkProps>) => React.JSX.Element;
-};
 export const UserButton: UserButtonExportType = Object.assign(_UserButton, {
   UserProfilePage: UserProfilePage,
   UserProfileLink: UserProfileLink,
 });
 
 export function OrganizationProfilePage({ children }: PropsWithChildren<OrganizationProfilePageProps>) {
-  if (isDevelopmentEnvironment()) {
-    console.error(organizationProfilePageRenderedError);
-  }
+  errorInDevMode(organizationProfilePageRenderedError);
   return <div>{children}</div>;
 }
 
 export function OrganizationProfileLink({ children }: PropsWithChildren<OrganizationProfileLinkProps>) {
-  if (isDevelopmentEnvironment()) {
-    console.error(organizationProfileLinkRenderedError);
-  }
+  errorInDevMode(organizationProfileLinkRenderedError);
   return <div>{children}</div>;
 }
 
@@ -202,10 +205,6 @@ const _OrganizationProfile = withClerk(
   'OrganizationProfile',
 );
 
-type OrganizationProfileExportType = typeof _OrganizationProfile & {
-  Page: ({ children }: PropsWithChildren<OrganizationProfilePageProps>) => React.JSX.Element;
-  Link: ({ children }: PropsWithChildren<OrganizationProfileLinkProps>) => React.JSX.Element;
-};
 export const OrganizationProfile: OrganizationProfileExportType = Object.assign(_OrganizationProfile, {
   Page: OrganizationProfilePage,
   Link: OrganizationProfileLink,
@@ -239,10 +238,6 @@ const _OrganizationSwitcher = withClerk(
   'OrganizationSwitcher',
 );
 
-type OrganizationSwitcherExportType = typeof _OrganizationSwitcher & {
-  OrganizationProfilePage: ({ children }: PropsWithChildren<OrganizationProfilePageProps>) => React.JSX.Element;
-  OrganizationProfileLink: ({ children }: PropsWithChildren<OrganizationProfileLinkProps>) => React.JSX.Element;
-};
 export const OrganizationSwitcher: OrganizationSwitcherExportType = Object.assign(_OrganizationSwitcher, {
   OrganizationProfilePage: OrganizationProfilePage,
   OrganizationProfileLink: OrganizationProfileLink,

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -49,7 +49,10 @@ class Portal extends React.PureComponent<MountProps> {
   private portalRef = React.createRef<HTMLDivElement>();
 
   componentDidUpdate(prevProps: Readonly<MountProps>) {
-    if (prevProps.props.appearance !== this.props.props.appearance) {
+    if (
+      prevProps.props.appearance !== this.props.props.appearance ||
+      prevProps.props?.customPages?.length !== this.props.props?.customPages?.length
+    ) {
       this.props.updateProps({ node: this.portalRef.current, props: this.props.props });
     }
   }

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -25,7 +25,7 @@ import type {
   UserProfilePageProps,
   WithClerkProp,
 } from '../types';
-import { errorInDevMode, useOrganizationProfileCustomPages, useUserProfileCustomPages } from '../utils';
+import { logErrorInDevMode, useOrganizationProfileCustomPages, useUserProfileCustomPages } from '../utils';
 import { withClerk } from './withClerk';
 
 type UserProfileExportType = typeof _UserProfile & {
@@ -141,13 +141,13 @@ export const SignUp = withClerk(({ clerk, ...props }: WithClerkProp<SignUpProps>
 }, 'SignUp');
 
 export function UserProfilePage({ children }: PropsWithChildren<UserProfilePageProps>) {
-  errorInDevMode(userProfilePageRenderedError);
-  return <div>{children}</div>;
+  logErrorInDevMode(userProfilePageRenderedError);
+  return <>{children}</>;
 }
 
 export function UserProfileLink({ children }: PropsWithChildren<UserProfileLinkProps>) {
-  errorInDevMode(userProfileLinkRenderedError);
-  return <div>{children}</div>;
+  logErrorInDevMode(userProfileLinkRenderedError);
+  return <>{children}</>;
 }
 
 const _UserProfile = withClerk(
@@ -189,18 +189,18 @@ const _UserButton = withClerk(
 );
 
 export const UserButton: UserButtonExportType = Object.assign(_UserButton, {
-  UserProfilePage: UserProfilePage,
-  UserProfileLink: UserProfileLink,
+  UserProfilePage,
+  UserProfileLink,
 });
 
 export function OrganizationProfilePage({ children }: PropsWithChildren<OrganizationProfilePageProps>) {
-  errorInDevMode(organizationProfilePageRenderedError);
-  return <div>{children}</div>;
+  logErrorInDevMode(organizationProfilePageRenderedError);
+  return <>{children}</>;
 }
 
 export function OrganizationProfileLink({ children }: PropsWithChildren<OrganizationProfileLinkProps>) {
-  errorInDevMode(organizationProfileLinkRenderedError);
-  return <div>{children}</div>;
+  logErrorInDevMode(organizationProfileLinkRenderedError);
+  return <>{children}</>;
 }
 
 const _OrganizationProfile = withClerk(
@@ -253,8 +253,8 @@ const _OrganizationSwitcher = withClerk(
 );
 
 export const OrganizationSwitcher: OrganizationSwitcherExportType = Object.assign(_OrganizationSwitcher, {
-  OrganizationProfilePage: OrganizationProfilePage,
-  OrganizationProfileLink: OrganizationProfileLink,
+  OrganizationProfilePage,
+  OrganizationProfileLink,
 });
 
 export const OrganizationList = withClerk(({ clerk, ...props }: WithClerkProp<OrganizationListProps>) => {

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -1,3 +1,4 @@
+import { logErrorInDevMode } from '@clerk/shared';
 import type {
   CreateOrganizationProps,
   OrganizationListProps,
@@ -25,7 +26,7 @@ import type {
   UserProfilePageProps,
   WithClerkProp,
 } from '../types';
-import { logErrorInDevMode, useOrganizationProfileCustomPages, useUserProfileCustomPages } from '../utils';
+import { useOrganizationProfileCustomPages, useUserProfileCustomPages } from '../utils';
 import { withClerk } from './withClerk';
 
 type UserProfileExportType = typeof _UserProfile & {

--- a/packages/react/src/components/uiComponents.tsx
+++ b/packages/react/src/components/uiComponents.tsx
@@ -38,6 +38,10 @@ type UserButtonExportType = typeof _UserButton & {
   UserProfileLink: typeof UserProfileLink;
 };
 
+type UserButtonPropsWithoutCustomPages = Omit<UserButtonProps, 'userProfileProps'> & {
+  userProfileProps?: Pick<UserProfileProps, 'additionalOAuthScopes' | 'appearance'>;
+};
+
 type OrganizationProfileExportType = typeof _OrganizationProfile & {
   Page: typeof OrganizationProfilePage;
   Link: typeof OrganizationProfileLink;
@@ -46,6 +50,10 @@ type OrganizationProfileExportType = typeof _OrganizationProfile & {
 type OrganizationSwitcherExportType = typeof _OrganizationSwitcher & {
   OrganizationProfilePage: typeof OrganizationProfilePage;
   OrganizationProfileLink: typeof OrganizationProfileLink;
+};
+
+type OrganizationSwitcherPropsWithoutCustomPages = Omit<OrganizationSwitcherProps, 'organizationProfileProps'> & {
+  organizationProfileProps?: Pick<OrganizationProfileProps, 'appearance'>;
 };
 
 // README: <Portal/> should be a class pure component in order for mount and unmount
@@ -142,37 +150,43 @@ export function UserProfileLink({ children }: PropsWithChildren<UserProfileLinkP
   return <div>{children}</div>;
 }
 
-const _UserProfile = withClerk(({ clerk, ...props }: WithClerkProp<PropsWithChildren<UserProfileProps>>) => {
-  const { customPages, customPagesPortals } = useUserProfileCustomPages(props.children);
-  return (
-    <Portal
-      mount={clerk.mountUserProfile}
-      unmount={clerk.unmountUserProfile}
-      updateProps={(clerk as any).__unstable__updateProps}
-      props={{ ...props, customPages }}
-      customPagesPortals={customPagesPortals}
-    />
-  );
-}, 'UserProfile');
+const _UserProfile = withClerk(
+  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<Omit<UserProfileProps, 'customPages'>>>) => {
+    const { customPages, customPagesPortals } = useUserProfileCustomPages(props.children);
+    return (
+      <Portal
+        mount={clerk.mountUserProfile}
+        unmount={clerk.unmountUserProfile}
+        updateProps={(clerk as any).__unstable__updateProps}
+        props={{ ...props, customPages }}
+        customPagesPortals={customPagesPortals}
+      />
+    );
+  },
+  'UserProfile',
+);
 
 export const UserProfile: UserProfileExportType = Object.assign(_UserProfile, {
   Page: UserProfilePage,
   Link: UserProfileLink,
 });
 
-const _UserButton = withClerk(({ clerk, ...props }: WithClerkProp<PropsWithChildren<UserButtonProps>>) => {
-  const { customPages, customPagesPortals } = useUserProfileCustomPages(props.children);
-  const userProfileProps = Object.assign(props.userProfileProps || {}, { customPages });
-  return (
-    <Portal
-      mount={clerk.mountUserButton}
-      unmount={clerk.unmountUserButton}
-      updateProps={(clerk as any).__unstable__updateProps}
-      props={{ ...props, userProfileProps }}
-      customPagesPortals={customPagesPortals}
-    />
-  );
-}, 'UserButton');
+const _UserButton = withClerk(
+  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<UserButtonPropsWithoutCustomPages>>) => {
+    const { customPages, customPagesPortals } = useUserProfileCustomPages(props.children);
+    const userProfileProps = Object.assign(props.userProfileProps || {}, { customPages });
+    return (
+      <Portal
+        mount={clerk.mountUserButton}
+        unmount={clerk.unmountUserButton}
+        updateProps={(clerk as any).__unstable__updateProps}
+        props={{ ...props, userProfileProps }}
+        customPagesPortals={customPagesPortals}
+      />
+    );
+  },
+  'UserButton',
+);
 
 export const UserButton: UserButtonExportType = Object.assign(_UserButton, {
   UserProfilePage: UserProfilePage,
@@ -190,7 +204,7 @@ export function OrganizationProfileLink({ children }: PropsWithChildren<Organiza
 }
 
 const _OrganizationProfile = withClerk(
-  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<OrganizationProfileProps>>) => {
+  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<Omit<OrganizationProfileProps, 'customPages'>>>) => {
     const { customPages, customPagesPortals } = useOrganizationProfileCustomPages(props.children);
     return (
       <Portal
@@ -222,7 +236,7 @@ export const CreateOrganization = withClerk(({ clerk, ...props }: WithClerkProp<
 }, 'CreateOrganization');
 
 const _OrganizationSwitcher = withClerk(
-  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<OrganizationSwitcherProps>>) => {
+  ({ clerk, ...props }: WithClerkProp<PropsWithChildren<OrganizationSwitcherPropsWithoutCustomPages>>) => {
     const { customPages, customPagesPortals } = useOrganizationProfileCustomPages(props.children);
     const organizationProfileProps = Object.assign(props.organizationProfileProps || {}, { customPages });
     return (

--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -27,26 +27,26 @@ export const multipleChildrenInButtonComponent = (name: string) =>
   `Clerk: You've passed multiple children components to <${name}/>. You can only pass a single child component or text.`;
 
 export const invalidStateError =
-  'Invalid state. Feel free to submit a bug or reach out to support here: https://clerk.com/support';
+  'Clerk: Invalid state. Feel free to submit a bug or reach out to support here: https://clerk.com/support';
 
 export const unsupportedNonBrowserDomainOrProxyUrlFunction =
-  'Unsupported usage of domain or proxyUrl. The usage of domain or proxyUrl as function is not supported in non-browser environments.';
+  'Clerk: Unsupported usage of domain or proxyUrl. The usage of domain or proxyUrl as function is not supported in non-browser environments.';
 
 export const userProfilePageRenderedError =
-  '<UserProfile.Page /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
+  'Clerk: <UserProfile.Page /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
 export const userProfileLinkRenderedError =
-  '<UserProfile.Link /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
+  'Clerk: <UserProfile.Link /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
 
 export const organizationProfilePageRenderedError =
-  '<OrganizationProfile.Page /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
+  'Clerk: <OrganizationProfile.Page /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
 export const organizationProfileLinkRenderedError =
-  '<OrganizationProfile.Link /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
+  'Clerk: <OrganizationProfile.Link /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
 
 export const customPagesIgnoredComponent = (componentName: string) =>
-  `<${componentName} /> can only accept <${componentName}.Page /> and <${componentName}.Link /> as its children. Any other provided component will be ignored.`;
+  `Clerk: <${componentName} /> can only accept <${componentName}.Page /> and <${componentName}.Link /> as its children. Any other provided component will be ignored.`;
 
 export const customPageWrongProps = (componentName: string) =>
-  `Missing props. <${componentName}.Page /> component requires the following props: url, label, labelIcon, alongside with children to be rendered inside the page.`;
+  `Clerk: Missing props. <${componentName}.Page /> component requires the following props: url, label, labelIcon, alongside with children to be rendered inside the page.`;
 
 export const customLinkWrongProps = (componentName: string) =>
-  `Missing props. <${componentName}.Link /> component requires the following props: url, label and labelIcon.`;
+  `Clerk: Missing props. <${componentName}.Link /> component requires the following props: url, label and labelIcon.`;

--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -37,11 +37,16 @@ export const userProfilePageRenderedError =
 export const userProfileLinkRenderedError =
   '<UserProfile.Link /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
 
-export const customPagesIngoredComponent =
-  '<UserProfile /> can only accept <UserProfile.Page /> and <UserProfile.Link /> as its children. Any other provided component will be ignored.';
+export const organizationProfilePageRenderedError =
+  '<OrganizationProfile.Page /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
+export const organizationProfileLinkRenderedError =
+  '<OrganizationProfile.Link /> component needs to be a direct child of `<OrganizationProfile />` or `<OrganizationSwitcher />`.';
 
-export const userProfilePageWrongProps =
-  'Missing props. <UserProfile.Page /> component requires the following props: url, label, labelIcon, alongside with children to be rendered inside the page.';
+export const customPagesIgnoredComponent = (componentName: string) =>
+  `<${componentName} /> can only accept <${componentName}.Page /> and <${componentName}.Link /> as its children. Any other provided component will be ignored.`;
 
-export const userProfileLinkWrongProps =
-  'Missing props. <UserProfile.Link /> component requires the following props: url, label and labelIcon.';
+export const customPageWrongProps = (componentName: string) =>
+  `Missing props. <${componentName}.Page /> component requires the following props: url, label, labelIcon, alongside with children to be rendered inside the page.`;
+
+export const customLinkWrongProps = (componentName: string) =>
+  `Missing props. <${componentName}.Link /> component requires the following props: url, label and labelIcon.`;

--- a/packages/react/src/errors.ts
+++ b/packages/react/src/errors.ts
@@ -31,3 +31,17 @@ export const invalidStateError =
 
 export const unsupportedNonBrowserDomainOrProxyUrlFunction =
   'Unsupported usage of domain or proxyUrl. The usage of domain or proxyUrl as function is not supported in non-browser environments.';
+
+export const userProfilePageRenderedError =
+  '<UserProfile.Page /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
+export const userProfileLinkRenderedError =
+  '<UserProfile.Link /> component needs to be a direct child of `<UserProfile />` or `<UserButton />`.';
+
+export const customPagesIngoredComponent =
+  '<UserProfile /> can only accept <UserProfile.Page /> and <UserProfile.Link /> as its children. Any other provided component will be ignored.';
+
+export const userProfilePageWrongProps =
+  'Missing props. <UserProfile.Page /> component requires the following props: url, label, labelIcon, alongside with children to be rendered inside the page.';
+
+export const userProfileLinkWrongProps =
+  'Missing props. <UserProfile.Link /> component requires the following props: url, label and labelIcon.';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -94,13 +94,13 @@ export type RedirectToSignUpProps = SignUpRedirectOptions;
 export type UserProfilePageProps = {
   url?: string;
   label: string;
-  labelIcon?: React.ReactElement;
+  labelIcon?: React.ReactNode;
 };
 
 export type UserProfileLinkProps = {
   url: string;
   label: string;
-  labelIcon: React.ReactElement;
+  labelIcon: React.ReactNode;
 };
 
 export type OrganizationProfilePageProps = UserProfilePageProps;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -102,3 +102,6 @@ export type UserProfileLinkProps = {
   label: string;
   labelIcon: React.ReactElement;
 };
+
+export type OrganizationProfilePageProps = UserProfilePageProps;
+export type OrganizationProfileLinkProps = UserProfileLinkProps;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -12,6 +12,7 @@ import type {
   SignUpRedirectOptions,
   UserResource,
 } from '@clerk/types';
+import type React from 'react';
 
 declare global {
   interface Window {
@@ -51,6 +52,7 @@ export interface MountProps {
   unmount: (node: HTMLDivElement) => void;
   updateProps: (props: any) => void;
   props?: any;
+  customPagesPortals?: any[];
 }
 
 export interface HeadlessBrowserClerk extends Clerk {
@@ -88,3 +90,15 @@ export type SignInWithMetamaskButtonProps = Pick<ButtonProps, 'redirectUrl' | 'c
 
 export type RedirectToSignInProps = SignInRedirectOptions;
 export type RedirectToSignUpProps = SignUpRedirectOptions;
+
+export type UserProfilePageProps = {
+  url?: string;
+  label: string;
+  labelIcon?: React.ReactElement;
+};
+
+export type UserProfileLinkProps = {
+  url: string;
+  label: string;
+  labelIcon: React.ReactElement;
+};

--- a/packages/react/src/utils/errorInDevMode.ts
+++ b/packages/react/src/utils/errorInDevMode.ts
@@ -1,0 +1,7 @@
+import { isDevelopmentEnvironment } from '@clerk/shared';
+
+export const errorInDevMode = (message: string) => {
+  if (isDevelopmentEnvironment()) {
+    console.error(message);
+  }
+};

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './isConstructor';
 export { loadClerkJsScript } from './loadClerkJsScript';
 export * from './useMaxAllowedInstancesGuard';
 export * from './useCustomElementPortal';
+export * from './useCustomPages';

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './errorThrower';
 export * from './isConstructor';
 export { loadClerkJsScript } from './loadClerkJsScript';
 export * from './useMaxAllowedInstancesGuard';
+export * from './useCustomElementPortal';

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -5,3 +5,4 @@ export { loadClerkJsScript } from './loadClerkJsScript';
 export * from './useMaxAllowedInstancesGuard';
 export * from './useCustomElementPortal';
 export * from './useCustomPages';
+export * from './errorInDevMode';

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -5,4 +5,4 @@ export { loadClerkJsScript } from './loadClerkJsScript';
 export * from './useMaxAllowedInstancesGuard';
 export * from './useCustomElementPortal';
 export * from './useCustomPages';
-export * from './errorInDevMode';
+export * from './logErrorInDevMode';

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -5,4 +5,3 @@ export { loadClerkJsScript } from './loadClerkJsScript';
 export * from './useMaxAllowedInstancesGuard';
 export * from './useCustomElementPortal';
 export * from './useCustomPages';
-export * from './logErrorInDevMode';

--- a/packages/react/src/utils/logErrorInDevMode.ts
+++ b/packages/react/src/utils/logErrorInDevMode.ts
@@ -1,6 +1,6 @@
 import { isDevelopmentEnvironment } from '@clerk/shared';
 
-export const errorInDevMode = (message: string) => {
+export const logErrorInDevMode = (message: string) => {
   if (isDevelopmentEnvironment()) {
     console.error(message);
   }

--- a/packages/react/src/utils/useCustomElementPortal.tsx
+++ b/packages/react/src/utils/useCustomElementPortal.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+// This function takes a component as prop, and returns functions that mount and unmount
+// the given component into a given node
+
+export const useCustomElementPortal = (component: JSX.Element) => {
+  const [node, setNode] = useState<Element | null>(null);
+
+  const mount = (node: Element) => {
+    setNode(node);
+  };
+  const unmount = () => {
+    setNode(null);
+  };
+
+  // If mount has been called, CustomElementPortal returns a portal that renders `component`
+  // into the passed node
+
+  // Otherwise, CustomElementPortal returns nothing
+  const CustomElementPortal = () => <>{node ? createPortal(component, node) : null}</>;
+
+  return { CustomElementPortal, mount, unmount };
+};

--- a/packages/react/src/utils/useCustomElementPortal.tsx
+++ b/packages/react/src/utils/useCustomElementPortal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
 
 export type UseCustomElementPortalParams = {
@@ -16,11 +16,8 @@ export type UseCustomElementPortalReturn = {
 // This function takes a component as prop, and returns functions that mount and unmount
 // the given component into a given node
 export const useCustomElementPortal = (elements: UseCustomElementPortalParams[]) => {
-  const [nodes, setNodes] = useState<(Element | null)[]>([]);
-
-  useEffect(() => {
-    setNodes(Array(elements.length).fill(null));
-  }, [elements.length]);
+  const initialState = Array(elements.length).fill(null);
+  const [nodes, setNodes] = useState<(Element | null)[]>(initialState);
 
   const portals: UseCustomElementPortalReturn[] = [];
 

--- a/packages/react/src/utils/useCustomElementPortal.tsx
+++ b/packages/react/src/utils/useCustomElementPortal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 export type UseCustomElementPortalParams = {
@@ -16,7 +16,11 @@ export type UseCustomElementPortalReturn = {
 // This function takes a component as prop, and returns functions that mount and unmount
 // the given component into a given node
 export const useCustomElementPortal = (elements: UseCustomElementPortalParams[]) => {
-  const [nodes, setNodes] = useState<(Element | null)[]>(Array(elements.length).fill(null));
+  const [nodes, setNodes] = useState<(Element | null)[]>([]);
+
+  useEffect(() => {
+    setNodes(Array(elements.length).fill(null));
+  }, [elements.length]);
 
   const portals: UseCustomElementPortalReturn[] = [];
 

--- a/packages/react/src/utils/useCustomElementPortal.tsx
+++ b/packages/react/src/utils/useCustomElementPortal.tsx
@@ -19,19 +19,10 @@ export const useCustomElementPortal = (elements: UseCustomElementPortalParams[])
   const initialState = Array(elements.length).fill(null);
   const [nodes, setNodes] = useState<(Element | null)[]>(initialState);
 
-  const portals: UseCustomElementPortalReturn[] = [];
-
-  elements.forEach((el, index) => {
-    const mount = (node: Element) => {
-      setNodes(prevState => prevState.map((n, i) => (i === index ? node : n)));
-    };
-    const unmount = () => {
-      setNodes(prevState => prevState.map((n, i) => (i === index ? null : n)));
-    };
-
-    const portal = () => <>{nodes[index] ? createPortal(el.component, nodes[index] as Element) : null}</>;
-    portals.push({ portal, mount, unmount, id: el.id });
-  });
-
-  return portals;
+  return elements.map((el, index) => ({
+    id: el.id,
+    mount: (node: Element) => setNodes(prevState => prevState.map((n, i) => (i === index ? node : n))),
+    unmount: () => setNodes(prevState => prevState.map((n, i) => (i === index ? null : n))),
+    portal: () => <>{nodes[index] ? createPortal(el.component, nodes[index] as Element) : null}</>,
+  }));
 };

--- a/packages/react/src/utils/useCustomPages.tsx
+++ b/packages/react/src/utils/useCustomPages.tsx
@@ -1,4 +1,3 @@
-import { isDevelopmentEnvironment } from '@clerk/shared';
 import type { CustomPage } from '@clerk/types';
 import type { ReactElement } from 'react';
 import React from 'react';
@@ -11,14 +10,9 @@ import {
 } from '../components/uiComponents';
 import { customLinkWrongProps, customPagesIgnoredComponent, customPageWrongProps } from '../errors';
 import type { UserProfilePageProps } from '../types';
+import { errorInDevMode } from './errorInDevMode';
 import type { UseCustomElementPortalParams, UseCustomElementPortalReturn } from './useCustomElementPortal';
 import { useCustomElementPortal } from './useCustomElementPortal';
-
-const errorInDevMode = (message: string) => {
-  if (isDevelopmentEnvironment()) {
-    console.error(message);
-  }
-};
 
 const isThatComponent = (v: any, component: React.ReactNode): v is React.ReactNode => {
   return !!v && React.isValidElement(v) && (v as React.ReactElement)?.type === component;

--- a/packages/react/src/utils/useCustomPages.tsx
+++ b/packages/react/src/utils/useCustomPages.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 
 import { UserProfileLink, UserProfilePage } from '../components/uiComponents';
 import { customPagesIngoredComponent, userProfileLinkWrongProps, userProfilePageWrongProps } from '../errors';
+import type { UserProfilePageProps } from '../types';
+import type { UseCustomElementPortalParams, UseCustomElementPortalReturn } from './useCustomElementPortal';
 import { useCustomElementPortal } from './useCustomElementPortal';
 
 const errorInDevMode = (message: string) => {
@@ -21,12 +23,16 @@ const isLinkComponent = (v: any): v is React.ReactNode => {
   return !!v && React.isValidElement(v) && (v as React.ReactElement)?.type === UserProfileLink;
 };
 
+type CustomPageWithIdType = UserProfilePageProps & { children?: React.ReactNode };
+
 export const useCustomPages = (userProfileChildren: React.ReactNode | React.ReactNode[]) => {
-  const customPages: CustomPage[] = [];
-  const customPagesPortals: React.ComponentType[] = [];
+  const validUserProfileChildren: CustomPageWithIdType[] = [];
+
   React.Children.forEach(userProfileChildren, child => {
     if (!isPageComponent(child) && !isLinkComponent(child)) {
-      errorInDevMode(customPagesIngoredComponent);
+      if (child) {
+        errorInDevMode(customPagesIngoredComponent);
+      }
       return;
     }
 
@@ -37,25 +43,10 @@ export const useCustomPages = (userProfileChildren: React.ReactNode | React.Reac
     if (isPageComponent(child)) {
       if (isReorderItem(props)) {
         // This is a reordering item
-        customPages.push({ label });
+        validUserProfileChildren.push({ label });
       } else if (isCustomPage(props)) {
         // this is a custom page
-        const { CustomElementPortal, mount, unmount } = useCustomElementPortal(children);
-        const {
-          CustomElementPortal: labelPortal,
-          mount: mountIcon,
-          unmount: unmountIcon,
-        } = useCustomElementPortal(labelIcon);
-        customPages.push({
-          url,
-          label,
-          mountIcon,
-          unmountIcon,
-          mount,
-          unmount,
-        });
-        customPagesPortals.push(CustomElementPortal);
-        customPagesPortals.push(labelPortal);
+        validUserProfileChildren.push({ label, labelIcon, children, url });
       } else {
         errorInDevMode(userProfilePageWrongProps);
         return;
@@ -65,17 +56,66 @@ export const useCustomPages = (userProfileChildren: React.ReactNode | React.Reac
     if (isLinkComponent(child)) {
       if (isExternalLink(props)) {
         // This is an external link
-        const {
-          CustomElementPortal: labelPortal,
-          mount: mountIcon,
-          unmount: unmountIcon,
-        } = useCustomElementPortal(labelIcon);
-        customPages.push({ label, url, mountIcon, unmountIcon });
-        customPagesPortals.push(labelPortal);
+        validUserProfileChildren.push({ label, labelIcon, url });
       } else {
         errorInDevMode(userProfileLinkWrongProps);
         return;
       }
+    }
+  });
+
+  const customPageContents: UseCustomElementPortalParams[] = [];
+  const customPageLabelIcons: UseCustomElementPortalParams[] = [];
+  const customLinkLabelIcons: UseCustomElementPortalParams[] = [];
+
+  validUserProfileChildren.forEach((cp, index) => {
+    if (isCustomPage(cp)) {
+      customPageContents.push({ component: cp.children, id: index });
+      customPageLabelIcons.push({ component: cp.labelIcon, id: index });
+      return;
+    }
+    if (isExternalLink(cp)) {
+      customLinkLabelIcons.push({ component: cp.labelIcon, id: index });
+    }
+  });
+
+  const customPageContentsPortals = useCustomElementPortal(customPageContents);
+  const customPageLabelIconsPortals = useCustomElementPortal(customPageLabelIcons);
+  const customLinkLabelIconsPortals = useCustomElementPortal(customLinkLabelIcons);
+
+  const customPages: CustomPage[] = [];
+  const customPagesPortals: React.ComponentType[] = [];
+
+  validUserProfileChildren.forEach((cp, index) => {
+    if (isReorderItem(cp)) {
+      customPages.push({ label: cp.label });
+      return;
+    }
+    if (isCustomPage(cp)) {
+      const {
+        portal: contentPortal,
+        mount,
+        unmount,
+      } = customPageContentsPortals.find(p => p.id === index) as UseCustomElementPortalReturn;
+      const {
+        portal: labelPortal,
+        mount: mountIcon,
+        unmount: unmountIcon,
+      } = customPageLabelIconsPortals.find(p => p.id === index) as UseCustomElementPortalReturn;
+      customPages.push({ label: cp.label, url: cp.url, mount, unmount, mountIcon, unmountIcon });
+      customPagesPortals.push(contentPortal);
+      customPagesPortals.push(labelPortal);
+      return;
+    }
+    if (isExternalLink(cp)) {
+      const {
+        portal: labelPortal,
+        mount: mountIcon,
+        unmount: unmountIcon,
+      } = customLinkLabelIconsPortals.find(p => p.id === index) as UseCustomElementPortalReturn;
+      customPages.push({ label: cp.label, url: cp.url, mountIcon, unmountIcon });
+      customPagesPortals.push(labelPortal);
+      return;
     }
   });
 

--- a/packages/react/src/utils/useCustomPages.tsx
+++ b/packages/react/src/utils/useCustomPages.tsx
@@ -1,0 +1,98 @@
+import { isDevelopmentEnvironment } from '@clerk/shared';
+import type { CustomPage } from '@clerk/types';
+import type { ReactElement } from 'react';
+import React from 'react';
+
+import { UserProfileLink, UserProfilePage } from '../components/uiComponents';
+import { customPagesIngoredComponent, userProfileLinkWrongProps, userProfilePageWrongProps } from '../errors';
+import { useCustomElementPortal } from './useCustomElementPortal';
+
+const errorInDevMode = (message: string) => {
+  if (isDevelopmentEnvironment()) {
+    console.error(message);
+  }
+};
+
+const isPageComponent = (v: any): v is React.ReactNode => {
+  return !!v && React.isValidElement(v) && (v as React.ReactElement)?.type === UserProfilePage;
+};
+
+const isLinkComponent = (v: any): v is React.ReactNode => {
+  return !!v && React.isValidElement(v) && (v as React.ReactElement)?.type === UserProfileLink;
+};
+
+export const useCustomPages = (userProfileChildren: React.ReactNode | React.ReactNode[]) => {
+  const customPages: CustomPage[] = [];
+  const customPagesPortals: React.ComponentType[] = [];
+  React.Children.forEach(userProfileChildren, child => {
+    if (!isPageComponent(child) && !isLinkComponent(child)) {
+      errorInDevMode(customPagesIngoredComponent);
+      return;
+    }
+
+    const { props } = child as ReactElement;
+
+    const { children, label, url, labelIcon } = props;
+
+    if (isPageComponent(child)) {
+      if (isReorderItem(props)) {
+        // This is a reordering item
+        customPages.push({ label });
+      } else if (isCustomPage(props)) {
+        // this is a custom page
+        const { CustomElementPortal, mount, unmount } = useCustomElementPortal(children);
+        const {
+          CustomElementPortal: labelPortal,
+          mount: mountIcon,
+          unmount: unmountIcon,
+        } = useCustomElementPortal(labelIcon);
+        customPages.push({
+          url,
+          label,
+          mountIcon,
+          unmountIcon,
+          mount,
+          unmount,
+        });
+        customPagesPortals.push(CustomElementPortal);
+        customPagesPortals.push(labelPortal);
+      } else {
+        errorInDevMode(userProfilePageWrongProps);
+        return;
+      }
+    }
+
+    if (isLinkComponent(child)) {
+      if (isExternalLink(props)) {
+        // This is an external link
+        const {
+          CustomElementPortal: labelPortal,
+          mount: mountIcon,
+          unmount: unmountIcon,
+        } = useCustomElementPortal(labelIcon);
+        customPages.push({ label, url, mountIcon, unmountIcon });
+        customPagesPortals.push(labelPortal);
+      } else {
+        errorInDevMode(userProfileLinkWrongProps);
+        return;
+      }
+    }
+  });
+
+  return { customPages, customPagesPortals };
+};
+
+const isReorderItem = (childProps: any): boolean => {
+  const { children, label, url, labelIcon } = childProps;
+  return !children && !url && !labelIcon && (label === 'account' || label === 'security');
+};
+
+const isCustomPage = (childProps: any): boolean => {
+  const { children, label, url, labelIcon } = childProps;
+  return !!children && !!url && !!labelIcon && !!label;
+};
+
+const isExternalLink = (childProps: any): boolean => {
+  const { children, label, url, labelIcon } = childProps;
+  return !children && !!url && !!labelIcon && !!label;
+};

--- a/packages/react/src/utils/useCustomPages.tsx
+++ b/packages/react/src/utils/useCustomPages.tsx
@@ -1,3 +1,4 @@
+import { logErrorInDevMode } from '@clerk/shared';
 import type { CustomPage } from '@clerk/types';
 import type { ReactElement } from 'react';
 import React from 'react';
@@ -10,7 +11,6 @@ import {
 } from '../components/uiComponents';
 import { customLinkWrongProps, customPagesIgnoredComponent, customPageWrongProps } from '../errors';
 import type { UserProfilePageProps } from '../types';
-import { logErrorInDevMode } from './logErrorInDevMode';
 import type { UseCustomElementPortalParams, UseCustomElementPortalReturn } from './useCustomElementPortal';
 import { useCustomElementPortal } from './useCustomElementPortal';
 

--- a/packages/react/src/utils/useCustomPages.tsx
+++ b/packages/react/src/utils/useCustomPages.tsx
@@ -10,7 +10,7 @@ import {
 } from '../components/uiComponents';
 import { customLinkWrongProps, customPagesIgnoredComponent, customPageWrongProps } from '../errors';
 import type { UserProfilePageProps } from '../types';
-import { errorInDevMode } from './errorInDevMode';
+import { logErrorInDevMode } from './logErrorInDevMode';
 import type { UseCustomElementPortalParams, UseCustomElementPortalReturn } from './useCustomElementPortal';
 import { useCustomElementPortal } from './useCustomElementPortal';
 
@@ -62,7 +62,7 @@ const useCustomPages = ({
   React.Children.forEach(children, child => {
     if (!isThatComponent(child, PageComponent) && !isThatComponent(child, LinkComponent)) {
       if (child) {
-        errorInDevMode(customPagesIgnoredComponent(componentName));
+        logErrorInDevMode(customPagesIgnoredComponent(componentName));
       }
       return;
     }
@@ -79,7 +79,7 @@ const useCustomPages = ({
         // this is a custom page
         validChildren.push({ label, labelIcon, children, url });
       } else {
-        errorInDevMode(customPageWrongProps(componentName));
+        logErrorInDevMode(customPageWrongProps(componentName));
         return;
       }
     }
@@ -89,7 +89,7 @@ const useCustomPages = ({
         // This is an external link
         validChildren.push({ label, labelIcon, url });
       } else {
-        errorInDevMode(customLinkWrongProps(componentName));
+        logErrorInDevMode(customLinkWrongProps(componentName));
         return;
       }
     }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -3,3 +3,4 @@ export { isStaging } from './instance';
 export { noop } from './noop';
 export * from './runtimeEnvironment';
 export * from './runWithExponentialBackOff';
+export { logErrorInDevMode } from './logErrorInDevMode';

--- a/packages/shared/src/utils/logErrorInDevMode.ts
+++ b/packages/shared/src/utils/logErrorInDevMode.ts
@@ -1,4 +1,4 @@
-import { isDevelopmentEnvironment } from '@clerk/shared';
+import { isDevelopmentEnvironment } from './runtimeEnvironment';
 
 export const logErrorInDevMode = (message: string) => {
   if (isDevelopmentEnvironment()) {

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -94,8 +94,6 @@ export type ProfileSectionId =
   | 'organizationDomains';
 export type ProfilePageId = 'account' | 'security' | 'organizationSettings' | 'organizationMembers';
 
-export type NavbarItemId = 'account' | 'security' | 'members' | 'settings';
-
 export type UserPreviewId = 'userButton' | 'personalWorkspace';
 export type OrganizationPreviewId = 'organizationSwitcher' | 'organizationList';
 
@@ -391,8 +389,8 @@ export type ElementsConfig = {
 
   navbar: WithOptions<never, never, never>;
   navbarButtons: WithOptions<never, ActiveState, never>;
-  navbarButton: WithOptions<NavbarItemId, ActiveState, never>;
-  navbarButtonIcon: WithOptions<NavbarItemId, ActiveState, never>;
+  navbarButton: WithOptions<string, ActiveState, never>;
+  navbarButtonIcon: WithOptions<string, ActiveState, never>;
   navbarMobileMenuRow: WithOptions<never, never, never>;
   navbarMobileMenuButton: WithOptions<never, never, never>;
   navbarMobileMenuButtonIcon: WithOptions<never, never, never>;

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -10,6 +10,7 @@ import type {
   UserProfileTheme,
 } from './appearance';
 import type { ClientResource } from './client';
+import type { CustomPage } from './customPages';
 import type { DisplayThemeJSON } from './json';
 import type { LocalizationResource } from './localization';
 import type { OAuthProvider, OAuthScope } from './oauth';
@@ -721,6 +722,16 @@ export type UserProfileProps = {
    * e.g. <UserProfile additionalOAuthScopes={{google: ['foo', 'bar'], github: ['qux']}} />
    */
   additionalOAuthScopes?: Partial<Record<OAuthProvider, OAuthScope[]>>;
+  /*
+   * Provide addition custom route items and pages to be rendered inside the UserProfile.
+   * e.g.
+   *  <UserProfile>
+   *    <UserProfile.Page label="Custom Page" url="custom-page" labelIcon={<div>C</div>}>
+   *      <div>Hello from custom page!</div>
+   *    </UserProfile.Page>
+   *  </UserProfile>
+   */
+  customPages?: CustomPage[];
 };
 
 export type OrganizationProfileProps = {
@@ -831,7 +842,7 @@ export type UserButtonProps = {
    * Specify options for the underlying <UserProfile /> component.
    * e.g. <UserButton userProfileProps={{additionalOAuthScopes: {google: ['foo', 'bar'], github: ['qux']}}} />
    */
-  userProfileProps?: Pick<UserProfileProps, 'additionalOAuthScopes' | 'appearance'>;
+  userProfileProps?: Pick<UserProfileProps, 'additionalOAuthScopes' | 'appearance' | 'customPages'>;
 };
 
 type PrimitiveKeys<T> = {

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -723,13 +723,7 @@ export type UserProfileProps = {
    */
   additionalOAuthScopes?: Partial<Record<OAuthProvider, OAuthScope[]>>;
   /*
-   * Provide addition custom route items and pages to be rendered inside the UserProfile.
-   * e.g.
-   *  <UserProfile>
-   *    <UserProfile.Page label="Custom Page" url="custom-page" labelIcon={<div>C</div>}>
-   *      <div>Hello from custom page!</div>
-   *    </UserProfile.Page>
-   *  </UserProfile>
+   * Provide custom pages and links to be rendered inside the UserProfile.
    */
   customPages?: CustomPage[];
 };
@@ -755,13 +749,7 @@ export type OrganizationProfileProps = {
    */
   appearance?: OrganizationProfileTheme;
   /*
-   * Provide addition custom route items and pages to be rendered inside the OrganizationProfile.
-   * e.g.
-   *  <OrganizationProfile>
-   *    <OrganizationProfile.Page label="Custom Page" url="custom-page" labelIcon={<div>C</div>}>
-   *      <div>Hello from custom page!</div>
-   *    </OrganizationProfile.Page>
-   *  </OrganizationProfile>
+   * Provide custom pages and links to be rendered inside the OrganizationProfile.
    */
   customPages?: CustomPage[];
 };

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -754,6 +754,16 @@ export type OrganizationProfileProps = {
    * prop of ClerkProvided (if one is provided)
    */
   appearance?: OrganizationProfileTheme;
+  /*
+   * Provide addition custom route items and pages to be rendered inside the OrganizationProfile.
+   * e.g.
+   *  <OrganizationProfile>
+   *    <OrganizationProfile.Page label="Custom Page" url="custom-page" labelIcon={<div>C</div>}>
+   *      <div>Hello from custom page!</div>
+   *    </OrganizationProfile.Page>
+   *  </OrganizationProfile>
+   */
+  customPages?: CustomPage[];
 };
 
 export type CreateOrganizationProps = {
@@ -932,7 +942,7 @@ export type OrganizationSwitcherProps = {
    * Specify options for the underlying <OrganizationProfile /> component.
    * e.g. <UserButton userProfileProps={{appearance: {...}}} />
    */
-  organizationProfileProps?: Pick<OrganizationProfileProps, 'appearance'>;
+  organizationProfileProps?: Pick<OrganizationProfileProps, 'appearance' | 'customPages'>;
 };
 
 export type OrganizationListProps = {

--- a/packages/types/src/customPages.ts
+++ b/packages/types/src/customPages.ts
@@ -1,0 +1,8 @@
+export type CustomPage = {
+  label: string;
+  url?: string;
+  mountIcon?: (el: HTMLDivElement) => void;
+  unmountIcon?: (el?: HTMLDivElement) => void;
+  mount?: (el: HTMLDivElement) => void;
+  unmount?: (el?: HTMLDivElement) => void;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -49,3 +49,4 @@ export * from './utils';
 export * from './verification';
 export * from './web3';
 export * from './web3Wallet';
+export * from './customPages';


### PR DESCRIPTION
## Description
This PR introduces custom pages and links inside the `UserProfile` and `OrganizationProfile` components.
# UserProfile
## Custom Pages

The `UserProfile` component supports the addition of custom pages. These custom pages can be rendered inside the `UserProfile` component and provide a way to incorporate app-specific settings or additional functionality.

To add a custom page, use the `<UserProfile.Page>` component. It accepts the following props:

- `label`: The name that will be displayed in the navigation sidebar for the custom page.
- `labelIcon`: An icon displayed next to the label in the navigation sidebar.
- `url`: The path segment that will be used to navigate to the custom page. (e.g. if the `UserProfile` component is rendered at `/user`, then the custom page will be accessed at `/user/{url}` when using path routing)
- `children`: The components to be rendered as content inside the custom page.

Types:

```tsx
type UserProfilePageProps = {
  label: string;
  labelIcon: React.ReactElement;
  url: string;
  children: React.ReactElement;
};
```

Example usage:

```tsx
<UserProfile>
  <UserProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
    <MyCustomPageContent />
  </UserProfile.Page>
  <UserProfile.Page label="Custom2" url="custom2" labelIcon={<CustomIcon />}>
    <MyCustomPageContent2 />
  </UserProfile.Page>
</UserProfile>
```

## Custom Links

In addition to custom pages, you can add external links to the `UserProfile` navigation sidebar using the `<UserProfile.Link>` component. It accepts the following props:

- `label`: The name that will be displayed in the navigation sidebar for the link.
- `labelIcon`: An icon displayed next to the label in the navigation sidebar.
- `url`: The absolute or relative url to navigate to.

Types:

```tsx
type UserProfileLinkProps = {
  label: string;
  labelIcon: React.ReactElement;
  url: string;
};
```

Example usage:

```tsx
<UserProfile>
  <UserProfile.Link label="External" url="/home" labelIcon={<Icon />} />
</UserProfile>
```

## Advanced

### Reordering Default Routes

If you want to reorder the default routes (`Account` and `Security`) in the `UserProfile` navigation sidebar, you can use the `<UserProfile.Page>` component with the `label` prop set to `'account'` or `'security'`. This will target the existing default page and allow you to rearrange it.

Example usage:

```tsx
<UserProfile>
  <UserProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
    <MyCustomPageContent />
  </UserProfile.Page>
  <UserProfile.Link label="External" url="/home" labelIcon={<Icon />} />
  <UserProfile.Page label="account" />
  <UserProfile.Page label="security" />
</UserProfile>
```

The above will result in the following order:

1. Custom Page
2. External
3. Account
4. Security

**Notes**

- The first page in the list will be rendered under the root path `/` (its `url` will be ignored) and the Clerk pages will be rendered under the path `/account`.
- The first item in the list cannot be a `<UserProfile.Link>` component.

### Using custom pages with the UserButton component

If you are using the `UserButton` component with the default props (where the `UserProfile` opens as a modal), then you should also be providing these custom pages as children to the component (using the `<UserButton.UserProfilePage>` and `<UserButton.UserProfileLink>` components respectively).

Example usage:

```tsx
<UserButton afterSignOutUrl='/'>
  <UserButton.UserProfilePage 
		label="Custom" 
		url="custom" 
		labelIcon={<CustomIcon />}
	>
    <MyCustomPageContent />
  </UserButton.UserProfilePage>
	<UserButton.UserProfileLink label="Link" url="/home" labelIcon={<Icon />} />
</UserButton>
```

This repetition of the same property can be avoided when the user is using the `userProfileMode='navigation'` and `userProfileUrl='<some url>'` props on the `UserButton` component and has implemented a dedicated page for the `UserProfile` component.

# OrganizationProfile

## Custom Pages

The `OrganizationProfile` component supports the addition of custom pages. These custom pages can be rendered inside the `OrganizationProfile` component and provide a way to incorporate organization-specific settings or additional functionality.

To add a custom page, use the `<OrganizationProfile.Page>` component. It accepts the following props:

- `label`: The name that will be displayed in the navigation sidebar for the custom page.
- `labelIcon`: An icon displayed next to the label in the navigation sidebar.
- `url`: The path segment that will be used to navigate to the custom page. (e.g. if the `OrganizationProfile` component is rendered at `/organization`, then the custom page will be accessed at `/organization/{url}` when using path routing)
- `children`: The components to be rendered as content inside the custom page.

Types:

```tsx
type OrganizationProfilePageProps = {
  label: string;
  labelIcon: React.ReactElement;
  url: string;
  children: React.ReactElement;
};
```

Example usage:

```tsx
<OrganizationProfile>
  <OrganizationProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
    <MyCustomPageContent />
  </OrganizationProfile.Page>
  <OrganizationProfile.Page label="Custom2" url="custom2" labelIcon={<CustomIcon />}>
    <MyCustomPageContent2 />
  </OrganizationProfile.Page>
</OrganizationProfile>

```

## Custom Links

In addition to custom pages, you can add external links to the `OrganizationProfile` navigation sidebar using the `<OrganizationProfile.Link>` component. It accepts the following props:

- `label`: The name that will be displayed in the navigation sidebar for the link.
- `labelIcon`: An icon displayed next to the label in the navigation sidebar.
- `url`: The absolute or relative url to navigate to.

Types:

```tsx
type OrganizationProfileLinkProps = {
  label: string;
  labelIcon: React.ReactElement;
  url: string;
};
```

Example usage:

```tsx
<OrganizationProfile>
  <OrganizationProfile.Link label="External" url="/home" labelIcon={<Icon />} />
</OrganizationProfile>
```

## Advanced

### Reordering Default Routes

If you want to reorder the default routes (`Members` and `Settings`) in the `OrganizationProfile` navigation sidebar, you can use the `<OrganizationProfile.Page>` component with the `label` prop set to `'members'` or `'settings'`. This will target the existing default page and allow you to rearrange it.

Example usage:

```tsx
<OrganizationProfile>
  <OrganizationProfile.Page label="Custom Page" url="custom" labelIcon={<CustomIcon />}>
    <MyCustomPageContent />
  </OrganizationProfile.Page>
  <OrganizationProfile.Link label="External" url="/home" labelIcon={<Icon />} />
  <OrganizationProfile.Page label="members" />
  <OrganizationProfile.Page label="settings" />
</OrganizationProfile>

```

The above will result in the following order:

1. Custom Page
2. External
3. Members
4. Settings

**Notes**

- The first page in the list will be rendered under the root path `/` (its `url` will be ignored) and the Clerk pages will be rendered under the path `/organitzation-members` and `/organization-settings`.
- The first item in the list cannot be an `<OrganizationProfile.Link>` component.

### Using custom pages with the OrganizationSwitcher component

If you are using the `OrganizationSwitcher` component with the default props (where the `OrganizationProfile` opens as a modal), then you should also be providing these custom pages as children to the component (using the `<OrganizationSwitcher.OrganizationProfilePage>` and `<OrganizationSwitcher.OrganizationProfileLink>` components respectively).

Example usage:

```tsx
<OrganizationSwitcher>
  <OrganizationSwitcher.OrganizationProfilePage
    label="Custom"
    url="custom"
    labelIcon={<CustomIcon />}
  >
    <MyCustomPageContent />
  </OrganizationSwitcher.OrganizationProfilePage>
  <OrganizationSwitcher.OrganizationProfileLink label="Link" url="/home" labelIcon={<Icon />} />
</OrganizationSwitcher>
```

This repetition of the same property can be avoided when the user is using the `organizationProfileMode='navigation'` and `organizationProfileUrl='<some url>'` props on the `OrganizationSwitcher` component and has implemented a dedicated page for the `OrganizationProfile` component.

### Caveats

- These custom components can be rendered **only on the client**, and in Next.js projects, they need to be under the `"use client";` flag.


## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
