### PR TITLE
feat(shared): Organization hooks with `setData` and `revalidate` (#1745)

### DIFF
--- a/.changeset/blue-ghosts-float.md
+++ b/.changeset/blue-ghosts-float.md
@@ -1,0 +1,6 @@
+---
+'@clerk/shared': minor
+---
+
+Expose `revalidate` and `setData` for paginated lists of data in organization hooks.
+`const {userMemberships:{revalidate, setData}} = useOrganizationList({userMemberships:true})`

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserInvitationList.tsx
@@ -5,7 +5,7 @@ import { useCoreClerk, useCoreOrganizationList } from '../../contexts';
 import { localizationKeys } from '../../customizables';
 import { useCardState, withCardStateProvider } from '../../elements';
 import { handleError } from '../../utils';
-import { updateCacheInPlace } from '../OrganizationSwitcher/utils';
+import { populateCacheUpdateItem } from '../OrganizationSwitcher/utils';
 import { PreviewListItem, PreviewListItemButton } from './shared';
 import { MembershipPreview } from './UserMembershipList';
 import { organizationListParams } from './utils';
@@ -39,7 +39,7 @@ export const InvitationPreview = withCardStateProvider((props: UserOrganizationI
       })
       .then(([updatedItem, organization]) => {
         // Update cache in case another listener depends on it
-        updateCacheInPlace(userInvitations)(updatedItem);
+        void userInvitations?.setData?.(cachedPages => populateCacheUpdateItem(updatedItem, cachedPages));
         setAcceptedOrganization(organization);
       })
       .catch(err => handleError(err, [], card.setError));

--- a/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationList/UserSuggestionList.tsx
@@ -4,7 +4,7 @@ import { useCoreOrganizationList } from '../../contexts';
 import { localizationKeys, Text } from '../../customizables';
 import { useCardState, withCardStateProvider } from '../../elements';
 import { handleError } from '../../utils';
-import { updateCacheInPlace } from '../OrganizationSwitcher/utils';
+import { populateCacheUpdateItem } from '../OrganizationSwitcher/utils';
 import { PreviewListItem, PreviewListItemButton } from './shared';
 import { organizationListParams } from './utils';
 
@@ -17,7 +17,7 @@ export const AcceptRejectInvitationButtons = (props: OrganizationSuggestionResou
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updateCacheInPlace(userSuggestions))
+      .then(updatedItem => userSuggestions?.setData?.(pages => populateCacheUpdateItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/ActiveMembersList.tsx
@@ -9,16 +9,9 @@ import { DataTable, RoleSelect, RowContainer } from './MemberListTable';
 
 export const ActiveMembersList = () => {
   const card = useCardState();
-  const { organization, memberships, ...rest } = useCoreOrganization({
+  const { organization, memberships } = useCoreOrganization({
     memberships: true,
   });
-
-  const mutateSwrState = () => {
-    const unstable__mutate = (rest as any).unstable__mutate;
-    if (unstable__mutate && typeof unstable__mutate === 'function') {
-      unstable__mutate();
-    }
-  };
 
   if (!organization) {
     return null;
@@ -27,7 +20,7 @@ export const ActiveMembersList = () => {
   const handleRoleChange = (membership: OrganizationMembershipResource) => (newRole: MembershipRole) => {
     return card
       .runAsync(async () => {
-        await membership.update({ role: newRole });
+        return await membership.update({ role: newRole });
       })
       .catch(err => handleError(err, [], card.setError));
   };
@@ -36,9 +29,9 @@ export const ActiveMembersList = () => {
     return card
       .runAsync(async () => {
         const destroyedMembership = await membership.destroy();
+        await memberships?.revalidate?.();
         return destroyedMembership;
       })
-      .then(mutateSwrState)
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RemoveDomainPage.tsx
@@ -66,7 +66,7 @@ export const RemoveDomainPage = () => {
       successMessage={localizationKeys('organizationProfile.removeDomainPage.successMessage', {
         domain: ref.current?.name,
       })}
-      deleteResource={() => domain?.delete().then(() => (domains as any).unstable__mutate())}
+      deleteResource={() => domain?.delete().then(() => domains?.revalidate?.())}
       breadcrumbTitle={localizationKeys('organizationProfile.profilePage.domainSection.title')}
       Breadcrumbs={OrganizationProfileBreadcrumbs}
     />

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/RequestToJoinList.tsx
@@ -49,23 +49,29 @@ const RequestRow = withCardStateProvider(
   (props: { request: OrganizationMembershipRequestResource; onError: ReturnType<typeof useCardState>['setError'] }) => {
     const { request, onError } = props;
     const card = useCardState();
-    const { membershipRequests } = useCoreOrganization({
+    const { membership, membershipRequests } = useCoreOrganization({
       membershipRequests: membershipRequestsParams,
     });
 
     const onAccept = () => {
+      if (!membership || !membershipRequests) {
+        return;
+      }
       return card
         .runAsync(async () => {
           await request.accept();
-          await (membershipRequests as any).unstable__mutate?.();
+          await membershipRequests.revalidate();
         }, 'accept')
         .catch(err => handleError(err, [], onError));
     };
     const onReject = () => {
+      if (!membership || !membershipRequests) {
+        return;
+      }
       return card
         .runAsync(async () => {
           await request.reject();
-          await (membershipRequests as any).unstable__mutate?.();
+          await membershipRequests.revalidate();
         }, 'reject')
         .catch(err => handleError(err, [], onError));
     };

--- a/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainPage.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationProfile/VerifiedDomainPage.tsx
@@ -55,7 +55,7 @@ export const VerifiedDomainPage = withCardStateProvider(() => {
   const card = useCardState();
   const { organizationSettings } = useEnvironment();
 
-  const { organization, domains } = useCoreOrganization({
+  const { membership, organization, domains } = useCoreOrganization({
     domains: {
       infinite: true,
     },
@@ -147,7 +147,7 @@ export const VerifiedDomainPage = withCardStateProvider(() => {
   });
 
   const updateEnrollmentMode = async () => {
-    if (!domain || !organization) {
+    if (!domain || !organization || !membership || !domains) {
       return;
     }
 
@@ -157,7 +157,7 @@ export const VerifiedDomainPage = withCardStateProvider(() => {
         deletePending: deletePending.checked,
       });
 
-      await (domains as any).unstable__mutate();
+      await domains.revalidate();
 
       await navigate('../../');
     } catch (e) {

--- a/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
+++ b/packages/clerk-js/src/ui/components/OrganizationSwitcher/UserInvitationSuggestionList.tsx
@@ -9,7 +9,7 @@ import { useInView } from '../../hooks';
 import type { PropsOfComponent } from '../../styledSystem';
 import { common } from '../../styledSystem';
 import { handleError } from '../../utils';
-import { organizationListParams, removeItemFromPaginatedCache, updateCacheInPlace } from './utils';
+import { organizationListParams, populateCacheRemoveItem, populateCacheUpdateItem } from './utils';
 
 const useFetchInvitations = () => {
   const { userInvitations, userSuggestions } = useCoreOrganizationList(organizationListParams);
@@ -44,7 +44,7 @@ const AcceptRejectSuggestionButtons = (props: OrganizationSuggestionResource) =>
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(updateCacheInPlace(userSuggestions))
+      .then(updatedItem => userSuggestions?.setData?.(pages => populateCacheUpdateItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 
@@ -81,7 +81,7 @@ const AcceptRejectInvitationButtons = (props: UserOrganizationInvitationResource
   const handleAccept = () => {
     return card
       .runAsync(props.accept)
-      .then(removeItemFromPaginatedCache(userInvitations))
+      .then(updatedItem => userInvitations?.setData?.(pages => populateCacheRemoveItem(updatedItem, pages)))
       .catch(err => handleError(err, [], card.setError));
   };
 

--- a/packages/shared/src/react/hooks/useOrganization.tsx
+++ b/packages/shared/src/react/hooks/useOrganization.tsx
@@ -56,7 +56,9 @@ type UseOrganizationParams = {
       });
 };
 
-type UseOrganizationReturn =
+type UseOrganization = <T extends UseOrganizationParams>(
+  params?: T,
+) =>
   | {
       isLoaded: false;
       organization: undefined;
@@ -103,13 +105,23 @@ type UseOrganizationReturn =
        */
       membershipList: OrganizationMembershipResource[] | null | undefined;
       membership: OrganizationMembershipResource | null | undefined;
-      domains: PaginatedResources<OrganizationDomainResource> | null;
-      membershipRequests: PaginatedResources<OrganizationMembershipRequestResource> | null;
-      memberships: PaginatedResources<OrganizationMembershipResource> | null;
-      invitations: PaginatedResources<OrganizationInvitationResource> | null;
+      domains: PaginatedResources<
+        OrganizationDomainResource,
+        T['membershipRequests'] extends { infinite: true } ? true : false
+      > | null;
+      membershipRequests: PaginatedResources<
+        OrganizationMembershipRequestResource,
+        T['membershipRequests'] extends { infinite: true } ? true : false
+      > | null;
+      memberships: PaginatedResources<
+        OrganizationMembershipResource,
+        T['memberships'] extends { infinite: true } ? true : false
+      > | null;
+      invitations: PaginatedResources<
+        OrganizationInvitationResource,
+        T['invitations'] extends { infinite: true } ? true : false
+      > | null;
     };
-
-type UseOrganization = (params?: UseOrganizationParams) => UseOrganizationReturn;
 
 const undefinedPaginatedResource = {
   data: undefined,
@@ -124,6 +136,8 @@ const undefinedPaginatedResource = {
   fetchPrevious: undefined,
   hasNextPage: false,
   hasPreviousPage: false,
+  revalidate: undefined,
+  setData: undefined,
 } as const;
 
 export const useOrganization: UseOrganization = params => {

--- a/packages/shared/src/react/hooks/useOrganizationList.tsx
+++ b/packages/shared/src/react/hooks/useOrganizationList.tsx
@@ -38,8 +38,26 @@ type UseOrganizationListParams = {
 };
 
 type OrganizationList = ReturnType<typeof createOrganizationList>;
+const undefinedPaginatedResource = {
+  data: undefined,
+  count: undefined,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  page: undefined,
+  pageCount: undefined,
+  fetchPage: undefined,
+  fetchNext: undefined,
+  fetchPrevious: undefined,
+  hasNextPage: false,
+  hasPreviousPage: false,
+  revalidate: undefined,
+  setData: undefined,
+} as const;
 
-type UseOrganizationListReturn =
+type UseOrganizationList = <T extends UseOrganizationListParams>(
+  params?: T,
+) =>
   | {
       isLoaded: false;
       /**
@@ -60,28 +78,19 @@ type UseOrganizationListReturn =
       organizationList: OrganizationList;
       createOrganization: (params: CreateOrganizationParams) => Promise<OrganizationResource>;
       setActive: SetActive;
-      userMemberships: PaginatedResources<OrganizationMembershipResource>;
-      userInvitations: PaginatedResources<UserOrganizationInvitationResource>;
-      userSuggestions: PaginatedResources<OrganizationSuggestionResource>;
+      userMemberships: PaginatedResources<
+        OrganizationMembershipResource,
+        T['userMemberships'] extends { infinite: true } ? true : false
+      >;
+      userInvitations: PaginatedResources<
+        UserOrganizationInvitationResource,
+        T['userInvitations'] extends { infinite: true } ? true : false
+      >;
+      userSuggestions: PaginatedResources<
+        OrganizationSuggestionResource,
+        T['userSuggestions'] extends { infinite: true } ? true : false
+      >;
     };
-
-const undefinedPaginatedResource = {
-  data: undefined,
-  count: undefined,
-  isLoading: false,
-  isFetching: false,
-  isError: false,
-  page: undefined,
-  pageCount: undefined,
-  fetchPage: undefined,
-  fetchNext: undefined,
-  fetchPrevious: undefined,
-  hasNextPage: false,
-  hasPreviousPage: false,
-  unstable__mutate: undefined,
-} as const;
-
-type UseOrganizationList = (params?: UseOrganizationListParams) => UseOrganizationListReturn;
 
 export const useOrganizationList: UseOrganizationList = params => {
   const { userMemberships, userInvitations, userSuggestions } = params || {};

--- a/packages/shared/src/react/hooks/usePagesOrInfinite.ts
+++ b/packages/shared/src/react/hooks/usePagesOrInfinite.ts
@@ -3,8 +3,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useSWR, useSWRInfinite } from '../clerk-swr';
-import type { ValueOrSetter } from '../types';
-import type { PaginatedResources } from '../types';
+import type { CacheSetter, PaginatedResources, ValueOrSetter } from '../types';
 
 function getDifferentKeys(obj1: Record<string, unknown>, obj2: Record<string, unknown>): Record<string, unknown> {
   const keysSet = new Set(Object.keys(obj2));
@@ -55,10 +54,26 @@ export const useWithSafeValues = <T extends PagesOrInfiniteOptions>(params: T | 
 type ArrayType<DataArray> = DataArray extends Array<infer ElementType> ? ElementType : never;
 type ExtractData<Type> = Type extends { data: infer Data } ? ArrayType<Data> : Type;
 
+type DefaultOptions = {
+  /**
+   * Persists the previous pages with new ones in the same array
+   */
+  infinite?: boolean;
+  /**
+   * Return the previous key's data until the new data has been loaded
+   */
+  keepPreviousData?: boolean;
+  /**
+   * Should a request be triggered
+   */
+  enabled?: boolean;
+};
+
 type UsePagesOrInfinite = <
   Params extends PagesOrInfiniteOptions,
   FetcherReturnData extends Record<string, any>,
   CacheKeys = Record<string, unknown>,
+  TOptions extends DefaultOptions = DefaultOptions,
 >(
   /**
    * The parameters will be passed to the fetcher
@@ -71,24 +86,9 @@ type UsePagesOrInfinite = <
   /**
    * Internal configuration of the hook
    */
-  options: {
-    /**
-     * Persists the previous pages with new ones in the same array
-     */
-    infinite?: boolean;
-    /**
-     * Return the previous key's data until the new data has been loaded
-     */
-    keepPreviousData?: boolean;
-    /**
-     * Should a request be triggered
-     */
-    enabled?: boolean;
-  },
+  options: TOptions,
   cacheKeys: CacheKeys,
-) => PaginatedResources<ExtractData<FetcherReturnData>> & {
-  unstable__mutate: () => Promise<unknown>;
-};
+) => PaginatedResources<ExtractData<FetcherReturnData>, TOptions['infinite']>;
 
 export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, options, cacheKeys) => {
   const [paginatedPage, setPaginatedPage] = useState(params.initialPage ?? 1);
@@ -206,7 +206,17 @@ export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, options,
   const hasNextPage = count - offsetCount * pageSizeRef.current > page * pageSizeRef.current;
   const hasPreviousPage = (page - 1) * pageSizeRef.current > offsetCount * pageSizeRef.current;
 
-  const unstable__mutate = triggerInfinite ? swrInfiniteMutate : swrMutate;
+  const setData: CacheSetter = triggerInfinite
+    ? value =>
+        swrInfiniteMutate(value, {
+          revalidate: false,
+        })
+    : value =>
+        swrMutate(value, {
+          revalidate: false,
+        });
+
+  const revalidate = triggerInfinite ? () => swrInfiniteMutate() : () => swrMutate();
 
   return {
     data,
@@ -221,6 +231,9 @@ export const usePagesOrInfinite: UsePagesOrInfinite = (params, fetcher, options,
     fetchPrevious,
     hasNextPage,
     hasPreviousPage,
-    unstable__mutate,
+    // Let the hook return type define this type
+    revalidate: revalidate as any,
+    // Let the hook return type define this type
+    setData: setData as any,
   };
 };

--- a/packages/shared/src/react/types.ts
+++ b/packages/shared/src/react/types.ts
@@ -1,5 +1,12 @@
+import type { ClerkPaginatedResponse } from '@clerk/types';
+
 export type ValueOrSetter<T = unknown> = (size: T | ((_size: T) => T)) => void;
-export type PaginatedResources<T = unknown> = {
+
+export type CacheSetter<CData = any> = (
+  data?: CData | ((currentData?: CData) => Promise<undefined | CData> | undefined | CData),
+) => Promise<CData | undefined>;
+
+export type PaginatedResources<T = unknown, Infinite = false> = {
   data: T[];
   count: number;
   isLoading: boolean;
@@ -12,11 +19,15 @@ export type PaginatedResources<T = unknown> = {
   fetchNext: () => void;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
+  revalidate: () => Promise<void>;
+  setData: Infinite extends true
+    ? // Array of pages of data
+      CacheSetter<(ClerkPaginatedResponse<T> | undefined)[]>
+    : // Array of data
+      CacheSetter<ClerkPaginatedResponse<T> | undefined>;
 };
 
 // Utility type to convert PaginatedDataAPI to properties as undefined, except booleans set to false
 export type PaginatedResourcesWithDefault<T> = {
-  [K in keyof PaginatedResources<T>]: PaginatedResources<T>[K] extends boolean
-    ? false
-    : PaginatedResources<T>[K] | undefined;
+  [K in keyof PaginatedResources<T>]: PaginatedResources<T>[K] extends boolean ? false : undefined;
 };


### PR DESCRIPTION
Backporting #1745 to the release/v4 branch

(cherry picked from commit 743c4d20423790b554e66923466081c0d3b0d9ed)