### PR TITLE
fix(clerk-react,remix,shared): Make `exports.types` the first key in `exports`

### DIFF
--- a/.changeset/dull-gifts-yawn.md
+++ b/.changeset/dull-gifts-yawn.md
@@ -1,0 +1,7 @@
+---
+"@clerk/clerk-react": patch
+"@clerk/remix": patch
+"@clerk/shared": patch
+---
+
+Make `types` the first key in all `exports` keys defined in our packages. The TypeScript docs (https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) recommends so, as the the "exports" field is order-based.

--- a/.changeset/dull-gifts-yawn.md
+++ b/.changeset/dull-gifts-yawn.md
@@ -4,4 +4,4 @@
 "@clerk/shared": patch
 ---
 
-Make `types` the first key in all `exports` keys defined in our packages. The TypeScript docs (https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) recommends so, as the the "exports" field is order-based.
+Make `types` the first key in all `exports` maps defined in our packages' `package.json`. The [TypeScript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) recommends so, as the the `exports` map is order-based.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,9 +18,9 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     }
   },
   "files": [

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -18,9 +18,18 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "exports": {
-    ".": "./dist/index.js",
-    "./ssr.server": "./dist/ssr/index.js",
-    "./api.server": "./dist/api/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./ssr.server": {
+      "types": "./dist/ssr/index.d.ts",
+      "default": "./dist/ssr/index.js"
+    },
+    "./api.server": {
+      "types": "./dist/api/index.d.ts",
+      "default": "./dist/api/index.js"
+    }
   },
   "typesVersions": {
     "*": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,14 +12,14 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     },
     "./testUtils": {
+      "types": "./dist/types/testUtils/index.d.ts",
       "import": "./dist/esm/testUtils/index.js",
-      "require": "./dist/cjs/testUtils/index.js",
-      "types": "./dist/types/testUtils/index.d.ts"
+      "require": "./dist/cjs/testUtils/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description
The [TypeScript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) recommends so, but it's also because the "exports" field is order-based.

For example, a scenario where both the "types" and "import" condition could be active, "types" should be first so that it matches and returns a .d.ts file, rather than a .js file from the "import" condition.



<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
