### PR TITLE
fix(nextjs): Warn about misplaced middleware file when using auth or getAuth

### DIFF
--- a/.changeset/selfish-pens-laugh.md
+++ b/.changeset/selfish-pens-laugh.md
@@ -1,0 +1,5 @@
+---
+"@clerk/nextjs": patch
+---
+
+Update the error thrown by auth() or getAuth() to indicate that if the /src directory exists, then the middleware.ts file needs to be placed inside it, otherwise the middleware will not run.

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -31,10 +31,11 @@ Alternatively, you can set your own ignoredRoutes. See https://clerk.com/docs/ne
 export const getAuthAuthHeaderMissing = () => authAuthHeaderMissing('getAuth');
 
 export const authAuthHeaderMissing = (helperName = 'auth') =>
-  `Clerk: ${helperName}() was called but it looks like you aren't using authMiddleware in your middleware file. Please ensure the following:
-- Use authMiddleware in your middleware file.
-- Make sure your middleware matcher is configured correctly and it matches this route or page.
-- If you are using the /src directory, ensure that the middleware.ts file is located under it.
+  `Clerk: ${helperName}() was called but Clerk can't detect usage of authMiddleware(). Please ensure the following:
+- authMiddleware() is used in your Next.js Middleware.
+- Your Middleware matcher is configured to match this route or page.
+- If you are using the src directory, make sure the Middleware file is inside of it.
+
 For more details, see https://clerk.com/docs/quickstarts/get-started-with-nextjs.
 `;
 

--- a/packages/nextjs/src/server/errors.ts
+++ b/packages/nextjs/src/server/errors.ts
@@ -28,11 +28,15 @@ Alternatively, you can set your own ignoredRoutes. See https://clerk.com/docs/ne
 (This log only appears in development mode)
 `;
 
-export const getAuthAuthHeaderMissing = () =>
-  'You need to use "authMiddleware" (or the deprecated "withClerkMiddleware") in your Next.js middleware file. You also need to make sure that your middleware matcher is configured correctly and matches this route or page. See https://clerk.com/docs/quickstarts/get-started-with-nextjs';
+export const getAuthAuthHeaderMissing = () => authAuthHeaderMissing('getAuth');
 
-export const authAuthHeaderMissing = () =>
-  "Clerk: auth() was called but it looks like you aren't using `authMiddleware` in your middleware file. Please use `authMiddleware` and make sure your middleware matcher is configured correctly and it matches this route or page. See https://clerk.com/docs/quickstarts/get-started-with-nextjs";
+export const authAuthHeaderMissing = (helperName = 'auth') =>
+  `Clerk: ${helperName}() was called but it looks like you aren't using authMiddleware in your middleware file. Please ensure the following:
+- Use authMiddleware in your middleware file.
+- Make sure your middleware matcher is configured correctly and it matches this route or page.
+- If you are using the /src directory, ensure that the middleware.ts file is located under it.
+For more details, see https://clerk.com/docs/quickstarts/get-started-with-nextjs.
+`;
 
 export const clockSkewDetected = (verifyMessage: string) =>
   `Clerk: Clock skew detected. This usually means that your system clock is inaccurate. Clerk will continuously try to issue new tokens, as the existing ones will be treated as "expired" due to clock skew.


### PR DESCRIPTION
For NextJS 13 application, if the `/src` directory is used then the middleware file needs to be nested under it, otherwise the middleware will not run.

This is a very common user error - this commit updates the error message to list moving middleware under /src as a potential fix.

Fixes SDK-818

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
