### PR TITLE
fix(shared): Removal of `clerkError` property

### DIFF
--- a/.changeset/empty-donuts-walk.md
+++ b/.changeset/empty-donuts-walk.md
@@ -1,0 +1,5 @@
+---
+'@clerk/shared': patch
+---
+
+Revert the removal of the `clerkError` property from `ClerkAPIError` class.

--- a/packages/clerk-js/src/core/resources/Error.ts
+++ b/packages/clerk-js/src/core/resources/Error.ts
@@ -9,5 +9,6 @@ export {
   MagicLinkError,
   ClerkAPIResponseError,
   isClerkRuntimeError,
+  ClerkRuntimeError,
 } from '@clerk/shared';
 export type { MetamaskError } from '@clerk/shared';

--- a/packages/clerk-js/src/core/resources/SignUp.ts
+++ b/packages/clerk-js/src/core/resources/SignUp.ts
@@ -1,4 +1,4 @@
-import { ClerkRuntimeError, Poller } from '@clerk/shared';
+import { Poller } from '@clerk/shared';
 import type {
   AttemptEmailAddressVerificationParams,
   AttemptPhoneNumberVerificationParams,
@@ -30,7 +30,7 @@ import {
   clerkVerifyEmailAddressCalledBeforeCreate,
   clerkVerifyWeb3WalletCalledBeforeCreate,
 } from '../errors';
-import { BaseResource, SignUpVerifications } from './internal';
+import { BaseResource, ClerkRuntimeError, SignUpVerifications } from './internal';
 
 declare global {
   interface Window {
@@ -211,7 +211,9 @@ export class SignUp extends BaseResource implements SignUpResource {
     continueSignUp = false,
     unsafeMetadata,
     emailAddress,
-  }: AuthenticateWithRedirectParams & { unsafeMetadata?: SignUpUnsafeMetadata }): Promise<void> => {
+  }: AuthenticateWithRedirectParams & {
+    unsafeMetadata?: SignUpUnsafeMetadata;
+  }): Promise<void> => {
     const authenticateFn = (args: SignUpCreateParams | SignUpUpdateParams) =>
       continueSignUp && this.id ? this.update(args) : this.create(args);
 

--- a/packages/shared/src/errors/Error.ts
+++ b/packages/shared/src/errors/Error.ts
@@ -18,10 +18,6 @@ export function isKnownError(error: any) {
 }
 
 export function isClerkAPIResponseError(err: any): err is ClerkAPIResponseError {
-  if (err instanceof ClerkAPIResponseError) {
-    return true;
-  }
-
   return 'clerkError' in err;
 }
 
@@ -42,7 +38,7 @@ export function isClerkAPIResponseError(err: any): err is ClerkAPIResponseError 
  * }
  */
 export function isClerkRuntimeError(err: any): err is ClerkRuntimeError {
-  return err instanceof ClerkRuntimeError;
+  return 'clerkRuntimeError' in err;
 }
 
 export function isMetamaskError(err: any): err is MetamaskError {
@@ -68,6 +64,8 @@ export function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {
 }
 
 export class ClerkAPIResponseError extends Error {
+  clerkError: true;
+
   status: number;
   message: string;
 
@@ -80,6 +78,7 @@ export class ClerkAPIResponseError extends Error {
 
     this.status = status;
     this.message = message;
+    this.clerkError = true;
     this.errors = parseErrors(data);
   }
 
@@ -98,6 +97,8 @@ export class ClerkAPIResponseError extends Error {
  *   throw new ClerkRuntimeError('An error occurred', { code: 'password_invalid' });
  */
 export class ClerkRuntimeError extends Error {
+  clerkRuntimeError: true;
+
   /**
    * The error message.
    *
@@ -113,6 +114,7 @@ export class ClerkRuntimeError extends Error {
    * @memberof ClerkRuntimeError
    */
   code: string;
+
   constructor(message: string, { code }: { code: string }) {
     super(message);
 
@@ -120,6 +122,7 @@ export class ClerkRuntimeError extends Error {
 
     this.code = code;
     this.message = message;
+    this.clerkRuntimeError = true;
   }
 
   /**
@@ -142,6 +145,7 @@ export class MagicLinkError extends Error {
     Object.setPrototypeOf(this, MagicLinkError.prototype);
   }
 }
+
 // Check if the error is a MagicLinkError.
 
 export function isMagicLinkError(err: Error): err is MagicLinkError {


### PR DESCRIPTION
## Description


This PR reverts the unintended removal of `clerkError`. When missing it would cause the `isClerkAPIResponseError` return a wrong value

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
