### PR TITLE
chore(clerk-js): Remove custom Alert from invitation page and display error as global

### DIFF
--- a/.changeset/shiny-experts-notice.md
+++ b/.changeset/shiny-experts-notice.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Remove custom Alert from invitation page and display it as a global error instead (at the top of the component).

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/InviteMembersForm.tsx
@@ -72,8 +72,7 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
 
   const roleField = useFormControl('role', 'basic_member', {
     options: roles,
-    // TODO: localize this
-    label: 'Role',
+    label: localizationKeys('formFieldLabel__role'),
     placeholder: '',
   });
 
@@ -141,8 +140,8 @@ export const InviteMembersForm = (props: InviteMembersFormProps) => {
           direction='col'
           gap={2}
         >
-          <Text localizationKey={localizationKeys('formFieldLabel__role')} />
-          {/* @ts-expect-error */}
+          <Text localizationKey={roleField.label} />
+          {/*@ts-expect-error  Select expects options to be an array but useFormControl returns an optional field. */}
           <Select
             elementId='role'
             {...roleField.props}

--- a/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
+++ b/packages/clerk-js/src/ui/elements/contexts/CardStateContext.tsx
@@ -31,7 +31,7 @@ const useCardState = () => {
   const { translateError } = useLocalizations();
 
   const setIdle = (metadata?: Metadata) => setState(s => ({ ...s, status: 'idle', metadata }));
-  const setError = (metadata: ClerkRuntimeError | ClerkAPIError | Metadata) =>
+  const setError = (metadata: ClerkRuntimeError | ClerkAPIError | Metadata | string) =>
     setState(s => ({ ...s, error: translateError(metadata) }));
   const setLoading = (metadata?: Metadata) => setState(s => ({ ...s, status: 'loading', metadata }));
   const runAsync = async <T = unknown,>(cb: Promise<T> | (() => Promise<T>), metadata?: Metadata) => {


### PR DESCRIPTION
## Description


This PR removes the custom Alert from invitation page and displays it as a global error instead (at the top of the component).

## Before

https://github.com/clerkinc/javascript/assets/19269911/d1d581f1-f62c-42f2-b211-b1b42ebf029e



## After

https://github.com/clerkinc/javascript/assets/19269911/f558b871-9964-4a9a-9999-135eaaa0938e


<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
