### PR TITLE
feat(clerk-js): Enable element descriptors for active devices [SDK-859]

### DIFF
--- a/.changeset/mean-houses-juggle.md
+++ b/.changeset/mean-houses-juggle.md
@@ -1,0 +1,11 @@
+---
+'@clerk/clerk-js': patch
+'@clerk/types': patch
+---
+
+Introduces new element appearance descriptors:
+
+- `activeDeviceListItem` allows you to customize the appearance of the active device list (accordion) item
+  - `activeDeviceListItem__current` allows you to customize the appearance of the _current_ active device list (accordion) item
+- `activeDevice` allows you to customize the appearance of the active device item
+  - `activeDevice__current` allows you to customize the appearance of the _current_ active device item

--- a/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
+++ b/packages/clerk-js/src/ui/components/UserProfile/ActiveDevicesSection.tsx
@@ -47,21 +47,25 @@ const DeviceAccordion = (props: { session: SessionWithActivitiesResource }) => {
   };
 
   return (
-    <UserProfileAccordion title={<DeviceInfo session={props.session} />}>
+    <UserProfileAccordion
+      elementDescriptor={descriptors.activeDeviceListItem}
+      elementId={isCurrent ? descriptors.activeDeviceListItem.setId('current') : undefined}
+      title={<DeviceInfo session={props.session} />}
+    >
       <Col gap={4}>
         {isCurrent && (
           <LinkButtonWithDescription
-            title={localizationKeys('userProfile.start.activeDevicesSection.detailsTitle')}
             subtitle={localizationKeys('userProfile.start.activeDevicesSection.detailsSubtitle')}
+            title={localizationKeys('userProfile.start.activeDevicesSection.detailsTitle')}
           />
         )}
         {!isCurrent && (
           <LinkButtonWithDescription
-            title={localizationKeys('userProfile.start.activeDevicesSection.destructiveActionTitle')}
-            subtitle={localizationKeys('userProfile.start.activeDevicesSection.destructiveActionSubtitle')}
             actionLabel={localizationKeys('userProfile.start.activeDevicesSection.destructiveAction')}
             colorScheme='danger'
             onClick={revoke}
+            subtitle={localizationKeys('userProfile.start.activeDevicesSection.destructiveActionSubtitle')}
+            title={localizationKeys('userProfile.start.activeDevicesSection.destructiveActionTitle')}
           />
         )}
       </Col>
@@ -82,6 +86,8 @@ const DeviceInfo = (props: { session: SessionWithActivitiesResource }) => {
 
   return (
     <Flex
+      elementDescriptor={descriptors.activeDevice}
+      elementId={isCurrent ? descriptors.activeDevice.setId('current') : undefined}
       align='center'
       sx={t => ({
         gap: t.space.$8,

--- a/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
+++ b/packages/clerk-js/src/ui/customizables/elementDescriptors.ts
@@ -246,6 +246,8 @@ export const APPEARANCE_KEYS = containsAllElementsConfigKeys([
   'page',
   'pageHeader',
 
+  'activeDevice',
+  'activeDeviceListItem',
   'activeDeviceIcon',
 
   'impersonationFab',

--- a/packages/clerk-js/src/ui/elements/Accordion.tsx
+++ b/packages/clerk-js/src/ui/elements/Accordion.tsx
@@ -2,18 +2,20 @@ import React from 'react';
 
 import { Col, descriptors } from '../customizables';
 import { Caret } from '../icons';
+import type { PropsOfComponent } from '../styledSystem';
 import { animations } from '../styledSystem';
 import { ArrowBlockButton } from './ArrowBlockButton';
 
-type AccordionItemProps = React.PropsWithChildren<{
-  title: React.ReactElement | string;
-  icon?: React.ReactElement;
-  badge?: React.ReactElement;
-  defaultOpen?: boolean;
-  toggleable?: boolean;
-  scrollOnOpen?: boolean;
-  onCloseCallback?: () => void;
-}>;
+type AccordionItemProps = Omit<PropsOfComponent<typeof Col>, 'title'> &
+  React.PropsWithChildren<{
+    title: React.ReactElement | string;
+    icon?: React.ReactElement;
+    badge?: React.ReactElement;
+    defaultOpen?: boolean;
+    toggleable?: boolean;
+    scrollOnOpen?: boolean;
+    onCloseCallback?: () => void;
+  }>;
 
 export const AccordionItem = (props: AccordionItemProps) => {
   const {
@@ -25,6 +27,7 @@ export const AccordionItem = (props: AccordionItemProps) => {
     scrollOnOpen = false,
     badge,
     onCloseCallback = null,
+    ...rest
   } = props;
   const [isOpen, setIsOpen] = React.useState(defaultOpen);
   const contentRef = React.useRef<HTMLDivElement>(null);
@@ -52,10 +55,10 @@ export const AccordionItem = (props: AccordionItemProps) => {
     }
 
     return () => cancelAnimationFrame(requestRef);
-  }, [isOpen]);
+  }, [isOpen, scrollOnOpen]);
 
   return (
-    <Col>
+    <Col {...rest}>
       <ArrowBlockButton
         elementDescriptor={descriptors.accordionTriggerButton}
         variant='ghost'

--- a/packages/types/src/appearance.ts
+++ b/packages/types/src/appearance.ts
@@ -399,6 +399,8 @@ export type ElementsConfig = {
   page: WithOptions;
   pageHeader: WithOptions;
 
+  activeDevice: WithOptions<'current'>;
+  activeDeviceListItem: WithOptions<'current'>;
   activeDeviceIcon: WithOptions<'mobile' | 'desktop'>;
 
   impersonationFab: WithOptions;


### PR DESCRIPTION
## Description

Adds the following appearance keys for "Active devices":

- `cl-activeDeviceListItem`
- `cl-activeDeviceListItem__current`
- `cl-activeDevice`
- `cl-activeDevice__current`

### Before

<img width="853" alt="Screenshot 2023-10-31 at 5 39 36 PM" src="https://github.com/clerkinc/javascript/assets/26691/e7c01c4b-be27-4387-9ba6-abc3538815ae">

### After

<img width="852" alt="Screenshot 2023-10-31 at 5 39 49 PM" src="https://github.com/clerkinc/javascript/assets/26691/6de856d3-0e94-4adf-b3a5-31469d9a9913">

<!-- Fixes #(issue number) -->

SDK-859

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [x] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [x] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [x] `@clerk/types`
- [ ] `build/tooling/chore`
