### PR TITLE
Fix noisy deprecations sdk node

### DIFF
--- a/.changeset/tasty-toes-pump.md
+++ b/.changeset/tasty-toes-pump.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+---
+
+Avoid always showing deprecation warnings for `frontendApi` and `apiKey` in `@clerk/clerk-sdk-node`

--- a/packages/backend/src/tokens/factory.ts
+++ b/packages/backend/src/tokens/factory.ts
@@ -104,7 +104,7 @@ export function createAuthenticateRequest(params: CreateAuthenticateRequestOptio
       apiUrl,
       frontendApi: runtimeFrontendApi || buildtimeFrontendApi,
       publishableKey: runtimePublishableKey || buildtimePublishableKey,
-      proxyUrl: (runtimeProxyUrl || buildProxyUrl) as any,
+      proxyUrl: runtimeProxyUrl || buildProxyUrl,
       isSatellite: runtimeIsSatellite || buildtimeIsSatellite,
       domain: (runtimeDomain || buildtimeDomain) as any,
       userAgent: runtimeUserAgent || buildUserAgent,

--- a/packages/sdk-node/src/authenticateRequest.ts
+++ b/packages/sdk-node/src/authenticateRequest.ts
@@ -20,7 +20,9 @@ export async function loadInterstitial({
    */
   if (requestState.publishableKey || requestState.frontendApi) {
     return clerkClient.localInterstitial({
-      frontendApi: requestState.frontendApi,
+      // Use frontendApi only when legacy frontendApi is used to avoid showing deprecation warning
+      // since the requestState always contains the frontendApi constructed by publishableKey.
+      frontendApi: requestState.publishableKey ? '' : requestState.frontendApi,
       publishableKey: requestState.publishableKey,
       proxyUrl: requestState.proxyUrl,
       signInUrl: requestState.signInUrl,

--- a/packages/sdk-node/src/utils.ts
+++ b/packages/sdk-node/src/utils.ts
@@ -26,7 +26,7 @@ export const loadClientEnv = () => {
 export const loadApiEnv = () => {
   return {
     secretKey: process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '',
-    apiKey: process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '',
+    apiKey: process.env.CLERK_API_KEY || '',
     apiUrl: process.env.CLERK_API_URL || 'https://api.clerk.dev',
     apiVersion: process.env.CLERK_API_VERSION || 'v1',
     domain: process.env.CLERK_DOMAIN || '',


### PR DESCRIPTION
## Description

Avoid **always** showing `frontendApi` and `apiKey` on `@clerk/clerk-sdk-node`!

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
