### PR TITLE
feat(remix): Support defer() usage in rootAuthLoader()

### DIFF
--- a/.changeset/loud-peaches-travel.md
+++ b/.changeset/loud-peaches-travel.md
@@ -1,0 +1,5 @@
+---
+'@clerk/remix': minor
+---
+
+Support usage of Remix's `defer()` method in the loader passed to `rootAuthLoader()`.

--- a/packages/remix/src/ssr/rootAuthLoader.ts
+++ b/packages/remix/src/ssr/rootAuthLoader.ts
@@ -7,7 +7,6 @@ import { authenticateRequest } from './authenticateRequest';
 import type { LoaderFunctionArgs, LoaderFunctionReturn, RootAuthLoaderCallback, RootAuthLoaderOptions } from './types';
 import {
   assertValidHandlerResult,
-  getResponseClerkState,
   injectAuthIntoRequest,
   injectRequestStateIntoDeferredData,
   injectRequestStateIntoResponse,

--- a/playground/remix-node/app/root.tsx
+++ b/playground/remix-node/app/root.tsx
@@ -1,18 +1,20 @@
-import type { DataFunctionArgs, Headers } from '@remix-run/node';
+import { defer, type DataFunctionArgs, type Headers } from '@remix-run/node';
 import type { MetaFunction } from '@remix-run/react';
-import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from '@remix-run/react';
+import { Await, Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from '@remix-run/react';
 import { getClerkDebugHeaders, rootAuthLoader } from '@clerk/remix/ssr.server';
 import { ClerkApp, ClerkErrorBoundary } from '@clerk/remix';
+import { Suspense } from 'react';
 
 export const loader = (args: DataFunctionArgs) => {
   return rootAuthLoader(
     args,
     ({ request }) => {
       const { user } = request;
+      const data: Promise<{ foo: string }> = new Promise(r => r({ foo: 'bar' }))
 
       console.log('root User:', user);
 
-      return { user };
+      return defer({ user, data }, { headers: { 'x-bryce': 'cool guy' } })
     },
     { loadUser: true },
   );
@@ -27,10 +29,8 @@ export function headers({
   loaderHeaders: Headers;
   parentHeaders: Headers;
 }) {
-  return {
-    'x-parent-header': parentHeaders.get('x-parent-header'),
-    ...getClerkDebugHeaders(loaderHeaders),
-  };
+  console.log(loaderHeaders)
+  return loaderHeaders 
 }
 
 export const meta: MetaFunction = () => {
@@ -60,6 +60,11 @@ function App() {
         <Links />
       </head>
       <body>
+        <Suspense fallback="Loading...">
+          <Await resolve={loaderData.data}>
+            {val => (<>Hello {val.foo}</>)}
+          </Await>
+        </Suspense>
         <Outlet />
         <ScrollRestoration />
         <Scripts />

--- a/playground/remix-node/app/root.tsx
+++ b/playground/remix-node/app/root.tsx
@@ -14,7 +14,7 @@ export const loader = (args: DataFunctionArgs) => {
 
       console.log('root User:', user);
 
-      return defer({ user, data }, { headers: { 'x-bryce': 'cool guy' } })
+      return defer({ user, data }, { headers: { 'x-clerk': '1' } })
     },
     { loadUser: true },
   );


### PR DESCRIPTION
## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->
Add logic to support `defer()` usage in the wrapped loader. Currently, this isn't handled and we end up dropping the return value.

> **Note**
> I'm working on some integration tests for this locally, they will come in a followup.

<!-- Fixes #(issue number) -->

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [x] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
