### PR TITLE
chore(clerk-js): Fix broken Organization methods

### DIFF
--- a/.changeset/unlucky-carrots-exist.md
+++ b/.changeset/unlucky-carrots-exist.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/clerk-react': patch
+'@clerk/types': patch
+---
+
+Fix methods in clerk-js that consumede paginated endpoints in order to retrieve single resources.

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -5,7 +5,15 @@ import { mockNativeRuntime } from '../testUtils';
 import Clerk from './clerk';
 import { eventBus, events } from './events';
 import type { AuthConfig, DisplayConfig, Organization } from './resources/internal';
-import { Client, EmailLinkErrorCode, Environment, MagicLinkErrorCode, SignIn, SignUp } from './resources/internal';
+import {
+  BaseResource,
+  Client,
+  EmailLinkErrorCode,
+  Environment,
+  MagicLinkErrorCode,
+  SignIn,
+  SignUp,
+} from './resources/internal';
 import { SessionCookieService } from './services';
 import { mockJwt } from './test/fixtures';
 
@@ -2010,6 +2018,22 @@ describe('Clerk singleton', () => {
 
       const url = sut.buildUrlWithAuth('https://rested-anemone-14.accounts.dev');
       expect(url).toBe('https://rested-anemone-14.accounts.dev/?__dev_session=deadbeef');
+    });
+  });
+
+  describe('Organizations', () => {
+    it('getOrganization', async () => {
+      // @ts-ignore
+      BaseResource._fetch = jest.fn().mockResolvedValue({});
+      const sut = new Clerk(devFrontendApi);
+
+      await sut.getOrganization('some-org-id');
+
+      // @ts-ignore
+      expect(BaseResource._fetch).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/organizations/some-org-id',
+      });
     });
   });
 });

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -1152,10 +1152,8 @@ export default class Clerk implements ClerkInterface {
     return await OrganizationMembership.retrieve();
   };
 
-  public getOrganization = async (organizationId: string): Promise<Organization | undefined> => {
-    return (await OrganizationMembership.retrieve()).find(orgMem => orgMem.organization.id === organizationId)
-      ?.organization;
-  };
+  public getOrganization = async (organizationId: string): Promise<OrganizationResource> =>
+    Organization.get(organizationId);
 
   public updateEnvironment(environment: EnvironmentResource) {
     this.#environment = environment;

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -342,18 +342,19 @@ export class Organization extends BaseResource implements OrganizationResource {
 
   public async reload(params?: ClerkResourceReloadParams): Promise<this> {
     const { rotatingTokenNonce } = params || {};
-    const json = await BaseResource._fetch(
-      {
-        method: 'GET',
-        path: `/me/organization_memberships`,
-        rotatingTokenNonce,
-      },
-      { forceUpdateClient: true },
-    );
-    const currentOrganization = (json?.response as unknown as OrganizationMembershipJSON[]).find(
-      orgMem => orgMem.organization.id === this.id,
-    );
-    return this.fromJSON(currentOrganization?.organization as OrganizationJSON);
+
+    const json = (
+      await BaseResource._fetch<OrganizationJSON>(
+        {
+          path: `/organizations/${this.id}`,
+          method: 'GET',
+          rotatingTokenNonce,
+        },
+        { forceUpdateClient: true },
+      )
+    )?.response as unknown as OrganizationJSON;
+
+    return this.fromJSON(json);
   }
 }
 

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
@@ -1,8 +1,7 @@
 import type { OrganizationResource, UserOrganizationInvitationResource } from '@clerk/types';
 import { useState } from 'react';
 
-import { Organization } from '../../../core/resources/Organization';
-import { useCoreOrganizationList } from '../../contexts';
+import { useCoreClerk, useCoreOrganizationList } from '../../contexts';
 import { localizationKeys } from '../../customizables';
 import { useCardState, withCardStateProvider } from '../../elements';
 import { handleError } from '../../utils';
@@ -25,6 +24,7 @@ export const AcceptRejectInvitationButtons = (props: { onAccept: () => void }) =
 
 export const InvitationPreview = withCardStateProvider((props: UserOrganizationInvitationResource) => {
   const card = useCardState();
+  const { getOrganization } = useCoreClerk();
   const [acceptedOrganization, setAcceptedOrganization] = useState<OrganizationResource | null>(null);
   const { userInvitations } = useCoreOrganizationList({
     userInvitations: organizationListParams.userInvitations,
@@ -34,7 +34,7 @@ export const InvitationPreview = withCardStateProvider((props: UserOrganizationI
     return card
       .runAsync(async () => {
         const updatedItem = await props.accept();
-        const organization = await Organization.get(props.publicOrganizationData.id);
+        const organization = await getOrganization(props.publicOrganizationData.id);
         return [updatedItem, organization] as const;
       })
       .then(([updatedItem, organization]) => {

--- a/packages/react/src/isomorphicClerk.ts
+++ b/packages/react/src/isomorphicClerk.ts
@@ -719,10 +719,10 @@ export default class IsomorphicClerk {
     }
   };
 
-  getOrganization = async (organizationId: string): Promise<OrganizationResource | undefined | void> => {
+  getOrganization = async (organizationId: string): Promise<OrganizationResource | void> => {
     const callback = () => this.clerkjs?.getOrganization(organizationId);
     if (this.clerkjs && this.#loaded) {
-      return callback() as Promise<OrganizationResource | undefined>;
+      return callback() as Promise<OrganizationResource>;
     } else {
       this.premountMethodCalls.set('getOrganization', callback);
     }

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -442,7 +442,7 @@ export interface Clerk {
   /**
    * Retrieves a single organization by id.
    */
-  getOrganization: (organizationId: string) => Promise<OrganizationResource | undefined>;
+  getOrganization: (organizationId: string) => Promise<OrganizationResource>;
 
   /**
    * Handles a 401 response from Frontend API by refreshing the client and session object accordingly


### PR DESCRIPTION
## Description


This PR fixes 2 methods that seems to be flawed.

https://github.com/clerkinc/javascript/blob/214f658cf79983b8b44ae3228b0500d88e215345/packages/clerk-js/src/core/resources/Organization.ts#L325

https://github.com/clerkinc/javascript/blob/214f658cf79983b8b44ae3228b0500d88e215345/packages/clerk-js/src/core/clerk.ts#L1086

To provide you with more context, these 2 methods rely on endpoints that resolve with paginated data and the iterate through them and filter the array based on an organizatinoID. This concept is flawed, as there is great chance that the organization id you are looking for, might not be part of the first page of the results.
<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
