### PR TITLE
fix(clerk-js): Fix layout shift for Social block buttons

### DIFF
--- a/.changeset/honest-countries-repair.md
+++ b/.changeset/honest-countries-repair.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Updated the OAuth buttons in the SignIn and SignUp components to prevent layout shifts while loading.

--- a/packages/clerk-js/src/ui/common/InfiniteListSpinner.tsx
+++ b/packages/clerk-js/src/ui/common/InfiniteListSpinner.tsx
@@ -22,7 +22,7 @@ export const InfiniteListSpinner = forwardRef<HTMLDivElement>((_, ref) => {
         }}
       >
         <Spinner
-          size='md'
+          size='sm'
           colorScheme='primary'
         />
       </Box>

--- a/packages/clerk-js/src/ui/components/OrganizationList/shared.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/shared.tsx
@@ -83,7 +83,7 @@ export const PreviewListSpinner = forwardRef<HTMLDivElement>((_, ref) => {
         }}
       >
         <Spinner
-          size='md'
+          size='sm'
           colorScheme='primary'
         />
       </Box>

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/DomainList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/DomainList.tsx
@@ -144,7 +144,7 @@ export const DomainList = (props: DomainListProps) => {
             }}
           >
             <Spinner
-              size='md'
+              size='sm'
               colorScheme='primary'
             />
           </Box>

--- a/packages/clerk-js/src/ui/elements/Actions.tsx
+++ b/packages/clerk-js/src/ui/elements/Actions.tsx
@@ -95,7 +95,7 @@ export const Action = (props: ActionProps) => {
         sx={theme => ({ flex: `0 0 ${theme.sizes.$11}` })}
       >
         {status.isLoading ? (
-          <Spinner size='sm' />
+          <Spinner size='xs' />
         ) : (
           <Icon
             elementDescriptor={iconElementDescriptor}

--- a/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
+++ b/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
@@ -80,11 +80,6 @@ export const ArrowBlockButton = (props: ArrowBlockButtonProps) => {
               elementDescriptor={spinnerElementDescriptor}
               elementId={spinnerElementId}
               size={'md'}
-              sx={theme => [
-                {
-                  padding: theme.space.$2,
-                },
-              ]}
             />
           ) : !isIconElement && leftIcon ? (
             <Icon

--- a/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
+++ b/packages/clerk-js/src/ui/elements/ArrowBlockButton.tsx
@@ -73,7 +73,7 @@ export const ArrowBlockButton = (props: ArrowBlockButtonProps) => {
         <Flex
           as='span'
           center
-          sx={theme => ({ flex: `0 0 ${theme.space.$4}` })}
+          sx={theme => ({ flex: `0 0 ${theme.space.$5}` })}
         >
           {isLoading ? (
             <Spinner
@@ -89,7 +89,7 @@ export const ArrowBlockButton = (props: ArrowBlockButtonProps) => {
               sx={[
                 theme => ({
                   color: theme.colors.$blackAlpha600,
-                  width: theme.sizes.$4,
+                  width: theme.sizes.$5,
                   position: 'absolute',
                 }),
                 leftIconSx,

--- a/packages/clerk-js/src/ui/elements/SocialButtons.tsx
+++ b/packages/clerk-js/src/ui/elements/SocialButtons.tsx
@@ -84,7 +84,7 @@ export const SocialButtons = React.memo((props: SocialButtonsRootProps) => {
               isDisabled={card.isLoading}
               src={strategyToDisplayData[strategy].iconUrl}
               alt={`Sign in with ${strategyToDisplayData[strategy].name}`}
-              sx={theme => ({ width: theme.sizes.$5 })}
+              sx={theme => ({ width: theme.sizes.$5, height: 'auto', maxWidth: '100%' })}
             />
           }
         />

--- a/packages/clerk-js/src/ui/primitives/Spinner.tsx
+++ b/packages/clerk-js/src/ui/primitives/Spinner.tsx
@@ -37,8 +37,9 @@ const { applyVariants, filterProps } = createVariants(theme => {
         md: { [thickness]: theme.sizes.$1 },
       },
       size: {
-        sm: { [size]: theme.sizes.$3 },
-        md: { [size]: theme.sizes.$4 },
+        xs: { [size]: theme.sizes.$3 },
+        sm: { [size]: theme.sizes.$4 },
+        md: { [size]: theme.sizes.$5 },
         lg: { [size]: theme.sizes.$6 },
         xl: { [size]: theme.sizes.$8 },
       },
@@ -50,7 +51,7 @@ const { applyVariants, filterProps } = createVariants(theme => {
     defaultVariants: {
       speed: 'normal',
       thickness: 'sm',
-      size: 'md',
+      size: 'sm',
     },
   };
 });


### PR DESCRIPTION
## Description
This PR fixes layout shift that is happening when Social block button is in loading state.

## Before:

https://github.com/clerkinc/javascript/assets/6823226/0334d15c-7228-4f70-9f79-c024c1cf0a94

## After:

https://github.com/clerkinc/javascript/assets/6823226/78d402a6-cb83-4bb5-a733-2a493adb0a0a


Fixes JS-792

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
