### PR TITLE
fix: Types and NextJS 14 support (#1939, #1948)

### DIFF
--- a/.changeset/late-dolphins-peel.md
+++ b/.changeset/late-dolphins-peel.md
@@ -1,0 +1,5 @@
+---
+"@clerk/backend": minor
+---
+
+Add support for NextJS 14

--- a/.changeset/tasty-countries-walk.md
+++ b/.changeset/tasty-countries-walk.md
@@ -1,0 +1,5 @@
+---
+'@clerk/clerk-sdk-node': patch
+---
+
+Fix types of ClerkExpressWithAuth/ClerkExpressRequireAuth args

--- a/packages/backend/src/runtime/browser/fetch.mjs
+++ b/packages/backend/src/runtime/browser/fetch.mjs
@@ -5,3 +5,4 @@ export const RuntimeHeaders = Headers;
 export const RuntimeRequest = Request;
 export const RuntimeResponse = Response;
 export const RuntimeAbortController = AbortController;
+export const RuntimeFetch = fetch;

--- a/packages/backend/src/runtime/index.ts
+++ b/packages/backend/src/runtime/index.ts
@@ -18,7 +18,7 @@ import crypto from '#crypto';
 import * as fetchApisPolyfill from '#fetch';
 
 const {
-  default: fetch,
+  RuntimeFetch,
   RuntimeAbortController,
   RuntimeBlob,
   RuntimeFormData,
@@ -44,7 +44,7 @@ type Runtime = {
 // The globalThis object is supported for Node >= 12.0.
 //
 // https://github.com/supabase/supabase/issues/4417
-const globalFetch = fetch.bind(globalThis);
+const globalFetch = RuntimeFetch.bind(globalThis);
 // DO NOT CHANGE: Runtime needs to be imported as a default export so that we can stub its dependencies with Sinon.js
 // For more information refer to https://sinonjs.org/how-to/stub-dependency/
 const runtime: Runtime = {

--- a/packages/backend/src/runtime/node/fetch.js
+++ b/packages/backend/src/runtime/node/fetch.js
@@ -8,3 +8,4 @@ module.exports.RuntimeHeaders = Headers;
 module.exports.RuntimeRequest = Request;
 module.exports.RuntimeResponse = Response;
 module.exports.RuntimeAbortController = AbortController;
+module.exports.RuntimeFetch = fetch;

--- a/packages/sdk-node/src/clerkClient.ts
+++ b/packages/sdk-node/src/clerkClient.ts
@@ -75,13 +75,13 @@ export const clerkClient = new Proxy(clerkClientSingleton, {
 /**
  * Stand-alone express middlewares bound to the pre-initialised clerkClient
  */
-export const ClerkExpressRequireAuth = (...args: any) => {
+export const ClerkExpressRequireAuth = (...args: Parameters<ReturnType<typeof createClerkExpressRequireAuth>>) => {
   const env = { ...loadApiEnv(), ...loadClientEnv() };
   const fn = createClerkExpressRequireAuth({ clerkClient, ...env });
   return fn(...args);
 };
 
-export const ClerkExpressWithAuth = (...args: any) => {
+export const ClerkExpressWithAuth = (...args: Parameters<ReturnType<typeof createClerkExpressWithAuth>>) => {
   const env = { ...loadApiEnv(), ...loadClientEnv() };
   const fn = createClerkExpressWithAuth({ clerkClient, ...env });
   return fn(...args);


### PR DESCRIPTION
## Description

PRs synced:
- https://github.com/clerkinc/javascript/pull/1939
- https://github.com/clerkinc/javascript/pull/1948

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [x] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [x] other:

## Packages affected

- [x] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [x] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
