### PR TITLE
chore(clerk-js): Deprecate FormControl

### DIFF
--- a/.changeset/bright-trainers-sort.md
+++ b/.changeset/bright-trainers-sort.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Internal refactoring of form fields, deprecation of Form.Control and introduction of Form.PlainInput.

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/AddDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/AddDomainPage.tsx
@@ -53,10 +53,10 @@ export const AddDomainPage = withCardStateProvider(() => {
     >
       <Form.Root onSubmit={onSubmit}>
         <Form.ControlRow elementId={nameField.id}>
-          <Form.Control
+          <Form.PlainInput
             {...nameField.props}
             autoFocus
-            required
+            isRequired
           />
         </Form.ControlRow>
         <FormButtons isDisabled={!canSubmit} />

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -32,44 +32,36 @@ export const SignUpForm = (props: SignUpFormProps) => {
       {(shouldShow('firstName') || shouldShow('lastName')) && (
         <Form.ControlRow elementId='name'>
           {shouldShow('firstName') && (
-            <Form.Control
-              {...{
-                ...formState.firstName.props,
-                isRequired: fields.firstName!.required,
-                isOptional: !fields.firstName!.required,
-              }}
+            <Form.PlainInput
+              {...formState.firstName.props}
+              isRequired={fields.firstName!.required}
+              isOptional={!fields.firstName!.required}
             />
           )}
           {shouldShow('lastName') && (
-            <Form.Control
-              {...{
-                ...formState.lastName.props,
-                isRequired: fields.lastName!.required,
-                isOptional: !fields.lastName!.required,
-              }}
+            <Form.PlainInput
+              {...formState.lastName.props}
+              isRequired={fields.lastName!.required}
+              isOptional={!fields.lastName!.required}
             />
           )}
         </Form.ControlRow>
       )}
       {shouldShow('username') && (
         <Form.ControlRow elementId='username'>
-          <Form.Control
-            {...{
-              ...formState.username.props,
-              isRequired: fields.username!.required,
-              isOptional: !fields.username!.required,
-            }}
+          <Form.PlainInput
+            {...formState.username.props}
+            isRequired={fields.username!.required}
+            isOptional={!fields.username!.required}
           />
         </Form.ControlRow>
       )}
       {shouldShow('emailAddress') && (
         <Form.ControlRow elementId='emailAddress'>
-          <Form.Control
-            {...{
-              ...formState.emailAddress.props,
-              isRequired: fields.emailAddress!.required,
-              isOptional: !fields.emailAddress!.required,
-            }}
+          <Form.PlainInput
+            {...formState.emailAddress.props}
+            isRequired={fields.emailAddress!.required}
+            isOptional={!fields.emailAddress!.required}
             actionLabel={canToggleEmailPhone ? 'Use phone instead' : undefined}
             onActionClicked={canToggleEmailPhone ? () => handleEmailPhoneToggle('phoneNumber') : undefined}
           />

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -43,6 +43,7 @@ export const SignUpForm = (props: SignUpFormProps) => {
               {...formState.lastName.props}
               isRequired={fields.lastName!.required}
               isOptional={!fields.lastName!.required}
+              isDisabled={true}
             />
           )}
         </Form.ControlRow>

--- a/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
+++ b/packages/clerk-js/src/ui/components/SignUp/SignUpForm.tsx
@@ -43,7 +43,6 @@ export const SignUpForm = (props: SignUpFormProps) => {
               {...formState.lastName.props}
               isRequired={fields.lastName!.required}
               isOptional={!fields.lastName!.required}
-              isDisabled={true}
             />
           )}
         </Form.ControlRow>

--- a/packages/clerk-js/src/ui/components/UserProfile/UsernamePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UsernamePage.tsx
@@ -40,8 +40,8 @@ export const UsernamePage = withCardStateProvider(() => {
           <Form.ControlRow elementId={usernameField.id}>
             <Form.PlainInput
               {...usernameField.props}
-              required
               autoFocus
+              isRequired
             />
           </Form.ControlRow>
           <FormButtons isDisabled={!canSubmit} />

--- a/packages/clerk-js/src/ui/components/UserProfile/UsernamePage.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/UsernamePage.tsx
@@ -38,7 +38,7 @@ export const UsernamePage = withCardStateProvider(() => {
       >
         <Form.Root onSubmit={updatePassword}>
           <Form.ControlRow elementId={usernameField.id}>
-            <Form.Control
+            <Form.PlainInput
               {...usernameField.props}
               required
               autoFocus

--- a/packages/clerk-js/src/ui/elements/FieldControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FieldControl.tsx
@@ -1,0 +1,262 @@
+import type { FieldId } from '@clerk/types';
+import type { PropsWithChildren } from 'react';
+import React, { forwardRef } from 'react';
+
+import type { LocalizationKey } from '../customizables';
+import {
+  descriptors,
+  Flex,
+  FormControl as FormControlPrim,
+  FormLabel,
+  Icon as IconCustomizable,
+  Input,
+  Link,
+  localizationKeys,
+  Text,
+  useLocalizations,
+} from '../customizables';
+import { useFieldMessageVisibility } from '../hooks';
+import { FormFieldContextProvider, sanitizeInputProps, useFormControl, useFormField } from '../primitives/hooks';
+import type { PropsOfComponent } from '../styledSystem';
+import type { useFormControl as useFormControlUtil } from '../utils';
+import { useFormControlFeedback } from '../utils';
+import { useCardState } from './contexts';
+import { useFormState } from './Form';
+import type { FormFeedbackProps } from './FormControl';
+import { delay, FormFeedback } from './FormControl';
+
+type FormControlProps = Omit<PropsOfComponent<typeof Input>, 'label' | 'placeholder'> &
+  ReturnType<typeof useFormControlUtil<FieldId>>['props'] & {
+    isDisabled?: boolean;
+  };
+
+export const Root = (props: PropsWithChildren<FormControlProps>) => {
+  const card = useCardState();
+  const { submittedWithEnter } = useFormState();
+  const {
+    id,
+    errorText,
+    isRequired,
+    sx,
+    setError,
+    successfulText,
+    setSuccessful,
+    hasLostFocus,
+    enableErrorAfterBlur,
+    informationText,
+    isFocused: _isFocused,
+    setWarning,
+    setHasPassedComplexity,
+    hasPassedComplexity,
+    warningText,
+  } = props;
+
+  const { debounced: debouncedState } = useFormControlFeedback({
+    errorText,
+    informationText,
+    enableErrorAfterBlur,
+    hasPassedComplexity,
+    isFocused: _isFocused,
+    hasLostFocus,
+    successfulText,
+    warningText,
+    skipBlur: submittedWithEnter,
+  });
+
+  const errorMessage = useFieldMessageVisibility(debouncedState.errorText, delay);
+  const isDisabled = props.isDisabled || card.isLoading;
+
+  return (
+    <FormFieldContextProvider {...props}>
+      {/*Most of our primitives still depend on this provider.*/}
+      {/*TODO: In follow-up PRs these will be removed*/}
+      <FormControlPrim
+        elementDescriptor={descriptors.formField}
+        elementId={descriptors.formField.setId(id)}
+        id={id}
+        hasError={!!errorMessage}
+        isDisabled={isDisabled}
+        isRequired={isRequired}
+        setError={setError}
+        setSuccessful={setSuccessful}
+        setWarning={setWarning}
+        setHasPassedComplexity={setHasPassedComplexity}
+        sx={sx}
+      >
+        {props.children}
+      </FormControlPrim>
+    </FormFieldContextProvider>
+  );
+};
+
+const FieldAction = (
+  props: PropsWithChildren<{ localizationKey?: LocalizationKey | string; onClick?: React.MouseEventHandler }>,
+) => {
+  const { isDisabled, id } = useFormControl();
+
+  if (!props.localizationKey && !props.children) {
+    return null;
+  }
+
+  return (
+    <Link
+      localizationKey={props.localizationKey}
+      elementDescriptor={descriptors.formFieldAction}
+      elementId={descriptors.formFieldLabel.setId(id as FieldId)}
+      isDisabled={isDisabled}
+      colorScheme='primary'
+      onClick={e => {
+        e.preventDefault();
+        props.onClick?.(e);
+      }}
+    >
+      {props.children}
+    </Link>
+  );
+};
+
+const FieldOptionalLabel = () => {
+  const { isDisabled, id } = useFormControl();
+  return (
+    <Text
+      localizationKey={localizationKeys('formFieldHintText__optional')}
+      elementDescriptor={descriptors.formFieldHintText}
+      elementId={descriptors.formFieldHintText.setId(id as FieldId)}
+      as='span'
+      colorScheme='neutral'
+      variant='smallRegular'
+      isDisabled={isDisabled}
+    />
+  );
+};
+
+const FieldLabelIcon = (props: { icon?: React.ComponentType }) => {
+  const { t } = useLocalizations();
+  if (!props.icon) {
+    return null;
+  }
+
+  return (
+    <Flex
+      as={'span'}
+      title={t(localizationKeys('formFieldHintText__slug'))}
+      sx={{
+        marginRight: 'auto',
+      }}
+    >
+      <IconCustomizable
+        icon={props.icon}
+        sx={theme => ({
+          marginLeft: theme.space.$0x5,
+          color: theme.colors.$blackAlpha400,
+          width: theme.sizes.$4,
+          height: theme.sizes.$4,
+        })}
+      />
+    </Flex>
+  );
+};
+
+const FieldLabel = (props: PropsWithChildren<{ localizationKey?: LocalizationKey | string }>) => {
+  const { hasError, isDisabled } = useFormControl();
+  const { isRequired, id, label } = useFormField();
+
+  if (!(props.localizationKey || label) && !props.children) {
+    return null;
+  }
+
+  return (
+    <FormLabel
+      localizationKey={props.localizationKey || label}
+      elementDescriptor={descriptors.formFieldLabel}
+      elementId={descriptors.formFieldLabel.setId(id as FieldId)}
+      hasError={!!hasError}
+      isDisabled={isDisabled}
+      isRequired={isRequired}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+      }}
+    >
+      {props.children}
+    </FormLabel>
+  );
+};
+
+const FieldLabelRow = (props: PropsWithChildren) => {
+  const { fieldId } = useFormField();
+  return (
+    <Flex
+      justify={'between'}
+      align='center'
+      elementDescriptor={descriptors.formFieldLabelRow}
+      elementId={descriptors.formFieldLabelRow.setId(fieldId)}
+      sx={theme => ({
+        marginBottom: theme.space.$1,
+        marginLeft: 0,
+      })}
+    >
+      {props.children}
+    </Flex>
+  );
+};
+
+const FieldFeedback = (props: Pick<FormFeedbackProps, 'elementDescriptors'>) => {
+  const {
+    errorText,
+    informationText,
+    enableErrorAfterBlur,
+    hasPassedComplexity,
+    isFocused,
+    hasLostFocus,
+    successfulText,
+    warningText,
+  } = useFormField();
+  const { submittedWithEnter } = useFormState();
+  const { debounced } = useFormControlFeedback({
+    errorText,
+    informationText,
+    enableErrorAfterBlur,
+    hasPassedComplexity,
+    isFocused,
+    hasLostFocus,
+    successfulText,
+    warningText,
+    skipBlur: submittedWithEnter,
+  });
+
+  return (
+    <FormFeedback
+      {...{
+        ...debounced,
+        elementDescriptors: props.elementDescriptors,
+      }}
+    />
+  );
+};
+
+const InputElement = forwardRef<HTMLInputElement>((_, ref) => {
+  const { t } = useLocalizations();
+  const formField = useFormField();
+  const { placeholder, ...inputProps } = sanitizeInputProps(formField);
+  return (
+    <Input
+      ref={ref}
+      elementDescriptor={descriptors.formFieldInput}
+      elementId={descriptors.formFieldInput.setId(formField.fieldId)}
+      {...inputProps}
+      placeholder={t(placeholder)}
+    />
+  );
+});
+
+export const Field = {
+  Root: Root,
+  Label: FieldLabel,
+  LabelRow: FieldLabelRow,
+  Input: InputElement,
+  Action: FieldAction,
+  AsOptional: FieldOptionalLabel,
+  LabelIcon: FieldLabelIcon,
+  Feedback: FieldFeedback,
+};

--- a/packages/clerk-js/src/ui/elements/FieldControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FieldControl.tsx
@@ -16,7 +16,7 @@ import {
   useLocalizations,
 } from '../customizables';
 import { useFieldMessageVisibility } from '../hooks';
-import { FormFieldContextProvider, sanitizeInputProps, useFormControl, useFormField } from '../primitives/hooks';
+import { FormFieldContextProvider, sanitizeInputProps, useFormField } from '../primitives/hooks';
 import type { PropsOfComponent } from '../styledSystem';
 import type { useFormControl as useFormControlUtil } from '../utils';
 import { useFormControlFeedback } from '../utils';
@@ -25,10 +25,8 @@ import { useFormState } from './Form';
 import type { FormFeedbackProps } from './FormControl';
 import { delay, FormFeedback } from './FormControl';
 
-type FormControlProps = Omit<PropsOfComponent<typeof Input>, 'label' | 'placeholder'> &
-  ReturnType<typeof useFormControlUtil<FieldId>>['props'] & {
-    isDisabled?: boolean;
-  };
+type FormControlProps = Omit<PropsOfComponent<typeof Input>, 'label' | 'placeholder' | 'disabled' | 'required'> &
+  ReturnType<typeof useFormControlUtil<FieldId>>['props'];
 
 export const Root = (props: PropsWithChildren<FormControlProps>) => {
   const card = useCardState();
@@ -67,7 +65,7 @@ export const Root = (props: PropsWithChildren<FormControlProps>) => {
   const isDisabled = props.isDisabled || card.isLoading;
 
   return (
-    <FormFieldContextProvider {...props}>
+    <FormFieldContextProvider {...{ ...props, isDisabled }}>
       {/*Most of our primitives still depend on this provider.*/}
       {/*TODO: In follow-up PRs these will be removed*/}
       <FormControlPrim
@@ -92,7 +90,7 @@ export const Root = (props: PropsWithChildren<FormControlProps>) => {
 const FieldAction = (
   props: PropsWithChildren<{ localizationKey?: LocalizationKey | string; onClick?: React.MouseEventHandler }>,
 ) => {
-  const { isDisabled, id } = useFormControl();
+  const { fieldId, isDisabled } = useFormField();
 
   if (!props.localizationKey && !props.children) {
     return null;
@@ -102,7 +100,7 @@ const FieldAction = (
     <Link
       localizationKey={props.localizationKey}
       elementDescriptor={descriptors.formFieldAction}
-      elementId={descriptors.formFieldLabel.setId(id as FieldId)}
+      elementId={descriptors.formFieldLabel.setId(fieldId)}
       isDisabled={isDisabled}
       colorScheme='primary'
       onClick={e => {
@@ -116,12 +114,12 @@ const FieldAction = (
 };
 
 const FieldOptionalLabel = () => {
-  const { isDisabled, id } = useFormControl();
+  const { fieldId, isDisabled } = useFormField();
   return (
     <Text
       localizationKey={localizationKeys('formFieldHintText__optional')}
       elementDescriptor={descriptors.formFieldHintText}
-      elementId={descriptors.formFieldHintText.setId(id as FieldId)}
+      elementId={descriptors.formFieldHintText.setId(fieldId)}
       as='span'
       colorScheme='neutral'
       variant='smallRegular'
@@ -158,8 +156,7 @@ const FieldLabelIcon = (props: { icon?: React.ComponentType }) => {
 };
 
 const FieldLabel = (props: PropsWithChildren<{ localizationKey?: LocalizationKey | string }>) => {
-  const { hasError, isDisabled } = useFormControl();
-  const { isRequired, id, label } = useFormField();
+  const { isRequired, id, label, isDisabled, hasError } = useFormField();
 
   if (!(props.localizationKey || label) && !props.children) {
     return null;

--- a/packages/clerk-js/src/ui/elements/Form.tsx
+++ b/packages/clerk-js/src/ui/elements/Form.tsx
@@ -1,11 +1,14 @@
 import { createContextAndHook } from '@clerk/shared/react';
 import type { FieldId } from '@clerk/types';
+import type { PropsWithChildren } from 'react';
 import React, { useState } from 'react';
 
+import type { LocalizationKey } from '../customizables';
 import { Button, descriptors, Flex, Form as FormPrim, localizationKeys } from '../customizables';
 import { useLoadingStatus } from '../hooks';
 import type { PropsOfComponent } from '../styledSystem';
 import { useCardState } from './contexts';
+import { Field } from './FieldControl';
 import { FormControl } from './FormControl';
 
 const [FormState, useFormState] = createContextAndHook<{
@@ -118,10 +121,53 @@ const FormControlRow = (props: Omit<PropsOfComponent<typeof Flex>, 'elementId'> 
   );
 };
 
+type CommonFieldRootProps = Omit<PropsOfComponent<typeof Field.Root>, 'children'>;
+
+type CommonInputProps = CommonFieldRootProps & {
+  isOptional?: boolean;
+  actionLabel?: string | LocalizationKey;
+  onActionClicked?: React.MouseEventHandler;
+  icon?: React.ComponentType;
+};
+
+const CommonInputWrapper = (props: PropsWithChildren<CommonInputProps>) => {
+  const { isOptional, icon, actionLabel, children, onActionClicked, ...fieldProps } = props;
+  return (
+    <Field.Root {...fieldProps}>
+      <Field.LabelRow>
+        <Field.Label />
+        <Field.LabelIcon icon={icon} />
+        {!actionLabel && isOptional && <Field.AsOptional />}
+        {actionLabel && (
+          <Field.Action
+            localizationKey={actionLabel}
+            onClick={onActionClicked}
+          />
+        )}
+        <Field.Action />
+      </Field.LabelRow>
+      {children}
+      <Field.Feedback />
+    </Field.Root>
+  );
+};
+
+const PlainInput = (props: CommonInputProps) => {
+  return (
+    <CommonInputWrapper {...props}>
+      <Field.Input />
+    </CommonInputWrapper>
+  );
+};
+
 export const Form = {
   Root: FormRoot,
   ControlRow: FormControlRow,
+  /**
+   * @deprecated Use Form.PlainInput
+   */
   Control: FormControl,
+  PlainInput,
   SubmitButton: FormSubmit,
   ResetButton: FormReset,
 };

--- a/packages/clerk-js/src/ui/elements/FormControl.tsx
+++ b/packages/clerk-js/src/ui/elements/FormControl.tsx
@@ -89,7 +89,7 @@ const getInputElementForType = ({
   return CustomInputs[customInput] || Input;
 };
 
-function useFormTextAnimation() {
+export function useFormTextAnimation() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
   const getFormTextAnimation = useCallback(
@@ -117,7 +117,7 @@ function useFormTextAnimation() {
   };
 }
 
-const useCalculateErrorTextHeight = ({ feedback }: { feedback: string }) => {
+export const useCalculateErrorTextHeight = ({ feedback }: { feedback: string }) => {
   const [height, setHeight] = useState(0);
 
   const calculateHeight = useCallback(
@@ -136,11 +136,11 @@ const useCalculateErrorTextHeight = ({ feedback }: { feedback: string }) => {
   };
 };
 
-type FormFeedbackDescriptorsKeys = 'error' | 'warning' | 'info' | 'success';
+export type FormFeedbackDescriptorsKeys = 'error' | 'warning' | 'info' | 'success';
 
 type Feedback = { feedback?: string; feedbackType?: FeedbackType; shouldEnter: boolean };
 
-type FormFeedbackProps = Partial<ReturnType<typeof useFormControlFeedback>['debounced'] & { id: FieldId }> & {
+export type FormFeedbackProps = Partial<ReturnType<typeof useFormControlFeedback>['debounced'] & { id: FieldId }> & {
   elementDescriptors?: Partial<Record<FormFeedbackDescriptorsKeys, ElementDescriptor>>;
 };
 

--- a/packages/clerk-js/src/ui/elements/RadioGroup.tsx
+++ b/packages/clerk-js/src/ui/elements/RadioGroup.tsx
@@ -4,6 +4,9 @@ import type { LocalizationKey } from '../customizables';
 import { Col, descriptors, Flex, FormLabel, Input, Text } from '../customizables';
 import type { PropsOfComponent } from '../styledSystem';
 
+/**
+ * @deprecated
+ */
 export const RadioGroup = (
   props: PropsOfComponent<typeof Input> & {
     radioOptions?: {
@@ -30,6 +33,9 @@ export const RadioGroup = (
   );
 };
 
+/**
+ * @deprecated
+ */
 const RadioGroupItem = (props: {
   inputProps: PropsOfComponent<typeof Input>;
   value: string;

--- a/packages/clerk-js/src/ui/elements/RadioGroup.tsx
+++ b/packages/clerk-js/src/ui/elements/RadioGroup.tsx
@@ -4,9 +4,6 @@ import type { LocalizationKey } from '../customizables';
 import { Col, descriptors, Flex, FormLabel, Input, Text } from '../customizables';
 import type { PropsOfComponent } from '../styledSystem';
 
-/**
- * @deprecated
- */
 export const RadioGroup = (
   props: PropsOfComponent<typeof Input> & {
     radioOptions?: {
@@ -33,9 +30,6 @@ export const RadioGroup = (
   );
 };
 
-/**
- * @deprecated
- */
 const RadioGroupItem = (props: {
   inputProps: PropsOfComponent<typeof Input>;
   value: string;

--- a/packages/clerk-js/src/ui/primitives/FormControl.tsx
+++ b/packages/clerk-js/src/ui/primitives/FormControl.tsx
@@ -4,6 +4,11 @@ import { Flex } from './Flex';
 import type { FormControlProps } from './hooks';
 import { FormControlContextProvider } from './hooks';
 
+/**
+ * @deprecated Use Field.Root
+ * Each controlled field should have their own UI wrapper.
+ * Field.Root is just a Provider
+ */
 export const FormControl = (props: React.PropsWithChildren<FormControlProps>) => {
   const {
     hasError,

--- a/packages/clerk-js/src/ui/primitives/Input.tsx
+++ b/packages/clerk-js/src/ui/primitives/Input.tsx
@@ -49,6 +49,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref)
   });
   const { onChange } = useInput(propsWithoutVariants.onChange);
   const { isDisabled, hasError, focusRing, isRequired, ...rest } = propsWithoutVariants;
+  const _disabled = isDisabled || formControlProps.isDisabled;
+  const _required = isRequired || formControlProps.isRequired;
+  const _hasError = hasError || formControlProps.hasError;
 
   return (
     <input
@@ -56,11 +59,12 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref)
       ref={ref}
       onChange={onChange}
       disabled={isDisabled}
-      required={isRequired || formControlProps.isRequired}
+      required={_required}
       id={props.id || formControlProps.id}
-      aria-invalid={hasError || formControlProps.hasError}
+      aria-invalid={_hasError}
       aria-describedby={formControlProps.errorMessageId}
-      aria-required={formControlProps.isRequired}
+      aria-required={_required}
+      aria-disabled={_disabled}
       css={applyVariants(propsWithoutVariants)}
     />
   );

--- a/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
+++ b/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
@@ -92,7 +92,10 @@ export const FormControlContextProvider = (props: React.PropsWithChildren<FormCo
   return <FormControlContext.Provider value={value}>{props.children}</FormControlContext.Provider>;
 };
 
-type FormFieldProviderProps = ReturnType<typeof useFormControlUtil<FieldId>>['props'];
+type FormFieldProviderProps = ReturnType<typeof useFormControlUtil<FieldId>>['props'] & {
+  hasError?: boolean;
+  isDisabled?: boolean;
+};
 
 type FormFieldContextValue = Omit<FormFieldProviderProps, 'id'> & {
   errorMessageId?: string;
@@ -105,6 +108,8 @@ export const FormFieldContextProvider = (props: React.PropsWithChildren<FormFiel
   const {
     id: propsId,
     isRequired = false,
+    isDisabled = false,
+    hasError = false,
     setError,
     setSuccessful,
     setWarning,
@@ -123,6 +128,8 @@ export const FormFieldContextProvider = (props: React.PropsWithChildren<FormFiel
   const value = React.useMemo(
     () => ({
       isRequired,
+      isDisabled,
+      hasError,
       id,
       fieldId: propsId,
       errorMessageId,
@@ -131,7 +138,7 @@ export const FormFieldContextProvider = (props: React.PropsWithChildren<FormFiel
       setWarning,
       setHasPassedComplexity,
     }),
-    [isRequired, id, errorMessageId, setError, setSuccessful, setHasPassedComplexity],
+    [isRequired, isDisabled, hasError, id, errorMessageId, setError, setSuccessful, setHasPassedComplexity],
   );
   return (
     <FormFieldContext.Provider

--- a/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
+++ b/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
@@ -1,6 +1,5 @@
 import { createContextAndHook } from '@clerk/shared/react';
 import type { ClerkAPIError, FieldId } from '@clerk/types';
-import type { ClerkAPIError } from '@clerk/types';
 import React from 'react';
 
 import type { useFormControl as useFormControlUtil } from '../../utils/useFormControl';
@@ -111,9 +110,11 @@ export const FormFieldContextProvider = (props: React.PropsWithChildren<FormFiel
     isDisabled = false,
     hasError = false,
     setError,
-    setSuccessful,
+    setSuccess,
     setWarning,
     setHasPassedComplexity,
+    setInfo,
+    clearFeedback,
     children,
     ...rest
   } = props;
@@ -124,7 +125,7 @@ export const FormFieldContextProvider = (props: React.PropsWithChildren<FormFiel
    * Track whether the `FormErrorText` has been rendered.
    * We use this to append its id the `aria-describedby` of the `input`.
    */
-  const errorMessageId = rest.errorText ? `error-${propsId}` : '';
+  const errorMessageId = hasError ? `error-${propsId}` : '';
   const value = React.useMemo(
     () => ({
       isRequired,
@@ -134,11 +135,26 @@ export const FormFieldContextProvider = (props: React.PropsWithChildren<FormFiel
       fieldId: propsId,
       errorMessageId,
       setError,
-      setSuccessful,
+      setSuccess,
       setWarning,
+      setInfo,
+      clearFeedback,
       setHasPassedComplexity,
     }),
-    [isRequired, isDisabled, hasError, id, errorMessageId, setError, setSuccessful, setHasPassedComplexity],
+    [
+      isRequired,
+      hasError,
+      id,
+      propsId,
+      errorMessageId,
+      isDisabled,
+      setError,
+      setSuccess,
+      setWarning,
+      setInfo,
+      clearFeedback,
+      setHasPassedComplexity,
+    ],
   );
   return (
     <FormFieldContext.Provider
@@ -158,28 +174,30 @@ export const sanitizeInputProps = (
   obj: ReturnType<typeof useFormField>,
   keep?: (keyof ReturnType<typeof useFormField>)[],
 ) => {
+  /* eslint-disable */
   const {
     radioOptions,
     validatePassword,
-    warningText,
-    informationText,
     hasPassedComplexity,
-    enableErrorAfterBlur,
     isFocused,
-    hasLostFocus,
-    successfulText,
-    errorText,
+    feedback,
+    feedbackType,
     setHasPassedComplexity,
     setWarning,
-    setSuccessful,
+    setSuccess,
     setError,
+    setInfo,
     errorMessageId,
     fieldId,
     label,
     ...inputProps
   } = obj;
+  /* eslint-enable */
 
   keep?.forEach(key => {
+    /**
+     * Ignore error for the index type as we have defined it explicitly above
+     */
     // @ts-ignore
     inputProps[key] = obj[key];
   });

--- a/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
+++ b/packages/clerk-js/src/ui/primitives/hooks/useFormControl.tsx
@@ -1,7 +1,13 @@
 import { createContextAndHook } from '@clerk/shared/react';
+import type { ClerkAPIError, FieldId } from '@clerk/types';
 import type { ClerkAPIError } from '@clerk/types';
 import React from 'react';
 
+import type { useFormControl as useFormControlUtil } from '../../utils/useFormControl';
+
+/**
+ * @deprecated
+ */
 export type FormControlProps = {
   /**
    * The custom `id` to use for the form control. This is passed directly to the form element (e.g, Input).
@@ -19,11 +25,20 @@ export type FormControlProps = {
   clearFeedback: () => void;
 };
 
+/**
+ * @deprecated
+ */
 type FormControlContextValue = Required<FormControlProps> & { errorMessageId: string };
 
+/**
+ * @deprecated Use FormFieldContextProvider
+ */
 export const [FormControlContext, , useFormControl] =
   createContextAndHook<FormControlContextValue>('FormControlContext');
 
+/**
+ * @deprecated Use FormFieldContextProvider
+ */
 export const FormControlContextProvider = (props: React.PropsWithChildren<FormControlProps>) => {
   const {
     id: propsId,
@@ -75,4 +90,92 @@ export const FormControlContextProvider = (props: React.PropsWithChildren<FormCo
     ],
   );
   return <FormControlContext.Provider value={value}>{props.children}</FormControlContext.Provider>;
+};
+
+type FormFieldProviderProps = ReturnType<typeof useFormControlUtil<FieldId>>['props'];
+
+type FormFieldContextValue = Omit<FormFieldProviderProps, 'id'> & {
+  errorMessageId?: string;
+  id?: string;
+  fieldId?: FieldId;
+};
+export const [FormFieldContext, useFormField] = createContextAndHook<FormFieldContextValue>('FormFieldContext');
+
+export const FormFieldContextProvider = (props: React.PropsWithChildren<FormFieldProviderProps>) => {
+  const {
+    id: propsId,
+    isRequired = false,
+    setError,
+    setSuccessful,
+    setWarning,
+    setHasPassedComplexity,
+    children,
+    ...rest
+  } = props;
+  // TODO: This shouldnt be targettable
+  const id = `${propsId}-field`;
+
+  /**
+   * Track whether the `FormErrorText` has been rendered.
+   * We use this to append its id the `aria-describedby` of the `input`.
+   */
+  const errorMessageId = rest.errorText ? `error-${propsId}` : '';
+  const value = React.useMemo(
+    () => ({
+      isRequired,
+      id,
+      fieldId: propsId,
+      errorMessageId,
+      setError,
+      setSuccessful,
+      setWarning,
+      setHasPassedComplexity,
+    }),
+    [isRequired, id, errorMessageId, setError, setSuccessful, setHasPassedComplexity],
+  );
+  return (
+    <FormFieldContext.Provider
+      value={{
+        value: {
+          ...value,
+          ...rest,
+        },
+      }}
+    >
+      {props.children}
+    </FormFieldContext.Provider>
+  );
+};
+
+export const sanitizeInputProps = (
+  obj: ReturnType<typeof useFormField>,
+  keep?: (keyof ReturnType<typeof useFormField>)[],
+) => {
+  const {
+    radioOptions,
+    validatePassword,
+    warningText,
+    informationText,
+    hasPassedComplexity,
+    enableErrorAfterBlur,
+    isFocused,
+    hasLostFocus,
+    successfulText,
+    errorText,
+    setHasPassedComplexity,
+    setWarning,
+    setSuccessful,
+    setError,
+    errorMessageId,
+    fieldId,
+    label,
+    ...inputProps
+  } = obj;
+
+  keep?.forEach(key => {
+    // @ts-ignore
+    inputProps[key] = obj[key];
+  });
+
+  return inputProps;
 };

--- a/packages/clerk-js/src/ui/utils/useFormControl.ts
+++ b/packages/clerk-js/src/ui/utils/useFormControl.ts
@@ -48,6 +48,8 @@ type FieldStateProps<Id> = {
   value: string;
   checked?: boolean;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
+  onBlur: React.FocusEventHandler<HTMLInputElement>;
+  onFocus: React.FocusEventHandler<HTMLInputElement>;
   feedback: string;
   feedbackType: FeedbackType;
   setError: (error: string | ClerkAPIError | undefined) => void;
@@ -57,6 +59,7 @@ type FieldStateProps<Id> = {
   setHasPassedComplexity: (b: boolean) => void;
   clearFeedback: () => void;
   hasPassedComplexity: boolean;
+  isFocused: boolean;
 } & Omit<Options, 'defaultChecked'>;
 
 export type FormControlState<Id = string> = FieldStateProps<Id> & {
@@ -87,6 +90,7 @@ export const useFormControl = <Id extends string>(
 
   const { translateError, t } = useLocalizations();
   const [value, setValueInternal] = useState<string>(initialState);
+  const [isFocused, setFocused] = useState(false);
   const [checked, setCheckedInternal] = useState<boolean>(opts?.defaultChecked || false);
   const [hasPassedComplexity, setHasPassedComplexity] = useState(false);
   const [feedback, setFeedback] = useState<{ message: string; type: FeedbackType }>({
@@ -130,6 +134,14 @@ export const useFormControl = <Id extends string>(
     setFeedback({ message: '', type: 'info' });
   };
 
+  const onFocus: FormControlState['onFocus'] = () => {
+    setFocused(true);
+  };
+
+  const onBlur: FormControlState['onBlur'] = () => {
+    setFocused(false);
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { defaultChecked, validatePassword: validatePasswordProp, buildErrorMessage, ...restOpts } = opts;
 
@@ -141,6 +153,8 @@ export const useFormControl = <Id extends string>(
     setSuccess,
     setError,
     onChange,
+    onBlur,
+    onFocus,
     setWarning,
     feedback: feedback.message || t(opts.infoText),
     feedbackType: feedback.type,
@@ -149,6 +163,7 @@ export const useFormControl = <Id extends string>(
     hasPassedComplexity,
     setHasPassedComplexity,
     validatePassword: opts.type === 'password' ? opts.validatePassword : undefined,
+    isFocused,
     ...restOpts,
   };
 
@@ -178,10 +193,8 @@ type DebouncingOption = {
   isFocused?: boolean;
   delayInMs?: number;
 };
-
 export const useFormControlFeedback = (opts?: DebouncingOption): DebouncedFeedback => {
   const { feedback = '', delayInMs = 100, feedbackType = 'info', isFocused = false } = opts || {};
-
   const shouldHide = isFocused ? false : ['info', 'warning'].includes(feedbackType);
 
   const debouncedState = useDebounce(


### PR DESCRIPTION
## Description

This is PR starts the refactoring process for our forms. The main focus is refactoring how our fields are structure, starting the `PlainInput` which represents a simple input element.

In the immediate feature we want to completely drop Form.Control and offer these alternatives
- Form.PasswordInput
- Form.Checkbox
- Form.RadioGroup
- Form.InputGroup

Their API will remain simple and those will be opinionated about the UI they represent, the underlying implementation will allow for easy changes tho.

- Replace Form.Control with Form.PlainInput (example usage)
- Top level API remains simple, but the internally Form.PlainInput is very modular.
- Renaming contexts and hooks with the `field` prefix in order to clearly indicate that the internal state reflects to a field not the entire form
  - `FormFieldContextProvider` replaces `FormControlContextProvider` (both need to co-exist until the refactor is complete)
- Force the usage of isDisabled, isRequired over the native html attributes



<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
