### PR TITLE
chore(repo): Replace clerk.dev with clerk.com

### DIFF
--- a/.changeset/friendly-vans-develop.md
+++ b/.changeset/friendly-vans-develop.md
@@ -1,0 +1,12 @@
+---
+'gatsby-plugin-clerk': patch
+'@clerk/clerk-js': patch
+'@clerk/clerk-sdk-node': patch
+'@clerk/backend': patch
+'@clerk/fastify': patch
+'@clerk/nextjs': patch
+'@clerk/shared': patch
+'@clerk/clerk-expo': patch
+---
+
+Internal update default apiUrl domain from clerk.dev to clerk.com

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -1,4 +1,4 @@
-export const API_URL = 'https://api.clerk.dev';
+export const API_URL = 'https://api.clerk.com';
 export const API_VERSION = 'v1';
 
 // TODO: Get information from package.json or define them from ESBuild

--- a/packages/backend/src/tokens/keys.test.ts
+++ b/packages/backend/src/tokens/keys.test.ts
@@ -54,7 +54,7 @@ export default (QUnit: QUnit) => {
         skipJwksCache: true,
       });
 
-      fakeFetch.calledOnceWith('https://api.clerk.dev/v1/jwks', {
+      fakeFetch.calledOnceWith('https://api.clerk.com/v1/jwks', {
         method: 'GET',
         headers: {
           Authorization: 'Bearer deadbeef',
@@ -73,7 +73,7 @@ export default (QUnit: QUnit) => {
         skipJwksCache: true,
       });
 
-      fakeFetch.calledOnceWith('https://api.clerk.dev/v1/jwks', {
+      fakeFetch.calledOnceWith('https://api.clerk.com/v1/jwks', {
         method: 'GET',
         headers: {
           Authorization: 'Bearer deadbeef',

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -1121,7 +1121,7 @@ describe('Clerk singleton', () => {
                 external_verification_redirect_url: '',
                 error: {
                   code: 'not_allowed_to_sign_up',
-                  long_message: 'You cannot sign up with test@clerk.dev since this is a restricted application.',
+                  long_message: 'You cannot sign up with test@clerk.com since this is a restricted application.',
                   message: 'Not allowed to sign up',
                   meta: {
                     session_id: 'sess_1yDceUR8SIKtQ0gIOO8fNsW7nhe',

--- a/packages/clerk-js/src/core/resources/OrganizationDomain.test.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationDomain.test.ts
@@ -5,7 +5,7 @@ describe('OrganizationDomain', () => {
     const organization = new OrganizationDomain({
       object: 'organization_domain',
       id: 'test_domain_id',
-      name: 'clerk.dev',
+      name: 'clerk.com',
       organization_id: 'test_org_id',
       enrollment_mode: 'manual_invitation',
       verification: {
@@ -14,7 +14,7 @@ describe('OrganizationDomain', () => {
         strategy: 'email_code',
         status: 'verified',
       },
-      affiliation_email_address: 'some@clerk.dev',
+      affiliation_email_address: 'some@clerk.com',
       created_at: 12345,
       updated_at: 5678,
     });
@@ -26,7 +26,7 @@ describe('OrganizationDomain', () => {
     const organization = new OrganizationDomain({
       object: 'organization_domain',
       id: 'test_domain_id',
-      name: 'clerk.dev',
+      name: 'clerk.com',
       organization_id: 'test_org_id',
       enrollment_mode: 'manual_invitation',
       verification: null,

--- a/packages/clerk-js/src/core/resources/User.test.ts
+++ b/packages/clerk-js/src/core/resources/User.test.ts
@@ -74,7 +74,7 @@ describe('User', () => {
     const userWithUnverifiedEmail = new User({
       email_addresses: [
         {
-          emailAddress: 'unverified@clerk.dev',
+          emailAddress: 'unverified@clerk.com',
           verification: null,
         },
       ],
@@ -88,7 +88,7 @@ describe('User', () => {
     const userWithVerifiedEmail = new User({
       email_addresses: [
         {
-          emailAddress: 'unverified@clerk.dev',
+          emailAddress: 'unverified@clerk.com',
           verification: {
             status: 'verified',
           },

--- a/packages/clerk-js/src/core/resources/__snapshots__/OrganizationDomain.test.ts.snap
+++ b/packages/clerk-js/src/core/resources/__snapshots__/OrganizationDomain.test.ts.snap
@@ -7,7 +7,7 @@ OrganizationDomain {
   "delete": [Function],
   "enrollmentMode": "manual_invitation",
   "id": "test_domain_id",
-  "name": "clerk.dev",
+  "name": "clerk.com",
   "organizationId": "test_org_id",
   "pathRoot": "",
   "prepareAffiliationVerification": [Function],
@@ -20,12 +20,12 @@ OrganizationDomain {
 
 exports[`OrganizationDomain has the same initial properties 1`] = `
 OrganizationDomain {
-  "affiliationEmailAddress": "some@clerk.dev",
+  "affiliationEmailAddress": "some@clerk.com",
   "attemptAffiliationVerification": [Function],
   "delete": [Function],
   "enrollmentMode": "manual_invitation",
   "id": "test_domain_id",
-  "name": "clerk.dev",
+  "name": "clerk.com",
   "organizationId": "test_org_id",
   "pathRoot": "",
   "prepareAffiliationVerification": [Function],

--- a/packages/clerk-js/src/core/test/fixtures.ts
+++ b/packages/clerk-js/src/core/test/fixtures.ts
@@ -68,7 +68,7 @@ export const createEmail = (params?: Partial<EmailAddressJSON>): EmailAddressJSO
   return {
     object: 'email_address',
     id: params?.email_address || '',
-    email_address: 'test@clerk.dev',
+    email_address: 'test@clerk.com',
     reserved: false,
     verification: {
       status: 'verified',
@@ -106,7 +106,7 @@ export const createExternalAccount = (params?: Partial<ExternalAccountJSON>): Ex
     identification_id: '98675202',
     provider_user_id: '3232',
     approved_scopes: '',
-    email_address: 'test@clerk.dev',
+    email_address: 'test@clerk.com',
     first_name: 'First name',
     last_name: 'Last name',
     avatar_url: '',

--- a/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/__tests__/CreateOrganization.test.tsx
@@ -72,7 +72,7 @@ describe('CreateOrganization', () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
     const { getByText } = render(<CreateOrganization />, { wrapper });
@@ -83,7 +83,7 @@ describe('CreateOrganization', () => {
     const { wrapper, fixtures, props } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
 
@@ -111,7 +111,7 @@ describe('CreateOrganization', () => {
     const { wrapper, fixtures, props } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
 
@@ -139,7 +139,7 @@ describe('CreateOrganization', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
 
@@ -167,7 +167,7 @@ describe('CreateOrganization', () => {
       const { wrapper, fixtures, props } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
 
@@ -191,7 +191,7 @@ describe('CreateOrganization', () => {
       const { wrapper, fixtures, props } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
 

--- a/packages/clerk-js/src/ui/components/OrganizationList/__tests__/OrganizationList.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/__tests__/OrganizationList.test.tsx
@@ -16,7 +16,7 @@ describe('OrganizationList', () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
 
@@ -40,7 +40,7 @@ describe('OrganizationList', () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
 
@@ -88,7 +88,7 @@ describe('OrganizationList', () => {
       const { wrapper, props } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
         });
       });
@@ -118,7 +118,7 @@ describe('OrganizationList', () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
 
@@ -198,7 +198,7 @@ describe('OrganizationList', () => {
     it('display CreateOrganization within OrganizationList', async () => {
       const { wrapper } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.com'] });
       });
 
       const { queryByLabelText, getByRole, userEvent, queryByRole } = render(<OrganizationList />, { wrapper });
@@ -224,7 +224,7 @@ describe('OrganizationList', () => {
     it('display CreateOrganization and navigates to Invite Members', async () => {
       const { wrapper } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.com'] });
       });
 
       const { getByLabelText, getByRole, userEvent, queryByText } = render(<OrganizationList />, { wrapper });
@@ -247,7 +247,7 @@ describe('OrganizationList', () => {
           f.withOrganizations();
           f.withUser({
             id: 'test_user_id',
-            email_addresses: ['test@clerk.dev'],
+            email_addresses: ['test@clerk.com'],
           });
         });
 
@@ -276,7 +276,7 @@ describe('OrganizationList', () => {
           f.withOrganizations();
           f.withUser({
             id: 'test_user_id',
-            email_addresses: ['test@clerk.dev'],
+            email_addresses: ['test@clerk.com'],
           });
         });
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/InviteMembersPage.test.tsx
@@ -14,7 +14,7 @@ describe('InviteMembersPage', () => {
   it('renders the component', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
 
     const { getByText } = render(<InviteMembersPage />, { wrapper });
@@ -26,7 +26,7 @@ describe('InviteMembersPage', () => {
       const { wrapper } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
         });
       });
@@ -34,7 +34,7 @@ describe('InviteMembersPage', () => {
       const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
       expect(getByRole('button', { name: 'Send invitations' })).toBeDisabled();
 
-      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.dev,');
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
       expect(getByRole('button', { name: 'Send invitations' })).not.toBeDisabled();
     });
 
@@ -42,17 +42,17 @@ describe('InviteMembersPage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
         });
       });
 
       fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
       const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
-      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.dev,');
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
-        emailAddresses: ['test+1@clerk.dev'],
+        emailAddresses: ['test+1@clerk.com'],
         role: 'basic_member' as MembershipRole,
       });
     });
@@ -61,7 +61,7 @@ describe('InviteMembersPage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
         });
       });
@@ -70,11 +70,11 @@ describe('InviteMembersPage', () => {
       const { getByRole, userEvent, getByTestId } = render(<InviteMembersPage />, { wrapper });
       await userEvent.type(
         getByTestId('tag-input'),
-        'test+1@clerk.dev,test+2@clerk.dev,test+3@clerk.dev,test+4@clerk.dev,',
+        'test+1@clerk.com,test+2@clerk.com,test+3@clerk.com,test+4@clerk.com,',
       );
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
-        emailAddresses: ['test+1@clerk.dev', 'test+2@clerk.dev', 'test+3@clerk.dev', 'test+4@clerk.dev'],
+        emailAddresses: ['test+1@clerk.com', 'test+2@clerk.com', 'test+3@clerk.com', 'test+4@clerk.com'],
         role: 'basic_member' as MembershipRole,
       });
     });
@@ -83,19 +83,19 @@ describe('InviteMembersPage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
         });
       });
 
       fixtures.clerk.organization?.inviteMembers.mockResolvedValueOnce([{}] as OrganizationInvitationResource[]);
       const { getByRole, userEvent, getByText, getByTestId } = render(<InviteMembersPage />, { wrapper });
-      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.dev,');
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
       await userEvent.click(getByRole('button', { name: 'Member' }));
       await userEvent.click(getByText('Admin'));
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       expect(fixtures.clerk.organization?.inviteMembers).toHaveBeenCalledWith({
-        emailAddresses: ['test+1@clerk.dev'],
+        emailAddresses: ['test+1@clerk.com'],
         role: 'admin' as MembershipRole,
       });
     });
@@ -104,7 +104,7 @@ describe('InviteMembersPage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
         });
       });
@@ -114,21 +114,21 @@ describe('InviteMembersPage', () => {
           data: [
             {
               code: 'duplicate_record',
-              long_message: 'There are already pending invitations for the following email addresses: test+1@clerk.dev',
+              long_message: 'There are already pending invitations for the following email addresses: test+1@clerk.com',
               message: 'duplicate invitation',
-              meta: { email_addresses: ['test+5@clerk.dev', 'test+6@clerk.dev', 'test+7@clerk.dev'] },
+              meta: { email_addresses: ['test+5@clerk.com', 'test+6@clerk.com', 'test+7@clerk.com'] },
             },
           ],
           status: 400,
         }),
       );
       const { getByRole, userEvent, getByText, getByTestId } = render(<InviteMembersPage />, { wrapper });
-      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.dev,');
+      await userEvent.type(getByTestId('tag-input'), 'test+1@clerk.com,');
       await userEvent.click(getByRole('button', { name: 'Send invitations' }));
       await waitFor(() =>
         expect(
           getByText(
-            'The invitations could not be sent. There are already pending invitations for the following email addresses: test+5@clerk.dev, test+6@clerk.dev, and test+7@clerk.dev.',
+            'The invitations could not be sent. There are already pending invitations for the following email addresses: test+5@clerk.com, test+6@clerk.com, and test+7@clerk.com.',
           ),
         ).toBeInTheDocument(),
       );
@@ -199,7 +199,7 @@ describe('InviteMembersPage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'admin' }],
         });
       });

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/LeaveOrganizationPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/LeaveOrganizationPage.test.tsx
@@ -13,7 +13,7 @@ describe('LeaveOrganizationPage', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
       });
     });
@@ -36,7 +36,7 @@ describe('LeaveOrganizationPage', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
       });
     });

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationMembers.test.tsx
@@ -14,7 +14,7 @@ describe('OrganizationMembers', () => {
   it('renders the Organization Members page', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: ['Org1'] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1'] });
     });
 
     fixtures.clerk.session?.isAuthorized.mockResolvedValue(true);
@@ -37,7 +37,7 @@ describe('OrganizationMembers', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withOrganizationDomains();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: ['Org1'] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1'] });
     });
 
     fixtures.clerk.session?.isAuthorized.mockResolvedValue(true);
@@ -52,7 +52,7 @@ describe('OrganizationMembers', () => {
   it('shows an invite button inside invitations tab if the current user is an admin', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
 
     fixtures.clerk.session?.isAuthorized.mockResolvedValue(true);
@@ -70,7 +70,7 @@ describe('OrganizationMembers', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1' }],
       });
     });
@@ -89,7 +89,7 @@ describe('OrganizationMembers', () => {
   it('navigates to invite screen when user clicks on Invite button', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
 
     fixtures.clerk.session?.isAuthorized.mockResolvedValue(true);
@@ -136,7 +136,7 @@ describe('OrganizationMembers', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', id: '1' }],
       });
     });
@@ -198,7 +198,7 @@ describe('OrganizationMembers', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', id: '1' }],
       });
     });
@@ -228,7 +228,7 @@ describe('OrganizationMembers', () => {
       f.withOrganizations();
       f.withOrganizationDomains();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', id: '1' }],
       });
     });
@@ -257,14 +257,14 @@ describe('OrganizationMembers', () => {
       createFakeOrganizationInvitation({
         id: '1',
         role: 'admin',
-        emailAddress: 'admin1@clerk.dev',
+        emailAddress: 'admin1@clerk.com',
         organizationId: '1',
         createdAt: new Date('2022-01-01'),
       }),
       createFakeOrganizationInvitation({
         id: '2',
         role: 'basic_member',
-        emailAddress: 'member2@clerk.dev',
+        emailAddress: 'member2@clerk.com',
         organizationId: '1',
         createdAt: new Date('2022-01-01'),
       }),
@@ -272,7 +272,7 @@ describe('OrganizationMembers', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', id: '1' }],
       });
     });
@@ -288,9 +288,9 @@ describe('OrganizationMembers', () => {
     const { queryByText, findByRole } = render(<OrganizationMembers />, { wrapper });
     await userEvent.click(await findByRole('tab', { name: 'Invitations' }));
     expect(fixtures.clerk.organization?.getInvitations).toHaveBeenCalled();
-    expect(queryByText('admin1@clerk.dev')).toBeInTheDocument();
+    expect(queryByText('admin1@clerk.com')).toBeInTheDocument();
     expect(queryByText('Admin')).toBeInTheDocument();
-    expect(queryByText('member2@clerk.dev')).toBeInTheDocument();
+    expect(queryByText('member2@clerk.com')).toBeInTheDocument();
     expect(queryByText('Member')).toBeInTheDocument();
   });
 
@@ -301,7 +301,7 @@ describe('OrganizationMembers', () => {
           id: '1',
           publicUserData: {
             userId: '1',
-            identifier: 'admin1@clerk.dev',
+            identifier: 'admin1@clerk.com',
           },
           organizationId: '1',
           createdAt: new Date('2022-01-01'),
@@ -310,7 +310,7 @@ describe('OrganizationMembers', () => {
           id: '2',
           publicUserData: {
             userId: '1',
-            identifier: 'member2@clerk.dev',
+            identifier: 'member2@clerk.com',
           },
           organizationId: '1',
           createdAt: new Date('2022-01-01'),
@@ -322,7 +322,7 @@ describe('OrganizationMembers', () => {
       f.withOrganizations();
       f.withOrganizationDomains();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', id: '1' }],
       });
     });
@@ -348,8 +348,8 @@ describe('OrganizationMembers', () => {
       status: 'pending',
     });
 
-    expect(queryByText('admin1@clerk.dev')).toBeInTheDocument();
-    expect(queryByText('member2@clerk.dev')).toBeInTheDocument();
+    expect(queryByText('admin1@clerk.com')).toBeInTheDocument();
+    expect(queryByText('member2@clerk.com')).toBeInTheDocument();
   });
 
   it('shows the "You" badge when the member id from the list matches the current session user id', async () => {
@@ -361,7 +361,7 @@ describe('OrganizationMembers', () => {
       f.withOrganizations();
       f.withUser({
         id: '1',
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', id: '1' }],
       });
     });

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationProfile.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationProfile.test.tsx
@@ -12,7 +12,7 @@ describe('OrganizationProfile', () => {
   it('includes buttons for the bigger sections', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: ['Org1'] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1'] });
     });
 
     const { getByText } = render(<OrganizationProfile />, { wrapper });

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationSettings.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/OrganizationSettings.test.tsx
@@ -13,12 +13,12 @@ describe('OrganizationSettings', () => {
   it.skip('enables organization profile button and disables leave when user is the only admin', async () => {
     const adminsList: OrganizationMembershipResource[] = [createFakeMember({ id: '1', orgId: '1', role: 'admin' })];
     const domainList: OrganizationDomainResource[] = [
-      createFakeDomain({ id: '1', organizationId: '1', name: 'clerk.dev' }),
+      createFakeDomain({ id: '1', organizationId: '1', name: 'clerk.com' }),
     ];
 
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: [{ name: 'Org1' }] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1' }] });
     });
 
     fixtures.clerk.organization?.getMemberships.mockReturnValue(Promise.resolve({ data: adminsList, total_count: 1 }));
@@ -40,12 +40,12 @@ describe('OrganizationSettings', () => {
 
   it('enables organization profile button and enables leave when user is admin and there is more', async () => {
     const domainList: OrganizationDomainResource[] = [
-      createFakeDomain({ id: '1', organizationId: '1', name: 'clerk.dev' }),
+      createFakeDomain({ id: '1', organizationId: '1', name: 'clerk.com' }),
     ];
 
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: [{ name: 'Org1' }] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1' }] });
     });
 
     fixtures.clerk.organization?.getDomains.mockReturnValue(
@@ -69,7 +69,7 @@ describe('OrganizationSettings', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
       });
     });
@@ -90,7 +90,7 @@ describe('OrganizationSettings', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -108,7 +108,7 @@ describe('OrganizationSettings', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', admin_delete_enabled: true }],
         });
       });
@@ -139,7 +139,7 @@ describe('OrganizationSettings', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', admin_delete_enabled: true }],
         });
       });
@@ -162,7 +162,7 @@ describe('OrganizationSettings', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1' }],
         });
       });
@@ -187,7 +187,7 @@ describe('OrganizationSettings', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/ProfileSettingsPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/__tests__/ProfileSettingsPage.test.tsx
@@ -12,7 +12,7 @@ describe('ProfileSettingsPage', () => {
   it('renders the component', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
+      f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: [{ name: 'Org1', role: 'admin' }] });
     });
 
     const { getByDisplayValue } = render(<ProfileSettingsPage />, { wrapper });
@@ -23,7 +23,7 @@ describe('ProfileSettingsPage', () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', slug: '', role: 'admin' }],
       });
     });
@@ -38,7 +38,7 @@ describe('ProfileSettingsPage', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', slug: '', role: 'admin' }],
       });
     });
@@ -55,7 +55,7 @@ describe('ProfileSettingsPage', () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', slug: '', role: 'admin' }],
       });
     });
@@ -72,7 +72,7 @@ describe('ProfileSettingsPage', () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', slug: '', role: 'admin' }],
       });
     });

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/__tests__/OrganizationSwitcher.test.tsx
@@ -12,7 +12,7 @@ describe('OrganizationSwitcher', () => {
   it('renders component', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withOrganizations();
-      f.withUser({ email_addresses: ['test@clerk.dev'] });
+      f.withUser({ email_addresses: ['test@clerk.com'] });
     });
     fixtures.clerk.session?.isAuthorized.mockResolvedValue(false);
     const { queryByRole } = await act(() => render(<OrganizationSwitcher />, { wrapper }));
@@ -23,7 +23,7 @@ describe('OrganizationSwitcher', () => {
     it('shows the personal workspace when enabled', async () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.com'] });
       });
       fixtures.clerk.session?.isAuthorized.mockResolvedValue(false);
       props.setProps({ hidePersonal: false });
@@ -34,7 +34,7 @@ describe('OrganizationSwitcher', () => {
     it('does not show the personal workspace when disabled', async () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.com'] });
       });
       fixtures.clerk.session?.isAuthorized.mockResolvedValue(false);
       props.setProps({ hidePersonal: true });
@@ -49,7 +49,7 @@ describe('OrganizationSwitcher', () => {
     it('shows the counter for pending suggestions and invitations', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.com'] });
       });
 
       fixtures.clerk.user?.getOrganizationInvitations.mockReturnValueOnce(
@@ -82,7 +82,7 @@ describe('OrganizationSwitcher', () => {
         f.withOrganizations();
         f.withOrganizationDomains();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', id: '1', role: 'admin' }],
         });
       });
@@ -124,7 +124,7 @@ describe('OrganizationSwitcher', () => {
     it('opens the organization switcher popover when clicked', async () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'], create_organization_enabled: true });
+        f.withUser({ email_addresses: ['test@clerk.com'], create_organization_enabled: true });
       });
       fixtures.clerk.session?.isAuthorized.mockResolvedValue(false);
       props.setProps({ hidePersonal: true });
@@ -136,7 +136,7 @@ describe('OrganizationSwitcher', () => {
     it('lists all organizations the user belongs to', async () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
-        f.withUser({ email_addresses: ['test@clerk.dev'], organization_memberships: ['Org1', 'Org2'] });
+        f.withUser({ email_addresses: ['test@clerk.com'], organization_memberships: ['Org1', 'Org2'] });
       });
       fixtures.clerk.session?.isAuthorized.mockResolvedValue(false);
       props.setProps({ hidePersonal: false });
@@ -155,7 +155,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: role as MembershipRole }],
         });
       });
@@ -171,7 +171,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, fixtures, props } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -187,7 +187,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, fixtures, props } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
           create_organization_enabled: true,
         });
@@ -204,7 +204,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
           create_organization_enabled: false,
         });
@@ -219,7 +219,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
           create_organization_enabled: false,
         });
@@ -263,7 +263,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
           create_organization_enabled: false,
         });
@@ -309,7 +309,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, props, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [
             { name: 'Org1', role: 'basic_member' },
             { name: 'Org2', role: 'admin' },
@@ -338,7 +338,7 @@ describe('OrganizationSwitcher', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [
             { name: 'Org1', role: 'basic_member' },
             { name: 'Org2', role: 'admin' },

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/ResetPassword.test.tsx
@@ -43,7 +43,7 @@ describe('ResetPassword', () => {
   });
 
   it('renders a hidden identifier field', async () => {
-    const identifier = 'test@clerk.dev';
+    const identifier = 'test@clerk.com';
     const { wrapper } = await createFixtures(f => {
       f.startSignInWithEmailAddress({ identifier });
     });

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInAccountSwitcher.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInAccountSwitcher.test.tsx
@@ -7,9 +7,9 @@ const { createFixtures } = bindCreateFixtures('SignIn');
 
 const initConfig = createFixtures.config(f => {
   f.withMultiSessionMode();
-  f.withUser({ first_name: 'Nick', last_name: 'Kouk', email_addresses: ['test1@clerk.dev'] });
-  f.withUser({ first_name: 'Mike', last_name: 'Lamar', email_addresses: ['test2@clerk.dev'] });
-  f.withUser({ first_name: 'Graciela', last_name: 'Brennan', email_addresses: ['test3@clerk.dev'] });
+  f.withUser({ first_name: 'Nick', last_name: 'Kouk', email_addresses: ['test1@clerk.com'] });
+  f.withUser({ first_name: 'Mike', last_name: 'Lamar', email_addresses: ['test2@clerk.com'] });
+  f.withUser({ first_name: 'Graciela', last_name: 'Brennan', email_addresses: ['test3@clerk.com'] });
 });
 
 describe('SignInAccountSwitcher', () => {

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInFactorOne.test.tsx
@@ -25,11 +25,11 @@ describe('SignInFactorOne', () => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress({ first_factors: ['email_code', 'email_link'] });
       f.withPassword();
-      f.startSignInWithEmailAddress({ supportEmailCode: true, supportEmailLink: true, identifier: 'test@clerk.dev' });
+      f.startSignInWithEmailAddress({ supportEmailCode: true, supportEmailLink: true, identifier: 'test@clerk.com' });
     });
 
     render(<SignInFactorOne />, { wrapper });
-    screen.getByText('test@clerk.dev');
+    screen.getByText('test@clerk.com');
   });
 
   it('prefills the phone number if the identifier is a phone number', async () => {
@@ -123,7 +123,7 @@ describe('SignInFactorOne', () => {
       });
 
       it('should render the other methods component when clicking on "Forgot password"', async () => {
-        const email = 'test@clerk.dev';
+        const email = 'test@clerk.com';
         const { wrapper } = await createFixtures(f => {
           f.withEmailAddress();
           f.withPassword();
@@ -489,7 +489,7 @@ describe('SignInFactorOne', () => {
 
   describe('Use another method', () => {
     it('should render the other authentication methods list component when clicking on "Use another method"', async () => {
-      const email = 'test@clerk.dev';
+      const email = 'test@clerk.com';
       const { wrapper } = await createFixtures(f => {
         f.withEmailAddress({ first_factors: ['email_code', 'email_link'] });
         f.withPassword();
@@ -504,7 +504,7 @@ describe('SignInFactorOne', () => {
     });
 
     it('"Use another method" should not exist if only the current strategy is available', async () => {
-      const email = 'test@clerk.dev';
+      const email = 'test@clerk.com';
       const { wrapper } = await createFixtures(f => {
         f.withEmailAddress({ first_factors: [], verifications: [] });
         f.withPassword();
@@ -536,7 +536,7 @@ describe('SignInFactorOne', () => {
     });
 
     it('should list all the enabled first factor methods', async () => {
-      const email = 'test@clerk.dev';
+      const email = 'test@clerk.com';
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withEmailAddress();
         f.withPassword();
@@ -552,7 +552,7 @@ describe('SignInFactorOne', () => {
     });
 
     it('should list enabled first factor methods without the current one', async () => {
-      const email = 'test@clerk.dev';
+      const email = 'test@clerk.com';
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withSocialProvider({ provider: 'google' });
         f.withEmailAddress();
@@ -586,7 +586,7 @@ describe('SignInFactorOne', () => {
     });
 
     it('clicking the email link method should show the magic link screen', async () => {
-      const email = 'test@clerk.dev';
+      const email = 'test@clerk.com';
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withEmailAddress();
         f.withPassword();
@@ -610,7 +610,7 @@ describe('SignInFactorOne', () => {
     });
 
     it('clicking the email code method should show the email code input', async () => {
-      const email = 'test@clerk.dev';
+      const email = 'test@clerk.com';
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withEmailAddress();
         f.withPassword();

--- a/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignIn/__tests__/SignInStart.test.tsx
@@ -90,7 +90,7 @@ describe('SignInStart', () => {
       });
       fixtures.signIn.create.mockReturnValueOnce(Promise.resolve({ status: 'needs_first_factor' } as SignInResource));
       const { userEvent } = render(<SignInStart />, { wrapper });
-      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.dev');
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
       await userEvent.click(screen.getByText('Continue'));
       expect(fixtures.signIn.create).toHaveBeenCalled();
     });
@@ -101,7 +101,7 @@ describe('SignInStart', () => {
       });
       fixtures.signIn.create.mockReturnValueOnce(Promise.resolve({ status: 'needs_first_factor' } as SignInResource));
       const { userEvent } = render(<SignInStart />, { wrapper });
-      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.dev');
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
       await userEvent.click(screen.getByText('Continue'));
       expect(fixtures.signIn.create).toHaveBeenCalled();
       expect(fixtures.router.navigate).toHaveBeenCalledWith('factor-one');
@@ -114,7 +114,7 @@ describe('SignInStart', () => {
       fixtures.signIn.create.mockReturnValueOnce(Promise.resolve({ status: 'needs_second_factor' } as SignInResource));
       const { userEvent } = render(<SignInStart />, { wrapper });
       expect(screen.getByText('Continue')).toBeInTheDocument();
-      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.dev');
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
       await userEvent.click(screen.getByText('Continue'));
       expect(fixtures.signIn.create).toHaveBeenCalled();
       expect(fixtures.router.navigate).toHaveBeenCalledWith('factor-two');
@@ -133,7 +133,7 @@ describe('SignInStart', () => {
         } as unknown as SignInResource),
       );
       const { userEvent } = render(<SignInStart />, { wrapper });
-      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.dev');
+      await userEvent.type(screen.getByLabelText(/email address/i), 'hello@clerk.com');
       await userEvent.click(screen.getByText('Continue'));
       expect(fixtures.signIn.create).toHaveBeenCalled();
       expect(fixtures.signIn.authenticateWithRedirect).toHaveBeenCalledWith({

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpStart.test.tsx
@@ -154,14 +154,14 @@ describe('SignUpStart', () => {
         f.withName({ required: true });
       });
 
-      fixtures.clerk.client.signUp.emailAddress = 'george@clerk.dev';
+      fixtures.clerk.client.signUp.emailAddress = 'george@clerk.com';
       fixtures.clerk.client.signUp.firstName = 'George';
       fixtures.clerk.client.signUp.lastName = 'Clerk';
       fixtures.clerk.client.signUp.phoneNumber = '+1123456789';
 
       const screen = render(<SignUpStart />, { wrapper });
 
-      expect(screen.getByRole('textbox', { name: 'Email address' })).toHaveValue('george@clerk.dev');
+      expect(screen.getByRole('textbox', { name: 'Email address' })).toHaveValue('george@clerk.com');
       expect(screen.getByRole('textbox', { name: 'First name' })).toHaveValue('George');
       expect(screen.getByRole('textbox', { name: 'Last name' })).toHaveValue('Clerk');
       expect(screen.getByRole('textbox', { name: 'Phone number' })).toHaveValue('(123) 456-789');

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyEmail.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyEmail.test.tsx
@@ -15,16 +15,16 @@ describe('SignUpVerifyEmail', () => {
   it('shows the email associated with the sign up', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withEmailAddress({ required: true });
-      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.dev' });
+      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
     render(<SignUpVerifyEmail />, { wrapper });
-    screen.getByText('test@clerk.dev');
+    screen.getByText('test@clerk.com');
   });
 
   it('shows the verify with link message', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true, verifications: ['email_link'] });
-      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.dev' });
+      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
     fixtures.signUp.createEmailLinkFlow.mockImplementation(
       () =>
@@ -41,7 +41,7 @@ describe('SignUpVerifyEmail', () => {
   it('shows the verify with code message', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true, verifications: ['email_code'] });
-      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.dev' });
+      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
     fixtures.signUp.createEmailLinkFlow.mockImplementation(
       () =>
@@ -58,7 +58,7 @@ describe('SignUpVerifyEmail', () => {
   it('clicking on the edit icon navigates to the previous route', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true });
-      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.dev' });
+      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
     const { userEvent } = render(<SignUpVerifyEmail />, { wrapper });
     await userEvent.click(
@@ -72,7 +72,7 @@ describe('SignUpVerifyEmail', () => {
   it('Resend link button exists', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true, verifications: ['email_link'] });
-      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.dev' });
+      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
     fixtures.signUp.createEmailLinkFlow.mockImplementation(
       () =>
@@ -90,7 +90,7 @@ describe('SignUpVerifyEmail', () => {
   it('Resend code button exists', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
       f.withEmailAddress({ required: true, verifications: ['email_code'] });
-      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.dev' });
+      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
     fixtures.signUp.createEmailLinkFlow.mockImplementation(
       () =>

--- a/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyPhone.test.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/__tests__/SignUpVerifyPhone.test.tsx
@@ -47,7 +47,7 @@ describe('SignUpVerifyPhone', () => {
   it('Resend code button exists', async () => {
     const { wrapper } = await createFixtures(f => {
       f.withPhoneNumber({ required: true });
-      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.dev' });
+      f.startSignUpWithEmailAddress({ emailAddress: 'test@clerk.com' });
     });
     render(<SignUpVerifyPhone />, { wrapper });
     const resendButton = screen.getByText(/Resend/i);

--- a/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserButton/__tests__/UserButton.test.tsx
@@ -15,7 +15,7 @@ describe('UserButton', () => {
 
   it('renders button when there is a user', async () => {
     const { wrapper } = await createFixtures(f => {
-      f.withUser({ email_addresses: ['test@clerk.dev'] });
+      f.withUser({ email_addresses: ['test@clerk.com'] });
     });
     const { queryByRole } = render(<UserButton />, { wrapper });
     expect(queryByRole('button')).not.toBeNull();
@@ -27,7 +27,7 @@ describe('UserButton', () => {
         first_name: 'First',
         last_name: 'Last',
         username: 'username1',
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
     const { getByText, getByRole, userEvent } = render(<UserButton />, { wrapper });
@@ -41,7 +41,7 @@ describe('UserButton', () => {
         first_name: 'First',
         last_name: 'Last',
         username: 'username1',
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
     const { getByText, getByRole, userEvent } = render(<UserButton />, { wrapper });
@@ -56,7 +56,7 @@ describe('UserButton', () => {
         first_name: 'First',
         last_name: 'Last',
         username: 'username1',
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
     const { getByText, getByRole, userEvent } = render(<UserButton />, { wrapper });
@@ -75,21 +75,21 @@ describe('UserButton', () => {
         first_name: 'First1',
         last_name: 'Last1',
         username: 'username1',
-        email_addresses: ['test1@clerk.dev'],
+        email_addresses: ['test1@clerk.com'],
       });
       f.withUser({
         id: '2',
         first_name: 'First2',
         last_name: 'Last2',
         username: 'username2',
-        email_addresses: ['test2@clerk.dev'],
+        email_addresses: ['test2@clerk.com'],
       });
       f.withUser({
         id: '3',
         first_name: 'First3',
         last_name: 'Last3',
         username: 'username3',
-        email_addresses: ['test3@clerk.dev'],
+        email_addresses: ['test3@clerk.com'],
       });
     });
 
@@ -130,7 +130,7 @@ describe('UserButton', () => {
           first_name: 'TestFirstName',
           last_name: 'TestLastName',
           username: 'username1',
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       props.setProps({ showName: true });
@@ -140,7 +140,7 @@ describe('UserButton', () => {
 
     it('gives priority to showing username next to the button over email', async () => {
       const { wrapper, props } = await createFixtures(f => {
-        f.withUser({ first_name: '', last_name: '', username: 'username1', email_addresses: ['test@clerk.dev'] });
+        f.withUser({ first_name: '', last_name: '', username: 'username1', email_addresses: ['test@clerk.com'] });
       });
       props.setProps({ showName: true });
       const { getByText } = render(<UserButton />, { wrapper });
@@ -149,11 +149,11 @@ describe('UserButton', () => {
 
     it('shows email next to the button if there is no username or first/last name', async () => {
       const { wrapper, props } = await createFixtures(f => {
-        f.withUser({ first_name: '', last_name: '', username: '', email_addresses: ['test@clerk.dev'] });
+        f.withUser({ first_name: '', last_name: '', username: '', email_addresses: ['test@clerk.com'] });
       });
       props.setProps({ showName: true });
       const { getByText } = render(<UserButton />, { wrapper });
-      expect(getByText('test@clerk.dev')).toBeDefined();
+      expect(getByText('test@clerk.com')).toBeDefined();
     });
 
     it('does not show an identifier next to the button', async () => {
@@ -162,7 +162,7 @@ describe('UserButton', () => {
           first_name: 'TestFirstName',
           last_name: 'TestLastName',
           username: 'username1',
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       props.setProps({ showName: false });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/EmailPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/EmailPage.test.tsx
@@ -8,7 +8,7 @@ const { createFixtures } = bindCreateFixtures('UserProfile');
 
 const initConfig = createFixtures.config(f => {
   f.withEmailAddress();
-  f.withUser({ email_addresses: [{ email_address: 'test@clerk.dev' }] });
+  f.withUser({ email_addresses: [{ email_address: 'test@clerk.com' }] });
 });
 
 describe('EmailPage', () => {
@@ -58,9 +58,9 @@ describe('EmailPage', () => {
       fixtures.clerk.user!.createEmailAddress.mockReturnValueOnce(Promise.resolve({} as any));
       const { userEvent } = render(<EmailPage />, { wrapper });
 
-      await userEvent.type(screen.getByLabelText(/email address/i), 'test+2@clerk.dev');
+      await userEvent.type(screen.getByLabelText(/email address/i), 'test+2@clerk.com');
       await userEvent.click(screen.getByText(/continue/i));
-      expect(fixtures.clerk.user?.createEmailAddress).toHaveBeenCalledWith({ email: 'test+2@clerk.dev' });
+      expect(fixtures.clerk.user?.createEmailAddress).toHaveBeenCalledWith({ email: 'test+2@clerk.com' });
     });
   });
 

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/MfaBackupCodeCreatePage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/MfaBackupCodeCreatePage.test.tsx
@@ -8,7 +8,7 @@ import { MfaBackupCodeCreatePage } from '../MfaBackupCodeCreatePage';
 const { createFixtures } = bindCreateFixtures('UserProfile');
 
 const initConfig = createFixtures.config(f => {
-  f.withUser({ email_addresses: ['test@clerk.dev'] });
+  f.withUser({ email_addresses: ['test@clerk.com'] });
 });
 
 describe('MfaBackupCodeCreatePage', () => {

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PasswordPage.test.tsx
@@ -41,7 +41,7 @@ describe('PasswordPage', () => {
   });
 
   it('renders a hidden identifier field', async () => {
-    const identifier = 'test@clerk.dev';
+    const identifier = 'test@clerk.com';
     const { wrapper } = await createFixtures(f => {
       f.startSignInWithEmailAddress({ identifier });
     });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/PhonePage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/PhonePage.test.tsx
@@ -8,7 +8,7 @@ const { createFixtures } = bindCreateFixtures('UserProfile');
 
 const initConfig = createFixtures.config(f => {
   f.withPhoneNumber();
-  f.withUser({ email_addresses: ['test@clerk.dev'] });
+  f.withUser({ email_addresses: ['test@clerk.com'] });
 });
 
 describe('PhonePage', () => {

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/ProfilePage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/ProfilePage.test.tsx
@@ -9,14 +9,14 @@ const { createFixtures } = bindCreateFixtures('UserProfile');
 describe('ProfilePage', () => {
   it('renders the component', async () => {
     const { wrapper } = await createFixtures(f => {
-      f.withUser({ email_addresses: ['test@clerk.dev'] });
+      f.withUser({ email_addresses: ['test@clerk.com'] });
     });
     render(<ProfilePage />, { wrapper });
   });
 
   it('shows the title', async () => {
     const { wrapper } = await createFixtures(f => {
-      f.withUser({ email_addresses: ['test@clerk.dev'] });
+      f.withUser({ email_addresses: ['test@clerk.com'] });
     });
     render(<ProfilePage />, { wrapper });
 
@@ -28,7 +28,7 @@ describe('ProfilePage', () => {
       const { wrapper } = await createFixtures(f => {
         f.withName();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           first_name: 'F',
           last_name: 'L',
         });
@@ -120,7 +120,7 @@ describe('ProfilePage', () => {
     it('shows the image', async () => {
       const { wrapper } = await createFixtures(f => {
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           profile_image_url: 'https://clerk.com',
           image_url: 'https://clerk.com',
           first_name: 'F',
@@ -135,7 +135,7 @@ describe('ProfilePage', () => {
     it('clicking "Upload image" opens the "Upload" section', async () => {
       const { wrapper } = await createFixtures(f => {
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       const { userEvent } = render(<ProfilePage />, { wrapper });
@@ -148,7 +148,7 @@ describe('ProfilePage', () => {
     it('clicking "Remove image" calls the appropriate function', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           profile_image_url: 'https://clerk.com',
           image_url:
             'https://img.clerkstage.dev/70726f78792f68747470733a2f2f696d616765732e6c636c636c65726b2e636f6d2f75706c6f616465642f696d675f324f4559646f346e575263766579536c6a366b7775757a336e79472e6a706567',
@@ -164,7 +164,7 @@ describe('ProfilePage', () => {
     xit('"Remove image" is not shown when a default image exists', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           image_url:
             'https://img.clerkstage.dev/64656661756c742f696e735f3248326461375851494c494b727555654e464967456b73396878362f757365725f3249454d6b59705573514465427162327564677843717565345757?initials=GD',
         });
@@ -181,7 +181,7 @@ describe('ProfilePage', () => {
       const { wrapper } = await createFixtures(f => {
         f.withName();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       render(<ProfilePage />, { wrapper });
@@ -194,7 +194,7 @@ describe('ProfilePage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withName();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       const { userEvent } = render(<ProfilePage />, { wrapper });
@@ -207,7 +207,7 @@ describe('ProfilePage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withName();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       const { userEvent } = render(<ProfilePage />, { wrapper });
@@ -220,7 +220,7 @@ describe('ProfilePage', () => {
       const { wrapper } = await createFixtures(f => {
         f.withName();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       render(<ProfilePage />, { wrapper });
@@ -232,7 +232,7 @@ describe('ProfilePage', () => {
       const { wrapper } = await createFixtures(f => {
         f.withName();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
         });
       });
       const { userEvent } = render(<ProfilePage />, { wrapper });
@@ -246,7 +246,7 @@ describe('ProfilePage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withName();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           first_name: 'F',
           last_name: 'L',
         });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/RemoveEmailPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/RemoveEmailPage.test.tsx
@@ -8,7 +8,7 @@ const { createFixtures } = bindCreateFixtures('UserProfile');
 
 const initConfig = createFixtures.config(f => {
   f.withEmailAddress();
-  f.withUser({ email_addresses: [{ email_address: 'test@clerk.dev', id: 'id' }] });
+  f.withUser({ email_addresses: [{ email_address: 'test@clerk.com', id: 'id' }] });
 });
 
 describe('RemoveEmailPage', () => {
@@ -35,7 +35,7 @@ describe('RemoveEmailPage', () => {
       fixtures.router.params.id = 'id';
       render(<RemoveEmailPage />, { wrapper });
 
-      screen.getByText(/test@clerk.dev/);
+      screen.getByText(/test@clerk.com/);
     });
   });
 

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/RemoveMfaTOTPPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/RemoveMfaTOTPPage.test.tsx
@@ -8,7 +8,7 @@ import { RemoveMfaTOTPPage } from '../RemoveResourcePage';
 const { createFixtures } = bindCreateFixtures('UserProfile');
 
 const initConfig = createFixtures.config(f => {
-  f.withUser({ email_addresses: ['test@clerk.dev'] });
+  f.withUser({ email_addresses: ['test@clerk.com'] });
 });
 
 describe('RemoveMfaTOTPPAge', () => {

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/RootPage.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/RootPage.test.tsx
@@ -10,7 +10,7 @@ const { createFixtures } = bindCreateFixtures('UserProfile');
 describe('RootPage', () => {
   it('renders the component', async () => {
     const { wrapper, fixtures } = await createFixtures(f => {
-      f.withUser({ email_addresses: ['test@clerk.dev'] });
+      f.withUser({ email_addresses: ['test@clerk.com'] });
     });
     fixtures.clerk.user?.getSessions.mockReturnValue(Promise.resolve([]));
 
@@ -21,7 +21,7 @@ describe('RootPage', () => {
   describe('Sections', () => {
     it('shows the bigger sections', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.com'] });
       });
       fixtures.clerk.user!.getSessions.mockReturnValue(Promise.resolve([]));
 
@@ -33,7 +33,7 @@ describe('RootPage', () => {
 
     it('shows the profile section along with the identifier of the user and has a button', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
-        f.withUser({ email_addresses: ['test@clerk.dev'], first_name: 'George', last_name: 'Clerk' });
+        f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'George', last_name: 'Clerk' });
       });
       fixtures.clerk.user!.getSessions.mockReturnValue(Promise.resolve([]));
 
@@ -46,7 +46,7 @@ describe('RootPage', () => {
 
     it('shows the profile section along with the identifier of the user and has a button', async () => {
       const { wrapper, fixtures } = await createFixtures(f => {
-        f.withUser({ email_addresses: ['test@clerk.dev'], first_name: 'George', last_name: 'Clerk' });
+        f.withUser({ email_addresses: ['test@clerk.com'], first_name: 'George', last_name: 'Clerk' });
       });
       fixtures.clerk.user!.getSessions.mockReturnValue(Promise.resolve([]));
 
@@ -58,7 +58,7 @@ describe('RootPage', () => {
     });
 
     it('shows the email addresses section with the email addresses of the user and has appropriate buttons', async () => {
-      const emails = ['test@clerk.dev', 'test2@clerk.dev'];
+      const emails = ['test@clerk.com', 'test2@clerk.com'];
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withEmailAddress();
         f.withUser({
@@ -109,7 +109,7 @@ describe('RootPage', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withSocialProvider({ provider: 'google' });
         f.withUser({
-          external_accounts: [{ provider: 'google', email_address: 'testgoogle@clerk.dev' }],
+          external_accounts: [{ provider: 'google', email_address: 'testgoogle@clerk.com' }],
           first_name: 'George',
           last_name: 'Clerk',
         });
@@ -119,7 +119,7 @@ describe('RootPage', () => {
       render(<RootPage />, { wrapper });
       await waitFor(() => expect(fixtures.clerk.user?.getSessions).toHaveBeenCalled());
       screen.getByText(/Connected Accounts/i);
-      screen.getByText(/testgoogle@clerk.dev/i);
+      screen.getByText(/testgoogle@clerk.com/i);
       const externalAccountButton = screen.getByText(/google/i);
       expect(externalAccountButton.closest('button')).not.toBeNull();
     });

--- a/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/__tests__/UserProfile.test.tsx
@@ -11,7 +11,7 @@ describe('UserProfile', () => {
   describe('Navigation', () => {
     it('includes buttons for the bigger sections', async () => {
       const { wrapper } = await createFixtures(f => {
-        f.withUser({ email_addresses: ['test@clerk.dev'] });
+        f.withUser({ email_addresses: ['test@clerk.com'] });
       });
 
       render(<UserProfile />, { wrapper });

--- a/packages/clerk-js/src/ui/customizables/makeResponsive.tsx
+++ b/packages/clerk-js/src/ui/customizables/makeResponsive.tsx
@@ -31,12 +31,7 @@ export const makeResponsive = <P extends React.JSX.IntrinsicElements['img']>(
   return responsiveComponent as ResponsivePrimitive<P>;
 };
 
-const CLERK_IMAGE_URL_BASES = [
-  'https://img.clerk.com/',
-  'https://img.clerk.dev/',
-  'https://img.clerkstage.dev/',
-  'https://img.lclclerk.com/',
-];
+const CLERK_IMAGE_URL_BASES = ['https://img.clerk.com/', 'https://img.clerkstage.dev/', 'https://img.lclclerk.com/'];
 
 const isClerkImage = (src?: string): boolean => {
   return !!CLERK_IMAGE_URL_BASES.some(base => src?.includes(base));

--- a/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganization.test.tsx
+++ b/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganization.test.tsx
@@ -40,7 +40,7 @@ describe('useOrganization', () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
       });
     });
@@ -69,7 +69,7 @@ describe('useOrganization', () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
       });
     });
 
@@ -91,7 +91,7 @@ describe('useOrganization', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -221,7 +221,7 @@ describe('useOrganization', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -323,7 +323,7 @@ describe('useOrganization', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -336,7 +336,7 @@ describe('useOrganization', () => {
               organizationId: '1',
               publicUserData: {
                 userId: 'test_user1',
-                identifier: 'test1@clerk.dev',
+                identifier: 'test1@clerk.com',
               },
             }),
             createFakeOrganizationMembershipRequest({
@@ -344,7 +344,7 @@ describe('useOrganization', () => {
               organizationId: '1',
               publicUserData: {
                 userId: 'test_user2',
-                identifier: 'test2@clerk.dev',
+                identifier: 'test2@clerk.com',
               },
             }),
           ],
@@ -372,7 +372,7 @@ describe('useOrganization', () => {
               organizationId: '1',
               publicUserData: {
                 userId: 'test_user3',
-                identifier: 'test3@clerk.dev',
+                identifier: 'test3@clerk.com',
               },
             }),
             createFakeOrganizationMembershipRequest({
@@ -380,7 +380,7 @@ describe('useOrganization', () => {
               organizationId: '1',
               publicUserData: {
                 userId: 'test_user4',
-                identifier: 'test4@clerk.dev',
+                identifier: 'test4@clerk.com',
               },
             }),
           ],

--- a/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganizationList.test.tsx
+++ b/packages/clerk-js/src/ui/hooks/__tests__/useCoreOrganizationList.test.tsx
@@ -28,7 +28,7 @@ describe('useOrganizationList', () => {
     const { wrapper } = await createFixtures(f => {
       f.withOrganizations();
       f.withUser({
-        email_addresses: ['test@clerk.dev'],
+        email_addresses: ['test@clerk.com'],
         organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
       });
     });
@@ -68,7 +68,7 @@ describe('useOrganizationList', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -184,7 +184,7 @@ describe('useOrganizationList', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -338,7 +338,7 @@ describe('useOrganizationList', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -422,7 +422,7 @@ describe('useOrganizationList', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -528,7 +528,7 @@ describe('useOrganizationList', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });
@@ -612,7 +612,7 @@ describe('useOrganizationList', () => {
       const { wrapper, fixtures } = await createFixtures(f => {
         f.withOrganizations();
         f.withUser({
-          email_addresses: ['test@clerk.dev'],
+          email_addresses: ['test@clerk.com'],
           organization_memberships: [{ name: 'Org1', role: 'basic_member' }],
         });
       });

--- a/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtureHelpers.ts
@@ -122,7 +122,7 @@ const createSignInFixtureHelpers = (baseClient: ClientJSON) => {
 
   const startSignInWithEmailAddress = (params?: SignInWithEmailAddressParams) => {
     const {
-      identifier = 'hello@clerk.dev',
+      identifier = 'hello@clerk.com',
       supportPassword = true,
       supportEmailCode,
       supportEmailLink,
@@ -134,13 +134,13 @@ const createSignInFixtureHelpers = (baseClient: ClientJSON) => {
       supported_identifiers: ['email_address'],
       supported_first_factors: [
         ...(supportPassword ? [{ strategy: 'password' }] : []),
-        ...(supportEmailCode ? [{ strategy: 'email_code', safe_identifier: identifier || 'n*****@clerk.dev' }] : []),
-        ...(supportEmailLink ? [{ strategy: 'email_link', safe_identifier: identifier || 'n*****@clerk.dev' }] : []),
+        ...(supportEmailCode ? [{ strategy: 'email_code', safe_identifier: identifier || 'n*****@clerk.com' }] : []),
+        ...(supportEmailLink ? [{ strategy: 'email_link', safe_identifier: identifier || 'n*****@clerk.com' }] : []),
         ...(supportResetPassword
           ? [
               {
                 strategy: 'reset_password_email_code',
-                safe_identifier: identifier || 'n*****@clerk.dev',
+                safe_identifier: identifier || 'n*****@clerk.com',
                 emailAddressId: 'someEmailId',
               },
             ]
@@ -208,9 +208,9 @@ const createSignInFixtureHelpers = (baseClient: ClientJSON) => {
         : {}),
       supported_identifiers: ['email_address', 'phone_number'],
       supported_second_factors: [
-        ...(supportPhoneCode ? [{ strategy: 'phone_code', safe_identifier: identifier || 'n*****@clerk.dev' }] : []),
-        ...(supportTotp ? [{ strategy: 'totp', safe_identifier: identifier || 'n*****@clerk.dev' }] : []),
-        ...(supportBackupCode ? [{ strategy: 'backup_code', safe_identifier: identifier || 'n*****@clerk.dev' }] : []),
+        ...(supportPhoneCode ? [{ strategy: 'phone_code', safe_identifier: identifier || 'n*****@clerk.com' }] : []),
+        ...(supportTotp ? [{ strategy: 'totp', safe_identifier: identifier || 'n*****@clerk.com' }] : []),
+        ...(supportBackupCode ? [{ strategy: 'backup_code', safe_identifier: identifier || 'n*****@clerk.com' }] : []),
       ],
       user_data: { ...(createUserFixture() as any) },
     } as SignInJSON;
@@ -231,7 +231,7 @@ const createSignUpFixtureHelpers = (baseClient: ClientJSON) => {
   };
 
   const startSignUpWithEmailAddress = (params?: SignUpWithEmailAddressParams) => {
-    const { emailAddress = 'hello@clerk.dev', supportEmailLink = true, supportEmailCode = true } = params || {};
+    const { emailAddress = 'hello@clerk.com', supportEmailLink = true, supportEmailCode = true } = params || {};
     baseClient.sign_up = {
       id: 'sua_2HseAXFGN12eqlwARPMxyyUa9o9',
       status: 'missing_requirements',
@@ -268,7 +268,7 @@ const createAuthConfigFixtureHelpers = (environment: EnvironmentJSON) => {
 const createDisplayConfigFixtureHelpers = (environment: EnvironmentJSON) => {
   const dc = environment.display_config;
   const withSupportEmail = (opts?: { email: string }) => {
-    dc.support_email = opts?.email || 'support@clerk.dev';
+    dc.support_email = opts?.email || 'support@clerk.com';
   };
   const withoutClerkBranding = () => {
     dc.branded = false;

--- a/packages/clerk-js/src/utils/__tests__/email.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/email.test.ts
@@ -1,9 +1,9 @@
 import { buildEmailAddress } from '../email';
 
 test.each([
-  ['', 'support@clerk.dev'],
+  ['', 'support@clerk.com'],
   ['foo.com', 'support@foo.com'],
-  ['clerk.clerk.dev', 'support@clerk.dev'],
+  ['clerk.clerk.com', 'support@clerk.com'],
   ['clerk.foo.com', 'support@foo.com'],
   ['clerk.foo.bar.com', 'support@foo.bar.com'],
 ])('.buildSupportEmail(%s, %s)', (frontendApi, email) => {

--- a/packages/clerk-js/src/utils/__tests__/instance.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/instance.test.ts
@@ -17,7 +17,7 @@ describe('validateFrontendApi(str)', () => {
     ['clerk.abcef.12345.stg.lclclerk.com', true],
     ['clerk.abcef.12345.prod.lclclerk.com', true],
     ['clerk.prod.lclclerk.com', true],
-    ['clerk.dev.lclclerk.com', true],
+    ['clerk.com.lclclerk.com', true],
     ['clerk.happy.hippo-1.lcl.dev', true],
     ['clerk.sad.panda-99.stg.dev', true],
     ['clerk.foo.bar-12.dev.lclclerk.com', true],

--- a/packages/clerk-js/src/utils/__tests__/url.test.ts
+++ b/packages/clerk-js/src/utils/__tests__/url.test.ts
@@ -20,7 +20,7 @@ import {
 
 describe('isDevAccountPortalOrigin(url)', () => {
   const goodUrls: Array<[string | URL, boolean]> = [
-    ['clerk.dev.lclclerk.com', false],
+    ['clerk.com.lclclerk.com', false],
     ['clerk.prod.lclclerk.com', false],
     ['clerk.abc.efg.lclstage.dev', false],
     ['clerk.abc.efg.stgstage.dev', false],

--- a/packages/clerk-js/src/utils/email.ts
+++ b/packages/clerk-js/src/utils/email.ts
@@ -4,6 +4,6 @@ export type BuildEmailAddressParams = {
 };
 
 export function buildEmailAddress({ localPart, frontendApi }: BuildEmailAddressParams): string {
-  const domain = frontendApi ? frontendApi.replace('clerk.', '') : 'clerk.dev';
+  const domain = frontendApi ? frontendApi.replace('clerk.', '') : 'clerk.com';
   return `${localPart}@${domain}`;
 }

--- a/packages/expo/src/useOAuth.ts
+++ b/packages/expo/src/useOAuth.ts
@@ -44,7 +44,7 @@ export function useOAuth(useOAuthParams: UseOAuthFlowParams) {
     // Create a redirect url for the current platform and environment.
     //
     // This redirect URL needs to be whitelisted for your Clerk production instance via
-    // https://clerk.dev/docs/reference/backend-api/tag/Redirect-URLs#operation/CreateRedirectURL
+    // https://clerk.com/docs/reference/backend-api/tag/Redirect-URLs#operation/CreateRedirectURL
     //
     // For more information go to:
     // https://docs.expo.dev/versions/latest/sdk/auth-session/#authsessionmakeredirecturi

--- a/packages/fastify/src/__snapshots__/clerkClient.test.ts.snap
+++ b/packages/fastify/src/__snapshots__/clerkClient.test.ts.snap
@@ -4,7 +4,7 @@ exports[`clerk initializes clerk with constants 1`] = `
 [
   [
     {
-      "apiUrl": "https://api.clerk.dev",
+      "apiUrl": "https://api.clerk.com",
       "apiVersion": "v1",
       "jwtKey": "",
       "secretKey": "TEST_API_KEY",

--- a/packages/fastify/src/constants.ts
+++ b/packages/fastify/src/constants.ts
@@ -2,7 +2,7 @@
 import { constants } from '@clerk/backend';
 import { deprecated } from '@clerk/shared/deprecated';
 
-export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
+export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.com';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
 /**
  * Backend API key

--- a/packages/gatsby-plugin-clerk/package.json
+++ b/packages/gatsby-plugin-clerk/package.json
@@ -5,7 +5,7 @@
   "description": "Clerk SDK for Gatsby",
   "keywords": [
     "clerk",
-    "clerk.dev",
+    "clerk.com",
     "gatsby",
     "gatsby-plugin",
     "gatsby-plugin-clerk",

--- a/packages/gatsby-plugin-clerk/src/constants.ts
+++ b/packages/gatsby-plugin-clerk/src/constants.ts
@@ -1,6 +1,6 @@
 import { deprecated } from '@clerk/shared/deprecated';
 
-export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
+export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.com';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
 /**
  * @deprecated Use `CLERK_SECRET_KEY` instead.

--- a/packages/nextjs/src/server/constants.ts
+++ b/packages/nextjs/src/server/constants.ts
@@ -9,7 +9,7 @@ if (JS_VERSION) {
 }
 export const CLERK_JS_VERSION = process.env.NEXT_PUBLIC_CLERK_JS_VERSION || '';
 export const CLERK_JS_URL = process.env.NEXT_PUBLIC_CLERK_JS || '';
-export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.dev';
+export const API_URL = process.env.CLERK_API_URL || 'https://api.clerk.com';
 export const API_VERSION = process.env.CLERK_API_VERSION || 'v1';
 /**
  * @deprecated Use `CLERK_SECRET_KEY` instead.

--- a/packages/sdk-node/examples/express/.env.sample
+++ b/packages/sdk-node/examples/express/.env.sample
@@ -1,4 +1,4 @@
 CLERK_SECRET_KEY=test_foo
-CLERK_API_URL=https://api.clerk.dev
+CLERK_API_URL=https://api.clerk.com
 CLERK_LOGGING=false
 PORT=5000

--- a/packages/sdk-node/src/utils.ts
+++ b/packages/sdk-node/src/utils.ts
@@ -36,7 +36,7 @@ export const loadApiEnv = () => {
   return {
     secretKey: process.env.CLERK_SECRET_KEY || process.env.CLERK_API_KEY || '',
     apiKey: process.env.CLERK_API_KEY || '',
-    apiUrl: process.env.CLERK_API_URL || 'https://api.clerk.dev',
+    apiUrl: process.env.CLERK_API_URL || 'https://api.clerk.com',
     apiVersion: process.env.CLERK_API_VERSION || 'v1',
     domain: process.env.CLERK_DOMAIN || '',
     proxyUrl: process.env.CLERK_PROXY_URL || '',

--- a/packages/shared/src/__tests__/keys.test.ts
+++ b/packages/shared/src/__tests__/keys.test.ts
@@ -71,7 +71,7 @@ describe('isDevOrStagingUrl(url)', () => {
 
   const goodUrls: Array<[string | URL, boolean]> = [
     ['https://www.google.com', false],
-    ['https://www.clerk.dev', false],
+    ['https://www.clerk.com', false],
     ['https://www.lclclerk.com', false],
     ['clerk.prod.lclclerk.com', false],
     ['something.dev.lclclerk.com', true],


### PR DESCRIPTION
## Description

Since we have completely migrated to clerk.com, this PR replaces all references of the previous domain (`clerk.dev`) to `clerk.com`.
## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [x] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [x] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [x] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
