### PR TITLE
chore(clerk-js,types,shared): Deprecate `__unstable` methods for organizations

### DIFF
--- a/.changeset/light-coats-brush.md
+++ b/.changeset/light-coats-brush.md
@@ -1,0 +1,7 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/shared': patch
+'@clerk/types': patch
+---
+
+Deprecate `__unstable` methods for organizations.

--- a/packages/clerk-js/src/core/clerk.ts
+++ b/packages/clerk-js/src/core/clerk.ts
@@ -170,7 +170,14 @@ export default class Clerk implements ClerkInterface {
   #fapiClient: FapiClient;
   #instanceType: InstanceType;
   #isReady = false;
+
+  /**
+   * @deprecated Although this being a private field, this is a reminder to drop it with the next major release
+   */
   #lastOrganizationInvitation: OrganizationInvitationResource | null = null;
+  /**
+   * @deprecated Although this being a private field, this is a reminder to drop it with the next major release
+   */
   #lastOrganizationMember: OrganizationMembershipResource | null = null;
   #listeners: Array<(emission: Resources) => void> = [];
   #options: ClerkOptions = {};
@@ -1185,12 +1192,28 @@ export default class Clerk implements ClerkInterface {
     this.#emit();
   };
 
+  /**
+   * @deprecated This method will be dropped in the next major release.
+   * This method is only used in another deprecated part: `invitationList` from useOrganization
+   */
   __unstable__invitationUpdate(invitation: OrganizationInvitationResource) {
+    deprecated(
+      '__unstable__invitationUpdate',
+      'We are completely dropping this method as it was introduced for internal use only',
+    );
     this.#lastOrganizationInvitation = invitation;
     this.#emit();
   }
 
+  /**
+   * @deprecated This method will be dropped in the next major release.
+   * This method is only used in another deprecated part: `membershipList` from useOrganization
+   */
   __unstable__membershipUpdate(membership: OrganizationMembershipResource) {
+    deprecated(
+      '__unstable__invitationUpdate',
+      'We are completely dropping this method as it was introduced for internal use only',
+    );
     this.#lastOrganizationMember = membership;
     this.#emit();
   }

--- a/packages/shared/src/hooks/contexts.tsx
+++ b/packages/shared/src/hooks/contexts.tsx
@@ -25,7 +25,16 @@ const [SessionContext, useSessionContext] = createContextAndHook<ActiveSessionRe
 
 type OrganizationContextProps = {
   organization: OrganizationResource | null | undefined;
+
+  /**
+   * @deprecated This property will be dropped in the next major release.
+   * This property is only used in another deprecated part: `invitationList` from useOrganization
+   */
   lastOrganizationInvitation: OrganizationInvitationResource | null | undefined;
+  /**
+   * @deprecated This property will be dropped in the next major release.
+   * This property is only used in another deprecated part: `membershipList` from useOrganization
+   */
   lastOrganizationMember: OrganizationMembershipResource | null | undefined;
 };
 const [OrganizationContextInternal, useOrganizationContext] = createContextAndHook<{

--- a/packages/types/src/clerk.ts
+++ b/packages/types/src/clerk.ts
@@ -554,7 +554,15 @@ export interface Resources {
   session?: ActiveSessionResource | null;
   user?: UserResource | null;
   organization?: OrganizationResource | null;
+  /**
+   * @deprecated This property will be dropped in the next major release.
+   * This property is only used in another deprecated part: `invitationList` from useOrganization
+   */
   lastOrganizationInvitation?: OrganizationInvitationResource | null;
+  /**
+   * @deprecated This property will be dropped in the next major release.
+   * This property is only used in another deprecated part: `membershipList` from useOrganization
+   */
   lastOrganizationMember?: OrganizationMembershipResource | null;
 }
 


### PR DESCRIPTION
## Description

This PR continues with the deprecation of the underlying mechanism for organizations.

For context those values were passed around in order to trigger automatic revalidations when devs where reading `invitationList` or `membershipList` from `useOrganization`. Those have been deprecated in favour of `invitations` and `memberships` and  we are introducing mutations for those here.

Automatic revalidations of lists after calling clerk-js methods may return in the future as an "opt-in" mechanism

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
