### PR TITLE
fix(chrome-extension,nextjs,react): Ignore tests from build output

### DIFF
--- a/.changeset/lovely-plums-sin.md
+++ b/.changeset/lovely-plums-sin.md
@@ -1,0 +1,7 @@
+---
+"@clerk/chrome-extension": patch
+"@clerk/nextjs": patch
+"@clerk/clerk-react": patch
+---
+
+Ignore `.test.ts` files for the build output. Should result in smaller bundle size.

--- a/packages/chrome-extension/tsup.config.ts
+++ b/packages/chrome-extension/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(overrideOptions => {
   const shouldPublish = !!overrideOptions.env?.publish;
 
   const common: Options = {
-    entry: ['./src/**/*.{ts,tsx,js,jsx}'],
+    entry: ['./src/**/*.{ts,tsx,js,jsx}', '!./src/**/*.test.{ts,tsx}'],
     bundle: false,
     clean: true,
     minify: false,

--- a/packages/nextjs/tsup.config.ts
+++ b/packages/nextjs/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(overrideOptions => {
   const shouldPublish = !!overrideOptions.env?.publish;
 
   const common: Options = {
-    entry: ['./src/**/*.{ts,tsx,js,jsx}'],
+    entry: ['./src/**/*.{ts,tsx,js,jsx}', '!./src/**/*.test.{ts,tsx}'],
     // We want to preserve original file structure
     // so that the "use client" directives are not lost
     // and make debugging easier via node_modules easier

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(overrideOptions => {
   const shouldPublish = !!overrideOptions.env?.publish;
 
   const common: Options = {
-    entry: ['./src/**/*.{ts,tsx,js,jsx}'],
+    entry: ['./src/**/*.{ts,tsx,js,jsx}', '!./src/**/*.test.{ts,tsx}'],
     bundle: false,
     clean: true,
     minify: false,


### PR DESCRIPTION
## Description

If you look at e.g. https://unpkg.com/browse/@clerk/chrome-extension@0.4.12/dist/cjs/ you'll see that we bundle `exports.test.js` and `exports.test.js.map` 😱 

You can tell tsup to not add test files to the bundling like this:

```ts
entry: ['./src/**/*.{ts,tsx}', '!./src/**/*.test.{ts,tsx}'],
```

It uses [globby](https://www.npmjs.com/package/globby) so you can use `!` to ignore stuff.

Fixes SDK-801

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [x] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [x] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
