### PR TITLE
fix(clerk-js): Correctly set idle card state on add mfa error

### DIFF
--- a/.changeset/shy-dolls-serve.md
+++ b/.changeset/shy-dolls-serve.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Correctly set idle card state when an error occurs during the MFA set up phase.

--- a/packages/clerk-js/src/ui/components/UserProfile/MfaPhoneCodePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/MfaPhoneCodePage.tsx
@@ -75,21 +75,22 @@ const AddMfa = (props: AddMfaProps) => {
   const user = useCoreUser();
   const availableMethods = user.phoneNumbers.filter(p => !p.reservedForSecondFactor);
 
-  const enableMfa = (phone: PhoneNumberResource) => {
+  const enableMfa = async (phone: PhoneNumberResource) => {
     if (phone.verification.status !== 'verified') {
       return onUnverifiedPhoneClick(phone);
     }
 
     card.setLoading(phone.id);
-    phone
-      .setReservedForSecondFactor({ reserved: true })
-      .then(() => {
-        card.setIdle();
+    try {
+      await phone.setReservedForSecondFactor({ reserved: true }).then(() => {
+        resourceRef.current = phone;
         onSuccess();
-      })
-      .catch(err => handleError(err, [], card.setError));
-
-    resourceRef.current = phone;
+      });
+    } catch (err) {
+      handleError(err, [], card.setError);
+    } finally {
+      card.setIdle();
+    }
   };
 
   return (


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Set the card to the `idle` state after success or error.
<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
