### PR TITLE
chore(repo): Fix release workflow permissions

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -16,8 +16,13 @@ jobs:
     if: ${{ github.repository == 'clerkinc/javascript' }}
     runs-on: ${{ vars.RUNNER_LARGE }}
     permissions:
-      contents: read
+      contents: write
       id-token: write
+      packages: write
+      pull-requests: write
+      issues: read
+      statuses: write
+      checks: write
     steps:
       - name: Echo github context
         run: echo "$GITHUB_CONTEXT"


### PR DESCRIPTION
## Description

The PR https://github.com/clerkinc/javascript/pull/1891 added `permissions` to the release workflow - and apparently they are not additive.

So this PR looks at https://github.com/clerkinc/javascript/actions/runs/6558834152/job/17813206786#step:1:16 and implements the needed stuff from it. (https://github.com/changesets/action/issues/179#issuecomment-1139116421)