### PR TITLE
fix(backend): Support NextJS 14

### DIFF
--- a/.changeset/late-dolphins-peel.md
+++ b/.changeset/late-dolphins-peel.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": minor
+---
+
+Add support for NextJS 14

--- a/packages/backend/src/runtime/browser/fetch.mjs
+++ b/packages/backend/src/runtime/browser/fetch.mjs
@@ -5,3 +5,4 @@ export const RuntimeHeaders = Headers;
 export const RuntimeRequest = Request;
 export const RuntimeResponse = Response;
 export const RuntimeAbortController = AbortController;
+export const RuntimeFetch = fetch;

--- a/packages/backend/src/runtime/index.ts
+++ b/packages/backend/src/runtime/index.ts
@@ -15,17 +15,12 @@
 // @ts-ignore - These are package subpaths
 import crypto from '#crypto';
 // @ts-ignore - These are package subpaths
+import fetch from '#fetch';
+// @ts-ignore - These are package subpaths
 import * as fetchApisPolyfill from '#fetch';
 
-const {
-  default: fetch,
-  RuntimeAbortController,
-  RuntimeBlob,
-  RuntimeFormData,
-  RuntimeHeaders,
-  RuntimeRequest,
-  RuntimeResponse,
-} = fetchApisPolyfill;
+const { RuntimeAbortController, RuntimeBlob, RuntimeFormData, RuntimeHeaders, RuntimeRequest, RuntimeResponse } =
+  fetchApisPolyfill;
 
 type Runtime = {
   crypto: Crypto;

--- a/packages/backend/src/runtime/index.ts
+++ b/packages/backend/src/runtime/index.ts
@@ -15,12 +15,17 @@
 // @ts-ignore - These are package subpaths
 import crypto from '#crypto';
 // @ts-ignore - These are package subpaths
-import fetch from '#fetch';
-// @ts-ignore - These are package subpaths
 import * as fetchApisPolyfill from '#fetch';
 
-const { RuntimeAbortController, RuntimeBlob, RuntimeFormData, RuntimeHeaders, RuntimeRequest, RuntimeResponse } =
-  fetchApisPolyfill;
+const {
+  RuntimeFetch,
+  RuntimeAbortController,
+  RuntimeBlob,
+  RuntimeFormData,
+  RuntimeHeaders,
+  RuntimeRequest,
+  RuntimeResponse,
+} = fetchApisPolyfill;
 
 type Runtime = {
   crypto: Crypto;
@@ -39,7 +44,7 @@ type Runtime = {
 // The globalThis object is supported for Node >= 12.0.
 //
 // https://github.com/supabase/supabase/issues/4417
-const globalFetch = fetch.bind(globalThis);
+const globalFetch = RuntimeFetch.bind(globalThis);
 // DO NOT CHANGE: Runtime needs to be imported as a default export so that we can stub its dependencies with Sinon.js
 // For more information refer to https://sinonjs.org/how-to/stub-dependency/
 const runtime: Runtime = {

--- a/packages/backend/src/runtime/node/fetch.js
+++ b/packages/backend/src/runtime/node/fetch.js
@@ -8,3 +8,4 @@ module.exports.RuntimeHeaders = Headers;
 module.exports.RuntimeRequest = Request;
 module.exports.RuntimeResponse = Response;
 module.exports.RuntimeAbortController = AbortController;
+module.exports.RuntimeFetch = fetch;


### PR DESCRIPTION
## Description

Next14 seems to have changed the way it handles default exports when using the webpack bundler for some of their build variants when using `npm run dev`. This commit ensures that we no longer use the default export in an effort to improve compat between the different nextjs versions. 

 More information can be found here: https://esbuild.github.io/content-types/#default-interop
 and here: https://github.com/clerkinc/javascript/pull/612

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/remix`
- [ ] `@clerk/types`
- [ ] `@clerk/themes`
- [ ] `@clerk/localizations`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/backend`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/fastify`
- [ ] `@clerk/chrome-extension`
- [ ] `gatsby-plugin-clerk`
- [ ] `build/tooling/chore`
