### PR TITLE
fix(clerk-js): Append initial values query params after hash

### DIFF
--- a/.changeset/wise-spiders-hammer.md
+++ b/.changeset/wise-spiders-hammer.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Append query params for sign-in and sign-up initial values after the hash in order to be readable via hash routing.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -63,7 +63,6 @@ import type { MountComponentRenderer } from '../ui/Components';
 import { completeSignUpFlow } from '../ui/components/SignUp/util';
 import {
   appendAsQueryParams,
-  appendUrlsAsQueryParams,
   buildURL,
   createBeforeUnloadTracker,
   createCookieHandler,
@@ -1572,7 +1571,7 @@ export default class Clerk implements ClerkInterface {
       return '';
     }
 
-    const opts: RedirectOptions = {
+    const urls: RedirectOptions = {
       afterSignInUrl: pickRedirectionProp('afterSignInUrl', { ctx: options, options: this.#options }, false),
       afterSignUpUrl: pickRedirectionProp('afterSignUpUrl', { ctx: options, options: this.#options }, false),
       redirectUrl: options?.redirectUrl || window.location.href,
@@ -1584,9 +1583,7 @@ export default class Clerk implements ClerkInterface {
       false,
     );
 
-    return this.buildUrlWithAuth(
-      appendUrlsAsQueryParams(appendAsQueryParams(signInOrUpUrl, options?.initialValues || {}), opts),
-    );
+    return this.buildUrlWithAuth(appendAsQueryParams(signInOrUpUrl, { values: options?.initialValues, urls }));
   };
 
   assertComponentsReady(controls: unknown): asserts controls is ReturnType<MountComponentRenderer> {

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -1,7 +1,7 @@
 import type { SignUpResource } from '@clerk/types';
 
 import {
-  appendUrlsAsQueryParams,
+  appendAsQueryParams,
   buildURL,
   getAllETLDs,
   getETLDPlusOneFromFrontendApi,
@@ -242,30 +242,29 @@ describe('trimTrailingSlash(string)', () => {
 describe('appendQueryParams(base,url)', () => {
   it('returns the same url if no params provided', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendUrlsAsQueryParams(base);
+    const res = appendAsQueryParams(base);
     expect(res).toBe('https://dashboard.clerk.com/');
   });
 
   it('handles URL objects', () => {
     const base = new URL('https://dashboard.clerk.com');
     const url = new URL('https://dashboard.clerk.com/applications/appid/instances/');
-    const res = appendUrlsAsQueryParams(base, { redirect_url: url });
+    const res = appendAsQueryParams(base, { urls: { redirect_url: url } });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F');
   });
 
   it('handles plain strings', () => {
     const base = 'https://dashboard.clerk.com';
     const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendUrlsAsQueryParams(base, { redirect_url: url });
+    const res = appendAsQueryParams(base, { urls: { redirect_url: url } });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F');
   });
 
   it('handles multiple params', () => {
     const base = 'https://dashboard.clerk.com';
     const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendUrlsAsQueryParams(base, {
-      redirect_url: url,
-      after_sign_in_url: url,
+    const res = appendAsQueryParams(base, {
+      urls: { redirect_url: url, after_sign_in_url: url },
     });
     expect(res).toBe(
       'https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F&after_sign_in_url=%2Fapplications%2Fappid%2Finstances%2F',
@@ -274,26 +273,26 @@ describe('appendQueryParams(base,url)', () => {
 
   it('skips falsy values', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendUrlsAsQueryParams(base, { redirect_url: undefined });
+    const res = appendAsQueryParams(base, { urls: { redirect_url: undefined } });
     expect(res).toBe('https://dashboard.clerk.com/');
   });
 
   it('converts relative to absolute urls', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendUrlsAsQueryParams(base, { redirect_url: '/test' });
+    const res = appendAsQueryParams(base, { urls: { redirect_url: '/test' } });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
   });
 
   it('converts keys from camel to snake case', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendUrlsAsQueryParams(base, { redirectUrl: '/test' });
+    const res = appendAsQueryParams(base, { urls: { redirectUrl: '/test' } });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
   });
 
   it('keeps origin before appending if base and url have different origin', () => {
     const base = new URL('https://dashboard.clerk.com');
     const url = new URL('https://www.google.com/something');
-    const res = appendUrlsAsQueryParams(base, { redirect_url: url });
+    const res = appendAsQueryParams(base, { urls: { redirect_url: url } });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fwww.google.com%2Fsomething');
   });
 });

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -246,53 +246,46 @@ describe('appendQueryParams(base,url)', () => {
     expect(res).toBe('https://dashboard.clerk.com/');
   });
 
-  it('handles URL objects', () => {
-    const base = new URL('https://dashboard.clerk.com');
-    const url = new URL('https://dashboard.clerk.com/applications/appid/instances/');
-    const res = appendAsQueryParams(base, { urls: { redirect_url: url } });
-    expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F');
-  });
-
   it('handles plain strings', () => {
     const base = 'https://dashboard.clerk.com';
     const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendAsQueryParams(base, { urls: { redirect_url: url } });
-    expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F');
+    const res = appendAsQueryParams(base, { redirect_url: url });
+    expect(res).toBe(
+      'https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fdashboard.clerk.com%2Fapplications%2Fappid%2Finstances%2F',
+    );
   });
 
   it('handles multiple params', () => {
     const base = 'https://dashboard.clerk.com';
     const url = 'https://dashboard.clerk.com/applications/appid/instances/';
-    const res = appendAsQueryParams(base, {
-      urls: { redirect_url: url, after_sign_in_url: url },
-    });
+    const res = appendAsQueryParams(base, { redirect_url: url, after_sign_in_url: url });
     expect(res).toBe(
-      'https://dashboard.clerk.com/#/?redirect_url=%2Fapplications%2Fappid%2Finstances%2F&after_sign_in_url=%2Fapplications%2Fappid%2Finstances%2F',
+      'https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fdashboard.clerk.com%2Fapplications%2Fappid%2Finstances%2F&after_sign_in_url=https%3A%2F%2Fdashboard.clerk.com%2Fapplications%2Fappid%2Finstances%2F',
     );
   });
 
   it('skips falsy values', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { urls: { redirect_url: undefined } });
+    const res = appendAsQueryParams(base, { redirect_url: undefined });
     expect(res).toBe('https://dashboard.clerk.com/');
   });
 
   it('converts relative to absolute urls', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { urls: { redirect_url: '/test' } });
+    const res = appendAsQueryParams(base, { redirect_url: 'http://localhost/test' });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
   });
 
   it('converts keys from camel to snake case', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const res = appendAsQueryParams(base, { urls: { redirectUrl: '/test' } });
+    const res = appendAsQueryParams(base, { redirectUrl: 'http://localhost/test' });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=http%3A%2F%2Flocalhost%2Ftest');
   });
 
   it('keeps origin before appending if base and url have different origin', () => {
     const base = new URL('https://dashboard.clerk.com');
-    const url = new URL('https://www.google.com/something');
-    const res = appendAsQueryParams(base, { urls: { redirect_url: url } });
+    const url = new URL('https://www.google.com/something').href;
+    const res = appendAsQueryParams(base, { redirect_url: url });
     expect(res).toBe('https://dashboard.clerk.com/#/?redirect_url=https%3A%2F%2Fwww.google.com%2Fsomething');
   });
 });

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -210,25 +210,17 @@ export const trimTrailingSlash = (path: string): string => {
   return (path || '').replace(/\/+$/, '');
 };
 
+export const stripSameOrigin = (url: URL, baseUrl: URL): string => {
+  const sameOrigin = baseUrl.origin === url.origin;
+  return sameOrigin ? stripOrigin(url) : `${url}`;
+};
+
 export const appendAsQueryParams = (
   baseUrl: string | URL,
-  options?: {
-    values?: Record<string, string | null | undefined>;
-    urls?: Record<string, string | URL | null | undefined>;
-  },
+  values: Record<string, string | null | undefined> = {},
 ): string => {
-  const { values = {}, urls = {} } = options || {};
   const base = toURL(baseUrl);
   const params = new URLSearchParams();
-  for (const [key, val] of Object.entries(urls)) {
-    if (!val) {
-      continue;
-    }
-    const url = toURL(val);
-    const sameOrigin = base.origin === url.origin;
-    params.append(camelToSnake(key), sameOrigin ? stripOrigin(url) : `${url}`);
-  }
-
   for (const [key, val] of Object.entries(values)) {
     if (!val) {
       continue;

--- a/packages/clerk-js/src/utils/url.ts
+++ b/packages/clerk-js/src/utils/url.ts
@@ -210,10 +210,14 @@ export const trimTrailingSlash = (path: string): string => {
   return (path || '').replace(/\/+$/, '');
 };
 
-export const appendUrlsAsQueryParams = (
+export const appendAsQueryParams = (
   baseUrl: string | URL,
-  urls: Record<string, string | URL | null | undefined> = {},
+  options?: {
+    values?: Record<string, string | null | undefined>;
+    urls?: Record<string, string | URL | null | undefined>;
+  },
 ): string => {
+  const { values = {}, urls = {} } = options || {};
   const base = toURL(baseUrl);
   const params = new URLSearchParams();
   for (const [key, val] of Object.entries(urls)) {
@@ -225,25 +229,17 @@ export const appendUrlsAsQueryParams = (
     params.append(camelToSnake(key), sameOrigin ? stripOrigin(url) : `${url}`);
   }
 
-  // The following line will prepend the hash with a `/`.
-  // This is required for ClerkJS Components Hash router to work as expected
-  // as it treats the hash as sub-path with its nested querystring parameters.
-  return `${base}${params.toString() ? '#/?' + params.toString() : ''}`;
-};
-
-export const appendAsQueryParams = (
-  baseUrl: string | URL,
-  values: Record<string, string | null | undefined> = {},
-): string => {
-  const base = toURL(baseUrl);
   for (const [key, val] of Object.entries(values)) {
     if (!val) {
       continue;
     }
-    base.searchParams.append(camelToSnake(key), val);
+    params.append(camelToSnake(key), val);
   }
 
-  return baseUrl.toString() + base.search;
+  // The following line will prepend the hash with a `/`.
+  // This is required for ClerkJS Components Hash router to work as expected
+  // as it treats the hash as sub-path with its nested querystring parameters.
+  return `${base}${params.toString() ? '#/?' + params.toString() : ''}`;
 };
 
 export const hasExternalAccountSignUpError = (signUp: SignUpResource): boolean => {


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

When calling `Clerk.redirectToSignIn/Up()`, the initial values query params were being added as normal query params, instead of being appended after the hash. This means that they were not being picked up in a hash routing environment. This PR addresses that issue and appends them the same way as the redirect urls.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
