### PR TITLE
chore(clerk-js): Keep CreateOrganizationForm disabled if avatar has been uploaded and org name is empty

### DIFF
--- a/.changeset/hot-shoes-roll.md
+++ b/.changeset/hot-shoes-roll.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Keep `CreateOrganizationForm` disabled in case of an uploaded avatar and organization name is empty.

--- a/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
+++ b/packages/clerk-js/src/ui/components/CreateOrganization/CreateOrganizationForm.tsx
@@ -46,7 +46,7 @@ export const CreateOrganizationForm = (props: CreateOrganizationFormProps) => {
   });
 
   const dataChanged = !!nameField.value;
-  const canSubmit = dataChanged || !!file;
+  const canSubmit = dataChanged;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Description
In this pr we disable the form of `CreateOrganizationForm` when avatar has been selected but organization name is empty in order to have the same experience when no avatar has been selected

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`

### Before

https://github.com/clerkinc/javascript/assets/14893769/ff97cb63-acea-4427-980c-cd083e21f8e0

### After

https://github.com/clerkinc/javascript/assets/14893769/dbb6b000-982b-4fd8-a06f-c99b6518d3ac


