### PR TITLE
fix(nextjs,remix,clerk-sdk-node,shared): Use isTruthy helper

### DIFF
--- a/.changeset/fifty-rats-rhyme.md
+++ b/.changeset/fifty-rats-rhyme.md
@@ -1,0 +1,8 @@
+---
+"@clerk/nextjs": patch
+"@clerk/remix": patch
+"@clerk/clerk-sdk-node": patch
+"@clerk/shared": patch
+---
+
+Introduce `isTruthy` helper to better cast environment variables to a boolean. Previously only the string `"true"` was checked, now `true`, `"true"`, `"1"`, and `1` will work.

--- a/packages/nextjs/src/server/constants.ts
+++ b/packages/nextjs/src/server/constants.ts
@@ -1,4 +1,5 @@
 import { deprecated } from '@clerk/shared/deprecated';
+import { isTruthy } from '@clerk/shared/underscore';
 
 /**
  * @deprecated Use `CLERK_JS_VERSION` instead.
@@ -29,6 +30,6 @@ if (FRONTEND_API) {
 export const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
 export const DOMAIN = process.env.NEXT_PUBLIC_CLERK_DOMAIN || '';
 export const PROXY_URL = process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '';
-export const IS_SATELLITE = process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true' || false;
+export const IS_SATELLITE = isTruthy(process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE) || false;
 export const SIGN_IN_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '';
 export const SIGN_UP_URL = process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '';

--- a/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
+++ b/packages/nextjs/src/utils/mergeNextClerkPropsWithEnv.ts
@@ -1,4 +1,5 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
+import { isTruthy } from '@clerk/shared/underscore';
+
 import type { NextClerkProviderProps } from '../types';
 
 export const mergeNextClerkPropsWithEnv = (props: Omit<NextClerkProviderProps, 'children'>) => {
@@ -10,7 +11,7 @@ export const mergeNextClerkPropsWithEnv = (props: Omit<NextClerkProviderProps, '
     clerkJSVersion: props.clerkJSVersion || process.env.NEXT_PUBLIC_CLERK_JS_VERSION,
     proxyUrl: props.proxyUrl || process.env.NEXT_PUBLIC_CLERK_PROXY_URL || '',
     domain: props.domain || process.env.NEXT_PUBLIC_CLERK_DOMAIN || '',
-    isSatellite: props.isSatellite || process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE === 'true',
+    isSatellite: props.isSatellite || isTruthy(process.env.NEXT_PUBLIC_CLERK_IS_SATELLITE),
     signInUrl: props.signInUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL || '',
     signUpUrl: props.signUpUrl || process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL || '',
     afterSignInUrl: props.afterSignInUrl || process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL || '',

--- a/packages/remix/src/ssr/authenticateRequest.ts
+++ b/packages/remix/src/ssr/authenticateRequest.ts
@@ -1,6 +1,9 @@
 import type { RequestState } from '@clerk/backend';
 import { buildRequestUrl, Clerk } from '@clerk/backend';
-import { deprecated, handleValueOrFn, isHttpOrHttps, isProxyUrlRelative } from '@clerk/shared';
+import { deprecated } from '@clerk/shared/deprecated';
+import { handleValueOrFn } from '@clerk/shared/handleValueOrFn';
+import { isHttpOrHttps, isProxyUrlRelative } from '@clerk/shared/proxy';
+import { isTruthy } from '@clerk/shared/underscore';
 
 import {
   noSecretKeyOrApiKeyError,
@@ -60,7 +63,7 @@ export function authenticateRequest(args: LoaderFunctionArgs, opts: RootAuthLoad
 
   const isSatellite =
     handleValueOrFn(opts.isSatellite, new URL(request.url)) ||
-    getEnvVariable('CLERK_IS_SATELLITE', context) === 'true' ||
+    isTruthy(getEnvVariable('CLERK_IS_SATELLITE', context)) ||
     false;
 
   const requestURL = buildRequestUrl(request);

--- a/packages/sdk-node/src/utils.ts
+++ b/packages/sdk-node/src/utils.ts
@@ -1,5 +1,5 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
 import { deprecated } from '@clerk/shared/deprecated';
+import { isTruthy } from '@clerk/shared/underscore';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 // https://nextjs.org/docs/api-routes/api-middlewares#connectexpress-middleware-support
@@ -41,7 +41,7 @@ export const loadApiEnv = () => {
     domain: process.env.CLERK_DOMAIN || '',
     proxyUrl: process.env.CLERK_PROXY_URL || '',
     signInUrl: process.env.CLERK_SIGN_IN_URL || '',
-    isSatellite: process.env.CLERK_IS_SATELLITE === 'true',
+    isSatellite: isTruthy(process.env.CLERK_IS_SATELLITE),
     jwtKey: process.env.CLERK_JWT_KEY || '',
   };
 };

--- a/packages/shared/src/__tests__/underscore.test.ts
+++ b/packages/shared/src/__tests__/underscore.test.ts
@@ -1,4 +1,4 @@
-import { deepCamelToSnake, deepSnakeToCamel, isIPV4Address, titleize, toSentence } from '../underscore';
+import { deepCamelToSnake, deepSnakeToCamel, isIPV4Address, isTruthy, titleize, toSentence } from '../underscore';
 
 describe('toSentence', () => {
   it('returns a single item as-is', () => {
@@ -176,5 +176,31 @@ describe('camelToSnakeKeys', () => {
     expect(sampleObject).not.toHaveProperty('oneKey');
     expect(anotherSampleObject.one_key).toEqual(1);
     expect(anotherSampleObject).not.toHaveProperty('oneKey');
+  });
+});
+
+describe(`isTruthy`, () => {
+  it(`handles booleans`, () => {
+    expect(isTruthy(true)).toBe(true);
+    expect(isTruthy(false)).toBe(false);
+  });
+  it(`handles true or false strings `, () => {
+    expect(isTruthy(`true`)).toBe(true);
+    expect(isTruthy(`false`)).toBe(false);
+    expect(isTruthy(`TRUE`)).toBe(true);
+    expect(isTruthy(`FALSE`)).toBe(false);
+    expect(isTruthy(`TruE`)).toBe(true);
+    expect(isTruthy(`FalsE`)).toBe(false);
+  });
+  it(`handles numbers`, () => {
+    expect(isTruthy(`1`)).toBe(true);
+    expect(isTruthy(`0`)).toBe(false);
+    expect(isTruthy(`-1`)).toBe(false);
+    expect(isTruthy(1)).toBe(true);
+    expect(isTruthy(0)).toBe(false);
+    expect(isTruthy(-1)).toBe(false);
+  });
+  it(`defaults to false`, () => {
+    expect(isTruthy(`foobar`)).toBe(false);
   });
 });

--- a/packages/shared/src/underscore.ts
+++ b/packages/shared/src/underscore.ts
@@ -82,3 +82,27 @@ export const deepCamelToSnake = createDeepObjectTransformer(camelToSnake);
  * camelCased keys are removed.
  */
 export const deepSnakeToCamel = createDeepObjectTransformer(snakeToCamel);
+
+/**
+ * Returns true for `true`, true, positive numbers.
+ * Returns false for `false`, false, 0, negative integers and anything else.
+ */
+export function isTruthy(value: any): boolean {
+  // Return if Boolean
+  if (typeof value === `boolean`) return value;
+
+  // Return false if null or undefined
+  if (value === undefined || value === null) return false;
+
+  // If the String is true or false
+  if (value.toLowerCase() === `true`) return true;
+  if (value.toLowerCase() === `false`) return false;
+
+  // Now check if it's a number
+  const number = parseInt(value, 10);
+  if (isNaN(number)) return false;
+  if (number > 0) return true;
+
+  // Default to false
+  return false;
+}

--- a/packages/shared/src/underscore.ts
+++ b/packages/shared/src/underscore.ts
@@ -87,7 +87,7 @@ export const deepSnakeToCamel = createDeepObjectTransformer(snakeToCamel);
  * Returns true for `true`, true, positive numbers.
  * Returns false for `false`, false, 0, negative integers and anything else.
  */
-export function isTruthy(value: any): boolean {
+export function isTruthy(value: unknown): boolean {
   // Return if Boolean
   if (typeof value === `boolean`) return value;
 
@@ -95,11 +95,13 @@ export function isTruthy(value: any): boolean {
   if (value === undefined || value === null) return false;
 
   // If the String is true or false
-  if (value.toLowerCase() === `true`) return true;
-  if (value.toLowerCase() === `false`) return false;
+  if (typeof value === `string`) {
+    if (value.toLowerCase() === `true`) return true;
+    if (value.toLowerCase() === `false`) return false;
+  }
 
   // Now check if it's a number
-  const number = parseInt(value, 10);
+  const number = parseInt(value as string, 10);
   if (isNaN(number)) return false;
   if (number > 0) return true;
 


### PR DESCRIPTION
## Description

Small QoL improvement to use an `isTruthy` helper for cases when we check if an env var is `true`. Could lead to subtle bugs if people not use the String `"true"` but something else that is truthy.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [x] `@clerk/remix`
- [x] `@clerk/clerk-sdk-node`
- [x] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
