### PR TITLE
fix(nextjs): Import `deprecatedObjectProperty` from subpath

### DIFF
--- a/.changeset/twenty-turkeys-tell.md
+++ b/.changeset/twenty-turkeys-tell.md
@@ -1,0 +1,5 @@
+---
+'@clerk/nextjs': patch
+---
+
+Imports `deprecatedObjectProperty` from `@clerk/shared` as subpath.

--- a/packages/nextjs/src/server/getAuth.ts
+++ b/packages/nextjs/src/server/getAuth.ts
@@ -8,7 +8,7 @@ import {
   signedInAuthObject,
   signedOutAuthObject,
 } from '@clerk/backend';
-import { deprecatedObjectProperty } from '@clerk/shared';
+import { deprecatedObjectProperty } from '@clerk/shared/deprecated';
 import type { SecretKeyOrApiKey } from '@clerk/types';
 
 import { withLogger } from '../utils/debugLogger';
@@ -54,7 +54,7 @@ export const createGetAuth = ({
       // When the auth status is set, we trust that the middleware has already run
       // Then, we don't have to re-verify the JWT here,
       // we can just strip out the claims manually.
-      const authStatus = getAuthKeyFromRequest(req, 'AuthStatus');
+      const authStatus = getAuthKeyFromRequest(req, 'AuthStatus') as AuthStatus;
       const authMessage = getAuthKeyFromRequest(req, 'AuthMessage');
       const authReason = getAuthKeyFromRequest(req, 'AuthReason');
       logger.debug('Headers debug', { authStatus, authMessage, authReason });
@@ -125,7 +125,7 @@ type BuildClerkPropsInitState = { user?: User | null; session?: Session | null; 
 type BuildClerkProps = (req: RequestLike, authState?: BuildClerkPropsInitState) => Record<string, unknown>;
 
 export const buildClerkProps: BuildClerkProps = (req, initState = {}) => {
-  const authStatus = getAuthKeyFromRequest(req, 'AuthStatus');
+  const authStatus = getAuthKeyFromRequest(req, 'AuthStatus') as AuthStatus;
   const authMessage = getAuthKeyFromRequest(req, 'AuthMessage');
   const authReason = getAuthKeyFromRequest(req, 'AuthReason');
 


### PR DESCRIPTION
## Description

This PR fixes an issue with imports & subpaths.

It also casts authStatus in order the pre-commit hooks to allow for the commit.

This needs to only be merged to v4, because this code was previously only merged to v4.

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerkinc/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
