### PR TITLE
fix(clerk-js): Re-initialize Client singleton instance on Client destroy

### DIFF
--- a/.changeset/soft-birds-thank.md
+++ b/.changeset/soft-birds-thank.md
@@ -2,4 +2,4 @@
 '@clerk/clerk-js': patch
 ---
 
-Re-initialize the Client to default values when is detroyed
+Re-initialize the Client to default values when is destroyed

--- a/.changeset/soft-birds-thank.md
+++ b/.changeset/soft-birds-thank.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-js': patch
+---
+
+Re-initialize the Client to default values when is detroyed

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -501,7 +501,7 @@ describe('Clerk singleton', () => {
       });
     });
 
-    it('destroyes the current client after sign out', async () => {
+    it('destroys the current client after sign out', async () => {
       const spyOnDestroy = jest.fn().mockImplementation(() => {
         return Promise.resolve().then(async () => {
           const clientInstance = await Client.getInstance().fetch();

--- a/packages/clerk-js/src/core/clerk.test.ts
+++ b/packages/clerk-js/src/core/clerk.test.ts
@@ -500,40 +500,6 @@ describe('Clerk singleton', () => {
         expect(sut.setActive).toHaveBeenCalledWith({ session: null });
       });
     });
-
-    it('destroys the current client after sign out', async () => {
-      const spyOnDestroy = jest.fn().mockImplementation(() => {
-        return Promise.resolve().then(async () => {
-          const clientInstance = await Client.getInstance().fetch();
-          clientInstance.id = undefined;
-          clientInstance.sessions = [];
-          clientInstance.signUp = new SignUp();
-          clientInstance.signIn = new SignIn();
-          clientInstance.lastActiveSessionId = null;
-          clientInstance.createdAt = null;
-          clientInstance.updatedAt = null;
-        });
-      });
-      mockClientFetch.mockReturnValue(
-        Promise.resolve({
-          id: '1',
-          activeSessions: [mockSession1],
-          sessions: [mockSession1],
-          destroy: spyOnDestroy,
-        }),
-      );
-
-      const sut = new Clerk(frontendApi);
-      sut.setActive = jest.fn();
-      await sut.load();
-      await sut.signOut();
-      await waitFor(() => {
-        expect(sut.client?.id).toBeUndefined();
-        expect(sut.client?.sessions.length).toBe(0);
-        expect(spyOnDestroy).toHaveBeenCalled();
-        expect(mockClientFetch).toHaveBeenCalled();
-      });
-    });
   });
 
   describe('.navigate(to)', () => {

--- a/packages/clerk-js/src/core/resources/Client.test.ts
+++ b/packages/clerk-js/src/core/resources/Client.test.ts
@@ -3,12 +3,9 @@ import type { ClientJSON } from '@clerk/types';
 import { createSession } from '../test/fixtures';
 import { BaseResource, Client } from './internal';
 
-export const mockJwt =
-  'eyJhbGciOiJSUzI1NiIsImtpZCI6Imluc18yR0lvUWhiVXB5MGhYN0IyY1ZrdVRNaW5Yb0QiLCJ0eXAiOiJKV1QifQ.eyJhenAiOiJodHRwczovL2FjY291bnRzLmluc3BpcmVkLnB1bWEtNzQubGNsLmRldiIsImV4cCI6MTY2NjY0ODMxMCwiaWF0IjoxNjY2NjQ4MjUwLCJpc3MiOiJodHRwczovL2NsZXJrLmluc3BpcmVkLnB1bWEtNzQubGNsLmRldiIsIm5iZiI6MTY2NjY0ODI0MCwic2lkIjoic2Vzc18yR2JEQjRlbk5kQ2E1dlMxenBDM1h6Zzl0SzkiLCJzdWIiOiJ1c2VyXzJHSXBYT0VwVnlKdzUxcmtabjlLbW5jNlN4ciJ9.n1Usc-DLDftqA0Xb-_2w8IGs4yjCmwc5RngwbSRvwevuZOIuRoeHmE2sgCdEvjfJEa7ewL6EVGVcM557TWPW--g_J1XQPwBy8tXfz7-S73CEuyRFiR97L2AHRdvRtvGtwR-o6l8aHaFxtlmfWbQXfg4kFJz2UGe9afmh3U9-f_4JOZ5fa3mI98UMy1-bo20vjXeWQ9aGrqaxHQxjnzzC-1Kpi5LdPvhQ16H0dPB8MHRTSM5TAuLKTpPV7wqixmbtcc2-0k6b9FKYZNqRVTaIyV-lifZloBvdzlfOF8nW1VVH_fx-iW5Q3hovHFcJIULHEC1kcAYTubbxzpgeVQepGg';
-
 describe('Client Singleton', () => {
   it('destroy', async () => {
-    const session = createSession({});
+    const session = createSession();
     const clientObjectJSON: ClientJSON = {
       object: 'client',
       id: 'test_id',
@@ -17,14 +14,33 @@ describe('Client Singleton', () => {
       sign_in: null,
       sign_up: null,
       sessions: [session],
-      created_at: jest.now(),
+      created_at: jest.now() - 1000,
+      updated_at: jest.now(),
+    };
+
+    const destroyedSession = createSession({
+      id: 'test_session_id',
+      abandon_at: jest.now(),
+      status: 'ended',
+      last_active_token: undefined,
+    });
+
+    const clientObjectDeletedJSON = {
+      id: 'test_id_deleted',
+      status: 'ended',
+      last_active_session_id: null,
+      sign_in: null,
+      sign_up: null,
+      sessions: [destroyedSession],
+      created_at: jest.now() - 1000,
       updated_at: jest.now(),
     };
 
     // @ts-expect-error This is a private method that we are mocking
     BaseResource._fetch = jest.fn().mockReturnValue(
       Promise.resolve({
-        response: clientObjectJSON,
+        client: null,
+        response: clientObjectDeletedJSON,
       }),
     );
 

--- a/packages/clerk-js/src/core/resources/Client.test.ts
+++ b/packages/clerk-js/src/core/resources/Client.test.ts
@@ -1,0 +1,50 @@
+import type { ClientJSON } from '@clerk/types';
+
+import { createSession } from '../test/fixtures';
+import { BaseResource, Client } from './internal';
+
+export const mockJwt =
+  'eyJhbGciOiJSUzI1NiIsImtpZCI6Imluc18yR0lvUWhiVXB5MGhYN0IyY1ZrdVRNaW5Yb0QiLCJ0eXAiOiJKV1QifQ.eyJhenAiOiJodHRwczovL2FjY291bnRzLmluc3BpcmVkLnB1bWEtNzQubGNsLmRldiIsImV4cCI6MTY2NjY0ODMxMCwiaWF0IjoxNjY2NjQ4MjUwLCJpc3MiOiJodHRwczovL2NsZXJrLmluc3BpcmVkLnB1bWEtNzQubGNsLmRldiIsIm5iZiI6MTY2NjY0ODI0MCwic2lkIjoic2Vzc18yR2JEQjRlbk5kQ2E1dlMxenBDM1h6Zzl0SzkiLCJzdWIiOiJ1c2VyXzJHSXBYT0VwVnlKdzUxcmtabjlLbW5jNlN4ciJ9.n1Usc-DLDftqA0Xb-_2w8IGs4yjCmwc5RngwbSRvwevuZOIuRoeHmE2sgCdEvjfJEa7ewL6EVGVcM557TWPW--g_J1XQPwBy8tXfz7-S73CEuyRFiR97L2AHRdvRtvGtwR-o6l8aHaFxtlmfWbQXfg4kFJz2UGe9afmh3U9-f_4JOZ5fa3mI98UMy1-bo20vjXeWQ9aGrqaxHQxjnzzC-1Kpi5LdPvhQ16H0dPB8MHRTSM5TAuLKTpPV7wqixmbtcc2-0k6b9FKYZNqRVTaIyV-lifZloBvdzlfOF8nW1VVH_fx-iW5Q3hovHFcJIULHEC1kcAYTubbxzpgeVQepGg';
+
+describe('Client Singleton', () => {
+  it('destroy', async () => {
+    const session = createSession({});
+    const clientObjectJSON: ClientJSON = {
+      object: 'client',
+      id: 'test_id',
+      status: 'active',
+      last_active_session_id: 'test_session_id',
+      sign_in: null,
+      sign_up: null,
+      sessions: [session],
+      created_at: jest.now(),
+      updated_at: jest.now(),
+    };
+
+    // @ts-expect-error This is a private method that we are mocking
+    BaseResource._fetch = jest.fn().mockReturnValue(
+      Promise.resolve({
+        response: clientObjectJSON,
+      }),
+    );
+
+    const client = Client.getInstance().fromJSON(clientObjectJSON);
+    expect(client.sessions.length).toBe(1);
+    expect(client.createdAt).not.toBeNull();
+    expect(client.updatedAt).not.toBeNull();
+    expect(client.lastActiveSessionId).not.toBeNull();
+
+    await client.destroy();
+
+    expect(client.sessions.length).toBe(0);
+    expect(client.createdAt).toBeNull();
+    expect(client.updatedAt).toBeNull();
+    expect(client.lastActiveSessionId).toBeNull();
+
+    // @ts-expect-error This is a private method that we are mocking
+    expect(BaseResource._fetch).toHaveBeenCalledWith({
+      method: 'DELETE',
+      path: `/client`,
+    });
+  });
+});

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -57,6 +57,7 @@ export class Client extends BaseResource implements ClientResource {
     return this._baseDelete({ path: '/client' }).then(() => {
       SessionTokenCache.clear();
       this.sessions = [];
+      Client.instance = new Client();
     });
   }
 

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -57,7 +57,11 @@ export class Client extends BaseResource implements ClientResource {
     return this._baseDelete({ path: '/client' }).then(() => {
       SessionTokenCache.clear();
       this.sessions = [];
-      Client.instance = new Client();
+      this.signUp = new SignUp();
+      this.signIn = new SignIn();
+      this.lastActiveSessionId = null;
+      this.createdAt = null;
+      this.updatedAt = null;
     });
   }
 

--- a/packages/clerk-js/src/core/resources/Client.ts
+++ b/packages/clerk-js/src/core/resources/Client.ts
@@ -57,8 +57,8 @@ export class Client extends BaseResource implements ClientResource {
     return this._baseDelete({ path: '/client' }).then(() => {
       SessionTokenCache.clear();
       this.sessions = [];
-      this.signUp = new SignUp();
-      this.signIn = new SignIn();
+      this.signUp = new SignUp(null);
+      this.signIn = new SignIn(null);
       this.lastActiveSessionId = null;
       this.createdAt = null;
       this.updatedAt = null;

--- a/packages/clerk-js/src/core/test/fixtures.ts
+++ b/packages/clerk-js/src/core/test/fixtures.ts
@@ -8,6 +8,8 @@ import type {
   OrganizationPermission,
   PhoneNumberJSON,
   SessionJSON,
+  SignInJSON,
+  SignUpJSON,
   UserJSON,
 } from '@clerk/types';
 
@@ -166,8 +168,7 @@ export const createUser = (params: WithUserParams): UserJSON => {
   return res;
 };
 
-export const createSession = (sessionParams: WithSessionParams = {}, userParams: WithUserParams = {}) => {
-  const user = createUser(userParams);
+export const createSession = (sessionParams: WithSessionParams = {}, user: Partial<UserJSON> = {}) => {
   return {
     object: 'session',
     id: sessionParams.id,
@@ -183,7 +184,7 @@ export const createSession = (sessionParams: WithSessionParams = {}, userParams:
       last_name: user.last_name,
       image_url: user.image_url,
       has_image: user.has_image,
-      identifier: user.email_addresses.find(e => e.id === user.primary_email_address_id)?.email_address || '',
+      identifier: user.email_addresses?.find(e => e.id === user.primary_email_address_id)?.email_address || '',
       profile_image_url: user.profile_image_url,
     },
     created_at: sessionParams.created_at || jest.now() - 1000,
@@ -193,6 +194,56 @@ export const createSession = (sessionParams: WithSessionParams = {}, userParams:
       jwt: mockJwt,
     },
   } as SessionJSON;
+};
+
+export const createSignIn = (signInParams: Partial<SignInJSON> = {}, user: Partial<UserJSON> = {}) => {
+  return {
+    id: signInParams.id,
+    created_session_id: signInParams.created_session_id,
+    status: signInParams.status,
+    first_factor_verification: signInParams.first_factor_verification,
+    identifier: signInParams.identifier,
+    object: 'sign_in',
+    second_factor_verification: signInParams.second_factor_verification,
+    supported_external_accounts: signInParams.supported_external_accounts,
+    supported_first_factors: signInParams.supported_first_factors,
+    supported_identifiers: signInParams.supported_identifiers,
+    supported_second_factors: signInParams.supported_second_factors,
+    user_data: {
+      first_name: user.first_name,
+      last_name: user.last_name,
+      image_url: user.image_url,
+      has_image: user.has_image,
+      profile_image_url: user.profile_image_url,
+    },
+  } as SignInJSON;
+};
+
+export const createSignUp = (signUpParams: Partial<SignUpJSON> = {}) => {
+  return {
+    id: signUpParams.id,
+    created_session_id: signUpParams.created_session_id,
+    status: signUpParams.status,
+    abandon_at: signUpParams.abandon_at,
+    created_user_id: signUpParams.created_user_id,
+    email_address: signUpParams.email_address,
+    external_account: signUpParams.external_account,
+    external_account_strategy: signUpParams.external_account_strategy,
+    first_name: signUpParams.first_name,
+    has_password: signUpParams.has_password,
+    last_name: signUpParams.last_name,
+    missing_fields: signUpParams.missing_fields,
+    object: 'sign_up',
+    optional_fields: signUpParams.optional_fields,
+    phone_number: signUpParams.phone_number,
+    required_fields: signUpParams.required_fields,
+    supported_external_accounts: signUpParams.supported_external_accounts,
+    unsafe_metadata: signUpParams.unsafe_metadata,
+    unverified_fields: signUpParams.unverified_fields,
+    username: signUpParams.username,
+    verifications: signUpParams.verifications,
+    web3_wallet: signUpParams.web3_wallet,
+  } as SignUpJSON;
 };
 
 export const clerkMock = () => {

--- a/packages/clerk-js/src/core/test/fixtures.ts
+++ b/packages/clerk-js/src/core/test/fixtures.ts
@@ -7,6 +7,7 @@ import type {
   OrganizationMembershipJSON,
   OrganizationPermission,
   PhoneNumberJSON,
+  SessionJSON,
   UserJSON,
 } from '@clerk/types';
 
@@ -158,9 +159,38 @@ export const createUser = (params: WithUserParams): UserJSON => {
     organization_memberships: (params.organization_memberships || []).map(o =>
       typeof o === 'string' ? createOrganizationMembership({ name: o }) : createOrganizationMembership(o),
     ),
-  } as any as UserJSON;
+  } as UserJSON;
   res.primary_email_address_id = res.email_addresses[0]?.id;
   return res;
+};
+
+export const createSession = (params: WithUserParams) => {
+  const user = createUser(params);
+  return {
+    object: 'session',
+    id: 'session_1',
+    status: 'active',
+    expire_at: jest.now() + 5000,
+    abandon_at: jest.now() + 5000,
+    last_active_at: jest.now(),
+    last_active_organization_id: null,
+    actor: null,
+    user: createUser({}),
+    public_user_data: {
+      first_name: user.first_name,
+      last_name: user.last_name,
+      image_url: user.image_url,
+      has_image: user.has_image,
+      identifier: user.email_addresses.find(e => e.id === user.primary_email_address_id)?.email_address || '',
+      profile_image_url: user.profile_image_url,
+    },
+    created_at: 1697449745962,
+    updated_at: 1698763366892,
+    last_active_token: {
+      object: 'token',
+      jwt: mockJwt,
+    },
+  } as SessionJSON;
 };
 
 export const clerkMock = () => {

--- a/packages/clerk-js/src/core/test/fixtures.ts
+++ b/packages/clerk-js/src/core/test/fixtures.ts
@@ -26,6 +26,8 @@ type WithUserParams = Omit<
   organization_memberships?: Array<string | OrgParams>;
 };
 
+type WithSessionParams = Partial<SessionJSON>;
+
 export const getOrganizationId = (orgParams: OrgParams) => orgParams?.id || orgParams?.name || 'test_id';
 
 export const createOrganizationMembership = (params: OrgParams): OrganizationMembershipJSON => {
@@ -164,17 +166,17 @@ export const createUser = (params: WithUserParams): UserJSON => {
   return res;
 };
 
-export const createSession = (params: WithUserParams) => {
-  const user = createUser(params);
+export const createSession = (sessionParams: WithSessionParams = {}, userParams: WithUserParams = {}) => {
+  const user = createUser(userParams);
   return {
     object: 'session',
-    id: 'session_1',
-    status: 'active',
-    expire_at: jest.now() + 5000,
-    abandon_at: jest.now() + 5000,
-    last_active_at: jest.now(),
-    last_active_organization_id: null,
-    actor: null,
+    id: sessionParams.id,
+    status: sessionParams.status,
+    expire_at: sessionParams.expire_at || jest.now() + 5000,
+    abandon_at: sessionParams.abandon_at,
+    last_active_at: sessionParams.last_active_at || jest.now(),
+    last_active_organization_id: sessionParams.last_active_organization_id,
+    actor: sessionParams.actor,
     user: createUser({}),
     public_user_data: {
       first_name: user.first_name,
@@ -184,8 +186,8 @@ export const createSession = (params: WithUserParams) => {
       identifier: user.email_addresses.find(e => e.id === user.primary_email_address_id)?.email_address || '',
       profile_image_url: user.profile_image_url,
     },
-    created_at: 1697449745962,
-    updated_at: 1698763366892,
+    created_at: sessionParams.created_at || jest.now() - 1000,
+    updated_at: sessionParams.updated_at || jest.now(),
     last_active_token: {
       object: 'token',
       jwt: mockJwt,


### PR DESCRIPTION
## Description
This PR will assign the Client properties to the default values on destroy.

## Checklist

- [X] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [X] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
