### PR TITLE
fix(clerk-js): Use the issued at timestamp from JWT for the MemoryTokenCache

### DIFF
--- a/packages/clerk-js/src/core/tokenCache.test.ts
+++ b/packages/clerk-js/src/core/tokenCache.test.ts
@@ -12,8 +12,25 @@ jest.mock('./resources/Base', () => {
   };
 });
 
-const jwt =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NzU4NzY3OTAsImRhdGEiOiJmb29iYXIiLCJpYXQiOjE2NzU4NzY3MzB9.Z1BC47lImYvaAtluJlY-kBo0qOoAk42Xb-gNrB2SxJg';
+const mockJwtToken = (now: number): string => {
+  const nowInSeconds = Math.floor(now / 1000);
+  const payload = {
+    iat: nowInSeconds,
+    exp: nowInSeconds + 60,
+    data: 'foobar',
+  };
+
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+  };
+
+  const base64Header = Buffer.from(JSON.stringify(header)).toString('base64');
+  const base64Payload = Buffer.from(JSON.stringify(payload)).toString('base64');
+  const signature = 'Z1BC47lImYvaAtluJlY-kBo0qOoAk42Xb-gNrB2SxJg';
+
+  return `${base64Header}.${base64Payload}.${signature}`;
+};
 
 describe('MemoryTokenCache', () => {
   beforeAll(() => {
@@ -30,7 +47,7 @@ describe('MemoryTokenCache', () => {
       const token = new Token({
         object: 'token',
         id: 'foo',
-        jwt,
+        jwt: mockJwtToken(Date.now()),
       });
 
       const tokenResolver = new Promise<TokenResource>(resolve => setTimeout(() => resolve(token), 100));
@@ -57,7 +74,7 @@ describe('MemoryTokenCache', () => {
     const token = new Token({
       object: 'token',
       id: 'foo',
-      jwt,
+      jwt: mockJwtToken(Date.now()),
     });
 
     let isResolved = false;
@@ -113,7 +130,7 @@ describe('MemoryTokenCache', () => {
       const token = new Token({
         object: 'token',
         id: 'foo',
-        jwt,
+        jwt: mockJwtToken(Date.now()),
       });
 
       const tokenResolver = Promise.resolve(token);
@@ -138,7 +155,7 @@ describe('MemoryTokenCache', () => {
       const token = new Token({
         object: 'token',
         id: 'foo',
-        jwt,
+        jwt: mockJwtToken(Date.now()),
       });
 
       const tokenResolver = Promise.resolve(token);

--- a/packages/clerk-js/src/core/tokenCache.test.ts
+++ b/packages/clerk-js/src/core/tokenCache.test.ts
@@ -14,6 +14,7 @@ jest.mock('./resources/Base', () => {
 
 const mockJwtToken = (now: number): string => {
   const nowInSeconds = Math.floor(now / 1000);
+
   const payload = {
     iat: nowInSeconds,
     exp: nowInSeconds + 60,
@@ -47,7 +48,7 @@ describe('MemoryTokenCache', () => {
       const token = new Token({
         object: 'token',
         id: 'foo',
-        jwt: mockJwtToken(Date.now()),
+        jwt: mockJwtToken(jest.now()),
       });
 
       const tokenResolver = new Promise<TokenResource>(resolve => setTimeout(() => resolve(token), 100));
@@ -74,7 +75,7 @@ describe('MemoryTokenCache', () => {
     const token = new Token({
       object: 'token',
       id: 'foo',
-      jwt: mockJwtToken(Date.now()),
+      jwt: mockJwtToken(jest.now()),
     });
 
     let isResolved = false;
@@ -130,7 +131,7 @@ describe('MemoryTokenCache', () => {
       const token = new Token({
         object: 'token',
         id: 'foo',
-        jwt: mockJwtToken(Date.now()),
+        jwt: mockJwtToken(jest.now()),
       });
 
       const tokenResolver = Promise.resolve(token);
@@ -155,7 +156,7 @@ describe('MemoryTokenCache', () => {
       const token = new Token({
         object: 'token',
         id: 'foo',
-        jwt: mockJwtToken(Date.now()),
+        jwt: mockJwtToken(jest.now()),
       });
 
       const tokenResolver = Promise.resolve(token);

--- a/packages/clerk-js/src/core/tokenCache.ts
+++ b/packages/clerk-js/src/core/tokenCache.ts
@@ -13,7 +13,7 @@ type Seconds = number;
 
 interface TokenCacheValue {
   entry: TokenCacheEntry;
-  createdAt: Seconds;
+  createdAt?: Seconds;
   expiresIn?: Seconds;
 }
 
@@ -69,8 +69,7 @@ const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
 
     const key = cacheKey.toKey();
 
-    const createdAt = Math.floor(Date.now() / 1000);
-    const value: TokenCacheValue = { entry, createdAt };
+    const value: TokenCacheValue = { entry };
 
     const deleteKey = () => {
       if (cache.get(key) === value) {
@@ -86,6 +85,7 @@ const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
 
         // Mutate cached value and set expirations
         value.expiresIn = expiresIn;
+        value.createdAt = issuedAt;
         timer = setTimeout(deleteKey, expiresIn * 1000);
 
         // Teach ClerkJS not to block the exit of the event loop when used in Node environments.
@@ -110,7 +110,7 @@ const MemoryTokenCache = (prefix = KEY_PREFIX): TokenCache => {
     }
 
     const nowSeconds = Math.floor(Date.now() / 1000);
-    const elapsedSeconds = nowSeconds - value.createdAt;
+    const elapsedSeconds = nowSeconds - value.createdAt!;
     // We will include the authentication poller interval as part of the leeway to ensure
     // that the cache value will be valid for more than the SYNC_LEEWAY or the leeway in the next poll.
     const expiresSoon = value.expiresIn! - elapsedSeconds < (leeway || 1) + SYNC_LEEWAY;


### PR DESCRIPTION
## Description
This PR changes the `createdAt` value when storing a token to the `MemoryTokenCache` from the current user time to the issued at time of the token to check how much time has elapsed from when the token has been issued.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
