### PR TITLE
feat(clerk-js): Replace __unstable__invitationUpdate with InvitationUpdate event

### DIFF
--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -103,6 +103,7 @@ import {
   clerkOAuthCallbackDidNotCompleteSignInSignUp,
   clerkRedirectUrlIsMissingScheme,
 } from './errors';
+import { eventBus, events } from './events';
 import type { FapiClient, FapiRequestCallback } from './fapiClient';
 import createFapiClient from './fapiClient';
 import {
@@ -301,6 +302,12 @@ export default class Clerk implements ClerkInterface {
     } else {
       this.#isReady = await this.#loadInNonStandardBrowser();
     }
+
+    // setup global events for standard/non-standard browser
+    eventBus.on(events.InvitationUpdate, ({ invitation }) => {
+      this.#lastOrganizationInvitation = invitation;
+      this.#emit();
+    });
   };
 
   public signOut: SignOut = async (callbackOrOptions?: SignOutCallback | SignOutOptions, options?: SignOutOptions) => {
@@ -1186,11 +1193,6 @@ export default class Clerk implements ClerkInterface {
 
     this.#emit();
   };
-
-  __unstable__invitationUpdate(invitation: OrganizationInvitationResource) {
-    this.#lastOrganizationInvitation = invitation;
-    this.#emit();
-  }
 
   __unstable__membershipUpdate(membership: OrganizationMembershipResource) {
     this.#lastOrganizationMember = membership;

--- a/packages/clerk-js/src/core/events.ts
+++ b/packages/clerk-js/src/core/events.ts
@@ -1,16 +1,19 @@
-import type { TokenResource } from '@clerk/types';
+import type { OrganizationInvitationResource, TokenResource } from '@clerk/types';
 
 export const events = {
   TokenUpdate: 'token:update',
+  InvitationUpdate: 'invitation:update',
 } as const;
 
 type ClerkEvent = (typeof events)[keyof typeof events];
 type EventHandler<E extends ClerkEvent> = (payload: EventPayload[E]) => void;
 
 type TokenUpdatePayload = { token: TokenResource | null };
+type InvitationUpdatePayload = { invitation: OrganizationInvitationResource };
 
 type EventPayload = {
   [events.TokenUpdate]: TokenUpdatePayload;
+  [events.InvitationUpdate]: InvitationUpdatePayload;
 };
 
 const createEventBus = () => {


### PR DESCRIPTION
## Description

Attempt to replace some `__unstable` handlers with events.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
