### PR TITLE
chore(clerk-sdk-node): Drop noisy deprecation of unstable_options in sdk-node

### DIFF
--- a/.changeset/seven-shrimps-train.md
+++ b/.changeset/seven-shrimps-train.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-sdk-node': patch
+---
+
+Avoid always showing `__unstable_options` deprecation warning in all applications and SDKs using `@clerk/clerk-sdk-node`

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -5,12 +5,18 @@ import { createClerkExpressRequireAuth } from './clerkExpressRequireAuth';
 import { createClerkExpressWithAuth } from './clerkExpressWithAuth';
 import { loadApiEnv, loadClientEnv } from './utils';
 
+type ExtendedClerk = ReturnType<typeof _Clerk> & {
+  expressWithAuth: ReturnType<typeof createClerkExpressWithAuth>;
+  expressRequireAuth: ReturnType<typeof createClerkExpressRequireAuth>;
+  verifyToken: typeof _verifyToken;
+} & ReturnType<typeof createBasePropForRedwoodCompatibility>;
+
 /**
  * This needs to be a *named* function in order to support the older
  * new Clerk() syntax for v4 compatibility.
  * Arrow functions can never be called with the new keyword because they do not have the [[Construct]] method
  */
-export function Clerk(options: ClerkOptions) {
+export function Clerk(options: ClerkOptions): ExtendedClerk {
   const clerkClient = _Clerk(options);
   const expressWithAuth = createClerkExpressWithAuth({ ...options, clerkClient });
   const expressRequireAuth = createClerkExpressRequireAuth({ ...options, clerkClient });
@@ -19,13 +25,12 @@ export function Clerk(options: ClerkOptions) {
     return _verifyToken(token, { issuer, ...options, ...verifyOpts });
   };
 
-  return {
-    ...clerkClient,
+  return Object.assign(clerkClient, {
     expressWithAuth,
     expressRequireAuth,
     verifyToken,
     ...createBasePropForRedwoodCompatibility(),
-  };
+  });
 }
 
 const createBasePropForRedwoodCompatibility = () => {

--- a/playground/cra-js/package.json
+++ b/playground/cra-js/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@clerk/clerk-react": "*",
+    "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
+    "@clerk/shared": "file:.yalc/@clerk/shared",
+    "@clerk/types": "file:.yalc/@clerk/types",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/playground/express/package.json
+++ b/playground/express/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@clerk/backend": "file:.yalc/@clerk/backend",
     "@clerk/clerk-sdk-node": "file:.yalc/@clerk/clerk-sdk-node",
+    "@clerk/shared": "file:.yalc/@clerk/shared",
     "@clerk/types": "file:.yalc/@clerk/types",
     "dotenv": "^16.0.3",
     "ejs": "^3.1.6",

--- a/playground/express/src/routes/private.ts
+++ b/playground/express/src/routes/private.ts
@@ -1,11 +1,11 @@
 import type { Response } from 'express';
 
-import { ClerkExpressRequireAuth, clerkClient } from '@clerk/clerk-sdk-node';
+import { clerkClient } from '@clerk/clerk-sdk-node';
 import { Router } from 'express';
 
 const router = Router();
 
-router.use(ClerkExpressRequireAuth({ clerkClient }));
+router.use((...args)=>clerkClient.expressRequireAuth()(...args));
 
 router.get('/me', async (req, reply: Response) => {
   return reply.json({ auth: req.auth });

--- a/playground/fastify/package.json
+++ b/playground/fastify/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@clerk/backend": "file:.yalc/@clerk/backend",
     "@clerk/fastify": "file:.yalc/@clerk/fastify",
+    "@clerk/shared": "file:.yalc/@clerk/shared",
     "@clerk/types": "file:.yalc/@clerk/types",
     "@fastify/view": "^8.0.0",
     "dotenv": "^16.0.3",

--- a/playground/remix-cf-pages/package.json
+++ b/playground/remix-cf-pages/package.json
@@ -11,9 +11,9 @@
     "yalc:add": "yalc add @clerk/types && yalc add @clerk/remix && yalc add @clerk/backend"
   },
   "dependencies": {
-    "@clerk/backend": "*",
-    "@clerk/remix": "*",
-    "@clerk/types": "*",
+    "@clerk/backend": "file:.yalc/@clerk/backend",
+    "@clerk/remix": "file:.yalc/@clerk/remix",
+    "@clerk/types": "file:.yalc/@clerk/types",
     "@remix-run/cloudflare": "^2.0.0",
     "@remix-run/cloudflare-pages": "^2.0.0",
     "@remix-run/react": "^2.0.0",

--- a/playground/vite-react-ts/package.json
+++ b/playground/vite-react-ts/package.json
@@ -12,6 +12,7 @@
     "yalc": "yalc add -- @clerk/clerk-react @clerk/types @clerk/shared"
   },
   "dependencies": {
+    "@clerk/clerk-js": "file:.yalc/@clerk/clerk-js",
     "@clerk/clerk-react": "file:.yalc/@clerk/clerk-react",
     "@clerk/shared": "file:.yalc/@clerk/shared",
     "@clerk/types": "file:.yalc/@clerk/types",


### PR DESCRIPTION
## Description

The `sdk-node` package is extending the backend `Clerk` with some extra methods. To do this, we expose a different `Clerk` from the `sdk-node` that returns the `clerkClient` instance of backend with some extra methods.
To add those extra methods to the return value we currently destruct the `clerkClient` to a new object and add the extra methods. By destructing the `clerkClient`, all it's methods and properties are being accessed, causing the `__unstable_options` deprecation warning to trigger and show the warning every time in applications using the `sdk-node` package.
To resolve this, we introduced an `ExtendedClerk` type as the return value of the sdk-node `Clerk` and changed the destructing to `Object.assign(clerkClient, ...extra...)`.

Warning :
```
DEPRECATION WARNING: "__unstable_options" is deprecated and will be removed in the next major release.
Use `createClerkClient({...})` to create a new clerk instance instead.
```

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
