### PR TITLE
fix(clerk-react): Use semver pkg

### DIFF
--- a/.changeset/poor-kings-marry.md
+++ b/.changeset/poor-kings-marry.md
@@ -1,0 +1,5 @@
+---
+"@clerk/clerk-react": patch
+---
+
+Replace internal logic of determining package tag & major version with [semver](https://www.npmjs.com/package/semver) in order to have a more robust solution

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
       },
       "workspaces": {
         "packages": [
-          "integration",
           "packages/*"
         ]
       }
@@ -85,6 +84,7 @@
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -700,7 +700,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -982,7 +982,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -993,7 +993,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1004,7 +1004,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -1093,7 +1093,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1104,7 +1104,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1115,7 +1115,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.21.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -1129,7 +1129,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1140,7 +1140,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1151,7 +1151,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1162,7 +1162,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1173,7 +1173,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1184,7 +1184,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1209,7 +1209,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1223,7 +1223,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.21.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
@@ -2321,7 +2321,7 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@builder.io/partytown": {
@@ -3504,6 +3504,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -3525,10 +3526,12 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.21.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3542,6 +3545,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3552,6 +3556,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.49.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3807,6 +3812,7 @@
     },
     "node_modules/@fastify/ajv-compiler": {
       "version": "3.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -3816,6 +3822,7 @@
     },
     "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
       "version": "8.12.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3830,18 +3837,22 @@
     },
     "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fastify/deepmerge": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-json-stringify": "^5.7.0"
@@ -4440,6 +4451,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -4452,6 +4464,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -4463,6 +4476,7 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@iarna/toml": {
@@ -4556,7 +4570,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -4571,7 +4585,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4579,7 +4593,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -4591,7 +4605,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -4602,7 +4616,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -4613,7 +4627,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4621,7 +4635,7 @@
     },
     "node_modules/@jest/console": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4637,7 +4651,7 @@
     },
     "node_modules/@jest/console/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4651,7 +4665,7 @@
     },
     "node_modules/@jest/console/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4666,7 +4680,7 @@
     },
     "node_modules/@jest/console/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4677,12 +4691,12 @@
     },
     "node_modules/@jest/console/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/console/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4690,7 +4704,7 @@
     },
     "node_modules/@jest/console/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4701,7 +4715,7 @@
     },
     "node_modules/@jest/core": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.5.0",
@@ -4747,7 +4761,7 @@
     },
     "node_modules/@jest/core/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4761,7 +4775,7 @@
     },
     "node_modules/@jest/core/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4776,7 +4790,7 @@
     },
     "node_modules/@jest/core/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4787,12 +4801,12 @@
     },
     "node_modules/@jest/core/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4800,7 +4814,7 @@
     },
     "node_modules/@jest/core/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -4813,7 +4827,7 @@
     },
     "node_modules/@jest/core/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4824,12 +4838,12 @@
     },
     "node_modules/@jest/core/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4840,7 +4854,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.5.0",
@@ -4854,7 +4868,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.5.0",
@@ -4866,7 +4880,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.4.3"
@@ -4877,7 +4891,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -4893,7 +4907,7 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -4907,7 +4921,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -4949,7 +4963,7 @@
     },
     "node_modules/@jest/reporters/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4963,7 +4977,7 @@
     },
     "node_modules/@jest/reporters/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4978,7 +4992,7 @@
     },
     "node_modules/@jest/reporters/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4989,12 +5003,12 @@
     },
     "node_modules/@jest/reporters/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5013,7 +5027,7 @@
     },
     "node_modules/@jest/reporters/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5021,7 +5035,7 @@
     },
     "node_modules/@jest/reporters/node_modules/jest-worker": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5035,7 +5049,7 @@
     },
     "node_modules/@jest/reporters/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5049,7 +5063,7 @@
     },
     "node_modules/@jest/reporters/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5060,7 +5074,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -5071,7 +5085,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.15",
@@ -5084,7 +5098,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.5.0",
@@ -5098,7 +5112,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.5.0",
@@ -5112,7 +5126,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -5137,7 +5151,7 @@
     },
     "node_modules/@jest/transform/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5151,7 +5165,7 @@
     },
     "node_modules/@jest/transform/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5166,7 +5180,7 @@
     },
     "node_modules/@jest/transform/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5177,17 +5191,17 @@
     },
     "node_modules/@jest/transform/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/transform/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/transform/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5195,12 +5209,12 @@
     },
     "node_modules/@jest/transform/node_modules/signal-exit": {
       "version": "3.0.7",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@jest/transform/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5211,7 +5225,7 @@
     },
     "node_modules/@jest/transform/node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -5223,7 +5237,7 @@
     },
     "node_modules/@jest/types": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -5239,7 +5253,7 @@
     },
     "node_modules/@jest/types/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5253,7 +5267,7 @@
     },
     "node_modules/@jest/types/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5268,7 +5282,7 @@
     },
     "node_modules/@jest/types/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5279,12 +5293,12 @@
     },
     "node_modules/@jest/types/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jest/types/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5292,7 +5306,7 @@
     },
     "node_modules/@jest/types/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7320,7 +7334,7 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -7374,7 +7388,7 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -7382,7 +7396,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -7936,7 +7950,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -7948,7 +7962,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.6.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -7956,7 +7970,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -7965,7 +7979,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.20.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
@@ -8173,7 +8187,7 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8207,12 +8221,12 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
@@ -8220,7 +8234,7 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
@@ -8356,7 +8370,7 @@
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -8436,8 +8450,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.5.3",
-      "license": "MIT"
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ=="
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
@@ -8491,7 +8506,7 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/testing-library__jest-dom": {
@@ -8540,7 +8555,7 @@
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -8548,7 +8563,7 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yoga-layout": {
@@ -8587,145 +8602,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "3.10.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/types": "3.10.1",
-        "@typescript-eslint/typescript-estree": "3.10.1",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
-      "version": "3.10.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "3.10.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "3.10.1",
-        "@typescript-eslint/visitor-keys": "3.10.1",
-        "debug": "^4.1.1",
-        "glob": "^7.1.6",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "3.10.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/estraverse": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -9572,6 +9448,7 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -9587,6 +9464,7 @@
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/accepts": {
@@ -9603,6 +9481,7 @@
     },
     "node_modules/acorn": {
       "version": "8.10.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -9630,6 +9509,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9689,6 +9569,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -9704,6 +9585,7 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.12.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -9718,6 +9600,7 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv-keywords": {
@@ -9751,7 +9634,7 @@
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -9765,7 +9648,7 @@
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
       "version": "0.21.3",
-      "devOptional": true,
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -9787,6 +9670,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9814,7 +9698,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -9869,6 +9753,7 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/are-we-there-yet": {
@@ -9888,7 +9773,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -10120,6 +10005,7 @@
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -10184,6 +10070,7 @@
     },
     "node_modules/avvio": {
       "version": "8.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "archy": "^1.0.0",
@@ -10231,38 +10118,9 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.5.0",
@@ -10282,7 +10140,7 @@
     },
     "node_modules/babel-jest/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10296,7 +10154,7 @@
     },
     "node_modules/babel-jest/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10311,7 +10169,7 @@
     },
     "node_modules/babel-jest/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -10322,12 +10180,12 @@
     },
     "node_modules/babel-jest/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-jest/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10335,7 +10193,7 @@
     },
     "node_modules/babel-jest/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10399,7 +10257,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -10414,7 +10272,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -10570,7 +10428,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -10658,7 +10516,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.5.0",
@@ -11068,7 +10926,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
@@ -11103,7 +10961,7 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/builtin-modules": {
@@ -11361,7 +11219,7 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11522,7 +11380,7 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11620,7 +11478,7 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/clean-regexp": {
@@ -11887,7 +11745,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -11932,7 +11790,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -11950,7 +11808,7 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color": {
@@ -13003,7 +12861,7 @@
     },
     "node_modules/dedent": {
       "version": "0.7.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -13054,6 +12912,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -13301,7 +13160,7 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13476,6 +13335,7 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -13687,7 +13547,7 @@
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14225,6 +14085,7 @@
     },
     "node_modules/eslint": {
       "version": "8.49.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -14786,23 +14647,6 @@
         "eslint": ">=5.0.0"
       }
     },
-    "node_modules/eslint-plugin-testing-library": {
-      "version": "3.10.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": "^3.10.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": "^5 || ^6 || ^7"
-      }
-    },
     "node_modules/eslint-plugin-tsdoc": {
       "version": "0.2.17",
       "license": "MIT",
@@ -14886,6 +14730,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -14991,6 +14836,7 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -15004,10 +14850,12 @@
     },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -15022,6 +14870,7 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -15032,10 +14881,12 @@
     },
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.20.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -15049,6 +14900,7 @@
     },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15056,6 +14908,7 @@
     },
     "node_modules/eslint/node_modules/js-yaml": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -15066,6 +14919,7 @@
     },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15076,6 +14930,7 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -15091,7 +14946,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -15184,6 +15039,7 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15196,6 +15052,7 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -15245,7 +15102,7 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -15260,7 +15117,7 @@
     },
     "node_modules/expect": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.5.0",
@@ -15283,7 +15140,7 @@
     },
     "node_modules/expect/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -15297,7 +15154,7 @@
     },
     "node_modules/expect/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -15312,7 +15169,7 @@
     },
     "node_modules/expect/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -15323,12 +15180,12 @@
     },
     "node_modules/expect/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/expect/node_modules/diff-sequences": {
       "version": "29.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -15336,7 +15193,7 @@
     },
     "node_modules/expect/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15344,7 +15201,7 @@
     },
     "node_modules/expect/node_modules/jest-diff": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -15358,7 +15215,7 @@
     },
     "node_modules/expect/node_modules/jest-matcher-utils": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -15372,7 +15229,7 @@
     },
     "node_modules/expect/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -15385,7 +15242,7 @@
     },
     "node_modules/expect/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15396,12 +15253,12 @@
     },
     "node_modules/expect/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/expect/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15634,10 +15491,12 @@
     },
     "node_modules/fast-content-type-parse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -15679,6 +15538,7 @@
     },
     "node_modules/fast-json-stringify": {
       "version": "5.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/deepmerge": "^1.0.0",
@@ -15691,6 +15551,7 @@
     },
     "node_modules/fast-json-stringify/node_modules/ajv": {
       "version": "8.12.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -15705,14 +15566,17 @@
     },
     "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
@@ -15720,6 +15584,7 @@
     },
     "node_modules/fast-redact": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15732,6 +15597,7 @@
     },
     "node_modules/fast-uri": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastest-levenshtein": {
@@ -15743,6 +15609,7 @@
     },
     "node_modules/fastify": {
       "version": "4.12.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/ajv-compiler": "^3.3.1",
@@ -15764,6 +15631,7 @@
     },
     "node_modules/fastify-plugin": {
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -15786,7 +15654,7 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
@@ -15908,6 +15776,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -16007,6 +15876,7 @@
     },
     "node_modules/find-my-way": {
       "version": "7.6.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -16023,6 +15893,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -16046,6 +15917,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -16057,6 +15929,7 @@
     },
     "node_modules/flat-cache/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -16075,6 +15948,7 @@
     },
     "node_modules/flat-cache/node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -16088,6 +15962,7 @@
     },
     "node_modules/flatted": {
       "version": "3.2.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -16366,6 +16241,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17312,128 +17188,6 @@
         }
       }
     },
-    "node_modules/gatsby/node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
-    "node_modules/gatsby/node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/gatsby/node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/gatsby/node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/gatsby/node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/gatsby/node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
     "node_modules/gatsby/node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "dev": true,
@@ -17770,28 +17524,6 @@
         }
       }
     },
-    "node_modules/gatsby/node_modules/eslint-plugin-jest": {
-      "version": "24.7.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">= 4",
-        "eslint": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/gatsby/node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -18047,7 +17779,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -18076,7 +17808,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -18296,6 +18028,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -18826,7 +18559,7 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-rewriter-wasm": {
@@ -19166,7 +18899,7 @@
     },
     "node_modules/import-local": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -19184,6 +18917,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -19351,6 +19085,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -19554,7 +19289,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19697,6 +19432,7 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19987,7 +19723,7 @@
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -19995,7 +19731,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -20010,7 +19746,7 @@
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "6.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -20018,7 +19754,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -20031,7 +19767,7 @@
     },
     "node_modules/istanbul-lib-report/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20039,7 +19775,7 @@
     },
     "node_modules/istanbul-lib-report/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20050,7 +19786,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -20063,7 +19799,7 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
       "version": "0.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20071,7 +19807,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.1.5",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -20116,7 +19852,7 @@
     },
     "node_modules/jest": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.5.0",
@@ -20141,7 +19877,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -20153,7 +19889,7 @@
     },
     "node_modules/jest-changed-files/node_modules/p-limit": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -20167,7 +19903,7 @@
     },
     "node_modules/jest-circus": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -20197,7 +19933,7 @@
     },
     "node_modules/jest-circus/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20211,7 +19947,7 @@
     },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20226,7 +19962,7 @@
     },
     "node_modules/jest-circus/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20237,12 +19973,12 @@
     },
     "node_modules/jest-circus/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/diff-sequences": {
       "version": "29.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -20250,7 +19986,7 @@
     },
     "node_modules/jest-circus/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20258,7 +19994,7 @@
     },
     "node_modules/jest-circus/node_modules/jest-diff": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -20272,7 +20008,7 @@
     },
     "node_modules/jest-circus/node_modules/jest-matcher-utils": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -20286,7 +20022,7 @@
     },
     "node_modules/jest-circus/node_modules/p-limit": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -20300,7 +20036,7 @@
     },
     "node_modules/jest-circus/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20313,7 +20049,7 @@
     },
     "node_modules/jest-circus/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20324,12 +20060,12 @@
     },
     "node_modules/jest-circus/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20340,7 +20076,7 @@
     },
     "node_modules/jest-cli": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.5.0",
@@ -20373,7 +20109,7 @@
     },
     "node_modules/jest-cli/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20387,7 +20123,7 @@
     },
     "node_modules/jest-cli/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20402,7 +20138,7 @@
     },
     "node_modules/jest-cli/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20413,12 +20149,12 @@
     },
     "node_modules/jest-cli/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-cli/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20426,7 +20162,7 @@
     },
     "node_modules/jest-cli/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20437,7 +20173,7 @@
     },
     "node_modules/jest-config": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -20481,7 +20217,7 @@
     },
     "node_modules/jest-config/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20495,7 +20231,7 @@
     },
     "node_modules/jest-config/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20510,7 +20246,7 @@
     },
     "node_modules/jest-config/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20521,12 +20257,12 @@
     },
     "node_modules/jest-config/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/glob": {
       "version": "7.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -20545,7 +20281,7 @@
     },
     "node_modules/jest-config/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20553,7 +20289,7 @@
     },
     "node_modules/jest-config/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20566,7 +20302,7 @@
     },
     "node_modules/jest-config/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20577,12 +20313,12 @@
     },
     "node_modules/jest-config/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20593,7 +20329,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -20604,7 +20340,7 @@
     },
     "node_modules/jest-each": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -20619,7 +20355,7 @@
     },
     "node_modules/jest-each/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20633,7 +20369,7 @@
     },
     "node_modules/jest-each/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20648,7 +20384,7 @@
     },
     "node_modules/jest-each/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20659,12 +20395,12 @@
     },
     "node_modules/jest-each/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-each/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20672,7 +20408,7 @@
     },
     "node_modules/jest-each/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20685,7 +20421,7 @@
     },
     "node_modules/jest-each/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20696,12 +20432,12 @@
     },
     "node_modules/jest-each/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-each/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20738,7 +20474,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -20754,7 +20490,7 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -20762,7 +20498,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -20786,7 +20522,7 @@
     },
     "node_modules/jest-haste-map/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20794,7 +20530,7 @@
     },
     "node_modules/jest-haste-map/node_modules/jest-worker": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -20808,7 +20544,7 @@
     },
     "node_modules/jest-haste-map/node_modules/supports-color": {
       "version": "8.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20822,7 +20558,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.4.3",
@@ -20834,7 +20570,7 @@
     },
     "node_modules/jest-leak-detector/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20845,7 +20581,7 @@
     },
     "node_modules/jest-leak-detector/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20858,12 +20594,12 @@
     },
     "node_modules/jest-leak-detector/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-message-util": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -20882,7 +20618,7 @@
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20896,7 +20632,7 @@
     },
     "node_modules/jest-message-util/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -20911,7 +20647,7 @@
     },
     "node_modules/jest-message-util/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20922,12 +20658,12 @@
     },
     "node_modules/jest-message-util/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20935,7 +20671,7 @@
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -20948,7 +20684,7 @@
     },
     "node_modules/jest-message-util/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20959,12 +20695,12 @@
     },
     "node_modules/jest-message-util/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20975,7 +20711,7 @@
     },
     "node_modules/jest-mock": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -20988,7 +20724,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21004,7 +20740,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -21012,7 +20748,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -21031,7 +20767,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.4.3",
@@ -21043,7 +20779,7 @@
     },
     "node_modules/jest-resolve/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21057,7 +20793,7 @@
     },
     "node_modules/jest-resolve/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21072,7 +20808,7 @@
     },
     "node_modules/jest-resolve/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21083,12 +20819,12 @@
     },
     "node_modules/jest-resolve/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-resolve/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21096,7 +20832,7 @@
     },
     "node_modules/jest-resolve/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21107,7 +20843,7 @@
     },
     "node_modules/jest-runner": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.5.0",
@@ -21138,7 +20874,7 @@
     },
     "node_modules/jest-runner/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21152,7 +20888,7 @@
     },
     "node_modules/jest-runner/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21167,7 +20903,7 @@
     },
     "node_modules/jest-runner/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21178,12 +20914,12 @@
     },
     "node_modules/jest-runner/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-runner/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21191,7 +20927,7 @@
     },
     "node_modules/jest-runner/node_modules/jest-worker": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -21205,7 +20941,7 @@
     },
     "node_modules/jest-runner/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21219,7 +20955,7 @@
     },
     "node_modules/jest-runner/node_modules/p-limit": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -21233,7 +20969,7 @@
     },
     "node_modules/jest-runner/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21244,7 +20980,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.5.0",
@@ -21276,7 +21012,7 @@
     },
     "node_modules/jest-runtime/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21290,7 +21026,7 @@
     },
     "node_modules/jest-runtime/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21305,7 +21041,7 @@
     },
     "node_modules/jest-runtime/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21316,12 +21052,12 @@
     },
     "node_modules/jest-runtime/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -21340,7 +21076,7 @@
     },
     "node_modules/jest-runtime/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21348,7 +21084,7 @@
     },
     "node_modules/jest-runtime/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21359,7 +21095,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -21392,7 +21128,7 @@
     },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21406,7 +21142,7 @@
     },
     "node_modules/jest-snapshot/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21421,7 +21157,7 @@
     },
     "node_modules/jest-snapshot/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21432,12 +21168,12 @@
     },
     "node_modules/jest-snapshot/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/diff-sequences": {
       "version": "29.4.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -21445,7 +21181,7 @@
     },
     "node_modules/jest-snapshot/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21453,7 +21189,7 @@
     },
     "node_modules/jest-snapshot/node_modules/jest-diff": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -21467,7 +21203,7 @@
     },
     "node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -21481,7 +21217,7 @@
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -21494,7 +21230,7 @@
     },
     "node_modules/jest-snapshot/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21505,12 +21241,12 @@
     },
     "node_modules/jest-snapshot/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21521,7 +21257,7 @@
     },
     "node_modules/jest-util": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -21537,7 +21273,7 @@
     },
     "node_modules/jest-util/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21551,7 +21287,7 @@
     },
     "node_modules/jest-util/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21566,7 +21302,7 @@
     },
     "node_modules/jest-util/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21577,12 +21313,12 @@
     },
     "node_modules/jest-util/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-util/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21590,7 +21326,7 @@
     },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21601,7 +21337,7 @@
     },
     "node_modules/jest-validate": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.5.0",
@@ -21617,7 +21353,7 @@
     },
     "node_modules/jest-validate/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21631,7 +21367,7 @@
     },
     "node_modules/jest-validate/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21646,7 +21382,7 @@
     },
     "node_modules/jest-validate/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21657,12 +21393,12 @@
     },
     "node_modules/jest-validate/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21670,7 +21406,7 @@
     },
     "node_modules/jest-validate/node_modules/pretty-format": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.4.3",
@@ -21683,7 +21419,7 @@
     },
     "node_modules/jest-validate/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -21694,12 +21430,12 @@
     },
     "node_modules/jest-validate/node_modules/react-is": {
       "version": "18.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21710,7 +21446,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.5.0",
@@ -21728,7 +21464,7 @@
     },
     "node_modules/jest-watcher/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21742,7 +21478,7 @@
     },
     "node_modules/jest-watcher/node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -21757,7 +21493,7 @@
     },
     "node_modules/jest-watcher/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21768,12 +21504,12 @@
     },
     "node_modules/jest-watcher/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-watcher/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21781,7 +21517,7 @@
     },
     "node_modules/jest-watcher/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21859,7 +21595,7 @@
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -21971,6 +21707,7 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
@@ -22180,7 +21917,7 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22188,6 +21925,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -22199,6 +21937,7 @@
     },
     "node_modules/light-my-request": {
       "version": "5.9.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "cookie": "^0.5.0",
@@ -22564,6 +22303,7 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -22699,6 +22439,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.mergewith": {
@@ -22972,7 +22713,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -22986,7 +22727,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -22999,7 +22740,7 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
@@ -23955,7 +23696,7 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-object-hash": {
@@ -24001,7 +23742,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24566,6 +24307,7 @@
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -24641,6 +24383,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@aashutoshrathi/word-wrap": "^1.2.3",
@@ -24739,6 +24482,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -24752,6 +24496,7 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -25241,6 +24986,7 @@
     },
     "node_modules/pino": {
       "version": "8.14.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -25261,6 +25007,7 @@
     },
     "node_modules/pino-abstract-transport": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^4.0.0",
@@ -25269,6 +25016,7 @@
     },
     "node_modules/pino-abstract-transport/node_modules/buffer": {
       "version": "6.0.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25291,6 +25039,7 @@
     },
     "node_modules/pino-abstract-transport/node_modules/readable-stream": {
       "version": "4.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -25304,6 +25053,7 @@
     },
     "node_modules/pino-abstract-transport/node_modules/split2": {
       "version": "4.2.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -25311,11 +25061,12 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -25323,7 +25074,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -25334,7 +25085,7 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -25346,7 +25097,7 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -25357,7 +25108,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -26126,6 +25877,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -26141,7 +25893,7 @@
     },
     "node_modules/prettier": {
       "version": "2.8.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
@@ -26234,6 +25986,7 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -26246,6 +25999,7 @@
     },
     "node_modules/process-warning": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -26266,7 +26020,7 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -26278,7 +26032,7 @@
     },
     "node_modules/prompts/node_modules/kleur": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -26333,6 +26087,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -26403,7 +26158,7 @@
     },
     "node_modules/pure-rand": {
       "version": "6.0.2",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -26506,6 +26261,7 @@
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/quick-lru": {
@@ -26612,6 +26368,7 @@
     },
     "node_modules/react": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -26747,6 +26504,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -27053,6 +26811,7 @@
     },
     "node_modules/real-require": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -27373,7 +27132,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27381,6 +27140,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27435,7 +27195,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -27446,7 +27206,7 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -27472,7 +27232,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -27508,6 +27268,7 @@
     },
     "node_modules/ret": {
       "version": "0.2.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -27531,6 +27292,7 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -27731,6 +27493,7 @@
     },
     "node_modules/safe-regex2": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ret": "~0.2.0"
@@ -27738,6 +27501,7 @@
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.4.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -27766,6 +27530,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27790,6 +27555,7 @@
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/select-hose": {
@@ -28009,6 +27775,7 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/set-function-name": {
@@ -28278,7 +28045,7 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
@@ -28591,6 +28358,7 @@
     },
     "node_modules/sonic-boom": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -28676,7 +28444,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -28685,7 +28453,7 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -28871,7 +28639,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
@@ -28921,7 +28689,7 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -28932,7 +28700,7 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29045,7 +28813,7 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -29074,7 +28842,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -29114,12 +28882,12 @@
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29199,6 +28967,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -29221,7 +28990,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29257,6 +29026,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -29771,7 +29541,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -29784,7 +29554,7 @@
     },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -29811,6 +29581,7 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/thenify": {
@@ -29834,6 +29605,7 @@
     },
     "node_modules/thread-stream": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
@@ -29904,6 +29676,7 @@
     },
     "node_modules/tiny-lru": {
       "version": "10.4.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -29940,7 +29713,7 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-fast-properties": {
@@ -30615,6 +30388,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -30625,7 +30399,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -30732,6 +30506,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -31064,7 +30839,7 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -31350,7 +31125,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
@@ -32152,7 +31927,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -32215,7 +31990,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -32229,7 +32004,7 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -32240,7 +32015,7 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -32383,7 +32158,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -32423,7 +32198,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -32460,7 +32235,7 @@
     },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -32476,6 +32251,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -33076,21 +32852,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/eslint-config-custom/node_modules/prettier": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "packages/expo": {
       "name": "@clerk/clerk-expo",
       "version": "0.19.12",
@@ -33242,6 +33003,7 @@
         "@clerk/shared": "1.0.0",
         "@clerk/types": "3.57.0",
         "eslint-config-custom": "*",
+        "semver": "^7.5.4",
         "tslib": "2.4.1"
       },
       "devDependencies": {
@@ -33249,6 +33011,7 @@
         "@types/node": "^16.11.55",
         "@types/react": "*",
         "@types/react-dom": "*",
+        "@types/semver": "^7.5.4",
         "eslint-config-custom": "*",
         "typescript": "*"
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,6 +59,7 @@
     "@clerk/shared": "1.0.0",
     "@clerk/types": "3.57.0",
     "eslint-config-custom": "*",
+    "semver": "^7.5.4",
     "tslib": "2.4.1"
   },
   "devDependencies": {
@@ -66,6 +67,7 @@
     "@types/node": "^16.11.55",
     "@types/react": "*",
     "@types/react-dom": "*",
+    "@types/semver": "^7.5.4",
     "eslint-config-custom": "*",
     "typescript": "*"
   },

--- a/packages/react/src/utils/versionSelector.ts
+++ b/packages/react/src/utils/versionSelector.ts
@@ -1,3 +1,6 @@
+import major from 'semver/functions/major';
+import prerelease from 'semver/functions/prerelease';
+
 /**
  * This version selector is a bit complicated, so here is the flow:
  * 1. Use the clerkJSVersion prop on the provider
@@ -24,6 +27,5 @@ export const versionSelector = (clerkJSVersion: string | undefined) => {
   return getMajorVersion(PACKAGE_VERSION);
 };
 
-// TODO: Replace these with "semver" package
-const getPrereleaseTag = (packageVersion: string) => packageVersion.match(/-(.*)\./)?.[1];
-const getMajorVersion = (packageVersion: string) => packageVersion.split('.')[0];
+const getPrereleaseTag = (packageVersion: string) => prerelease(packageVersion)?.[0].toString();
+const getMajorVersion = (packageVersion: string) => major(packageVersion).toString();


### PR DESCRIPTION
## Description

Replaces the brittle logic of `getPrereleaseTag` and `getMajorVersion` with [`semver`](https://www.npmjs.com/package/semver) as it's battle-tested and will cover more of the edge cases.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [x] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [ ] `build/tooling/chore`
