### PR TITLE
fix(nextjs): Drop `user`, `session`, `organization` from `auth()`

### DIFF
--- a/.changeset/thin-phones-drop.md
+++ b/.changeset/thin-phones-drop.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Drop `user`, `session`, and `organization` resouces from the returned value of `auth()`.

--- a/.changeset/thin-phones-drop.md
+++ b/.changeset/thin-phones-drop.md
@@ -2,4 +2,4 @@
 '@clerk/nextjs': patch
 ---
 
-Drop `user`, `session`, and `organization` resouces from the returned value of `auth()`.
+Drop `user`, `session`, and `organization` resources from the returned value of `auth()`.

--- a/packages/nextjs/src/server/getAuth.ts
+++ b/packages/nextjs/src/server/getAuth.ts
@@ -1,4 +1,4 @@
-import type { Organization, Session, SignedInAuthObject, SignedOutAuthObject, User } from '@clerk/backend';
+import type { AuthObject, Organization, Session, SignedInAuthObject, SignedOutAuthObject, User } from '@clerk/backend';
 import {
   AuthStatus,
   constants,
@@ -18,6 +18,8 @@ import { getAuthKeyFromRequest, getCookie, getHeader, injectSSRStateIntoObject }
 
 type GetAuthOpts = Partial<SecretKeyOrApiKey>;
 
+type AuthObjectWithoutResources<T extends AuthObject> = Omit<T, 'user' | 'organization' | 'session'>;
+
 export const createGetAuth = ({
   debugLoggerName,
   noAuthStatusMessage,
@@ -26,7 +28,10 @@ export const createGetAuth = ({
   debugLoggerName: string;
 }) =>
   withLogger(debugLoggerName, logger => {
-    return (req: RequestLike, opts?: GetAuthOpts): SignedInAuthObject | SignedOutAuthObject => {
+    return (
+      req: RequestLike,
+      opts?: GetAuthOpts,
+    ): AuthObjectWithoutResources<SignedInAuthObject | SignedOutAuthObject> => {
       const debug = getHeader(req, constants.Headers.EnableDebug) === 'true';
       if (debug) {
         logger.enable();


### PR DESCRIPTION
## Description

In this PR we are dropping  `user`, `session`, and `organization` resouces from the returned value of `auth()`. They were never officially supported as the middleware didn't support types for `loadUser`, `loadSession`.

Although by passing the types errors you could still load the resources. We consider bad practice to have extra 1-3 requests for each request that middleware captures so we should not allow developers to expect the resources returned from auth will be populated.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [x] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
