### PR TITLE
Include clerkTraceId for backend api errors

### DIFF
--- a/.changeset/sour-comics-stare.md
+++ b/.changeset/sour-comics-stare.md
@@ -1,0 +1,7 @@
+---
+'@clerk/backend': patch
+'@clerk/shared': patch
+---
+
+Add clerkTraceId to ClerkBackendApiResponse and ClerkAPIResponseError to allow for better tracing and debugging API error responses. 
+Uses `clerk_trace_id` when available in a response and defaults to [`cf-ray` identifier](https://developers.cloudflare.com/fundamentals/reference/cloudflare-ray-id/) if missing.  

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -1,3 +1,4 @@
+import { ClerkAPIResponseError } from '@clerk/shared/error';
 import type { ClerkAPIError, ClerkAPIErrorJSON } from '@clerk/types';
 import deepmerge from 'deepmerge';
 import snakecaseKeys from 'snakecase-keys';
@@ -37,6 +38,7 @@ export type ClerkBackendApiResponse<T> =
   | {
       data: null;
       errors: ClerkAPIError[];
+      clerkTraceId?: string;
     };
 
 export type RequestFunction = ReturnType<typeof buildRequest>;
@@ -52,13 +54,14 @@ const withLegacyReturn =
   (cb: any): LegacyRequestFunction =>
   async (...args) => {
     // @ts-ignore
-    const { data, errors, status, statusText } = await cb<T>(...args);
+    const { data, errors, status, statusText, clerkTraceId } = await cb<T>(...args);
     if (errors === null) {
       return data;
     } else {
       throw new ClerkAPIResponseError(statusText || '', {
         data: errors,
         status: status || '',
+        clerkTraceId,
       });
     }
   };
@@ -161,6 +164,7 @@ export function buildRequest(options: CreateBackendApiOptions) {
               message: err.message || 'Unexpected error',
             },
           ],
+          clerkTraceId: getTraceId(err, res?.headers),
         };
       }
 
@@ -171,11 +175,23 @@ export function buildRequest(options: CreateBackendApiOptions) {
         // @ts-expect-error
         status: res?.status,
         statusText: res?.statusText,
+        clerkTraceId: getTraceId(err, res?.headers),
       };
     }
   };
 
   return withLegacyReturn(request);
+}
+
+// Returns either clerk_trace_id if present in response json, otherwise defaults to CF-Ray header
+// If the request failed before receiving a response, returns undefined
+function getTraceId(data: unknown, headers?: Headers): string {
+  if (data && typeof data === 'object' && 'clerk_trace_id' in data && typeof data.clerk_trace_id === 'string') {
+    return data.clerk_trace_id;
+  }
+
+  const cfRay = headers?.get('cf-ray');
+  return cfRay || '';
 }
 
 function parseErrors(data: unknown): ClerkAPIError[] {
@@ -196,24 +212,4 @@ function parseError(error: ClerkAPIErrorJSON): ClerkAPIError {
       sessionId: error?.meta?.session_id,
     },
   };
-}
-
-class ClerkAPIResponseError extends Error {
-  clerkError: true;
-
-  status: number;
-  message: string;
-
-  errors: ClerkAPIError[];
-
-  constructor(message: string, { data, status }: { data: ClerkAPIError[]; status: number }) {
-    super(message);
-
-    Object.setPrototypeOf(this, ClerkAPIResponseError.prototype);
-
-    this.clerkError = true;
-    this.message = message;
-    this.status = status;
-    this.errors = data;
-  }
 }

--- a/packages/backend/src/util/mockFetch.ts
+++ b/packages/backend/src/util/mockFetch.ts
@@ -42,4 +42,14 @@ export function jsonError(body: unknown, status = 500) {
   return Promise.resolve(mockResponse);
 }
 
-const mockHeadersGet = (key: string) => (key === constants.Headers.ContentType ? constants.ContentTypes.Json : null);
+const mockHeadersGet = (key: string) => {
+  if (key === constants.Headers.ContentType) {
+    return constants.ContentTypes.Json;
+  }
+
+  if (key === 'cf-ray') {
+    return 'mock_cf_ray';
+  }
+
+  return null;
+};

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -22,6 +22,7 @@ export function isNetworkError(e: any): boolean {
 interface ClerkAPIResponseOptions {
   data: ClerkAPIErrorJSON[];
   status: number;
+  clerkTraceId?: string;
 }
 
 // For a comprehensive Metamask error list, please see
@@ -88,24 +89,32 @@ export class ClerkAPIResponseError extends Error {
 
   status: number;
   message: string;
+  clerkTraceId?: string;
 
   errors: ClerkAPIError[];
 
-  constructor(message: string, { data, status }: ClerkAPIResponseOptions) {
+  constructor(message: string, { data, status, clerkTraceId }: ClerkAPIResponseOptions) {
     super(message);
 
     Object.setPrototypeOf(this, ClerkAPIResponseError.prototype);
 
     this.status = status;
     this.message = message;
+    this.clerkTraceId = clerkTraceId;
     this.clerkError = true;
     this.errors = parseErrors(data);
   }
 
   public toString = () => {
-    return `[${this.name}]\nMessage:${this.message}\nStatus:${this.status}\nSerialized errors: ${this.errors.map(e =>
-      JSON.stringify(e),
+    let message = `[${this.name}]\nMessage:${this.message}\nStatus:${this.status}\nSerialized errors: ${this.errors.map(
+      e => JSON.stringify(e),
     )}`;
+
+    if (this.clerkTraceId) {
+      message += `\nClerk Trace ID: ${this.clerkTraceId}`;
+    }
+
+    return message;
   };
 }
 


### PR DESCRIPTION
## Description

This PR adds `clerkTraceId` in `ClerkBackendApiResponse`. This can help debug issues with API responses especially when errors happen server side or transiently and they can't be viewed in the console. 

## Changes

1. Use `ClerkAPIResponseError` from `@clerk/shared`. 
2. Updated `ClerkBackendApiResponse` interface to include `clerkTraceId` when available.
3. Extract `clerkTraceId` either from backend error response or headers in `buildRequest`.
4. Pass the new `clerkTraceId` value to `withLegacyReturn` and then to the constructor of `ClerkAPIResponseError`.
5. Update `toString` for `ClerkAPIResponseError` so it can also log the clerkTraceId.

Now callining `.toString()` on an error should show the trace id

![Screenshot 2023-10-17 at 12 45 50 PM](https://github.com/clerkinc/javascript/assets/9081019/e51b914d-19eb-4b6b-ac12-5df5bef4b7c6)

The same is true for simply calling console.log on the error

![Screenshot 2023-10-16 at 4 49 20 PM](https://github.com/clerkinc/javascript/assets/9081019/b3b06ef8-85c1-4386-95d6-10dcc4acb9ce)

## Notes

DX is a bit weird here since fields that are different between success and error cannot be accessed by default in typescript and they do not appear in code completion(intelisense/language server). They can be accessed however by
checking if they exist in the object.

```ts
if ("clerkTraceId" in clerkBackendApiResponse) {
  console.log(`Error Trace: ${response.clerkTraceId}`);
}
```

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [x] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
