### PR TITLE
chore(repo): Fix tests display name

### DIFF
--- a/.changeset/loud-lions-compete.md
+++ b/.changeset/loud-lions-compete.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix tests to have the correct display name prefix

--- a/packages/chrome-extension/jest.config.js
+++ b/packages/chrome-extension/jest.config.js
@@ -1,8 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { name, version } = require('./package.json');
 
 module.exports = {
-  displayName: 'clerk-js',
+  displayName: name.replace('@clerk', ''),
   injectGlobals: true,
 
   roots: ['<rootDir>/src'],

--- a/packages/clerk-js/jest.config.js
+++ b/packages/clerk-js/jest.config.js
@@ -1,6 +1,8 @@
+const { name } = require('./package.json');
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const config = {
-  displayName: 'clerk-js',
+  displayName: name.replace('@clerk', ''),
   injectGlobals: true,
 
   testEnvironment: '<rootDir>/jest.jsdom-with-timezone.ts',

--- a/packages/fastify/jest.config.js
+++ b/packages/fastify/jest.config.js
@@ -1,6 +1,8 @@
+const { name } = require('./package.json');
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  displayName: 'fastify',
+  displayName: name.replace('@clerk', ''),
   injectGlobals: true,
   roots: ['<rootDir>/src'],
   testMatch: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],

--- a/packages/nextjs/jest.config.js
+++ b/packages/nextjs/jest.config.js
@@ -1,9 +1,11 @@
+const { name } = require('./package.json');
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   globals: {
     PACKAGE_VERSION: '0.0.0-test',
   },
-  displayName: 'nextjs',
+  displayName: name.replace('@clerk', ''),
   injectGlobals: true,
   roots: ['<rootDir>/src'],
   testMatch: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,5 +1,7 @@
+const { name } = require('./package.json');
+
 module.exports = {
-  displayName: 'clerk-js',
+  displayName: name.replace('@clerk', ''),
   injectGlobals: true,
 
   roots: ['<rootDir>/src'],

--- a/packages/sdk-node/jest.config.js
+++ b/packages/sdk-node/jest.config.js
@@ -1,4 +1,7 @@
+const { name } = require('./package.json');
+
 module.exports = {
+  displayName: name.replace('@clerk', ''),
   roots: ['<rootDir>/src'],
   testMatch: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],
   transform: {

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -1,6 +1,8 @@
+const { name } = require('./package.json');
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const config = {
-  displayName: 'shared',
+  displayName: name.replace('@clerk', ''),
   injectGlobals: true,
 
   testEnvironment: 'jsdom',


### PR DESCRIPTION
## Description

Make `displayName` in `jest.config.js` consistent across all monorepo packages.

## Checklist

- [x] `npm test` runs as expected.
- [x] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerkinc/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [x] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:

## Packages affected

- [ ] `@clerk/backend`
- [ ] `@clerk/chrome-extension`
- [ ] `@clerk/clerk-js`
- [ ] `@clerk/clerk-expo`
- [ ] `@clerk/fastify`
- [ ] `gatsby-plugin-clerk`
- [ ] `@clerk/localizations`
- [ ] `@clerk/nextjs`
- [ ] `@clerk/clerk-react`
- [ ] `@clerk/remix`
- [ ] `@clerk/clerk-sdk-node`
- [ ] `@clerk/shared`
- [ ] `@clerk/themes`
- [ ] `@clerk/types`
- [x] `build/tooling/chore`
