### PR TITLE
fix(nextjs): Deprecate `user`, `session`, `organization` from `auth()`

### DIFF
--- a/.changeset/three-rings-wash.md
+++ b/.changeset/three-rings-wash.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Deprecate `user`, `session`, and `organization` resources from the returned value of `auth()`.


### PR DESCRIPTION
## Description

Deprecation before removal of resources. See #1947 

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
