### PR TITLE
chore(clerk-js,types): Drop `experimental_force_oauth_first` & `experimental__forceOauthFirst`

### DIFF
--- a/.changeset/pretty-planes-kick.md
+++ b/.changeset/pretty-planes-kick.md
@@ -1,0 +1,6 @@
+---
+"@clerk/clerk-js": patch
+"@clerk/types": patch
+---
+
+Drop `experimental_force_oauth_first` & `experimental__forceOauthFirst` from `DisplayConfig`

--- a/packages/clerk-js/src/core/resources/DisplayConfig.ts
+++ b/packages/clerk-js/src/core/resources/DisplayConfig.ts
@@ -72,7 +72,6 @@ export class DisplayConfig extends BaseResource implements DisplayConfigResource
     this.captchaPublicKey = data.captcha_public_key;
     this.supportEmail = data.support_email || '';
     this.clerkJSVersion = data.clerk_js_version;
-    this.experimental__forceOauthFirst = data.experimental_force_oauth_first || false;
     this.organizationProfileUrl = data.organization_profile_url;
     this.createOrganizationUrl = data.create_organization_url;
     this.afterLeaveOrganizationUrl = data.after_leave_organization_url;

--- a/packages/clerk-js/src/ui/utils/test/fixtures.ts
+++ b/packages/clerk-js/src/ui/utils/test/fixtures.ts
@@ -72,9 +72,8 @@ const createBaseDisplayConfig = (): DisplayConfigJSON => {
     create_organization_url: 'https://accounts.clerk.com/create-organization',
     after_leave_organization_url: 'https://dashboard.clerk.com',
     after_create_organization_url: 'https://dashboard.clerk.com',
-    support_email: null,
+    support_email: '',
     branded: true,
-    experimental_force_oauth_first: false,
     clerk_js_version: '4',
   };
 };

--- a/packages/types/src/displayConfig.ts
+++ b/packages/types/src/displayConfig.ts
@@ -29,7 +29,6 @@ export interface DisplayConfigJSON {
   theme: DisplayThemeJSON;
   user_profile_url: string;
   clerk_js_version?: string;
-  experimental_force_oauth_first?: boolean;
   organization_profile_url: string;
   create_organization_url: string;
   after_leave_organization_url: string;


### PR DESCRIPTION
## Description

We are dropping the `experimental_force_oauth_first` & `experimental__forceOauthFirst` from the `DisplayConfig` and `DisplayConfigJSON`. The feature that those 2 were introduced for, is not used anymore, so we will drop those 2 and create an internal ticket to support that use case as part of a more generic solution / feature.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [x] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
