### PR TITLE
feat(clerk-js,backend): Throw error if signInUrl is on same origin as a satellite app

### DIFF
--- a/.changeset/polite-rats-care.md
+++ b/.changeset/polite-rats-care.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/backend': patch
+---
+
+Throw an error if the `signInUrl` is on the same origin of a satellite application or if it is of invalid format

--- a/packages/backend/src/tokens/request.test.ts
+++ b/packages/backend/src/tokens/request.test.ts
@@ -319,12 +319,14 @@ export default (QUnit: QUnit) => {
         apiKey: 'deadbeef',
         clientUat: '0',
         isSatellite: true,
+        signInUrl: 'https://primary.dev/sign-in',
         domain: 'satellite.dev',
       });
 
       assertInterstitial(assert, requestState, {
         reason: AuthErrorReason.SatelliteCookieNeedsSyncing,
         isSatellite: true,
+        signInUrl: 'https://primary.dev/sign-in',
         domain: 'satellite.dev',
       });
       assert.equal(requestState.message, '');
@@ -337,6 +339,7 @@ export default (QUnit: QUnit) => {
         apiKey: 'deadbeef',
         clientUat: '0',
         isSatellite: true,
+        signInUrl: 'https://primary.dev/sign-in',
         domain: 'satellite.dev',
         userAgent: '[some-agent]',
       });
@@ -344,6 +347,7 @@ export default (QUnit: QUnit) => {
       assertSignedOut(assert, requestState, {
         reason: AuthErrorReason.SatelliteCookieNeedsSyncing,
         isSatellite: true,
+        signInUrl: 'https://primary.dev/sign-in',
         domain: 'satellite.dev',
       });
       assertSignedOutToAuth(assert, requestState);

--- a/packages/backend/src/tokens/request.ts
+++ b/packages/backend/src/tokens/request.ts
@@ -102,6 +102,19 @@ function assertProxyUrlOrDomain(proxyUrlOrDomain: string | undefined) {
   }
 }
 
+function assertSignInUrlFormatAndOrigin(_signInUrl: string, origin: string) {
+  let signInUrl: URL;
+  try {
+    signInUrl = new URL(_signInUrl);
+  } catch {
+    throw new Error(`The signInUrl needs to have a absolute url format.`);
+  }
+
+  if (signInUrl.origin === origin) {
+    throw new Error(`The signInUrl needs to be on a different origin than your satellite application.`);
+  }
+}
+
 export async function authenticateRequest(options: AuthenticateRequestOptions): Promise<RequestState> {
   const { cookies, headers, searchParams } = buildRequest(options?.request);
 
@@ -128,6 +141,9 @@ export async function authenticateRequest(options: AuthenticateRequestOptions): 
 
   if (options.isSatellite) {
     assertSignInUrlExists(options.signInUrl, (options.secretKey || options.apiKey) as string);
+    if (options.signInUrl && options.origin /* could this actually be undefined? */) {
+      assertSignInUrlFormatAndOrigin(options.signInUrl, options.origin);
+    }
     assertProxyUrlOrDomain(options.proxyUrl || options.domain);
   }
 

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -94,6 +94,8 @@ import type { DevBrowserHandler } from './devBrowserHandler';
 import createDevBrowserHandler from './devBrowserHandler';
 import {
   clerkErrorInitFailed,
+  clerkInvalidSignInUrlFormat,
+  clerkInvalidSignInUrlOrigin,
   clerkMissingDevBrowserJwt,
   clerkMissingProxyUrlAndDomain,
   clerkMissingSignInUrlAsSatellite,
@@ -1276,16 +1278,34 @@ export default class Clerk implements ClerkInterface {
     }
   };
 
+  #assertSignInFormatAndOrigin = (_signInUrl: string, origin: string) => {
+    let signInUrl: URL;
+    try {
+      signInUrl = new URL(_signInUrl);
+    } catch {
+      clerkInvalidSignInUrlFormat();
+    }
+
+    if (signInUrl.origin === origin) {
+      clerkInvalidSignInUrlOrigin();
+    }
+  };
+
   #validateMultiDomainOptions = () => {
     if (!this.isSatellite) {
       return;
     }
+
     if (this.#instanceType === 'development' && !this.#options.signInUrl) {
       clerkMissingSignInUrlAsSatellite();
     }
 
     if (!this.proxyUrl && !this.domain) {
       clerkMissingProxyUrlAndDomain();
+    }
+
+    if (this.#options.signInUrl) {
+      this.#assertSignInFormatAndOrigin(this.#options.signInUrl, window.location.origin);
     }
   };
 

--- a/packages/clerk-js/src/core/errors.ts
+++ b/packages/clerk-js/src/core/errors.ts
@@ -94,6 +94,14 @@ export function clerkMissingProxyUrlAndDomain(): never {
   );
 }
 
+export function clerkInvalidSignInUrlOrigin(): never {
+  throw new Error(`${errorPrefix} The signInUrl needs to be on a different origin than your satellite application.`);
+}
+
+export function clerkInvalidSignInUrlFormat(): never {
+  throw new Error(`${errorPrefix} The signInUrl needs to have a absolute url format.`);
+}
+
 export function clerkMissingSignInUrlAsSatellite(): never {
   throw new Error(
     `${errorPrefix} Missing signInUrl. A satellite application needs to specify the signInUrl for development instances.`,


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
