### PR TITLE
fix(shared): Fix error on post-build script with existing subpath barel directories

### DIFF
--- a/scripts/subpath-workaround.mjs
+++ b/scripts/subpath-workaround.mjs
@@ -41,7 +41,10 @@ async function run() {
 
   // Create directories for each subpath name using the pkgJsonPlaceholder
   subpathHelperFile.subpathNames.forEach(name => {
-    fs.mkdirSync(new URL(`../packages/${pkgName}/${name}`, import.meta.url));
+    const directoryURL = new URL(`../packages/${pkgName}/${name}`, import.meta.url);
+    if (!fs.existsSync(directoryURL)) {
+      fs.mkdirSync(directoryURL);
+    }
     writeJSON(`../packages/${pkgName}/${name}/package.json`, pkgJsonPlaceholder(name));
   });
 


### PR DESCRIPTION
## Description

When building a repository with already existing subpath barrel files in shared, the `post-build` of shared package failed because of trying to create existing subpath files directories.
To resolve this we added a check to only create the directory if it does not exist.

PS: This issue is only visible in local development when the shared package is already built once (after the change that creates temporary directories subpath barrel directories).

## Checklist

- [x] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [x] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
