### PR TITLE
fix(clerk-js): Properly show the deprecation warnings for usage of limit and offset

### DIFF
--- a/.changeset/pretty-frogs-turn.md
+++ b/.changeset/pretty-frogs-turn.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Internal fix for deprecation warning when using limi & offset.

--- a/packages/clerk-js/src/core/resources/Organization.ts
+++ b/packages/clerk-js/src/core/resources/Organization.ts
@@ -168,14 +168,14 @@ export class Organization extends BaseResource implements OrganizationResource {
   getMemberships: GetMemberships = async getMembershipsParams => {
     const isDeprecatedParams = typeof getMembershipsParams === 'undefined' || !getMembershipsParams?.paginated;
 
-    if (!(getMembershipsParams as GetMembershipsParams)?.limit) {
+    if ((getMembershipsParams as GetMembershipsParams)?.limit) {
       deprecated(
         'limit',
         'Use `pageSize` instead in Organization.getMemberships.',
         'organization:getMemberships:limit',
       );
     }
-    if (!(getMembershipsParams as GetMembershipsParams)?.offset) {
+    if ((getMembershipsParams as GetMembershipsParams)?.offset) {
       deprecated('offset', 'Use `initialPage` instead in Organization.limit.', 'organization:getMemberships:offset');
     }
 

--- a/packages/clerk-js/src/core/resources/OrganizationMembership.ts
+++ b/packages/clerk-js/src/core/resources/OrganizationMembership.ts
@@ -37,14 +37,14 @@ export class OrganizationMembership extends BaseResource implements Organization
     const isDeprecatedParams =
       typeof retrieveMembershipsParams === 'undefined' || !retrieveMembershipsParams?.paginated;
 
-    if (!(retrieveMembershipsParams as RetrieveMembershipsParams)?.limit) {
+    if ((retrieveMembershipsParams as RetrieveMembershipsParams)?.limit) {
       deprecated(
         'limit',
         'Use `pageSize` instead in OrganizationMembership.retrieve.',
         'organization-membership:limit',
       );
     }
-    if (!(retrieveMembershipsParams as RetrieveMembershipsParams)?.offset) {
+    if ((retrieveMembershipsParams as RetrieveMembershipsParams)?.offset) {
       deprecated(
         'offset',
         'Use `initialPage` instead in OrganizationMembership.retrieve.',


### PR DESCRIPTION
## Description

Previously the deprecation warnings will be used when limit or offset was not used.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
