### PR TITLE
feat(clerk-js,types): Enable avatar shimmer by default

### DIFF
--- a/.changeset/tough-roses-hunt.md
+++ b/.changeset/tough-roses-hunt.md
@@ -1,0 +1,6 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Avatar Shimmer will be enabled by default for `<UserButton/>` and `<OrganizationSwitcher/>`.

--- a/packages/clerk-js/src/ui/customizables/parseAppearance.ts
+++ b/packages/clerk-js/src/ui/customizables/parseAppearance.ts
@@ -42,7 +42,7 @@ const defaultLayout: ParsedLayout = {
   helpPageUrl: '',
   privacyPageUrl: '',
   termsPageUrl: '',
-  shimmer: false,
+  shimmer: true,
 };
 
 /**

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -637,7 +637,7 @@ export type Layout = {
   privacyPageUrl?: string;
   /**
    * This option enables the shimmer animation for the avatars of <UserButton/> and <OrganizationSwitcher/>
-   * @default false
+   * @default true
    */
   shimmer?: boolean;
 };


### PR DESCRIPTION
## Description

This PR enables the avatar shimmer by default for `<UserButton/>` and `<OrganizationSwitcher/>`.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [X] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [X] `@clerk/types`
- [ ] `build/tooling/chore`
