### PR TITLE
chore(nextjs): Add deprecation warning for app-beta subpath export

### DIFF
--- a/.changeset/stupid-jeans-flash.md
+++ b/.changeset/stupid-jeans-flash.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Add deprecation warning for `@clerk/nextjs/app-beta` export. Use the `@clerk/nextjs` instead.

--- a/packages/nextjs/src/app-beta/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-beta/ClerkProvider.tsx
@@ -17,6 +17,10 @@ type NextAppClerkProviderProps = {
 } & Omit<IsomorphicClerkOptions, keyof PublishableKeyOrFrontendApi> &
   Partial<PublishableKeyOrFrontendApi>;
 
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export function ClerkProvider(props: NextAppClerkProviderProps) {
   const state = (initialState()?.__clerk_ssr_state || { sessionId: null, orgId: null, userId: null }) as InitialState;
   return (

--- a/packages/nextjs/src/app-beta/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-beta/ClerkProvider.tsx
@@ -1,3 +1,9 @@
+import { deprecated } from '@clerk/shared';
+
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
 /* eslint-disable turbo/no-undeclared-env-vars */
 import type { IsomorphicClerkOptions } from '@clerk/clerk-react';
 import type { InitialState, PublishableKeyOrFrontendApi } from '@clerk/types';

--- a/packages/nextjs/src/app-beta/auth.ts
+++ b/packages/nextjs/src/app-beta/auth.ts
@@ -14,10 +14,18 @@ const buildRequestLike = () => {
   return new NextRequest('https://placeholder.com', { headers: headers() });
 };
 
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export const auth = () => {
   return getAuth(buildRequestLike());
 };
 
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export const initialState = () => {
   return buildClerkProps(buildRequestLike());
 };

--- a/packages/nextjs/src/app-beta/auth.ts
+++ b/packages/nextjs/src/app-beta/auth.ts
@@ -1,3 +1,10 @@
+import { deprecated } from '@clerk/shared';
+
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
+
 import { headers } from 'next/headers';
 import { NextRequest } from 'next/server';
 

--- a/packages/nextjs/src/app-beta/clerkClient.ts
+++ b/packages/nextjs/src/app-beta/clerkClient.ts
@@ -1,1 +1,7 @@
+import { deprecated } from '@clerk/shared';
+
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
 export { clerkClient } from '../server/clerkClient';

--- a/packages/nextjs/src/app-beta/clerkClient.ts
+++ b/packages/nextjs/src/app-beta/clerkClient.ts
@@ -4,4 +4,10 @@ deprecated(
   '@clerk/nextjs/app-beta',
   'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
 );
-export { clerkClient } from '../server/clerkClient';
+import { clerkClient as _clerkClient } from '../server/clerkClient';
+
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const clerkClient = _clerkClient;

--- a/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
@@ -18,6 +18,10 @@ declare global {
   }
 }
 
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export const useAwaitableNavigate = () => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { push, refresh } = useRouter();
@@ -49,6 +53,10 @@ export const useAwaitableNavigate = () => {
   }, []);
 };
 
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export function ClerkProvider(props: ClerkProviderProps) {
   const navigate = useAwaitableNavigate();
   return (

--- a/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-beta/client/ClerkProvider.tsx
@@ -1,4 +1,10 @@
 'use client';
+import { deprecated } from '@clerk/shared';
+
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
 // !!! Note the import from react
 import type { ClerkProviderProps } from '@clerk/clerk-react';
 import { ClerkProvider as ReactClerkProvider } from '@clerk/clerk-react';

--- a/packages/nextjs/src/app-beta/client/clerk-react.ts
+++ b/packages/nextjs/src/app-beta/client/clerk-react.ts
@@ -1,25 +1,132 @@
 // HACK to show app-beta deprecation warning any of the below
 // There seems to be some issue when adding the deprecation in the index.ts
-export {
-  useUser,
-  useAuth,
-  useClerk,
-  useMagicLink,
-  useOrganization,
-  useOrganizationList,
-  useOrganizations,
-  useSession,
-  useSessionList,
-  useSignIn,
-  useSignUp,
-  SignedIn,
-  SignedOut,
-  ClerkLoaded,
-  ClerkLoading,
-  RedirectToUserProfile,
-  RedirectToSignIn,
-  RedirectToSignUp,
-  RedirectToCreateOrganization,
-  RedirectToOrganizationProfile,
-  AuthenticateWithRedirectCallback,
+import {
+  AuthenticateWithRedirectCallback as _AuthenticateWithRedirectCallback,
+  ClerkLoaded as _ClerkLoaded,
+  ClerkLoading as _ClerkLoading,
+  RedirectToCreateOrganization as _RedirectToCreateOrganization,
+  RedirectToOrganizationProfile as _RedirectToOrganizationProfile,
+  RedirectToSignIn as _RedirectToSignIn,
+  RedirectToSignUp as _RedirectToSignUp,
+  RedirectToUserProfile as _RedirectToUserProfile,
+  SignedIn as _SignedIn,
+  SignedOut as _SignedOut,
+  useAuth as _useAuth,
+  useClerk as _useClerk,
+  useMagicLink as _useMagicLink,
+  useOrganization as _useOrganization,
+  useOrganizationList as _useOrganizationList,
+  useOrganizations as _useOrganizations,
+  useSession as _useSession,
+  useSessionList as _useSessionList,
+  useSignIn as _useSignIn,
+  useSignUp as _useSignUp,
+  useUser as _useUser,
 } from '@clerk/clerk-react';
+
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useUser = _useUser;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useAuth = _useAuth;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useClerk = _useClerk;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useMagicLink = _useMagicLink;
+
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useOrganization = _useOrganization;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useOrganizationList = _useOrganizationList;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useOrganizations = _useOrganizations;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useSession = _useSession;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useSessionList = _useSessionList;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useSignIn = _useSignIn;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const useSignUp = _useSignUp;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const SignedIn = _SignedIn;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const SignedOut = _SignedOut;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const ClerkLoaded = _ClerkLoaded;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const ClerkLoading = _ClerkLoading;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const RedirectToUserProfile = _RedirectToUserProfile;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const RedirectToSignIn = _RedirectToSignIn;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const RedirectToSignUp = _RedirectToSignUp;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const RedirectToCreateOrganization = _RedirectToCreateOrganization;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const RedirectToOrganizationProfile = _RedirectToOrganizationProfile;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const AuthenticateWithRedirectCallback = _AuthenticateWithRedirectCallback;

--- a/packages/nextjs/src/app-beta/client/clerk-react.ts
+++ b/packages/nextjs/src/app-beta/client/clerk-react.ts
@@ -1,6 +1,5 @@
-'use client';
-export { ClerkProvider } from './ClerkProvider';
-
+// HACK to show app-beta deprecation warning any of the below
+// There seems to be some issue when adding the deprecation in the index.ts
 export {
   useUser,
   useAuth,
@@ -23,14 +22,4 @@ export {
   RedirectToCreateOrganization,
   RedirectToOrganizationProfile,
   AuthenticateWithRedirectCallback,
-} from './clerk-react';
-
-export {
-  SignIn,
-  SignUp,
-  UserButton,
-  UserProfile,
-  OrganizationSwitcher,
-  CreateOrganization,
-  OrganizationProfile,
-} from './ui-components';
+} from '@clerk/clerk-react';

--- a/packages/nextjs/src/app-beta/client/ui-components.tsx
+++ b/packages/nextjs/src/app-beta/client/ui-components.tsx
@@ -1,4 +1,10 @@
 'use client';
+import { deprecated } from '@clerk/shared';
+
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
 
 export {
   CreateOrganization,

--- a/packages/nextjs/src/app-beta/client/ui-components.tsx
+++ b/packages/nextjs/src/app-beta/client/ui-components.tsx
@@ -6,12 +6,48 @@ deprecated(
   'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
 );
 
-export {
-  CreateOrganization,
-  OrganizationProfile,
-  OrganizationSwitcher,
-  SignIn,
-  SignUp,
-  UserButton,
-  UserProfile,
+import {
+  CreateOrganization as _CreateOrganization,
+  OrganizationProfile as _OrganizationProfile,
+  OrganizationSwitcher as _OrganizationSwitcher,
+  SignIn as _SignIn,
+  SignUp as _SignUp,
+  UserButton as _UserButton,
+  UserProfile as _UserProfile,
 } from '@clerk/clerk-react';
+
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const CreateOrganization = _CreateOrganization;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const OrganizationProfile = _OrganizationProfile;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const OrganizationSwitcher = _OrganizationSwitcher;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const SignIn = _SignIn;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const SignUp = _SignUp;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const UserButton = _UserButton;
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
+export const UserProfile = _UserProfile;

--- a/packages/nextjs/src/app-beta/control-components.tsx
+++ b/packages/nextjs/src/app-beta/control-components.tsx
@@ -7,12 +7,20 @@ deprecated(
 );
 import { auth } from './auth';
 
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export function SignedIn(props: React.PropsWithChildren) {
   const { children } = props;
   const { userId } = auth();
   return userId ? <>{children}</> : null;
 }
 
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export function SignedOut(props: React.PropsWithChildren) {
   const { children } = props;
   const { userId } = auth();

--- a/packages/nextjs/src/app-beta/control-components.tsx
+++ b/packages/nextjs/src/app-beta/control-components.tsx
@@ -1,5 +1,10 @@
+import { deprecated } from '@clerk/shared';
 import React from 'react';
 
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
 import { auth } from './auth';
 
 export function SignedIn(props: React.PropsWithChildren) {

--- a/packages/nextjs/src/app-beta/currentUser.ts
+++ b/packages/nextjs/src/app-beta/currentUser.ts
@@ -8,7 +8,10 @@ deprecated(
 import { auth } from './auth';
 import { clerkClient } from './clerkClient';
 
-// eslint-disable-next-line @typescript-eslint/require-await
+/**
+ * @deprecated Use imports from `@clerk/nextjs` instead.
+ * For more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware
+ */
 export async function currentUser(): Promise<User | null> {
   const { userId } = auth();
   return userId ? clerkClient.users.getUser(userId) : null;

--- a/packages/nextjs/src/app-beta/currentUser.ts
+++ b/packages/nextjs/src/app-beta/currentUser.ts
@@ -1,8 +1,14 @@
 import type { User } from '@clerk/backend';
+import { deprecated } from '@clerk/shared';
 
+deprecated(
+  '@clerk/nextjs/app-beta',
+  'Use imports from `@clerk/nextjs` instead.\nFor more details, consult the middleware documentation: https://clerk.com/docs/nextjs/middleware',
+);
 import { auth } from './auth';
 import { clerkClient } from './clerkClient';
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function currentUser(): Promise<User | null> {
   const { userId } = auth();
   return userId ? clerkClient.users.getUser(userId) : null;

--- a/packages/nextjs/src/app-router/server/currentUser.ts
+++ b/packages/nextjs/src/app-router/server/currentUser.ts
@@ -3,6 +3,7 @@ import type { User } from '@clerk/backend';
 import { clerkClient } from '../../server/clerkClient';
 import { auth } from './auth';
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function currentUser(): Promise<User | null> {
   const { userId } = auth();
   return userId ? clerkClient.users.getUser(userId) : null;


### PR DESCRIPTION
## Description

The implementation in `app-beta` was an attempt to support the NextJS `app-router` early on. Since the `app-router` release is stable we will deprecate the `@clerk/nextjs/app-beta` subpath export and suggest using the stable `@clerk/nextjs` exports instead.

In this PR the following hacks were applied to add JSDocs and console warnings deprecations:
- we could not add a single deprecation warning in the `app-beta/index.ts` because it did not work so `deprecated` was added in each file
- Replaced import from `@clerk/clerk-react` with module to show deprecation warning (see: packages/nextjs/src/app-beta/client/clerk-react.ts)
- Use import with aliases for re-exported modules of `@clerk/clerk-react` to add JSDoc deprecations only for the exports from the `app-beta`

Since the whole folder `app-beta` will be removed in the next major version, there is no need to worry about those hacks.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
