### PR TITLE
fix(clerk-js): Correctly navigate to the continue route if needed during verification

### DIFF
--- a/.changeset/quiet-points-applaud.md
+++ b/.changeset/quiet-points-applaud.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': minor
+---
+
+Add new `/sign-up/continue/verify-phone-number` and `/sign-up/continue/verify-email-address` routes in order to allow navigating back to the `/sign-up/continue` step when editing the extra identifier that is provided in the `/sign-up/continue` step.

--- a/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUp.tsx
@@ -56,7 +56,21 @@ function SignUpRoutes(): JSX.Element {
           />
         </Route>
         <Route path='continue'>
-          <SignUpContinue />
+          <Route
+            path='verify-email-address'
+            canActivate={clerk => !!clerk.client.signUp.emailAddress}
+          >
+            <SignUpVerifyEmail />
+          </Route>
+          <Route
+            path='verify-phone-number'
+            canActivate={clerk => !!clerk.client.signUp.phoneNumber}
+          >
+            <SignUpVerifyPhone />
+          </Route>
+          <Route index>
+            <SignUpContinue />
+          </Route>
         </Route>
         <Route index>
           <SignUpStart />

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpContinue.tsx
@@ -143,8 +143,8 @@ function _SignUpContinue() {
       .then(res =>
         completeSignUpFlow({
           signUp: res,
-          verifyEmailPath: '../verify-email-address',
-          verifyPhonePath: '../verify-phone-number',
+          verifyEmailPath: './verify-email-address',
+          verifyPhonePath: './verify-phone-number',
           handleComplete: () => clerk.setActive({ session: res.createdSessionId, beforeEmit: navigateAfterSignUp }),
           navigate,
         }),


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

By adding these two new routes, we can navigate back to the `continue` step when needed, instead of going back to the start of the sign up flow.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
