### PR TITLE
Added style for prefers-color-scheme to interstitial head

### DIFF
--- a/.changeset/flat-pots-hear.md
+++ b/.changeset/flat-pots-hear.md
@@ -1,0 +1,5 @@
+---
+'@clerk/backend': minor
+---
+
+Added prefers-color-scheme to interstitial

--- a/packages/backend/src/tokens/interstitial.ts
+++ b/packages/backend/src/tokens/interstitial.ts
@@ -58,6 +58,13 @@ export function loadInterstitialFromLocal(options: Omit<LoadInterstitialOptions,
   return `
     <head>
         <meta charset="UTF-8" />
+        <style>
+          @media (prefers-color-scheme: dark) {
+            body {
+              background-color: black;
+            }
+          }
+        </style>
     </head>
     <body>
         <script>


### PR DESCRIPTION

## Description

This checks if the user prefers dark color schemes, and then sets the body to black. This could reduce 'flashes of white'.


## Checklist

- [ ] `npm test` runs as expected.
- [X] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [X] other: minor improvement

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [X] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
